### PR TITLE
feat(node): dial peers on startup

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -70,6 +70,8 @@ impl Client {
         match event {
             // Clients do not handle requests.
             NetworkEvent::RequestReceived { .. } => {}
+            // We do not listen on sockets.
+            NetworkEvent::NewListenAddr(_) => {}
             NetworkEvent::PeerAdded => {
                 self.events_channel
                     .broadcast(ClientEvent::ConnectedToNetwork);

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     storage::{ChunkStorage, RegisterStorage},
 };
 
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use xor_name::{XorName, XOR_NAME_LEN};
 
@@ -33,6 +33,8 @@ pub struct Node {
     registers: RegisterStorage,
     transfers: Transfers,
     events_channel: NodeEventsChannel,
+    /// Peers that are dialed at startup of node.
+    initial_peers: Vec<(PeerId, Multiaddr)>,
 }
 
 /// A unique identifier for a node in the network,


### PR DESCRIPTION
We dial optional peers on startup that will get added to our routing
table et al. This will cause our node to get booted by specifying a
bootstrap node address.
