### PR TITLE
feat: impl simple cli for wallet ops, sending

### DIFF
--- a/safenode/src/client/wallet.rs
+++ b/safenode/src/client/wallet.rs
@@ -34,7 +34,6 @@ impl<W: SendWallet> WalletClient<W> {
     /// Send tokens to another wallet.
     pub async fn send(&mut self, amount: Token, to: PublicAddress) -> Result<Vec<CreatedDbc>> {
         let dbcs = self.wallet.send(vec![(amount, to)], &self.client).await?;
-        // self.wallet.store().await;
         Ok(dbcs)
     }
 

--- a/safenode/src/client/wallet.rs
+++ b/safenode/src/client/wallet.rs
@@ -9,7 +9,9 @@
 use super::Client;
 
 use crate::protocol::{
-    client_transfers::{create_online_transfer, Outputs as TransferDetails, SpendRequestParams},
+    client_transfers::{
+        create_online_transfer, CreatedDbc, Outputs as TransferDetails, SpendRequestParams,
+    },
     messages::{Cmd, Request},
     wallet::{Error, Result, SendClient, SendWallet},
 };
@@ -30,9 +32,15 @@ impl<W: SendWallet> WalletClient<W> {
     }
 
     /// Send tokens to another wallet.
-    pub async fn send(&mut self, amount: Token, to: PublicAddress) -> Result<()> {
-        let _dbcs = self.wallet.send(vec![(amount, to)], &self.client).await?;
-        Ok(())
+    pub async fn send(&mut self, amount: Token, to: PublicAddress) -> Result<Vec<CreatedDbc>> {
+        let dbcs = self.wallet.send(vec![(amount, to)], &self.client).await?;
+        // self.wallet.store().await;
+        Ok(dbcs)
+    }
+
+    /// Return the wallet.
+    pub fn into_wallet(self) -> W {
+        self.wallet
     }
 }
 

--- a/safenode/src/protocol/wallet/mod.rs
+++ b/safenode/src/protocol/wallet/mod.rs
@@ -39,6 +39,7 @@ mod wallet_file;
 
 pub use self::{
     error::{Error, Result},
+    keys::parse_public_address,
     local_store::LocalWallet,
     // network_store::NetworkWallet,
 };


### PR DESCRIPTION
Resolves #128.

[feat: impl simple cli for wallet ops, sending](https://github.com/maidsafe/safe_network/commit/258624fdca16e4bafef77ede54b26ca3a4fbc925)

- Adds send operation.
- NB: Does not yet store the created dbcs, for giving them to the
recipients out of band.