### PR TITLE
WIP test: client CLI confirming dead node gone in closest

### DIFF
--- a/safenode/src/bin/kadnode.rs
+++ b/safenode/src/bin/kadnode.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     let socket_addr = SocketAddr::new(opt.ip, opt.port);
     let peers = parse_peer_multiaddreses(&opt.peers)?;
 
-    info!("Starting a node...");
+    info!("Starting a node (PID: {}) ...", std::process::id());
     let node_events_channel = Node::run(socket_addr, peers).await?;
 
     let mut node_events_rx = node_events_channel.subscribe();

--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -187,6 +187,17 @@ impl Client {
             .await)
     }
 
+    /// This is for network testing only
+    pub async fn get_closest(&self, dst: XorName) -> Vec<PeerId> {
+        match self.network.client_get_closest_peers(dst).await {
+            Ok(peers) => peers,
+            Err(err) => {
+                error!("Failed to get_closest of {dst:?} with error {err:?}");
+                vec![]
+            }
+        }
+    }
+
     // Send a `Request` to the provided set of nodes and wait for their responses concurrently.
     // If `get_all_responses` is true, we wait for the responses from all the nodes. Will return an
     // error if the request timeouts.

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -88,7 +88,6 @@ impl SwarmDriver {
     pub fn new(addr: SocketAddr) -> Result<(Network, mpsc::Receiver<NetworkEvent>, SwarmDriver)> {
         let mut cfg = KademliaConfig::default();
         let _ = cfg.set_query_timeout(Duration::from_secs(5 * 60));
-        let _ = cfg.set_connection_idle_timeout(Duration::from_secs(10 * 60));
 
         let request_response = request_response::Behaviour::new(
             MsgCodec(),
@@ -186,6 +185,7 @@ impl SwarmDriver {
         loop {
             tokio::select! {
                 some_event = self.swarm.next() => {
+                    trace!("received a swarm event {some_event:?}");
                     // TODO: currently disabled to provide a stable network.
                     // restart_at_random(self.swarm.local_peer_id());
                     if let Err(err) = self.handle_swarm_events(some_event.expect("Swarm stream to be infinite!")).await {


### PR DESCRIPTION
This PR allows the network behaviour on dead node to be confirmed via a client action.
Steps to testing is:
1, startup a network using `target\release\testnet.exe`
2, then start a client using `cargo run --release --bin safe -- --repeated`
    which will query closest against one of the existing node.
3, manually kill the target node by the PID
4, the killed node shall then disappear from the client fetched closest afterwards