### PR TITLE
ci: remove merge run on main

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,13 +2,12 @@ name: Check before merge
 
 on:
   # tests must run for a PR to be valid and pass merge queue muster
+  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
+  # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
     branches: [main]
   pull_request:
     branches: ["*"]
-  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
-  push:
-    branches: [main]
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.


### PR DESCRIPTION
Now we have merge queue again, we're running tests twice if we do this.

This simplifies that