### PR TITLE
feat: detect dead peer

### DIFF
--- a/safenode/src/bin/safenode/main.rs
+++ b/safenode/src/bin/safenode/main.rs
@@ -109,7 +109,7 @@ async fn start_node(
 ) -> Result<()> {
     let started_instant = std::time::Instant::now();
 
-    info!("Starting node (PID: {}) ...", std::process::id());
+    info!("Starting node ...");
     let (node_id, node_events_channel) = Node::run(node_socket_addr, peers).await?;
 
     // Channel to receive node ctrl cmds from RPC service if enabled

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -167,8 +167,24 @@ impl SwarmDriver {
                     }
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id, .. } => {
-                info!("Peer {} has gone offline", peer_id);
+            SwarmEvent::ConnectionClosed {
+                peer_id, endpoint, ..
+            } => {
+                // The connection closed due to no msg flow show as `endpoint::receiver`
+                // The connection closed due to peer dead show as `endpoint::dialer`
+                info!("Connection closed to Peer {peer_id} - {endpoint:?}");
+                if endpoint.is_dialer() {
+                    info!("Dead Peer {peer_id:?}");
+                    if self
+                        .swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .remove_address(&peer_id, endpoint.get_remote_address())
+                        .is_some()
+                    {
+                        info!("Removed dead peer {peer_id:?} from RT");
+                    }
+                }
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 if let Some(peer_id) = peer_id {

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -132,7 +132,7 @@ impl SwarmDriver {
         let keypair = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(keypair.public());
 
-        info!("Peer id: {:?}", peer_id);
+        info!("Node(PID: {}): {:?}", std::process::id(), peer_id);
 
         // QUIC configuration
         let quic_config = libp2p_quic::Config::new(&keypair);


### PR DESCRIPTION
This PR contains work to detect dead node properly and fire the report only once.