### PR TITLE
feat: add domain error

### DIFF
--- a/safenode/src/client/error.rs
+++ b/safenode/src/client/error.rs
@@ -17,11 +17,17 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("Node Error {0}.")]
+    Node(#[from] crate::node::Error),
+
     #[error("Network Error {0}.")]
     Network(#[from] crate::network::Error),
 
     #[error("Protocol error {0}.")]
     Protocol(#[from] crate::protocol::error::Error),
+
+    #[error("Protocol error {0}.")]
+    Domain(#[from] crate::domain::error::Error),
 
     #[error("Events receiver error {0}.")]
     EventsReceiver(#[from] tokio::sync::broadcast::error::RecvError),

--- a/safenode/src/client/register/offline_replica.rs
+++ b/safenode/src/client/register/offline_replica.rs
@@ -12,12 +12,15 @@ use super::{
 };
 
 use crate::{
-    domain::storage::{
-        register::{
-            Action, DataAuthority, Entry, EntryHash, Permissions, Policy,
-            Register as RegisterReplica, User,
+    domain::{
+        error::Error as DomainError,
+        storage::{
+            register::{
+                Action, DataAuthority, Entry, EntryHash, Permissions, Policy,
+                Register as RegisterReplica, User,
+            },
+            RegisterAddress,
         },
-        RegisterAddress,
     },
     protocol::{
         error::Error as ProtocolError,
@@ -95,7 +98,7 @@ impl RegisterOffline {
 
     /// Return a value corresponding to the provided 'hash', if present.
     pub fn get(&self, hash: EntryHash) -> Result<&Entry> {
-        let entry = self.register.get(hash).map_err(ProtocolError::Storage)?;
+        let entry = self.register.get(hash).map_err(DomainError::Storage)?;
         Ok(entry)
     }
 
@@ -141,12 +144,12 @@ impl RegisterOffline {
         let public_key = self.client.signer_pk();
         self.register
             .check_permissions(Action::Write, Some(User::Key(public_key)))
-            .map_err(ProtocolError::Storage)?;
+            .map_err(DomainError::Storage)?;
 
         let (_hash, edit) = self
             .register
             .write(entry.into(), children)
-            .map_err(ProtocolError::Storage)?;
+            .map_err(DomainError::Storage)?;
         let op = EditRegister {
             address: *self.register.address(),
             edit,

--- a/safenode/src/domain/client_transfers/offline.rs
+++ b/safenode/src/domain/client_transfers/offline.rs
@@ -167,9 +167,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     }
 
     // Finalize the tx builder to get the dbc builder.
-    let dbc_builder = tx_builder
-        .build(Hash::default(), &mut rng)
-        .map_err(Error::Dbcs)?;
+    let dbc_builder = tx_builder.build(Hash::default(), &mut rng)?;
 
     let signed_spends: BTreeMap<_, _> = dbc_builder
         .signed_spends()
@@ -206,8 +204,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     // Perform validations of input tx and signed spends,
     // as well as building the output DBCs.
     let mut created_dbcs: Vec<_> = dbc_builder
-        .build()
-        .map_err(Error::Dbcs)?
+        .build()?
         .into_iter()
         .map(|(dbc, amount)| CreatedDbc { dbc, amount })
         .collect();

--- a/safenode/src/domain/client_transfers/online.rs
+++ b/safenode/src/domain/client_transfers/online.rs
@@ -281,9 +281,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     }
 
     // Finalize the tx builder to get the dbc builder.
-    let dbc_builder = tx_builder
-        .build(Hash::default(), &mut rng)
-        .map_err(Error::Dbcs)?;
+    let dbc_builder = tx_builder.build(Hash::default(), &mut rng)?;
 
     let signed_spends: BTreeMap<_, _> = dbc_builder
         .signed_spends()
@@ -332,8 +330,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     // Perform validations of input tx and signed spends,
     // as well as building the output dbcs.
     let mut created_dbcs: Vec<_> = dbc_builder
-        .build()
-        .map_err(Error::Dbcs)?
+        .build()?
         .into_iter()
         .map(|(dbc, amount)| CreatedDbc { dbc, amount })
         .collect();

--- a/safenode/src/domain/error.rs
+++ b/safenode/src/domain/error.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::domain::{
-    node_transfers::Error as TransferError, storage::Error as StorageError,
-    wallet::Error as WalletError,
-};
+use crate::domain::{node_transfers::Error as TransferError, storage::Error as StorageError};
 
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, result};
@@ -28,7 +25,4 @@ pub enum Error {
     /// Errors in node transfer handling.
     #[error("Transfer error: {0:?}")]
     Transfers(#[from] TransferError),
-    /// An error from the sn_dbc crate.
-    #[error("Wallet error {0}")]
-    Wallet(#[from] WalletError),
 }

--- a/safenode/src/domain/error.rs
+++ b/safenode/src/domain/error.rs
@@ -6,34 +6,29 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_dbc::Error as DbcError;
+use crate::domain::{
+    node_transfers::Error as TransferError, storage::Error as StorageError,
+    wallet::Error as WalletError,
+};
 
 use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, result};
 use thiserror::Error;
 
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+/// A specialised `Result` type for protocol crate.
+pub type Result<T> = result::Result<T, Error>;
 
-/// Client transfer errors.
+/// Main error type for the crate.
 #[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 pub enum Error {
-    /// Not enough balance to perform a transaction
-    #[error("Not enough balance: {0}")]
-    NotEnoughBalance(String),
-    /// An error from the `sn_dbc` crate.
-    #[error("Dbc error: {0}")]
-    Dbcs(String),
-    /// DbcReissueFailed
-    #[error("DbcReissueFailed: {0}")]
-    DbcReissueFailed(String),
-    /// CouldNotGetFees
-    #[error("CouldNotGetFees: {0}")]
-    CouldNotGetFees(String),
-}
-
-impl From<DbcError> for Error {
-    fn from(error: DbcError) -> Self {
-        Error::Dbcs(error.to_string())
-    }
+    /// Storage error.
+    #[error("Storage error {0:?}")]
+    Storage(#[from] StorageError),
+    /// Errors in node transfer handling.
+    #[error("Transfer error: {0:?}")]
+    Transfers(#[from] TransferError),
+    /// An error from the sn_dbc crate.
+    #[error("Wallet error {0}")]
+    Wallet(#[from] WalletError),
 }

--- a/safenode/src/domain/fees/error.rs
+++ b/safenode/src/domain/fees/error.rs
@@ -20,9 +20,6 @@ pub enum Error {
     /// The Node signature over the `RequiredFee` is invalid.
     #[error("Node signature is invalid.")]
     RequiredFeeSignatureInvalid,
-    /// Decryption of the amount failed. Wrong key used.
-    #[error("Decryption of the amount failed. Wrong key used.")]
-    AmountDecryptionFailed,
     /// An error from the `sn_dbc` crate.
     #[error("Dbc error: {0}")]
     Dbcs(String),

--- a/safenode/src/domain/mod.rs
+++ b/safenode/src/domain/mod.rs
@@ -11,6 +11,8 @@ mod dbc_genesis;
 
 /// Client handling of token transfers.
 pub mod client_transfers;
+/// Errors.
+pub mod error;
 /// Types related to transfer fees.
 pub mod fees;
 /// Node handling of token transfers.

--- a/safenode/src/domain/node_transfers/error.rs
+++ b/safenode/src/domain/node_transfers/error.rs
@@ -8,10 +8,9 @@
 
 use crate::domain::{fees, storage::Error as StorageError};
 
-use sn_dbc::{Error as DbcError, SignedSpend, Token};
+use sn_dbc::Token;
 
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use thiserror::Error;
 
 /// Errors related to node handling of transfers.
@@ -30,9 +29,6 @@ pub enum Error {
     Fees(#[from] fees::Error),
     #[error("Contacting close group of parent spends failed: {0}.")]
     SpendParentCloseGroupIssue(String),
-    /// An error from the `sn_dbc` crate.
-    #[error("Dbc error: {0}")]
-    Dbcs(String),
     /// One or more parent spends of a requested spend had a different dst tx hash than the signed spend src tx hash.
     #[error(
         "The signed spend src tx ({signed_src_tx_hash:?}) did not match the provided source tx's hash: {provided_src_tx_hash:?}"
@@ -63,19 +59,7 @@ pub enum Error {
         /// The hash of the provided source tx.
         provided_src_tx_hash: sn_dbc::Hash,
     },
-    /// One or more parent spends of a requested spend could not be confirmed as valid.
-    /// The full set of parents checked are contained in this error.
-    #[error(
-        "A parent tx of a requested spend could not be confirmed as valid. All parent signed spends of that tx {0:?}"
-    )]
-    InvalidSpendParent(BTreeSet<Box<SignedSpend>>),
     /// Storage error.
     #[error("Storage error {0:?}")]
     Storage(#[from] StorageError),
-}
-
-impl From<DbcError> for Error {
-    fn from(error: DbcError) -> Self {
-        Error::Dbcs(error.to_string())
-    }
 }

--- a/safenode/src/domain/wallet/error.rs
+++ b/safenode/src/domain/wallet/error.rs
@@ -60,9 +60,3 @@ impl From<std::io::Error> for Error {
         Self::Io(error.to_string())
     }
 }
-
-// impl From<hex::FromHexError> for Error {
-//     fn from(error: hex::FromHexError) -> Self {
-//         Self::HexDecoding(error.to_string())
-//     }
-// }

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -100,7 +100,7 @@ impl SwarmDriver {
                     .behaviour_mut()
                     .request_response
                     .send_response(channel, resp)
-                    .map_err(Error::OutgoingResponseDropped)?;
+                    .map_err(|e| Error::OutgoingResponseDropped(e.to_string()))?;
             }
         }
         Ok(())

--- a/safenode/src/network/error.rs
+++ b/safenode/src/network/error.rs
@@ -8,7 +8,7 @@
 
 use super::{cmd::SwarmCmd, NetworkEvent};
 
-use libp2p::{kad, request_response::OutboundFailure, swarm::DialError, TransportError};
+use libp2p::{request_response::OutboundFailure, swarm::DialError, TransportError};
 use serde::{Deserialize, Serialize};
 use std::io;
 use thiserror::Error;
@@ -41,9 +41,6 @@ pub enum Error {
     #[error("Outbound Error")]
     OutboundError(String),
 
-    #[error("Kademlia Store error: {0}")]
-    KademliaStoreError(String),
-
     #[error("The mpsc::receiver for `NetworkEvent` has been dropped")]
     NetworkEventReceiverDropped(String),
 
@@ -52,9 +49,6 @@ pub enum Error {
 
     #[error("The mpsc::receiver for `SwarmCmd` has been dropped")]
     SwarmCmdReceiverDropped(String),
-
-    #[error("The oneshot::sender has been dropped")]
-    SenderDropped(String),
 
     #[error("Could not get CLOSE_GROUP_SIZE number of peers.")]
     NotEnoughPeers,
@@ -96,24 +90,6 @@ impl From<TransportError<io::Error>> for Error {
 impl From<oneshot::error::RecvError> for Error {
     fn from(error: oneshot::error::RecvError) -> Self {
         Self::Io(error.to_string())
-    }
-}
-
-impl From<kad::KademliaEvent> for Error {
-    fn from(_e: kad::KademliaEvent) -> Self {
-        Self::ReceivedKademliaEventDropped("No info attainable".to_string())
-    }
-}
-
-impl From<tokio::time::error::Elapsed> for Error {
-    fn from(e: tokio::time::error::Elapsed) -> Self {
-        Self::ResponseTimeout(e.to_string())
-    }
-}
-
-impl From<kad::store::Error> for Error {
-    fn from(e: kad::store::Error) -> Self {
-        Self::KademliaStoreError(e.to_string())
     }
 }
 

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -99,7 +99,7 @@ impl SwarmDriver {
                     let (sender, mut current_closest) =
                         self.pending_get_closest_peers.remove(id).ok_or_else(|| {
                             trace!("Can't locate query task {id:?}, shall be completed already.");
-                            Error::ReceivedKademliaEventDropped(event.clone())
+                            Error::ReceivedKademliaEventDropped("No info attainable".to_string())
                         })?;
 
                     // TODO: consider order the result and terminate when reach any of the

--- a/safenode/src/network/msg/mod.rs
+++ b/safenode/src/network/msg/mod.rs
@@ -43,7 +43,7 @@ impl SwarmDriver {
                     trace!("Got response for id: {request_id:?}, res: {response:?} ");
                     self.pending_requests
                         .remove(&request_id)
-                        .ok_or(Error::ReceivedResponseDropped(request_id))?
+                        .ok_or(Error::ReceivedResponseDropped(request_id.to_string()))?
                         .send(Ok(response))
                         .map_err(|_| Error::InternalMsgChannelDropped)?;
                 }
@@ -53,7 +53,7 @@ impl SwarmDriver {
             } => {
                 self.pending_requests
                     .remove(&request_id)
-                    .ok_or(Error::ReceivedResponseDropped(request_id))?
+                    .ok_or(Error::ReceivedResponseDropped(request_id.to_string()))?
                     .send(Err(error.into()))
                     .map_err(|_| Error::InternalMsgChannelDropped)?;
             }

--- a/safenode/src/node/error.rs
+++ b/safenode/src/node/error.rs
@@ -6,12 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+/// A specialised `Result` type for node crate.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Internal error.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum Error {
     #[error("Network Error {0}")]
@@ -22,7 +24,4 @@ pub enum Error {
 
     #[error("Domain error {0}")]
     Domain(#[from] crate::domain::error::Error),
-
-    #[error("ResponseTimeout")]
-    ResponseTimeout(#[from] tokio::time::error::Elapsed),
 }

--- a/safenode/src/node/error.rs
+++ b/safenode/src/node/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Protocol error {0}")]
     Protocol(#[from] crate::protocol::error::Error),
 
+    #[error("Domain error {0}")]
+    Domain(#[from] crate::domain::error::Error),
+
     #[error("ResponseTimeout")]
     ResponseTimeout(#[from] tokio::time::error::Elapsed),
 }

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -10,9 +10,10 @@ mod api;
 mod error;
 mod event;
 
-pub use self::event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver};
-
-use self::error::Error;
+pub use self::{
+    error::{Error, Result},
+    event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
+};
 
 use crate::{
     domain::{

--- a/safenode/src/protocol/error.rs
+++ b/safenode/src/protocol/error.rs
@@ -17,16 +17,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Error {
-    /// Dbc error.
-    #[error("Dbc Error {0}")]
-    Dbc(String),
     /// Unexpected responses.
     #[error("Unexpected responses")]
     UnexpectedResponses,
-    /// Bincode error.
-    #[error("Bincode error:: {0}")]
-    Bincode(String),
-    /// I/O error.
-    #[error("I/O error: {0}")]
-    Io(String),
 }

--- a/safenode/src/protocol/error.rs
+++ b/safenode/src/protocol/error.rs
@@ -6,8 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::domain::{node_transfers::Error as TransferError, storage::Error as StorageError};
-
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, result};
 use thiserror::Error;
@@ -19,13 +17,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Error {
-    /// Storage error.
-    #[error("Storage error {0:?}")]
-    Storage(#[from] StorageError),
-    /// Errors in node transfer handling.
-    #[error("TransferError: {0:?}")]
-    Transfers(#[from] TransferError),
-    /// An error from the sn_dbc crate.
+    /// Dbc error.
     #[error("Dbc Error {0}")]
     Dbc(String),
     /// Unexpected responses.

--- a/safenode/src/protocol/messages/mod.rs
+++ b/safenode/src/protocol/messages/mod.rs
@@ -46,7 +46,7 @@ pub enum Request {
 }
 
 /// Respond to other peers in the network
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Response {
     /// The response to a cmd.
     Cmd(CmdResponse),
@@ -102,5 +102,11 @@ impl ReplicatedData {
             Self::ValidSpend(spend) => DataAddress::Spend(dbc_address(spend.dbc_id())),
             Self::DoubleSpend((address, _)) => DataAddress::Spend(*address),
         }
+    }
+}
+
+impl std::fmt::Display for Response {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "Response")
     }
 }

--- a/safenode/src/protocol/messages/response.rs
+++ b/safenode/src/protocol/messages/response.rs
@@ -14,8 +14,7 @@ use crate::{
             Chunk,
         },
     },
-    node::NodeId,
-    protocol::error::Result,
+    node::{NodeId, Result},
 };
 
 #[allow(unused_imports)] // needed by rustdocs links
@@ -28,7 +27,7 @@ use std::{collections::BTreeSet, fmt::Debug};
 
 /// The response to a query, containing the query result.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum QueryResponse {
     //
     // ===== DBC Data =====
@@ -72,7 +71,7 @@ pub enum QueryResponse {
 }
 
 /// The response to a Cmd, containing the query result.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CmdResponse {
     //
     // ===== Dbc Spends =====


### PR DESCRIPTION
Also removes some unused error variants.

There is a refactor here as well, to include the Domain error in the Node errors, and avoid recursive referencing.
At the end of this line, Client error has a Node variant, which is errors that they receive from nodes when calling them.