### PR TITLE
feat: store created dbcs as hex to file (and load for deposit)

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -51,9 +51,9 @@ walkdir = "2.3.1"
 xor_name = "5.0.0"
 
 [dev-dependencies]
+assert_fs = "1.0.0"
 assert_matches = "1.5.0"
 proptest = { version = "1.0.0" }
-tempfile = "3.2.0"
 
 [build-dependencies]
 tonic-build = { version = "0.6.2" }

--- a/safenode/src/bin/cli/wallet.rs
+++ b/safenode/src/bin/cli/wallet.rs
@@ -19,8 +19,12 @@ use std::path::Path;
 
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
-    /// Tries to load any hex encoded `Dbc`s from the `received_dbcs`
+    /// Deposit `Dbc`s to the local wallet.
+    /// Tries to load any `Dbc`s from the `received_dbcs`
     /// path in the wallet dir, and deposit it to the wallet.
+    /// The user has to manually place received dbc files to
+    /// that dir, for example by choosing that path when downloading
+    /// the dbc file from email or browser.
     Deposit,
     Send {
         /// This shall be the number of nanos to send.

--- a/safenode/src/bin/cli/wallet.rs
+++ b/safenode/src/bin/cli/wallet.rs
@@ -15,16 +15,13 @@ use sn_dbc::Token;
 
 use clap::Parser;
 use eyre::Result;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
-    Deposit {
-        /// Tries to load a hex encoded `Dbc` from the
-        /// given path and deposit it to the wallet.
-        #[clap(name = "dbc-dir")]
-        dbc_dir: PathBuf,
-    },
+    /// Tries to load any hex encoded `Dbc`s from the `received_dbcs`
+    /// path in the wallet dir, and deposit it to the wallet.
+    Deposit,
     Send {
         /// This shall be the number of nanos to send.
         /// Necessary if the `send_to` argument has been given.
@@ -38,13 +35,13 @@ pub enum WalletCmds {
 
 pub(crate) async fn wallet_cmds(cmds: WalletCmds, client: &Client, root_dir: &Path) -> Result<()> {
     match cmds {
-        WalletCmds::Deposit { dbc_dir } => deposit(dbc_dir, root_dir).await?,
+        WalletCmds::Deposit => deposit(root_dir).await?,
         WalletCmds::Send { amount, to } => send(amount, to, client, root_dir).await?,
     }
     Ok(())
 }
 
-async fn deposit(_dbc_dir: PathBuf, root_dir: &Path) -> Result<()> {
+async fn deposit(root_dir: &Path) -> Result<()> {
     let mut wallet = LocalWallet::load_from(root_dir).await?;
 
     let previous_balance = wallet.balance();

--- a/safenode/src/client/wallet.rs
+++ b/safenode/src/client/wallet.rs
@@ -36,12 +36,11 @@ impl<W: SendWallet> WalletClient<W> {
     /// Send tokens to another wallet.
     pub async fn send(&mut self, amount: Token, to: PublicAddress) -> Result<Dbc> {
         let dbcs = self.wallet.send(vec![(amount, to)], &self.client).await?;
-        if let Some(info) = dbcs.into_iter().next() {
-            Ok(info.dbc)
-        } else {
-            Err(Error::CouldNotSendTokens(
-                "No DBCs were returned from the wallet.".to_string(),
-            ))
+        match &dbcs[..] {
+            [info, ..] => Ok(info.dbc.clone()),
+            [] => Err(Error::CouldNotSendTokens(
+                "No DBCs were returned from the wallet.".into(),
+            )),
         }
     }
 

--- a/safenode/src/domain/storage/address/dbc.rs
+++ b/safenode/src/domain/storage/address/dbc.rs
@@ -23,18 +23,18 @@ impl DbcAddress {
         Self(name)
     }
 
-    /// Returns the name, which is the `DbcId` XorName.
+    /// Return the name, which is the `DbcId` XorName.
     pub fn name(&self) -> &XorName {
         &self.0
     }
 }
 
-/// Returns the address of a Dbc with the given id.
+/// Return the address of a Dbc with the given id.
 pub fn dbc_address(dbc_id: &DbcId) -> DbcAddress {
     DbcAddress::new(dbc_name(dbc_id))
 }
 
-/// Returns the name of a Dbc with the given id.
+/// Return the name of a Dbc with the given id.
 pub fn dbc_name(dbc_id: &DbcId) -> XorName {
     XorName::from_content(&dbc_id.to_bytes())
 }

--- a/safenode/src/domain/storage/chunks/mod.rs
+++ b/safenode/src/domain/storage/chunks/mod.rs
@@ -148,16 +148,11 @@ impl Display for ChunkStorage {
 mod tests {
     use super::*;
 
+    use assert_fs::TempDir;
     use eyre::{eyre, Result};
     use futures::future::join_all;
     use rand::{rngs::OsRng, Rng};
     use rayon::{current_num_threads, prelude::*};
-    use tempfile::tempdir;
-
-    fn init_file_store() -> ChunkStorage {
-        let root = tempdir().expect("Failed to create temporary directory for chunk disk store");
-        ChunkStorage::new(root.path())
-    }
 
     #[tokio::test]
     async fn test_write_read_chunk() {
@@ -274,5 +269,10 @@ mod tests {
         bytes.extend(vec![0u8; remainder]);
 
         Bytes::from(bytes)
+    }
+
+    fn init_file_store() -> ChunkStorage {
+        let root = TempDir::new().expect("Should be able to create a temp dir.");
+        ChunkStorage::new(root.path())
     }
 }

--- a/safenode/src/domain/storage/registers/mod.rs
+++ b/safenode/src/domain/storage/registers/mod.rs
@@ -524,7 +524,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_try_load_stored() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, _, sk, name, policy) = create_register()?;
         let addr = cmd_create.dst();
@@ -568,7 +568,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_try_load_stored_inverted_cmds_order() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, _, sk, name, policy) = create_register()?;
         let addr = cmd_create.dst();
@@ -607,7 +607,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_apply_cmd_against_state() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, _, sk, name, policy) = create_register()?;
         let addr = cmd_create.dst();
@@ -668,7 +668,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_apply_cmd_against_state_inverted_cmds_order() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, _, sk, name, policy) = create_register()?;
         let addr = cmd_create.dst();
@@ -725,7 +725,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_write() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd, authority, _, _, _) = create_register()?;
         store.write(&cmd).await?;
@@ -751,7 +751,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_export() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, authority, sk, name, policy) = create_register()?;
         let addr = cmd_create.dst();
@@ -777,7 +777,7 @@ mod test {
         let stored_addrs = store.stored_addrs().await;
 
         // Create new store and update it with the data from first store
-        let new_store = new_store()?;
+        let new_store = new_store();
         for addr in stored_addrs {
             let replica = store.get_register_replica(&addr).await?;
             new_store.update(&replica).await?;
@@ -809,7 +809,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_non_existing_entry() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, authority, _, _, _) = create_register()?;
         store.write(&cmd_create).await?;
@@ -836,7 +836,7 @@ mod test {
 
     #[tokio::test]
     async fn test_register_non_existing_permissions() -> Result<()> {
-        let store = new_store()?;
+        let store = new_store();
 
         let (cmd_create, authority, _, _, _) = create_register()?;
         store.write(&cmd_create).await?;
@@ -903,11 +903,10 @@ mod test {
         }))
     }
 
-    fn new_store() -> Result<RegisterStorage> {
-        let tmp_dir = tempfile::tempdir()?;
+    fn new_store() -> RegisterStorage {
+        let tmp_dir = assert_fs::TempDir::new().expect("Should be able to create a temp dir.");
         let path = tmp_dir.path();
-        let store = RegisterStorage::new(path);
-        Ok(store)
+        RegisterStorage::new(path)
     }
 
     // Helper functions temporarily used for spentbook logic, but also used for tests.

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -287,8 +287,8 @@ impl Display for SpendStorage {
 mod tests {
     use super::*;
     use crate::domain::dbc_genesis::{create_genesis_dbc, split};
+    use assert_fs::TempDir;
     use sn_dbc::MainKey;
-    use tempfile::tempdir;
 
     #[tokio::test]
     async fn write_and_read_100_spends() {
@@ -471,7 +471,7 @@ mod tests {
     }
 
     fn init_file_store() -> SpendStorage {
-        let root = tempdir().expect("Failed to create temporary directory for spend drive store.");
+        let root = TempDir::new().expect("Should be able to create a temp dir.");
         SpendStorage::new(root.path())
     }
 }

--- a/safenode/src/domain/wallet/error.rs
+++ b/safenode/src/domain/wallet/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     /// Failed to serialize a main key to hex.
     #[error("Could not serialize main key to hex: {0}")]
     FailedToHexEncodeKey(String),
+    /// Dbc error.
+    #[error("Dbc error: {0}")]
+    Dbc(#[from] sn_dbc::Error),
     /// Bls error.
     #[error("Bls error: {0}")]
     Bls(#[from] bls::error::Error),

--- a/safenode/src/domain/wallet/keys.rs
+++ b/safenode/src/domain/wallet/keys.rs
@@ -82,13 +82,13 @@ fn bls_public_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::PublicKey> {
 mod test {
     use super::{get_main_key, store_new_keypair, MainKey};
 
-    use eyre::{eyre, Result};
-    use tempfile::{tempdir, TempDir};
+    use assert_fs::TempDir;
+    use eyre::Result;
 
     #[tokio::test]
     async fn reward_key_to_and_from_file() -> Result<()> {
         let main_key = MainKey::random();
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
         let root_dir = dir.path().to_path_buf();
         store_new_keypair(&root_dir, &main_key).await?;
         let secret_result = get_main_key(&root_dir)
@@ -98,7 +98,7 @@ mod test {
         Ok(())
     }
 
-    fn create_temp_dir() -> Result<TempDir> {
-        tempdir().map_err(|e| eyre!("Failed to create temp dir: {}", e))
+    fn create_temp_dir() -> TempDir {
+        TempDir::new().expect("Should be able to create a temp dir.")
     }
 }

--- a/safenode/src/domain/wallet/keys.rs
+++ b/safenode/src/domain/wallet/keys.rs
@@ -28,9 +28,9 @@ pub fn parse_public_address<T: AsRef<[u8]>>(hex: T) -> Result<PublicAddress> {
 
 /// Writes the public address and main key (hex-encoded) to different locations at disk.
 #[allow(clippy::result_large_err)]
-pub(super) async fn store_new_keypair(root_dir: &Path, main_key: &MainKey) -> Result<()> {
-    let secret_key_path = root_dir.join(MAIN_KEY_FILENAME);
-    let public_key_path = root_dir.join(PUBLIC_ADDRESS_FILENAME);
+pub(super) async fn store_new_keypair(wallet_dir: &Path, main_key: &MainKey) -> Result<()> {
+    let secret_key_path = wallet_dir.join(MAIN_KEY_FILENAME);
+    let public_key_path = wallet_dir.join(PUBLIC_ADDRESS_FILENAME);
     fs::write(secret_key_path, encode(main_key.to_bytes())).await?;
     fs::write(
         public_key_path,
@@ -42,8 +42,8 @@ pub(super) async fn store_new_keypair(root_dir: &Path, main_key: &MainKey) -> Re
 }
 
 /// Returns Some(sn_dbc::MainKey) or None if file doesn't exist. It assumes it's hex-encoded.
-pub(super) async fn get_main_key(root_dir: &Path) -> Result<Option<MainKey>> {
-    let path = root_dir.join(MAIN_KEY_FILENAME);
+pub(super) async fn get_main_key(wallet_dir: &Path) -> Result<Option<MainKey>> {
+    let path = wallet_dir.join(MAIN_KEY_FILENAME);
     if !path.is_file() {
         return Ok(None);
     }

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn created_dbc_to_file_can_be_deposited() -> Result<()> {
+    async fn store_created_dbc_gives_file_that_try_load_deposits_can_use() -> Result<()> {
         // Bring in the necessary traits.
         use super::{DepositWallet, SendWallet};
 

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -227,8 +227,8 @@ mod tests {
 
     use sn_dbc::{Dbc, DbcIdSource, DerivedKey, MainKey, PublicAddress, Token};
 
-    use eyre::{eyre, Result};
-    use tempfile::{tempdir, TempDir};
+    use assert_fs::TempDir;
+    use eyre::Result;
 
     #[tokio::test]
     async fn keyless_wallet_to_and_from_file() -> Result<()> {
@@ -236,7 +236,7 @@ mod tests {
         let mut wallet = KeyLessWallet::new();
         let genesis = create_genesis_dbc(&key).expect("Genesis creation to succeed.");
 
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
         let wallet_dir = dir.path().to_path_buf();
 
         wallet.deposit(vec![genesis], &key);
@@ -260,7 +260,7 @@ mod tests {
 
         let key = MainKey::random();
         let public_address = key.public_address();
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
 
         let deposit_only = LocalWallet {
             key,
@@ -291,7 +291,7 @@ mod tests {
         // Bring in the necessary trait.
         use super::{DepositWallet, Wallet};
 
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
 
         let mut deposit_only = LocalWallet {
             key: MainKey::random(),
@@ -318,7 +318,7 @@ mod tests {
 
         let key = MainKey::random();
         let genesis = create_genesis_dbc(&key).expect("Genesis creation to succeed.");
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
 
         let mut deposit_only = LocalWallet {
             key,
@@ -340,7 +340,7 @@ mod tests {
         use super::{DepositWallet, Wallet};
 
         let genesis = create_genesis_dbc(&MainKey::random()).expect("Genesis creation to succeed.");
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
 
         let mut local_wallet = LocalWallet {
             key: MainKey::random(),
@@ -360,7 +360,7 @@ mod tests {
         // Bring in the necessary traits.
         use super::{DepositWallet, Wallet};
 
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
         let root_dir = dir.path().to_path_buf();
 
         let mut depositor = LocalWallet::load_from(&root_dir).await?;
@@ -409,7 +409,7 @@ mod tests {
         // Bring in the necessary traits.
         use super::{DepositWallet, SendWallet, Wallet};
 
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
         let root_dir = dir.path().to_path_buf();
 
         let mut sender = LocalWallet::load_from(&root_dir).await?;
@@ -443,7 +443,7 @@ mod tests {
         // Bring in the necessary traits.
         use super::{DepositWallet, SendWallet, Wallet};
 
-        let dir = create_temp_dir()?;
+        let dir = create_temp_dir();
         let root_dir = dir.path().to_path_buf();
 
         let mut sender = LocalWallet::load_from(&root_dir).await?;
@@ -524,7 +524,7 @@ mod tests {
         // Bring in the necessary traits.
         use super::{DepositWallet, SendWallet};
 
-        let sender_root_dir = create_temp_dir()?;
+        let sender_root_dir = create_temp_dir();
         let sender_root_dir = sender_root_dir.path().to_path_buf();
 
         let mut sender = LocalWallet::load_from(&sender_root_dir).await?;
@@ -534,7 +534,7 @@ mod tests {
         let send_amount = 100;
 
         // Send to a new address.
-        let recipient_root_dir = create_temp_dir()?;
+        let recipient_root_dir = create_temp_dir();
         let recipient_root_dir = recipient_root_dir.path().to_path_buf();
         let mut recipient = LocalWallet::load_from(&recipient_root_dir).await?;
         let recipient_public_address = recipient.key.public_address();
@@ -585,10 +585,6 @@ mod tests {
         Ok(())
     }
 
-    fn create_temp_dir() -> Result<TempDir> {
-        tempdir().map_err(|e| eyre!("Failed to create temp dir: {}", e))
-    }
-
     #[derive(Clone)]
     struct MockSendClient;
 
@@ -607,5 +603,9 @@ mod tests {
 
             Ok(transfer)
         }
+    }
+
+    fn create_temp_dir() -> TempDir {
+        TempDir::new().expect("Should be able to create a temp dir.")
     }
 }

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -563,21 +563,23 @@ mod tests {
         tokio::fs::create_dir_all(&received_dbc_dir).await?;
         let received_dbc_file = received_dbc_dir.join(&dbc_id_file_name);
 
+        // Move the created dbc to the recipient's received_dbcs dir.
         tokio::fs::rename(created_dbc_file, &received_dbc_file).await?;
+
+        assert_eq!(0, recipient.wallet.balance().as_nano());
 
         recipient.try_load_deposits().await?;
 
         assert_eq!(1, recipient.wallet.available_dbcs.len());
 
-        let a_available = recipient
+        let available = recipient
             .wallet
             .available_dbcs
             .values()
             .last()
             .expect("There to be an available DBC.");
 
-        assert_eq!(a_available.id(), dbc_id);
-
+        assert_eq!(available.id(), dbc_id);
         assert_eq!(send_amount, recipient.wallet.balance().as_nano());
 
         Ok(())

--- a/safenode/src/domain/wallet/mod.rs
+++ b/safenode/src/domain/wallet/mod.rs
@@ -126,3 +126,8 @@ pub(super) struct KeyLessWallet {
     /// transfer history.
     dbcs_created_for_others: Vec<CreatedDbc>,
 }
+
+/// Return the name of a PublicAddress.
+pub fn public_address_name(public_address: &PublicAddress) -> xor_name::XorName {
+    xor_name::XorName::from_content(&public_address.to_bytes())
+}

--- a/safenode/src/domain/wallet/wallet_file.rs
+++ b/safenode/src/domain/wallet/wallet_file.rs
@@ -19,11 +19,17 @@ const WALLET_FILE_NAME: &str = "wallet";
 const CREATED_DBCS_DIR_NAME: &str = "created_dbcs";
 const RECEIVED_DBCS_DIR_NAME: &str = "received_dbcs";
 
+pub(super) async fn create_received_dbcs_dir(wallet_dir: &Path) -> Result<()> {
+    let received_dbcs_dir = wallet_dir.join(RECEIVED_DBCS_DIR_NAME);
+    fs::create_dir_all(&received_dbcs_dir).await?;
+    Ok(())
+}
+
 /// Writes the `KeyLessWallet` to the specified path.
 pub(super) async fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
     let wallet_path = wallet_dir.join(WALLET_FILE_NAME);
     let bytes = bincode::serialize(&wallet)?;
-    fs::write(wallet_path, bytes).await?;
+    fs::write(&wallet_path, bytes).await?;
     Ok(())
 }
 

--- a/safenode/src/domain/wallet/wallet_file.rs
+++ b/safenode/src/domain/wallet/wallet_file.rs
@@ -6,25 +6,30 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{error::Result, KeyLessWallet};
+use super::{error::Result, public_address_name, KeyLessWallet};
 
+use crate::domain::storage::dbc_name;
+
+use sn_dbc::Dbc;
 use std::path::Path;
 use tokio::fs;
 
 // Filename for storing a wallet.
-const WALLET_FILENAME: &str = "wallet";
+const WALLET_FILE_NAME: &str = "wallet";
+const CREATED_DBCS_DIR_NAME: &str = "created_dbcs";
+const RECEIVED_DBCS_DIR_NAME: &str = "received_dbcs";
 
 /// Writes the `KeyLessWallet` to the specified path.
-pub(super) async fn store_wallet(root_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
-    let wallet_path = root_dir.join(WALLET_FILENAME);
+pub(super) async fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
+    let wallet_path = wallet_dir.join(WALLET_FILE_NAME);
     let bytes = bincode::serialize(&wallet)?;
     fs::write(wallet_path, bytes).await?;
     Ok(())
 }
 
 /// Returns `Some(KeyLessWallet)` or None if file doesn't exist.
-pub(super) async fn get_wallet(root_dir: &Path) -> Result<Option<KeyLessWallet>> {
-    let path = root_dir.join(WALLET_FILENAME);
+pub(super) async fn get_wallet(wallet_dir: &Path) -> Result<Option<KeyLessWallet>> {
+    let path = wallet_dir.join(WALLET_FILE_NAME);
     if !path.is_file() {
         return Ok(None);
     }
@@ -33,4 +38,64 @@ pub(super) async fn get_wallet(root_dir: &Path) -> Result<Option<KeyLessWallet>>
     let wallet = bincode::deserialize(&bytes)?;
 
     Ok(Some(wallet))
+}
+
+/// Hex encode and write each `Dbc` to a separate file in respective
+/// recipient public address dir in the created dbcs dir. Each file is named after the dbc id.
+pub(super) async fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path) -> Result<()> {
+    // The create dbcs dir within the wallet dir.
+    let created_dbcs_path = wallet_dir.join(CREATED_DBCS_DIR_NAME);
+    for dbc in created_dbcs.into_iter() {
+        // One dir per recipient public address.
+        let public_address_name = public_address_name(dbc.public_address());
+        let public_address_dir = format!("public_address_{}", hex::encode(public_address_name));
+        let dbc_id_name = dbc_name(&dbc.id());
+        let dbc_id_file_name = format!("{}.dbc", hex::encode(dbc_id_name));
+
+        let public_address_dir_path = created_dbcs_path.join(&public_address_dir);
+        fs::create_dir_all(&public_address_dir_path).await?;
+
+        let dbc_file_path = public_address_dir_path.join(dbc_id_file_name);
+
+        let hex = dbc.to_hex()?;
+        fs::write(dbc_file_path, &hex).await?;
+    }
+    Ok(())
+}
+
+/// Loads all the dbcs found in the received dbcs dir.
+pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
+    // The new dbcs dir within the wallet dir.
+    let received_dbcs_path = wallet_dir.join(RECEIVED_DBCS_DIR_NAME);
+    let mut deposits = vec![];
+
+    for entry in walkdir::WalkDir::new(received_dbcs_path)
+        .into_iter()
+        .flatten()
+    {
+        if entry.file_type().is_file() {
+            let file_name = entry.file_name();
+            println!("Reading deposited tokens from {file_name:?}.");
+
+            let dbc_data = fs::read_to_string(entry.path()).await?;
+            let dbc = match Dbc::from_hex(dbc_data.trim()) {
+                Ok(dbc) => dbc,
+                Err(_) => {
+                    println!(
+                        "This file does not appear to have valid hex-encoded DBC data. \
+                        Skipping it."
+                    );
+                    continue;
+                }
+            };
+
+            deposits.push(dbc);
+        }
+    }
+
+    if deposits.is_empty() {
+        println!("No deposits found.");
+    }
+
+    Ok(deposits)
 }


### PR DESCRIPTION
Resolves #161 and #162.

When a users sends tokens, a client will now print the created dbcs to the `created_dbcs` dir in wallet dir.
This allows a client to send these files to the dbc recipients, for recipients to deposit the dbcs to their wallets.
(The received dbcs are placed in the `received_dbcs`dir, and user then just calls deposit on the client, and it loads them into the wallet.)