### PR TITLE
fix: use correct name for downloaded files

### DIFF
--- a/safenode/src/bin/cli/files.rs
+++ b/safenode/src/bin/cli/files.rs
@@ -78,7 +78,7 @@ async fn upload_files(files_path: PathBuf, file_api: &Files, root_dir: &Path) ->
     let content = bincode::serialize(&chunks_to_fetch)?;
     tokio::fs::create_dir_all(file_names_path.as_path()).await?;
     let date_time = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
-    let file_names_path = file_names_path.join(format!("file_names_{date_time}.txt"));
+    let file_names_path = file_names_path.join(format!("file_names_{date_time}"));
     println!("Writing {} bytes to {file_names_path:?}", content.len());
     fs::write(file_names_path, content)?;
 


### PR DESCRIPTION
Stores the file names to the xorname index doc, so that the downloaded files can get their proper file names.

Also removes the txt file extension for the index doc, since we store serialized data to the file (the `plain text document` file extension is then misleading).