### PR TITLE
Feat: verify nodes upon testnet startup

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Start a local network
         # Only run on non-PR events
         if: github.event_name != 'pull_request'
-        run: cargo run --release --bin testnet -- --interval 1 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 1 --node-path ./target/release/safenode
         id: section-startup
         env:
           RUST_LOG: "safenode,safe=trace"
@@ -288,7 +288,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 1 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 1 --node-path ./target/release/safenode
         id: section-startup
         env:
           RUST_LOG: "safenode,safe=trace"

--- a/README.md
+++ b/README.md
@@ -49,13 +49,36 @@ cargo run --release --example registers -- --user bob --reg-nickname myregister
 - Query basic node info
 ```
 $ cargo run --release --example safenode_rpc_client -- 127.0.0.1:12001 info
-Node info received:
+Node info:
 ===================
 RPC endpoint: http://127.0.0.1:12001
-Node Id: 65fbed(01100101)..
+Peer Id: 12D3KooWB5CXPPtbVzZ7K9dv8xLj4JAPVEQu7ehibs2bWrqwiowy
 Logs dir: /home/bochaco/.safe/node/local-test-network/safenode-1
+PID: 490955
 Binary version: 0.1.0
 Time since last restart: 650s
+```
+
+- Query info about node's connections to the network:
+```
+$ cargo run --release --example safenode_rpc_client -- 127.0.0.1:12001 netinfo
+Node's connections to the Network:
+
+Connected peers:
+Peer: 12D3KooWCRN4jQjyACrHq4mAq1ZLDDnA1E9cDGoGuXP1pZbRDJee
+Peer: 12D3KooWFc2PX9Y7bQfUULHrg1VYeNAVKyS5mUjQJfzDy3NqSn2t
+Peer: 12D3KooWA2jeb4YdkTb5zw2ajWK4zqgoVaMN5y1eDrkUCXoin94V
+Peer: 12D3KooWLHZBRw47aqXCedSYvv4QQWsYdEX9HnDV6YwZBjujWAZV
+Peer: 12D3KooWJUExWkuqProAgTBhABMeQoi25zBpqdmGEncs1X62NCtV
+Peer: 12D3KooWENu5uDQsSdb4XCVeLZhXav922uyWHnyfLFwC5KZGKrpR
+Peer: 12D3KooWSaEKWKPGh5Q3fQrn6xqsyvQsKT2y5XxxZXjCqQbP35eE
+Peer: 12D3KooWNCvmBaz1MkByYkYArxKVQdiCA4bKDDBgFBtBzcpfDwA5
+Peer: 12D3KooWJPkWZHnsqwwHCWXj5MV3MaoNXksTKRGMNjAcaqydYKRv
+
+Node's listeners:
+Listener: /ip4/127.0.0.1/udp/47117/quic-v1
+Listener: /ip4/192.168.0.155/udp/47117/quic-v1
+Listener: /ip4/172.17.0.1/udp/47117/quic-v1
 ```
 
 - Restarting/Updating/Stopping a node

--- a/safenode/examples/safenode_rpc_client.rs
+++ b/safenode/examples/safenode_rpc_client.rs
@@ -8,17 +8,19 @@
 
 use safenode_proto::safe_node_client::SafeNodeClient;
 use safenode_proto::{
-    NodeEventsRequest, NodeInfoRequest, RestartRequest, StopRequest, UpdateRequest,
+    NetworkInfoRequest, NodeEventsRequest, NodeInfoRequest, RestartRequest, StopRequest,
+    UpdateRequest,
 };
 use tonic::Request;
 
 use clap::Parser;
 use eyre::Result;
+use libp2p::{Multiaddr, PeerId};
+use std::str::FromStr;
 use std::{net::SocketAddr, time::Duration};
 use tokio_stream::StreamExt;
-use xor_name::{XorName, XOR_NAME_LEN};
 
-// this would include code generated from .proto file
+// this includes code generated from .proto files
 mod safenode_proto {
     tonic::include_proto!("safenode_proto");
 }
@@ -38,6 +40,9 @@ enum Cmd {
     /// Retrieve information about the node itself
     #[clap(name = "info")]
     Info,
+    /// Retrieve information about the node's connections to the network
+    #[clap(name = "netinfo")]
+    Netinfo,
     /// Start listening for node events.
     /// Note this blocks the app and it will print events as they are broadcasted by the node
     #[clap(name = "events")]
@@ -72,6 +77,7 @@ async fn main() -> Result<()> {
 
     match opt.cmd {
         Cmd::Info => node_info(addr).await,
+        Cmd::Netinfo => network_info(addr).await,
         Cmd::Events => node_events(addr).await,
         Cmd::Restart { delay_millis } => node_restart(addr, delay_millis).await,
         Cmd::Stop { delay_millis } => node_stop(addr, delay_millis).await,
@@ -84,18 +90,45 @@ pub async fn node_info(addr: SocketAddr) -> Result<()> {
     let mut client = SafeNodeClient::connect(endpoint.clone()).await?;
     let response = client.node_info(Request::new(NodeInfoRequest {})).await?;
     let node_info = response.get_ref();
-    let node_id = xorname_from_bytes(&node_info.node_id);
+    let peer_id = PeerId::from_bytes(&node_info.peer_id)?;
 
-    println!("Node info received:");
-    println!("===================");
+    println!("Node info:");
+    println!("==========");
     println!("RPC endpoint: {endpoint}");
-    println!("Node Id: {node_id:?}");
+    println!("Peer Id: {peer_id}");
     println!("Logs dir: {}", node_info.log_dir);
+    println!("PID: {}", node_info.pid);
     println!("Binary version: {}", node_info.bin_version);
     println!(
         "Time since last restart: {:?}",
         Duration::from_secs(node_info.uptime_secs)
     );
+
+    Ok(())
+}
+
+pub async fn network_info(addr: SocketAddr) -> Result<()> {
+    let endpoint = format!("https://{addr}");
+    let mut client = SafeNodeClient::connect(endpoint).await?;
+    let response = client
+        .network_info(Request::new(NetworkInfoRequest {}))
+        .await?;
+    let network_info = response.get_ref();
+
+    println!("Node's connections to the Network:");
+    println!();
+    println!("Connected peers:");
+    for bytes in network_info.connected_peers.iter() {
+        let peer_id = PeerId::from_bytes(bytes)?;
+        println!("Peer: {peer_id}");
+    }
+
+    println!();
+    println!("Node's listeners:");
+    for multiaddr_str in network_info.listeners.iter() {
+        let multiaddr = Multiaddr::from_str(multiaddr_str)?;
+        println!("Listener: {multiaddr}");
+    }
 
     Ok(())
 }
@@ -153,10 +186,4 @@ pub async fn node_update(addr: SocketAddr, delay_millis: u64) -> Result<()> {
         Duration::from_millis(delay_millis)
     );
     Ok(())
-}
-
-fn xorname_from_bytes(bytes: &[u8]) -> XorName {
-    let mut xorname = [0u8; XOR_NAME_LEN];
-    bytes.iter().enumerate().for_each(|(i, b)| xorname[i] = *b);
-    XorName(xorname)
 }

--- a/safenode/src/bin/safenode/rpc.rs
+++ b/safenode/src/bin/safenode/rpc.rs
@@ -14,6 +14,7 @@ use eyre::{ErrReport, Result};
 use std::{
     env,
     net::SocketAddr,
+    process,
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::{self, Sender};
@@ -60,6 +61,7 @@ impl SafeNode for SafeNodeRpcService {
         let resp = Response::new(NodeInfoResponse {
             peer_id: self.running_node.peer_id().to_bytes(),
             log_dir: self.log_dir.clone(),
+            pid: process::id(),
             bin_version: env!("CARGO_PKG_VERSION").to_string(),
             uptime_secs: self.started_instant.elapsed().as_secs(),
         });

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -130,7 +130,7 @@ impl SwarmDriver {
         let keypair = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(keypair.public());
 
-        info!("Node(PID: {}): {:?}", std::process::id(), peer_id);
+        info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
 
         // QUIC configuration
         let quic_config = libp2p_quic::Config::new(&keypair);

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -9,8 +9,13 @@
 mod api;
 mod error;
 mod event;
+mod node_id;
 
-pub use self::event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver};
+pub use self::{
+    api::RunningNode,
+    event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
+    node_id::NodeId,
+};
 
 use self::error::Error;
 
@@ -23,9 +28,6 @@ use crate::{
 };
 
 use libp2p::{Multiaddr, PeerId};
-use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
-use xor_name::XorName;
 
 /// `Node` represents a single node in the distributed network. It handles
 /// network events, processes incoming requests, interacts with the data
@@ -38,29 +40,4 @@ pub struct Node {
     events_channel: NodeEventsChannel,
     /// Peers that are dialed at startup of node.
     initial_peers: Vec<(PeerId, Multiaddr)>,
-}
-
-/// A unique identifier for a node in the network,
-/// by which we can know their location in the xor space.
-#[derive(
-    Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
-)]
-pub struct NodeId(XorName);
-
-impl NodeId {
-    /// Returns a `NodeId` representation of the `PeerId` by hashing its bytes.
-    pub fn from(peer_id: PeerId) -> Self {
-        Self(XorName::from_content(&peer_id.to_bytes()))
-    }
-
-    /// Returns this NodeId as bytes
-    pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-}
-
-impl Display for NodeId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "NodeId({:?})", self.0)
-    }
 }

--- a/safenode/src/node/node_id.rs
+++ b/safenode/src/node/node_id.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::PeerId;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+use xor_name::XorName;
+
+/// A unique identifier for a node in the network,
+/// by which we can know their location in the xor space.
+#[derive(
+    Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
+)]
+pub struct NodeId(XorName);
+
+impl NodeId {
+    /// Returns a `NodeId` representation of the `PeerId` by hashing its bytes.
+    pub fn from(peer_id: PeerId) -> Self {
+        Self(XorName::from_content(&peer_id.to_bytes()))
+    }
+
+    /// Returns this NodeId as bytes
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NodeId({:?})", self.0)
+    }
+}

--- a/safenode/src/protocol/safenode_proto/req_resp_types.proto
+++ b/safenode/src/protocol/safenode_proto/req_resp_types.proto
@@ -16,7 +16,7 @@ package safenode_proto;
 message NodeInfoRequest {}
 
 message NodeInfoResponse {
-  bytes node_id = 1;
+  bytes peer_id = 1;
   string log_dir = 2;
   string bin_version = 3;
   uint64 uptime_secs = 4;
@@ -49,3 +49,11 @@ message UpdateRequest {
 }
 
 message UpdateResponse {}
+
+// Information about how this node's connections to the network and peers
+message NetworkInfoRequest {}
+
+message NetworkInfoResponse {
+  repeated bytes connected_peers = 1;
+  repeated string listeners = 2;
+}

--- a/safenode/src/protocol/safenode_proto/req_resp_types.proto
+++ b/safenode/src/protocol/safenode_proto/req_resp_types.proto
@@ -17,9 +17,10 @@ message NodeInfoRequest {}
 
 message NodeInfoResponse {
   bytes peer_id = 1;
-  string log_dir = 2;
-  string bin_version = 3;
-  uint64 uptime_secs = 4;
+  uint32 pid = 2;
+  string log_dir = 3;
+  string bin_version = 4;
+  uint64 uptime_secs = 5;
 }
 
 // Stream of node events

--- a/safenode/src/protocol/safenode_proto/safenode.proto
+++ b/safenode/src/protocol/safenode_proto/safenode.proto
@@ -25,6 +25,9 @@ service SafeNode {
   // Returns information about this node
   rpc NodeInfo (NodeInfoRequest) returns (NodeInfoResponse);
 
+  // Returns information related to this node's connections to the network and peers
+  rpc NetworkInfo (NetworkInfoRequest) returns (NetworkInfoResponse);
+
   // Returns a stream of events as triggered by this node
   rpc NodeEvents (NodeEventsRequest) returns (stream NodeEvent);
 

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -16,7 +16,7 @@ chaos = []
 statemap = []
 otlp = []
 # verify-nodes: performs a last step querying and verifying net knowledge to lanched nodes
-verify-nodes = ["prost", "tonic", "tonic-build", "xor_name"]
+verify-nodes = ["prost", "tonic", "tonic-build", "libp2p"]
 
 [[bin]]
 path="src/main.rs"
@@ -27,13 +27,13 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
+libp2p = { version="0.51", optional = true }
 prost = { version = "0.9", optional = true }
 regex = "1.7.1"
 tonic = { version = "0.6.2", optional = true }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = "~0.3.1"
-xor_name = { version = "~5.0.0", optional = true }
 walkdir = "2"
 
 [dependencies.tokio]

--- a/sn_testnet/build.rs
+++ b/sn_testnet/build.rs
@@ -1,0 +1,14 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "verify-nodes")]
+    tonic_build::compile_protos("../safenode/src/protocol/safenode_proto/safenode.proto")?;
+
+    Ok(())
+}

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -56,9 +56,12 @@ impl Display for NodeInfo {
 }
 
 pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
-    let delay = Duration::from_secs(10);
-    println!("We'll be verifying testnet nodes info in {delay:?} ...");
-    sleep(delay).await;
+    let mut delay_secs = 10;
+    while delay_secs > 0 {
+        println!("We'll be verifying testnet nodes info in {delay_secs}secs ...");
+        sleep(Duration::from_secs(1)).await;
+        delay_secs -= 1;
+    }
     println!();
     println!("======== Verifying testnet nodes ========");
 

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -232,12 +232,7 @@ async fn run_network(
 
     // Perform a verification on the nodes launched (if requested) as a last step
     #[cfg(feature = "verify-nodes")]
-    check_testnet::run(
-        &testnet.nodes_dir_path,
-        node_count,
-        testnet.node_launch_interval,
-    )
-    .await?;
+    check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Example output of `testnet` tool when `verify-nodes` feature is set:
```
======== Verifying testnet nodes ========
Checking nodes log files to verify all (11) nodes have joined. Logs path: /home/bochaco/.safe/node/local-test-network
Number of nodes found in logs: 11

All nodes have joined. Nodes PIDs and PeerIds:
545427 -> 12D3KooWPuj3yQrWJUoMH1ud51SJLb1AjYGTW2ef2ix1xfvUX4iU @ /home/bochaco/.safe/node/local-test-network/safenode-1
545440 -> 12D3KooWJrd9S8R7jXPMzC1FhBLye7EiBx7Gkjt4BmU2HntC5XLr @ /home/bochaco/.safe/node/local-test-network/safenode-2
545453 -> 12D3KooWSK1GbUb4XNk4ZYUfq69KhfHRxCp5EsJ5hv4c4xSJQQeX @ /home/bochaco/.safe/node/local-test-network/safenode-3
545465 -> 12D3KooWLv5xwc26UDiPXofR1fRJ8XpG9EgV55tZu5dqcyckEYSF @ /home/bochaco/.safe/node/local-test-network/safenode-4
545477 -> 12D3KooWH6V49t1A84hrnLLYuW44UnLhvbmYtdy727tUshQUEyL3 @ /home/bochaco/.safe/node/local-test-network/safenode-5
545489 -> 12D3KooWJ7gp4YmEspxGQf7jeQz6HzLhRhC1CTsU2gFu1qWiXYRH @ /home/bochaco/.safe/node/local-test-network/safenode-6
545502 -> 12D3KooWFScbQrrJDChfdvLpA24AmsQM8rWieNkYoDS98Wuc87TD @ /home/bochaco/.safe/node/local-test-network/safenode-7
545514 -> 12D3KooWLWAj2zSnYKS53gHWJsmGmPVezrTtxRacHK9HDF8dZMgR @ /home/bochaco/.safe/node/local-test-network/safenode-8
545526 -> 12D3KooWBc1W4ScApvcNCeYt1TjQZPp1eMGQ3NMw4hzGmsNykuV1 @ /home/bochaco/.safe/node/local-test-network/safenode-9
545538 -> 12D3KooWP6e6okLsZkjThdBPEsoDPGSN5ZEYBKUtWQJyBnfR9uMr @ /home/bochaco/.safe/node/local-test-network/safenode-10
545551 -> 12D3KooWQrK7Z8hBk94bgxwooNrsXjH4axRyJ9v3pAw8WRXcG25Q @ /home/bochaco/.safe/node/local-test-network/safenode-11

Checking peer id and network knowledge of node with RPC at 127.0.0.1:12001
Connecting to node's RPC service at https://127.0.0.1:12001 ...
- PID: 545427
- Peer Id: 12D3KooWPuj3yQrWJUoMH1ud51SJLb1AjYGTW2ef2ix1xfvUX4iU
- Listeners:
   * /ip4/127.0.0.1/udp/48735/quic-v1/p2p/12D3KooWPuj3yQrWJUoMH1ud51SJLb1AjYGTW2ef2ix1xfvUX4iU
   * /ip4/192.168.0.155/udp/48735/quic-v1/p2p/12D3KooWPuj3yQrWJUoMH1ud51SJLb1AjYGTW2ef2ix1xfvUX4iU
   * /ip4/172.17.0.1/udp/48735/quic-v1/p2p/12D3KooWPuj3yQrWJUoMH1ud51SJLb1AjYGTW2ef2ix1xfvUX4iU
- Log dir: /home/bochaco/.safe/node/local-test-network/safenode-1


Checking peer id and network knowledge of node with RPC at 127.0.0.1:12002
Connecting to node's RPC service at https://127.0.0.1:12002 ...
- PID: 545440
- Peer Id: 12D3KooWJrd9S8R7jXPMzC1FhBLye7EiBx7Gkjt4BmU2HntC5XLr
- Listeners:
   * /ip4/127.0.0.1/udp/35984/quic-v1/p2p/12D3KooWJrd9S8R7jXPMzC1FhBLye7EiBx7Gkjt4BmU2HntC5XLr
   * /ip4/192.168.0.155/udp/35984/quic-v1/p2p/12D3KooWJrd9S8R7jXPMzC1FhBLye7EiBx7Gkjt4BmU2HntC5XLr
   * /ip4/172.17.0.1/udp/35984/quic-v1/p2p/12D3KooWJrd9S8R7jXPMzC1FhBLye7EiBx7Gkjt4BmU2HntC5XLr
- Log dir: /home/bochaco/.safe/node/local-test-network/safenode-2

...

PeerIds and network knowledge of nodes are the expected!
```
