### PR TITLE
remove timeout from `send_to_closest` + send to `self`

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -10,6 +10,7 @@ use super::{
     error::{Error, Result},
     Client, ClientEvent, ClientEventsChannel, ClientEventsReceiver, Register, RegisterOffline,
 };
+
 use crate::{
     domain::{
         client_transfers::SpendRequest,
@@ -21,11 +22,13 @@ use crate::{
         messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response, SpendQuery},
     },
 };
+
+use sn_dbc::{DbcId, SignedSpend};
+
 use bls::{PublicKey, SecretKey, Signature};
 use futures::future::select_all;
 use itertools::Itertools;
 use libp2p::{kad::RecordKey, PeerId};
-use sn_dbc::{DbcId, SignedSpend};
 use tokio::task::spawn;
 use tracing::trace;
 use xor_name::XorName;

--- a/safenode/src/log/mod.rs
+++ b/safenode/src/log/mod.rs
@@ -122,7 +122,7 @@ pub fn init_node_logging(log_dir: &Option<PathBuf>) -> Result<Option<WorkerGuard
     Ok(layers.guard)
 }
 
-/// Initialise logger for tests, this is run only once, even if called multiple times.
+/// Initialize logger for tests, this is run only once, even if called multiple times.
 #[cfg(test)]
 static TEST_INIT_LOGGER: std::sync::Once = std::sync::Once::new();
 #[cfg(test)]

--- a/safenode/src/log/mod.rs
+++ b/safenode/src/log/mod.rs
@@ -122,6 +122,23 @@ pub fn init_node_logging(log_dir: &Option<PathBuf>) -> Result<Option<WorkerGuard
     Ok(layers.guard)
 }
 
+/// Initialise logger for tests, this is run only once, even if called multiple times.
+#[cfg(test)]
+static TEST_INIT_LOGGER: std::sync::Once = std::sync::Once::new();
+#[cfg(test)]
+pub fn init_test_logger() {
+    TEST_INIT_LOGGER.call_once(|| {
+        tracing_subscriber::fmt::fmt()
+            // NOTE: uncomment this line for pretty printed log output.
+            //.pretty()
+            .with_ansi(false)
+            .with_target(false)
+            .event_format(crate::log::LogFormatter::default())
+            .try_init()
+            .unwrap_or_else(|_| println!("Error initializing logger"));
+    });
+}
+
 /// Get current root module name (e.g. "safenode")
 fn current_crate_str() -> &'static str {
     // Grab root from module path ("safenode::log::etc" -> "safenode")

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -36,7 +36,7 @@ pub enum SwarmCmd {
     },
     GetClosestPeers {
         xor_name: XorName,
-        sender: oneshot::Sender<(PeerId, HashSet<PeerId>)>,
+        sender: oneshot::Sender<HashSet<PeerId>>,
     },
     SendRequest {
         req: Request,

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -7,10 +7,12 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
+
 use crate::{
     network::error::Result,
     protocol::messages::{QueryResponse, Request, Response},
 };
+
 use libp2p::{
     kad::{Record, RecordKey},
     multiaddr::Protocol,

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -114,9 +114,8 @@ impl SwarmDriver {
                         closest_peers.peers.clone().into_iter().collect();
                     current_closest.extend(new_peers);
                     if current_closest.len() >= usize::from(K_VALUE) || step.last {
-                        let our_id = *self.swarm.local_peer_id();
                         sender
-                            .send((our_id, current_closest))
+                            .send(current_closest)
                             .map_err(|_| Error::InternalMsgChannelDropped)?;
                     } else {
                         let _ = self

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -11,6 +11,7 @@ use super::{
     msg::MsgCodec,
     SwarmDriver,
 };
+
 use crate::{
     domain::storage::Chunk,
     protocol::{
@@ -18,6 +19,7 @@ use crate::{
         messages::{QueryResponse, Request, Response},
     },
 };
+
 use libp2p::{
     kad::{store::MemoryStore, GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
     mdns,

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -569,6 +569,10 @@ mod tests {
                 let res = Response::Cmd(CmdResponse::StoreChunk(Ok(())));
                 assert!(channel.send(Ok(res)).is_ok());
             }
+            // keep the task running
+            loop {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
         });
 
         // Send a request to store a random chunk to `self`

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -458,7 +458,7 @@ mod tests {
     use super::SwarmDriver;
     use crate::{
         domain::storage::Chunk,
-        log::init_node_logging,
+        log::init_test_logger,
         network::{MsgResponder, NetworkEvent},
         protocol::messages::{Cmd, CmdResponse, Request, Response},
     };
@@ -483,7 +483,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn closest() -> Result<()> {
-        let _ = init_node_logging(&None)?;
+        init_test_logger();
         let mut networks_list = Vec::new();
         let mut network_events_recievers = BTreeMap::new();
         for _ in 1..25 {
@@ -550,7 +550,7 @@ mod tests {
 
     #[tokio::test]
     async fn msg_to_self_should_not_error_out() -> Result<()> {
-        let _ = init_node_logging(&None)?;
+        init_test_logger();
         let (net, mut event_rx, driver) = SwarmDriver::new(
             "0.0.0.0:0"
                 .parse::<SocketAddr>()

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -23,7 +23,9 @@ use self::{
     event::NodeBehaviour,
     msg::{MsgCodec, MsgProtocol},
 };
+
 use crate::protocol::messages::{QueryResponse, Request, Response};
+
 use futures::{future::select_all, StreamExt};
 use libp2p::{
     core::muxing::StreamMuxerBox,
@@ -353,7 +355,7 @@ impl Network {
             .await
     }
 
-    /// Send `Request` to the the given `PeerId` and await for the response.If `self` is the recepiant,
+    /// Send `Request` to the the given `PeerId` and await for the response. If `self` is the recepiant,
     /// then the `Request` is forwarded to itself and handled. Then a corresponding `Response` is created
     /// and forwarded to iself. Hence the flow remains the same and there is no branching at the upper
     /// layers.
@@ -456,12 +458,14 @@ impl Network {
 #[cfg(test)]
 mod tests {
     use super::SwarmDriver;
+
     use crate::{
         domain::storage::Chunk,
         log::init_test_logger,
         network::{MsgResponder, NetworkEvent},
         protocol::messages::{Cmd, CmdResponse, Request, Response},
     };
+
     use assert_matches::assert_matches;
     use bytes::Bytes;
     use eyre::{eyre, Result};
@@ -558,8 +562,8 @@ mod tests {
         )?;
         let _driver_handle = tokio::spawn(driver.run());
 
-        // spawn a task to handle the the Request that we recieve.
-        // This handles the request and sends a response back
+        // Spawn a task to handle the the Request that we recieve.
+        // This handles the request and sends a response back.
         let _event_handler = tokio::spawn(async move {
             loop {
                 if let Some(NetworkEvent::RequestReceived {
@@ -573,13 +577,13 @@ mod tests {
             }
         });
 
-        // Send a request to store a random chunk to `self`
+        // Send a request to store a random chunk to `self`.
         let mut random_data = [0u8; 128];
         thread_rng().fill(&mut random_data);
         let req = Request::Cmd(Cmd::StoreChunk(Chunk::new(Bytes::copy_from_slice(
             &random_data,
         ))));
-        // send the request to `self` and wait for a response
+        // Send the request to `self` and wait for a response.
         let now = tokio::time::Instant::now();
         loop {
             let mut res = net

--- a/safenode/src/network/msg/mod.rs
+++ b/safenode/src/network/msg/mod.rs
@@ -9,6 +9,7 @@
 mod codec;
 pub(crate) use codec::{MsgCodec, MsgProtocol};
 
+use crate::network::MsgResponder;
 use crate::network::{error::Error, NetworkEvent, SwarmDriver};
 use crate::protocol::messages::{Request, Response};
 use libp2p::request_response::{self, Message};
@@ -32,7 +33,7 @@ impl SwarmDriver {
                     self.event_sender
                         .send(NetworkEvent::RequestReceived {
                             req: request,
-                            channel,
+                            channel: MsgResponder::FromPeer(channel),
                         })
                         .await?
                 }

--- a/safenode/src/network/msg/mod.rs
+++ b/safenode/src/network/msg/mod.rs
@@ -7,11 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod codec;
+
 pub(crate) use codec::{MsgCodec, MsgProtocol};
 
-use crate::network::MsgResponder;
-use crate::network::{error::Error, NetworkEvent, SwarmDriver};
-use crate::protocol::messages::{Request, Response};
+use crate::{
+    network::{error::Error, MsgResponder, NetworkEvent, SwarmDriver},
+    protocol::messages::{Request, Response},
+};
+
 use libp2p::request_response::{self, Message};
 use tracing::{trace, warn};
 

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         wallet::LocalWallet,
     },
-    network::{close_group_majority, NetworkEvent, SwarmDriver, SwarmLocalState},
+    network::{close_group_majority, MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState},
     protocol::{
         error::Error as ProtocolError,
         messages::{
@@ -31,7 +31,6 @@ use crate::{
 };
 use libp2p::{
     kad::{Record, RecordKey},
-    request_response::ResponseChannel,
     Multiaddr, PeerId,
 };
 use sn_dbc::{DbcTransaction, SignedSpend};
@@ -160,7 +159,7 @@ impl Node {
     async fn handle_request(
         &mut self,
         request: Request,
-        response_channel: ResponseChannel<Response>,
+        response_channel: MsgResponder,
     ) -> Result<()> {
         trace!("Handling request: {request:?}");
         let response = match request {
@@ -404,7 +403,7 @@ impl Node {
         Err(super::Error::Protocol(ProtocolError::UnexpectedResponses))
     }
 
-    async fn send_response(&self, resp: Response, response_channel: ResponseChannel<Response>) {
+    async fn send_response(&self, resp: Response, response_channel: MsgResponder) {
         if let Err(err) = self.network.send_response(resp, response_channel).await {
             warn!("Error while sending response: {err:?}");
         }

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -11,6 +11,7 @@ use super::{
     event::NodeEventsChannel,
     Network, Node, NodeEvent, NodeId,
 };
+
 use crate::{
     domain::{
         dbc_genesis::is_genesis_parent_tx,
@@ -29,11 +30,13 @@ use crate::{
         },
     },
 };
+
+use sn_dbc::{DbcTransaction, SignedSpend};
+
 use libp2p::{
     kad::{Record, RecordKey},
     Multiaddr, PeerId,
 };
-use sn_dbc::{DbcTransaction, SignedSpend};
 use std::{collections::BTreeSet, net::SocketAddr, path::Path};
 use tokio::task::spawn;
 use xor_name::XorName;

--- a/safenode/src/node/error.rs
+++ b/safenode/src/node/error.rs
@@ -35,7 +35,4 @@ pub enum Error {
 
     #[error("Genesis error {0}")]
     Genesis(#[from] GenesisError),
-
-    #[error("ResponseTimeout")]
-    ResponseTimeout(#[from] tokio::time::error::Elapsed),
 }


### PR DESCRIPTION
fixes #193 
- fix(network): get our `PeerId` from Network
    - use `network.peer_id` instead of storing it around in `PendingGetClosest`
- fix(network): remove timeout from `send_to_closest`
    - The request_response Behaviour contains an inbuilt timeout. Hence, remove our custom timeout implementation.
- feat(network): set timeout through the `RequestResponse` behaviour
- fix(network): route `Request` and `Response` to self 
	- While using the `RequestResponse` behaviour, we get a `OutboundFailure::DialFailure`
if we try to send a request to `self`
	- So if `self` is the recipient of the `Request`, then route the request
  directly to `self` without using the `RequestResponse` behaviour.
	- This request, then follows the normal flow without having any custom
  branch on the upper layers. The produced `Response` is also routed
  back to `self`
- fix(test): initialize logging once for unit tests
	- else the test panics as we initialize multiple `Subscriber` instances, at multiple sub-processes when we call `cargo test`
