### PR TITLE
Terminate on get failure

### DIFF
--- a/safenode/src/client/chunks/mod.rs
+++ b/safenode/src/client/chunks/mod.rs
@@ -57,9 +57,6 @@ impl SmallFile {
 }
 
 impl LargeFile {
-    #[cfg(feature = "limit-client-upload-size")]
-    pub(crate) const CLIENT_UPLOAD_SIZE_LIMIT: usize = 10 * 1024 * 1024; // 10MiB currently.
-
     /// Enforces size >= [`MIN_ENCRYPTABLE_BYTES`] bytes.
     pub(crate) fn new(bytes: Bytes) -> Result<Self> {
         if MIN_ENCRYPTABLE_BYTES > bytes.len() {
@@ -68,15 +65,6 @@ impl LargeFile {
                 minimum: MIN_ENCRYPTABLE_BYTES,
             })
         } else {
-            #[cfg(feature = "limit-client-upload-size")]
-            {
-                if bytes.len() > Self::CLIENT_UPLOAD_SIZE_LIMIT {
-                    return Err(Error::UploadSizeLimitExceeded {
-                        size: bytes.len(),
-                        limit: Self::CLIENT_UPLOAD_SIZE_LIMIT,
-                    });
-                }
-            }
             Ok(Self { bytes })
         }
     }

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -152,7 +152,9 @@ impl SwarmDriver {
                             // To avoid the caller wait forever on a non-existring entry
                             if let Some(sender) = self.pending_query.remove(id) {
                                 sender
-                                    .send(QueryResponse::GetChunk(Err(ProtocolError::RecordNotFound)))
+                                    .send(QueryResponse::GetChunk(Err(
+                                        ProtocolError::RecordNotFound,
+                                    )))
                                     .map_err(|_| Error::InternalMsgChannelDropped)?;
                             }
                         }

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -14,7 +14,10 @@ use super::{
 
 use crate::{
     domain::storage::Chunk,
-    protocol::messages::{QueryResponse, Request, Response},
+    protocol::{
+        error::Error as ProtocolError,
+        messages::{QueryResponse, Request, Response},
+    },
 };
 use libp2p::{
     kad::{store::MemoryStore, GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
@@ -145,6 +148,14 @@ impl SwarmDriver {
                         }
                     } else {
                         warn!("Query {id:?} failed to get record with result {result:?}");
+                        if step.last {
+                            // To avoid the caller wait forever on a non-existring entry
+                            if let Some(sender) = self.pending_query.remove(id) {
+                                sender
+                                    .send(QueryResponse::GetChunk(Err(ProtocolError::RecordNotFound)))
+                                    .map_err(|_| Error::InternalMsgChannelDropped)?;
+                            }
+                        }
                         // TODO: send an error response back?
                     }
                 }


### PR DESCRIPTION
This PR terminates the wait on get_record in case of cann't find the record.
This will avoid a deadlock on non-existing entries.