### PR TITLE
Draft: temp disable double spend detection

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -344,11 +344,7 @@ impl Client {
             match select_all(list_of_futures).await {
                 (Ok(res), _, remaining_futures) => {
                     let res = res.map_err(Error::Network);
-                    let res_string = match &res {
-                        Ok(res) => format!("{res}"),
-                        Err(err) => format!("{err:?}"),
-                    };
-                    trace!("Got response for the req: {req:?}, res: {res_string}");
+                    println!("Got response for the req: {req:?}, res: {res:?}");
 
                     // return the first successful response
                     if !get_all_responses && res.is_ok() {

--- a/safenode/src/domain/node_transfers/error.rs
+++ b/safenode/src/domain/node_transfers/error.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Transfer errors.
-#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Error, custom_debug::Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Error {
     #[error("The transfer fee is missing.")]
     MissingFee((NodeId, DbcId)),
@@ -72,6 +72,7 @@ pub enum Error {
     },
     /// One or more parent spends of a requested spend could not be confirmed as valid.
     /// The full set of parents checked are contained in this error.
+    #[debug(skip)]
     #[error(
         "A parent tx of a requested spend could not be confirmed as valid. All parent signed spends of that tx {0:?}"
     )]

--- a/safenode/src/domain/storage/error.rs
+++ b/safenode/src/domain/storage/error.rs
@@ -100,6 +100,10 @@ pub enum Error {
     /// A spend that was attempted to be added was already marked as double spend.
     #[error("A spend that was attempted to be added was already marked as double spend: {0:?}")]
     AlreadyMarkedAsDoubleSpend(DbcAddress),
+    /// NB: This is a temporary error, which circumvents double spend detection for now.
+    /// A spend that was attempted to be added already existed.
+    #[error("A spend that was attempted to be added already existed: {0:?}")]
+    AlreadyExists(DbcAddress),
     /// An error from the `sn_dbc` crate.
     #[error("Dbc error: {0}")]
     Dbcs(String),

--- a/safenode/src/domain/storage/error.rs
+++ b/safenode/src/domain/storage/error.rs
@@ -14,14 +14,14 @@ use super::{
 use sn_dbc::{Error as DbcError, SignedSpend};
 
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, path::PathBuf, result};
+use std::{path::PathBuf, result};
 use thiserror::Error;
 
 /// A specialised `Result` type for protocol crate.
 pub type Result<T> = result::Result<T, Error>;
 
 /// Main error type for the crate.
-#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Error, Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Chunk not found.
@@ -80,13 +80,23 @@ pub enum Error {
     #[error("A double spend attempt was detected. Incoming and existing spend are not the same: {new:?}. Existing: {existing:?}")]
     DoubleSpendAttempt {
         /// New spend that we received.
+        #[debug(skip)]
         new: Box<SignedSpend>,
         /// Existing spend of same id that we already have.
+        #[debug(skip)]
         existing: Box<SignedSpend>,
     },
     /// We were notified about a double spend attempt, but they were for different dbcs.
-    #[error("We were notified about a double spend attempt, but they were for different dbcs: {0:?}. Existing: {1:?}")]
-    NotADoubleSpendAttempt(Box<SignedSpend>, Box<SignedSpend>),
+    #[debug(skip)]
+    #[error("We were notified about a double spend attempt, but they were for different dbcs. One: {one:?}, another: {other:?}")]
+    NotADoubleSpendAttempt {
+        /// One of the spends provided.
+        #[debug(skip)]
+        one: Box<SignedSpend>,
+        /// The other spend provided.
+        #[debug(skip)]
+        other: Box<SignedSpend>,
+    },
     /// A spend that was attempted to be added was already marked as double spend.
     #[error("A spend that was attempted to be added was already marked as double spend: {0:?}")]
     AlreadyMarkedAsDoubleSpend(DbcAddress),

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -101,20 +101,22 @@ impl SpendStorage {
         if let Ok(existing) = self.get(&address).await {
             let tamper_attempted = signed_spend.spend.hash() != existing.spend.hash();
             if tamper_attempted {
-                // We don't error if the double spend failed, as we rather want to
-                // announce the double spend attempt to close group. TODO: how to handle the error then?
-                self.try_store_double_spend(&existing, signed_spend).await?;
+                trace!("Tamper attempt detected, jsut rejecting the request.");
+                return Err(Error::AlreadyExists(address));
+                // // We don't error if the double spend failed, as we rather want to
+                // // announce the double spend attempt to close group. TODO: how to handle the error then?
+                // self.try_store_double_spend(&existing, signed_spend).await?;
 
-                // The spend is now permanently removed from the valid spends.
-                // We don't error if the remove failed, as we rather want to
-                // announce the double spend attempt to close group.
-                // The double spend will still be detected by querying for the spend.
-                self.remove(&address, &self.valid_spends_path).await?;
+                // // The spend is now permanently removed from the valid spends.
+                // // We don't error if the remove failed, as we rather want to
+                // // announce the double spend attempt to close group.
+                // // The double spend will still be detected by querying for the spend.
+                // self.remove(&address, &self.valid_spends_path).await?;
 
-                return Err(Error::DoubleSpendAttempt {
-                    new: Box::new(signed_spend.clone()),
-                    existing: Box::new(existing),
-                });
+                // return Err(Error::DoubleSpendAttempt {
+                //     new: Box::new(signed_spend.clone()),
+                //     existing: Box::new(existing),
+                // });
             }
         }
 

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -153,10 +153,10 @@ impl SpendStorage {
             // it isn't a double spend attempt either!
             // A node could erroneously send a notification of a double spend attempt,
             // so, we need to validate that.
-            return Err(Error::NotADoubleSpendAttempt(
-                Box::new(a_spend.clone()),
-                Box::new(b_spend.clone()),
-            ));
+            return Err(Error::NotADoubleSpendAttempt {
+                one: Box::new(a_spend.clone()),
+                other: Box::new(b_spend.clone()),
+            });
         }
 
         if self.is_unspendable(a_spend.dbc_id()).await {

--- a/safenode/src/network/msg/mod.rs
+++ b/safenode/src/network/msg/mod.rs
@@ -40,7 +40,7 @@ impl SwarmDriver {
                     request_id,
                     response,
                 } => {
-                    trace!("Got response for id: {request_id:?}, res: {response:?} ");
+                    trace!("Got response for id: {request_id:?}, res: {response}.");
                     self.pending_requests
                         .remove(&request_id)
                         .ok_or(Error::ReceivedResponseDropped(request_id))?

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -172,9 +172,9 @@ impl Node {
             Request::Query(query) => Response::Query(self.handle_query(query).await),
             Request::Event(event) => {
                 match event {
-                    Event::DoubleSpendAttempted(a_spend, b_spend) => {
+                    Event::DoubleSpendAttempted { new, existing } => {
                         self.transfers
-                            .try_add_double(a_spend.as_ref(), b_spend.as_ref())
+                            .try_add_double(new.as_ref(), existing.as_ref())
                             .await
                             .map_err(ProtocolError::Transfers)?;
                         return Ok(());

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -172,6 +172,18 @@ impl Node {
             Request::Query(query) => Response::Query(self.handle_query(query).await),
             Request::Event(event) => {
                 match event {
+                    Event::ValidSpendReceived {
+                        spend,
+                        parent_tx,
+                        fee_ciphers,
+                        parent_spends,
+                    } => {
+                        self.transfers
+                            .try_add(spend, parent_tx, fee_ciphers, parent_spends)
+                            .await
+                            .map_err(ProtocolError::Transfers)?;
+                        return Ok(());
+                    }
                     Event::DoubleSpendAttempted { new, existing } => {
                         self.transfers
                             .try_add_double(new.as_ref(), existing.as_ref())
@@ -285,9 +297,32 @@ impl Node {
                 // This will validate all the necessary components of the spend.
                 let res = match self
                     .transfers
-                    .try_add(signed_spend, parent_tx, fee_ciphers, parent_spends)
+                    .try_add(
+                        signed_spend.clone(),
+                        parent_tx.clone(),
+                        fee_ciphers.clone(),
+                        parent_spends.clone(),
+                    )
                     .await
                 {
+                    Ok(()) => {
+                        warn!("Broadcasting valid spend: {:?}", signed_spend.dbc_id());
+                        let event = Event::ValidSpendReceived {
+                            spend: signed_spend,
+                            parent_tx,
+                            fee_ciphers,
+                            parent_spends,
+                        };
+                        match self.send_to_closest(&Request::Event(event)).await {
+                            Ok(_) => {}
+                            Err(err) => {
+                                warn!(
+                                    "Failed to send double spend event to closest peers: {err:?}"
+                                );
+                            }
+                        }
+                        Ok(())
+                    }
                     Err(TransferError::Storage(StorageError::DoubleSpendAttempt {
                         new,
                         existing,

--- a/safenode/src/protocol/messages/mod.rs
+++ b/safenode/src/protocol/messages/mod.rs
@@ -56,7 +56,7 @@ pub enum Response {
 
 /// Messages to replicated data among nodes on the network
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(custom_debug::Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum ReplicatedData {
     /// A chunk of data.
     Chunk(Chunk),
@@ -65,8 +65,10 @@ pub enum ReplicatedData {
     /// An entire op log of a register.
     RegisterLog(ReplicatedRegisterLog),
     /// A valid spend.
+    #[debug(skip)]
     ValidSpend(SignedSpend),
     /// A dbc marked as having attempted double spend.
+    #[debug(skip)]
     DoubleSpend((DbcAddress, BTreeSet<SignedSpend>)),
 }
 


### PR DESCRIPTION
(On top of #195.)

This will prevent killing a dbc on accidental resend.
This will be disabled as soon as client wallet is refactored to mark dbcs as spend before publishing it, and store the actual spend for later re-publish at _any_ time in the future.