### PR TITLE
feat: have nodes broadcast valid spends

### DIFF
--- a/safenode/src/bin/safe/cli/register.rs
+++ b/safenode/src/bin/safe/cli/register.rs
@@ -10,7 +10,6 @@ use safenode::client::{Client, Error as ClientError};
 
 use clap::Subcommand;
 use eyre::Result;
-use tracing::trace;
 use xor_name::XorName;
 
 #[derive(Subcommand, Debug)]
@@ -48,30 +47,30 @@ pub(crate) async fn register_cmds(cmds: RegisterCmds, client: &Client) -> Result
 async fn create_register(name: String, client: &Client) -> Result<()> {
     let tag = 3006;
     let xorname = XorName::from_content(name.as_bytes());
-    trace!("Creating Register with '{name}' at xorname: {xorname:x} and tag {tag}");
+    println!("Creating Register with '{name}' at xorname: {xorname:x} and tag {tag}");
 
     let _register = client.create_register(xorname, tag).await?;
-    trace!("Successfully created register '{name}' at {xorname:?}, {tag}!");
+    println!("Successfully created register '{name}' at {xorname:?}, {tag}!");
     Ok(())
 }
 
 async fn edit_register(name: String, entry: String, client: &Client) -> Result<()> {
     let tag = 3006;
     let xorname = XorName::from_content(name.as_bytes());
-    trace!("Trying to retrieve Register from {xorname:?}, {tag}");
+    println!("Trying to retrieve Register from {xorname:?}, {tag}");
 
     match client.get_register(xorname, tag).await {
         Ok(mut register) => {
-            trace!(
+            println!(
                 "Successfully retrieved Register '{name}' from {}, {}!",
                 register.name(),
                 register.tag()
             );
-            trace!("Editing Register '{name}' with: {entry}");
+            println!("Editing Register '{name}' with: {entry}");
             match register.write(entry.as_bytes()).await {
                 Ok(()) => {}
                 Err(ref err @ ClientError::ContentBranchDetected(ref branches)) => {
-                    trace!(
+                    println!(
                         "We need to merge {} branches in Register entries: {err}",
                         branches.len()
                     );
@@ -81,7 +80,9 @@ async fn edit_register(name: String, entry: String, client: &Client) -> Result<(
             }
         }
         Err(error) => {
-            trace!("Did not retrieve Register '{name}' from all nodes in the close group! {error}")
+            println!(
+                "Did not retrieve Register '{name}' from all nodes in the close group! {error}"
+            )
         }
     }
 
@@ -91,19 +92,19 @@ async fn edit_register(name: String, entry: String, client: &Client) -> Result<(
 async fn get_registers(names: Vec<String>, client: &Client) -> Result<()> {
     let tag = 3006;
     for name in names {
-        trace!("Register name passed in via `register get` is '{name}'...");
+        println!("Register name passed in via `register get` is '{name}'...");
         let xorname = XorName::from_content(name.as_bytes());
 
-        trace!("Trying to retrieve Register from {xorname:?}, {tag}");
+        println!("Trying to retrieve Register from {xorname:?}, {tag}");
 
         match client.get_register(xorname, tag).await {
-            Ok(register) => trace!(
+            Ok(register) => println!(
                 "Successfully retrieved Register '{name}' from {}, {}!",
                 register.name(),
                 register.tag()
             ),
             Err(error) => {
-                trace!(
+                println!(
                     "Did not retrieve Register '{name}' from all nodes in the close group! {error}"
                 )
             }

--- a/safenode/src/bin/safe/cli/wallet.rs
+++ b/safenode/src/bin/safe/cli/wallet.rs
@@ -16,7 +16,6 @@ use sn_dbc::Token;
 use clap::Parser;
 use eyre::Result;
 use std::path::Path;
-use tracing::trace;
 
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
@@ -78,12 +77,12 @@ async fn deposit(root_dir: &Path) -> Result<()> {
 
     if deposited > 0 {
         if let Err(err) = wallet.store().await {
-            trace!("Failed to store deposited amount: {:?}", err);
+            println!("Failed to store deposited amount: {:?}", err);
         } else {
-            trace!("Deposited {:?}.", sn_dbc::Token::from_nano(deposited));
+            println!("Deposited {:?}.", sn_dbc::Token::from_nano(deposited));
         }
     } else {
-        trace!("Nothing deposited.");
+        println!("Nothing deposited.");
     }
 
     Ok(())
@@ -95,7 +94,7 @@ async fn send(amount: String, to: String, client: &Client, root_dir: &Path) -> R
     use std::str::FromStr;
     let amount = Token::from_str(&amount)?;
     if amount.as_nano() == 0 {
-        trace!("Invalid format or zero amount passed in. Nothing sent.");
+        println!("Invalid format or zero amount passed in. Nothing sent.");
         return Ok(());
     }
 
@@ -104,21 +103,21 @@ async fn send(amount: String, to: String, client: &Client, root_dir: &Path) -> R
 
     match wallet_client.send(amount, address).await {
         Ok(new_dbc) => {
-            trace!("Sent {amount:?} to {address:?}");
+            println!("Sent {amount:?} to {address:?}");
             let mut wallet = wallet_client.into_wallet();
             let new_balance = wallet.balance();
 
             if let Err(err) = wallet.store().await {
-                trace!("Failed to store wallet: {err:?}");
+                println!("Failed to store wallet: {err:?}");
             } else {
-                trace!("Successfully stored wallet with new balance {new_balance:?}.");
+                println!("Successfully stored wallet with new balance {new_balance:?}.");
             }
 
             wallet.store_created_dbc(new_dbc).await?;
-            trace!("Successfully stored new dbc to wallet dir. It can now be sent to the recipient, using any channel of choice.");
+            println!("Successfully stored new dbc to wallet dir. It can now be sent to the recipient, using any channel of choice.");
         }
         Err(err) => {
-            trace!("Failed to send {amount:?} to {address:?} due to {err:?}.");
+            println!("Failed to send {amount:?} to {address:?} due to {err:?}.");
         }
     }
 

--- a/safenode/src/bin/safe/mod.rs
+++ b/safenode/src/bin/safe/mod.rs
@@ -8,27 +8,22 @@
 
 mod cli;
 
-use self::cli::{files_cmds, register_cmds, wallet_cmds, Opt};
+use self::cli::{files_cmds, register_cmds, wallet_cmds, Opt, SubCmd};
 
-use crate::cli::SubCmd;
-
-use safenode::{
-    client::{Client, ClientEvent},
-    log::init_node_logging,
-};
+use safenode::client::{Client, ClientEvent};
 
 use clap::Parser;
 use eyre::Result;
 use std::path::PathBuf;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let opt = Opt::parse();
     // For client, default to log to std::out
-    let _log_appender_guard = init_node_logging(&None)?;
+    // This is ruining the log output for the CLI. Needs to be fixed.
+    // let _log_appender_guard = init_node_logging(&None)?;
 
-    info!("Instantiating a SAFE client...");
+    println!("Instantiating a SAFE client...");
 
     let secret_key = bls::SecretKey::random();
     let client = Client::new(secret_key)?;
@@ -37,7 +32,7 @@ async fn main() -> Result<()> {
     if let Ok(event) = client_events_rx.recv().await {
         match event {
             ClientEvent::ConnectedToNetwork => {
-                info!("Client connected to the Network");
+                println!("Client connected to the Network");
             }
         }
     }

--- a/safenode/src/domain/dbc_genesis.rs
+++ b/safenode/src/domain/dbc_genesis.rs
@@ -107,13 +107,13 @@ pub(crate) async fn send(
 pub async fn load_faucet_wallet(client: &Client) -> LocalWallet {
     let genesis_wallet = load_genesis_wallet().await;
 
-    trace!("Loading faucet...");
+    println!("Loading faucet...");
     let mut faucet_wallet = create_faucet_wallet().await;
 
     use super::wallet::{DepositWallet, Wallet};
     let faucet_balance = faucet_wallet.balance();
     if faucet_balance.as_nano() > 0 {
-        trace!("Faucet wallet balance: {faucet_balance}");
+        println!("Faucet wallet balance: {faucet_balance}");
         return faucet_wallet;
     }
 
@@ -122,7 +122,7 @@ pub async fn load_faucet_wallet(client: &Client) -> LocalWallet {
 
     let initial_fee_margin = 500_000;
     let faucet_balance = Token::from_nano(genesis_wallet.balance().as_nano() - initial_fee_margin);
-    trace!("Sending {faucet_balance} from genesis to faucet wallet..");
+    println!("Sending {faucet_balance} from genesis to faucet wallet..");
     let tokens = send(
         genesis_wallet,
         faucet_balance,
@@ -136,26 +136,26 @@ pub async fn load_faucet_wallet(client: &Client) -> LocalWallet {
         .store()
         .await
         .expect("Faucet wallet shall be stored successfully.");
-    trace!("Faucet wallet balance: {}", faucet_wallet.balance());
+    println!("Faucet wallet balance: {}", faucet_wallet.balance());
 
-    trace!("Waiting a short moment before verifying the transfer from genesis...");
+    println!("Waiting a short moment before verifying the transfer from genesis...");
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
-    trace!("Verifying the transfer from genesis...");
+    println!("Verifying the transfer from genesis...");
 
     use crate::domain::wallet::VerifyingClient;
     if let Err(error) = client.verify(&tokens).await {
-        trace!("Could not verify the transfer from genesis: {error:?}");
+        println!("Could not verify the transfer from genesis: {error:?}");
     }
 
     faucet_wallet
 }
 
 async fn load_genesis_wallet() -> LocalWallet {
-    trace!("Loading genesis...");
+    println!("Loading genesis...");
     let mut genesis_wallet = create_genesis_wallet().await;
     let genesis_balance = genesis_wallet.balance();
     if genesis_balance.as_nano() > 0 {
-        trace!("Genesis wallet balance: {genesis_balance}");
+        println!("Genesis wallet balance: {genesis_balance}");
         return genesis_wallet;
     }
 
@@ -167,7 +167,7 @@ async fn load_genesis_wallet() -> LocalWallet {
         .expect("Genesis wallet shall be stored successfully.");
 
     let genesis_balance = genesis_wallet.balance();
-    trace!("Genesis wallet balance: {genesis_balance}");
+    println!("Genesis wallet balance: {genesis_balance}");
 
     genesis_wallet
 }

--- a/safenode/src/domain/storage/error.rs
+++ b/safenode/src/domain/storage/error.rs
@@ -100,6 +100,10 @@ pub enum Error {
     /// A spend that was attempted to be added was already marked as double spend.
     #[error("A spend that was attempted to be added was already marked as double spend: {0:?}")]
     AlreadyMarkedAsDoubleSpend(DbcAddress),
+    /// NB: This is a temporary error, which circumvents double spend detection for now.
+    /// A spend that was attempted to be added already existed.
+    #[error("A spend that was attempted to be added already existed: {0:?}")]
+    AlreadyExists(DbcAddress),
     /// An error from the `sn_dbc` crate.
     #[error("Dbc error: {0}")]
     Dbcs(String),

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -347,6 +347,7 @@ mod tests {
             .expect("The exact same spend should be added.");
     }
 
+    #[ignore = "We have temporarily disabled the punishment of double spends. NB it is still detected and hindered, just not punished."]
     #[tokio::test]
     async fn double_spend_attempt_is_detected() {
         let mut storage = init_file_store();

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -101,20 +101,22 @@ impl SpendStorage {
         if let Ok(existing) = self.get(&address).await {
             let tamper_attempted = signed_spend.spend.hash() != existing.spend.hash();
             if tamper_attempted {
-                // We don't error if the double spend failed, as we rather want to
-                // announce the double spend attempt to close group. TODO: how to handle the error then?
-                self.try_store_double_spend(&existing, signed_spend).await?;
+                trace!("Tamper attempt detected, jsut rejecting the request.");
+                return Err(Error::AlreadyExists(address));
+                // // We don't error if the double spend failed, as we rather want to
+                // // announce the double spend attempt to close group. TODO: how to handle the error then?
+                // self.try_store_double_spend(&existing, signed_spend).await?;
 
-                // The spend is now permanently removed from the valid spends.
-                // We don't error if the remove failed, as we rather want to
-                // announce the double spend attempt to close group.
-                // The double spend will still be detected by querying for the spend.
-                self.remove(&address, &self.valid_spends_path).await?;
+                // // The spend is now permanently removed from the valid spends.
+                // // We don't error if the remove failed, as we rather want to
+                // // announce the double spend attempt to close group.
+                // // The double spend will still be detected by querying for the spend.
+                // self.remove(&address, &self.valid_spends_path).await?;
 
-                return Err(Error::DoubleSpendAttempt {
-                    new: Box::new(signed_spend.clone()),
-                    existing: Box::new(existing),
-                });
+                // return Err(Error::DoubleSpendAttempt {
+                //     new: Box::new(signed_spend.clone()),
+                //     existing: Box::new(existing),
+                // });
             }
         }
 

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -101,7 +101,7 @@ impl SpendStorage {
         if let Ok(existing) = self.get(&address).await {
             let tamper_attempted = signed_spend.spend.hash() != existing.spend.hash();
             if tamper_attempted {
-                trace!("Tamper attempt detected, jsut rejecting the request.");
+                trace!("Tamper attempt detected, just rejecting the request.");
                 return Err(Error::AlreadyExists(address));
                 // // We don't error if the double spend failed, as we rather want to
                 // // announce the double spend attempt to close group. TODO: how to handle the error then?

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -207,7 +207,7 @@ impl SendWallet for LocalWallet {
             if let Ok(derived_key) = dbc.derived_key(&self.key) {
                 available_dbcs.push((dbc.clone(), derived_key));
             } else {
-                warn!(
+                println!(
                     "Skipping DBC {:?} because we don't have the key to spend it",
                     dbc.id()
                 );
@@ -244,7 +244,7 @@ impl SendWallet for LocalWallet {
 
         // Last of all, register the spend in the network.
         if let Err(error) = client.send(transfer.clone()).await {
-            trace!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
+            println!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
             let _ = self.wallet.unconfirmed_txs.push(transfer);
         }
 
@@ -254,9 +254,9 @@ impl SendWallet for LocalWallet {
 
 async fn resend_pending_txs<C: SendClient>(local: &mut LocalWallet, client: &C) {
     for (index, transfer) in local.wallet.unconfirmed_txs.clone().into_iter().enumerate() {
-        trace!("Trying to republish pending tx: {:?}..", transfer.tx_hash);
+        println!("Trying to republish pending tx: {:?}..", transfer.tx_hash);
         if client.send(transfer.clone()).await.is_ok() {
-            trace!("Tx {:?} was successfully republished!", transfer.tx_hash);
+            println!("Tx {:?} was successfully republished!", transfer.tx_hash);
             let _ = local.wallet.unconfirmed_txs.remove(index);
             // We might want to be _really_ sure and do the below
             // as well, but it's not necessary.

--- a/safenode/src/domain/wallet/wallet_file.rs
+++ b/safenode/src/domain/wallet/wallet_file.rs
@@ -81,13 +81,13 @@ pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
     {
         if entry.file_type().is_file() {
             let file_name = entry.file_name();
-            trace!("Reading deposited tokens from {file_name:?}.");
+            println!("Reading deposited tokens from {file_name:?}.");
 
             let dbc_data = fs::read_to_string(entry.path()).await?;
             let dbc = match Dbc::from_hex(dbc_data.trim()) {
                 Ok(dbc) => dbc,
                 Err(_) => {
-                    trace!(
+                    println!(
                         "This file does not appear to have valid hex-encoded DBC data. \
                         Skipping it."
                     );
@@ -100,7 +100,7 @@ pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
     }
 
     if deposits.is_empty() {
-        trace!("No deposits found.");
+        println!("No deposits found.");
     }
 
     Ok(deposits)

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -311,7 +311,11 @@ impl Node {
                             fee_ciphers,
                             parent_spends,
                         };
-                        match self.send_to_closest(&Request::Event(event)).await {
+                        match self
+                            .network
+                            .node_send_to_closest(&Request::Event(event))
+                            .await
+                        {
                             Ok(_) => {}
                             Err(err) => {
                                 warn!(


### PR DESCRIPTION
Resolves #198.

As nodes broadcast a valid spend, it is very unlikely that it will only sit at one or a few nodes, due to client connection issues. It will most likely either go through in full, or not at all.

Also there is a temp disabling of _punishment_ on double spent detection.
This will prevent killing a dbc on accidental resend.
The detection is still there and hinders double spends, but the _punishment_ is disabled.

This can/will be enabled again as soon as client wallet is refactored to mark dbcs as spent before publishing it, and store the actual spend for later re-publish at any time in the future.