### PR TITLE
refactor: wallet logic to client state first

### DIFF
--- a/safenode/src/domain/client_transfers/mod.rs
+++ b/safenode/src/domain/client_transfers/mod.rs
@@ -72,7 +72,7 @@ pub struct Inputs {
 
 /// The created dbcs and change dbc from a transfer
 /// of tokens from one or more dbcs, into one or more new dbcs.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Outputs {
     /// The dbcs that were created containing
     /// the tokens sent to respective recipient.

--- a/safenode/src/domain/client_transfers/mod.rs
+++ b/safenode/src/domain/client_transfers/mod.rs
@@ -72,8 +72,12 @@ pub struct Inputs {
 
 /// The created dbcs and change dbc from a transfer
 /// of tokens from one or more dbcs, into one or more new dbcs.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Outputs {
+    /// This is the hash of the transaction
+    /// where all the below spends were made
+    /// and dbcs created.
+    pub tx_hash: sn_dbc::Hash,
     /// The dbcs that were created containing
     /// the tokens sent to respective recipient.
     pub created_dbcs: Vec<CreatedDbc>,
@@ -85,7 +89,7 @@ pub struct Outputs {
 }
 
 /// The parameters necessary to send a spend request to the network.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SpendRequest {
     /// The dbc to register in the network as spent.
     pub signed_spend: SignedSpend,

--- a/safenode/src/domain/client_transfers/offline.rs
+++ b/safenode/src/domain/client_transfers/offline.rs
@@ -167,6 +167,8 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
         .build(Hash::default(), &mut rng)
         .map_err(Error::Dbcs)?;
 
+    let tx_hash = dbc_builder.dst_tx.hash();
+
     let signed_spends: BTreeMap<_, _> = dbc_builder
         .signed_spends()
         .into_iter()
@@ -219,6 +221,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     });
 
     Ok(Outputs {
+        tx_hash,
         created_dbcs,
         change_dbc,
         all_spend_requests,

--- a/safenode/src/domain/client_transfers/online.rs
+++ b/safenode/src/domain/client_transfers/online.rs
@@ -281,6 +281,8 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
         .build(Hash::default(), &mut rng)
         .map_err(Error::Dbcs)?;
 
+    let tx_hash = dbc_builder.dst_tx.hash();
+
     let signed_spends: BTreeMap<_, _> = dbc_builder
         .signed_spends()
         .into_iter()
@@ -345,6 +347,7 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
     });
 
     Ok(Outputs {
+        tx_hash,
         created_dbcs,
         change_dbc,
         all_spend_requests,

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -178,20 +178,15 @@ impl SendWallet for LocalWallet {
         to: Vec<(Token, PublicAddress)>,
         client: &C,
     ) -> Result<Vec<CreatedDbc>> {
-        // First resend any pending txs.
-        // This is not guaranteed to succeed.
-        // If the spend was invalid to start with
-        // then it will always fail here.
-        // It can disrupt the use of the wallet, if
-        // we got change from that invalid tx, that
-        // we try to spend later.
-        // So either we need to make sure that the
-        // failing transfers are not failing due to being invalid,
-        // or we need a way to check that later and clear those out
-        // from the pending txs list. Since they could become "invalid"
-        // while being in the pending txs list (the DBCs they spend, became
-        // spent in other txs in the meanwhile), the latter solution
-        // of being able to check and clean out the list later seems to be necessary.
+        // First resend any pending txs. This is not guaranteed to succeed.
+        // If the spend was invalid to start with then it will always fail here.
+        // It can disrupt the use of the wallet, if we got change from that invalid
+        // tx, that we try to spend later. So either we need to make sure that the
+        // failing transfers are not failing due to being invalid, or we need a way
+        // to check that later and clear those out from the pending txs list.
+        // Since they could become "invalid" while being in the pending txs list
+        // (the DBCs they spend, became spent in other txs in the meanwhile), the latter
+        // solution of being able to check and clean out the list later seems to be necessary.
         resend_pending_txs(self, client).await;
 
         // do not make a pointless send to ourselves

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -243,10 +243,8 @@ impl SendWallet for LocalWallet {
             .extend(created_dbcs.clone());
 
         // Last of all, register the spend in the network.
-        let result = client.send(transfer.clone()).await;
-
-        if result.is_err() {
-            println!("The transfer was not successfully registered in the network. It will be retried later.");
+        if let Err(error) = client.send(transfer.clone()).await {
+            println!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
             let _ = self
                 .wallet
                 .unconfirmed_txs

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -101,7 +101,7 @@ impl KeyLessWallet {
             spent_dbcs: BTreeMap::new(),
             available_dbcs: BTreeMap::new(),
             dbcs_created_for_others: vec![],
-            unconfirmed_spends: BTreeMap::new(),
+            unconfirmed_txs: vec![],
         }
     }
 

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -244,7 +244,7 @@ impl SendWallet for LocalWallet {
 
         // Last of all, register the spend in the network.
         if let Err(error) = client.send(transfer.clone()).await {
-            println!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
+            trace!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
             let _ = self
                 .wallet
                 .unconfirmed_txs
@@ -258,9 +258,9 @@ impl SendWallet for LocalWallet {
 async fn resend_pending_txs<C: SendClient>(local: &mut LocalWallet, client: &C) {
     for (index, (tx_hash, transfer)) in local.wallet.unconfirmed_txs.clone().into_iter().enumerate()
     {
-        println!("Trying to republish pending tx: {tx_hash:?}..");
+        trace!("Trying to republish pending tx: {tx_hash:?}..");
         if client.send(transfer.clone()).await.is_ok() {
-            println!("Tx {tx_hash:?} was successfully republished!");
+            trace!("Tx {tx_hash:?} was successfully republished!");
             let _ = local.wallet.unconfirmed_txs.remove(index);
             // We might want to be _really_ sure and do the below
             // as well, but it's not necessary.

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -180,6 +180,18 @@ impl SendWallet for LocalWallet {
     ) -> Result<Vec<CreatedDbc>> {
         // First resend any pending txs.
         // This is not guaranteed to succeed.
+        // If the spend was invalid to start with
+        // then it will always fail here.
+        // It can disrupt the use of the wallet, if
+        // we got change from that invalid tx, that
+        // we try to spend later.
+        // So either we need to make sure that the
+        // failing transfers are not failing due to being invalid,
+        // or we need a way to check that later and clear those out
+        // from the pending txs list. Since they could become "invalid"
+        // while being in the pending txs list (the DBCs they spend, became
+        // spent in other txs in the meanwhile), the latter solution
+        // of being able to check and clean out the list later seems to be necessary.
         resend_pending_txs(self, client).await;
 
         // do not make a pointless send to ourselves

--- a/safenode/src/domain/wallet/local_store.rs
+++ b/safenode/src/domain/wallet/local_store.rs
@@ -232,7 +232,15 @@ impl SendWallet for LocalWallet {
             .extend(created_dbcs.clone());
 
         // Last of all, register the spend in the network.
-        let _result = client.send(transfer).await;
+        let result = client.send(transfer.clone()).await;
+
+        if result.is_err() {
+            println!("The transfer was not successfully registered in the network. It will be retried later.");
+            let _ = self
+                .wallet
+                .unconfirmed_txs
+                .push((transfer.tx_hash, transfer));
+        }
 
         Ok(created_dbcs)
     }

--- a/safenode/src/domain/wallet/mod.rs
+++ b/safenode/src/domain/wallet/mod.rs
@@ -48,15 +48,19 @@
 //! The bitcoin flow here is very useful: unspent, unconfirmed (in mempool), confirmed.
 //! These three states are held by both the client and the node, and is easy for the client to check and resolve.
 //!
-//! The most difficult situation for a client to resolve is a low-fee tx in mempool for a long time,
+//! The most difficult situation for a bitcoin client to resolve is a low-fee tx in mempool for a long time,
 //! which eventually clears from the mempool and becomes spendable again (which for us is a tx with too few nodes
-//! storing it, and eventually is not stored anywhere, which should be extremely rare, I would expect never happens).
+//! storing it, and eventually is not stored anywhere, which should be extremely rare and not expected ever happen).
 //!
 //! However, we also have a "mempool", our priority queue. The great difference there though, is that a client _can_
 //! update the fee on such a queued spend, and thus can always avoid a spend getting stuck in the queue!
 //! Removing it though is not allowed, but we could allow that. If some nodes have already processed it, then
 //! the client can't change that fact. But in the case that no node actually had processed it, then the client
 //! can successfully remove it from the queue, and then re-add it with a completely different transaction.
+//!
+//! Note: We do not represent at client the spend being in the priority queue, which we might want to do.
+//! In that case, before resending a transfer, we could just check if it has already been stored to the nodes.
+//! TBD.
 
 mod error;
 mod keys;

--- a/safenode/src/domain/wallet/mod.rs
+++ b/safenode/src/domain/wallet/mod.rs
@@ -76,9 +76,7 @@ use super::{
     fees::FeeCiphers,
 };
 
-use sn_dbc::{
-    Dbc, DbcId, DbcIdSource, DerivedKey, PublicAddress, RevealedAmount, SignedSpend, Token,
-};
+use sn_dbc::{Dbc, DbcId, DbcIdSource, DerivedKey, PublicAddress, RevealedAmount, Token};
 
 use async_trait::async_trait;
 use std::collections::BTreeMap;
@@ -182,7 +180,10 @@ pub(super) struct KeyLessWallet {
     spent_dbcs: BTreeMap<DbcId, Dbc>,
     /// These have not yet been successfully confirmed in
     /// the network and need to be republished, to reach network validity.
-    unconfirmed_spends: BTreeMap<DbcId, SignedSpend>,
+    /// We maintain the order they were added in, as to republish
+    /// them in the correct order, in case any later spend was
+    /// dependent on an earlier spend.
+    unconfirmed_txs: Vec<(sn_dbc::Hash, TransferDetails)>,
     /// These are the dbcs we own that are not yet spent.
     available_dbcs: BTreeMap<DbcId, Dbc>,
     /// These are the dbcs we've created by

--- a/safenode/src/domain/wallet/mod.rs
+++ b/safenode/src/domain/wallet/mod.rs
@@ -183,7 +183,7 @@ pub(super) struct KeyLessWallet {
     /// We maintain the order they were added in, as to republish
     /// them in the correct order, in case any later spend was
     /// dependent on an earlier spend.
-    unconfirmed_txs: Vec<(sn_dbc::Hash, TransferDetails)>,
+    unconfirmed_txs: Vec<TransferDetails>,
     /// These are the dbcs we own that are not yet spent.
     available_dbcs: BTreeMap<DbcId, Dbc>,
     /// These are the dbcs we've created by

--- a/safenode/src/domain/wallet/mod.rs
+++ b/safenode/src/domain/wallet/mod.rs
@@ -30,6 +30,33 @@
 //!
 //! We will already now pave for that, by mimicing that flow for the local storage of a Wallet.
 //! First though, a simpler local storage will be used. But after that a local register store can be implemented.
+//!
+//! ************************************************************************************************************
+//!
+//! When the client spends a dbc, ie signs the tx, the dbc must be marked locally as spent (ie pending).
+//! Only then should the client broadcast it.
+//!
+//! The client stores the tx as pending until either
+//!     a) all nodes respond with spent so the client locally changes it from pending to spent or
+//!     b) no nodes respond with spent so the client locally changes it to unspent.
+//!
+//! The best heuristic here is clients are in charge of their state, and the network is the source
+//! of truth for the state.
+//! If there’s ever a conflict in those states, the client can update their local state.
+//! Clients create events (are in charge), nodes store events (are source of truth).
+//!
+//! The bitcoin flow here is very useful: unspent, unconfirmed (in mempool), confirmed.
+//! These three states are held by both the client and the node, and is easy for the client to check and resolve.
+//!
+//! The most difficult situation for a client to resolve is a low-fee tx in mempool for a long time,
+//! which eventually clears from the mempool and becomes spendable again (which for us is a tx with too few nodes
+//! storing it, and eventually is not stored anywhere, which should be extremely rare, I would expect never happens).
+//!
+//! However, we also have a "mempool", our priority queue. The great difference there though, is that a client _can_
+//! update the fee on such a queued spend, and thus can always avoid a spend getting stuck in the queue!
+//! Removing it though is not allowed, but we could allow that. If some nodes have already processed it, then
+//! the client can't change that fact. But in the case that no node actually had processed it, then the client
+//! can successfully remove it from the queue, and then re-add it with a completely different transaction.
 
 mod error;
 mod keys;


### PR DESCRIPTION
Resolves #199.

The client had the wrong order. It should

1. Sign the tx.
2. Locally mark the dbc as spent.
3. Broadcast the signed tx.

The client won’t try to spend the dbc(s) again, sonce they are already marked as spent. It will however retry them if they are in the `pending_txs` list until the tx is confirmed.

The client replays their pending_txs on any send of tokens, as to not block those sends, by getting stuck with change dbcs not working due to parents not yet registered.
(Later it can readd non-spent dbcs to available again, if it turns out to be completely non-existent on the network, buit that's an advanced case).

It should be fine for a client to rebroadcast the same tx as many times as they want (with as long a gap as they want, maybe years later).
Clients must manage the state, if they see it’s stuck then just replay the tx same as if it’s the first time.