### PR TITLE
DEMO only: reproduce node many to many msg fail

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -108,6 +108,12 @@ jobs:
         run: cargo test --no-run --release
         timeout-minutes: 30
 
+      - name: Run many-to-many issue repro
+        # Only run on PRs w/ ubuntu
+        if: github.event_name != 'pull_request' || matrix.os == 'ubuntu-latest'
+        timeout-minutes: 25
+        run: cargo test --release -p safenode -- node_many_to_many
+
       - name: Run network tests
         # Only run on PRs w/ ubuntu
         if: github.event_name != 'pull_request' || matrix.os == 'ubuntu-latest'

--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -45,7 +45,7 @@ impl Client {
             events_channel,
             signer,
         };
-        let mut client_clone = client.clone();
+        let client_clone = client.clone();
 
         let _swarm_driver = spawn({
             trace!("Starting up client swarm_driver");
@@ -71,7 +71,7 @@ impl Client {
         Ok(client)
     }
 
-    fn handle_network_event(&mut self, event: NetworkEvent) -> Result<()> {
+    fn handle_network_event(&self, event: NetworkEvent) -> Result<()> {
         match event {
             // Clients do not handle requests.
             NetworkEvent::RequestReceived { .. } => {}

--- a/safenode/src/client/register/offline_replica.rs
+++ b/safenode/src/client/register/offline_replica.rs
@@ -238,7 +238,7 @@ impl RegisterOffline {
     async fn publish_register_create(&self, cmd: RegisterCmd) -> Result<()> {
         debug!("Publishing Register create cmd: {:?}", cmd.dst());
         let request = Request::Cmd(Cmd::Register(cmd));
-        let responses = self.client.send_to_closest(request).await?;
+        let responses = self.client.send_to_queried_closest(request).await?;
 
         let all_ok = responses
             .iter()
@@ -268,7 +268,7 @@ impl RegisterOffline {
     async fn publish_register_edit(&self, cmd: RegisterCmd) -> Result<()> {
         debug!("Publishing Register edit cmd: {:?}", cmd.dst());
         let request = Request::Cmd(Cmd::Register(cmd));
-        let responses = self.client.send_to_closest(request).await?;
+        let responses = self.client.send_to_queried_closest(request).await?;
 
         let all_ok = responses
             .iter()
@@ -299,7 +299,7 @@ impl RegisterOffline {
         let address = RegisterAddress { name, tag };
         debug!("Retrieving Register from: {address:?}");
         let request = Request::Query(Query::Register(RegisterQuery::Get(address)));
-        let responses = client.send_to_closest(request).await?;
+        let responses = client.send_to_queried_closest(request).await?;
 
         // We will return the first register we get.
         for resp in responses.iter().flatten() {

--- a/safenode/src/domain/client_transfers/online.rs
+++ b/safenode/src/domain/client_transfers/online.rs
@@ -360,7 +360,7 @@ async fn get_fees(dbc_id: DbcId, client: &Client) -> Result<BTreeMap<NodeId, Req
         priority: SpendPriority::Normal,
     }));
     let responses = client
-        .send_to_closest(request)
+        .send_to_local_closest(request)
         .await
         .map_err(|e| Error::CouldNotGetFees(e.to_string()))?;
 

--- a/safenode/src/domain/node_transfers/mod.rs
+++ b/safenode/src/domain/node_transfers/mod.rs
@@ -62,12 +62,12 @@ impl Transfers {
     }
 
     /// Get the required fee for the specified spend priority.
-    pub(crate) fn get_required_fee(
+    pub(crate) async fn get_required_fee(
         &self,
         dbc_id: DbcId,
         priority: SpendPriority,
     ) -> (NodeId, RequiredFee) {
-        let amount = Token::from_nano(self.current_fee(priority));
+        let amount = Token::from_nano(self.current_fee(priority).await);
 
         debug!("Returned amount for priority {priority:?}: {amount}");
 
@@ -81,15 +81,15 @@ impl Transfers {
     }
 
     /// Get the current fee for the specified spend priority.
-    fn current_fee(&self, priority: SpendPriority) -> u64 {
-        let spend_q_snapshot = self.spend_queue.snapshot();
+    async fn current_fee(&self, priority: SpendPriority) -> u64 {
+        let spend_q_snapshot = self.spend_queue.snapshot().await;
         let spend_q_stats = spend_q_snapshot.stats();
         spend_q_stats.map_to_fee(priority)
     }
 
     /// Tries to add a double spend that was detected by the network.
     pub(crate) async fn try_add_double(
-        &mut self,
+        &self,
         a_spend: &SignedSpend,
         b_spend: &SignedSpend,
     ) -> Result<()> {
@@ -101,7 +101,7 @@ impl Transfers {
     /// All the provided data will be validated, and
     /// if it is valid, the spend will be pushed onto the queue.
     pub(crate) async fn try_add(
-        &mut self,
+        &self,
         signed_spend: Box<SignedSpend>,
         parent_tx: Box<DbcTransaction>,
         fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
@@ -121,7 +121,9 @@ impl Transfers {
         }
 
         // 2. Try extract the fee paid for this spend, and validate it.
-        let paid_fee = self.validate_fee(&signed_spend.spend.dst_tx, fee_ciphers)?;
+        let paid_fee = self
+            .validate_fee(&signed_spend.spend.dst_tx, fee_ciphers)
+            .await?;
 
         // 3. Validate the spend itself.
         self.storage.validate(signed_spend.as_ref()).await?;
@@ -131,14 +133,16 @@ impl Transfers {
         validate_parent_spends(signed_spend.as_ref(), parent_tx.as_ref(), parent_spends)?;
 
         // This spend is valid and goes into the queue.
-        self.spend_queue.push(*signed_spend, paid_fee.as_nano());
+        self.spend_queue
+            .push(*signed_spend, paid_fee.as_nano())
+            .await;
 
         // If the rate limit has elapsed..
-        if self.spend_queue.elapsed() {
+        if self.spend_queue.elapsed().await {
             // .. we process one from the queue.
             // NB: This works for now. We can look at
             // a timeout backstop in coming iterations.
-            if let Some((signed_spend, _)) = self.spend_queue.pop() {
+            if let Some((signed_spend, _)) = self.spend_queue.pop().await {
                 return Ok(self.storage.try_add(&signed_spend).await?);
             }
         }
@@ -146,14 +150,14 @@ impl Transfers {
         Ok(())
     }
 
-    fn validate_fee(
+    async fn validate_fee(
         &self,
         dst_tx: &DbcTransaction,
         fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
     ) -> Result<Token> {
         let fee_paid = decipher_fee(&self.node_wallet, dst_tx, self.node_id, fee_ciphers)?;
 
-        let spend_q_snapshot = self.spend_queue.snapshot();
+        let spend_q_snapshot = self.spend_queue.snapshot().await;
         let spend_q_stats = spend_q_snapshot.stats();
 
         let (valid, lowest) = spend_q_stats.validate_fee(fee_paid.as_nano());

--- a/safenode/src/domain/storage/address/mod.rs
+++ b/safenode/src/domain/storage/address/mod.rs
@@ -24,6 +24,8 @@ use xor_name::XorName;
 /// An address of data on the network.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DataAddress {
+    /// For ping-pong msgs.
+    PingPong(XorName),
     ///
     Chunk(ChunkAddress),
     ///
@@ -36,10 +38,16 @@ impl DataAddress {
     /// The xorname.
     pub fn name(&self) -> &XorName {
         match self {
+            Self::PingPong(name) => name,
             Self::Chunk(address) => address.name(),
             Self::Register(address) => address.name(),
             Self::Spend(address) => address.name(),
         }
+    }
+
+    ///
+    pub fn pingpong(name: XorName) -> Self {
+        Self::PingPong(name)
     }
 
     ///
@@ -61,6 +69,7 @@ impl DataAddress {
 impl std::fmt::Display for DataAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            DataAddress::PingPong(name) => write!(f, "PingPong({name:?})"),
             DataAddress::Chunk(addr) => write!(f, "{addr:?}"),
             DataAddress::Register(addr) => write!(f, "{addr:?}"),
             DataAddress::Spend(addr) => write!(f, "{addr:?}"),

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -81,7 +81,7 @@ impl SpendStorage {
     /// NOTE: The `&mut self` signature is necessary to prevent race conditions
     /// and double spent attempts to be missed (as the validation and adding
     /// could otherwise happen in parallel in different threads.)
-    pub(crate) async fn try_add(&mut self, signed_spend: &SignedSpend) -> Result<()> {
+    pub(crate) async fn try_add(&self, signed_spend: &SignedSpend) -> Result<()> {
         self.validate(signed_spend).await?;
         self.add(signed_spend).await
     }
@@ -92,7 +92,7 @@ impl SpendStorage {
     /// NOTE: The `&mut self` signature is necessary to prevent race conditions
     /// and double spent attempts to be missed (as the validation and adding
     /// could otherwise happen in parallel in different threads.)
-    pub(crate) async fn validate(&mut self, signed_spend: &SignedSpend) -> Result<()> {
+    pub(crate) async fn validate(&self, signed_spend: &SignedSpend) -> Result<()> {
         let address = dbc_address(signed_spend.dbc_id());
         if self.try_get_double_spend(&address).await.is_ok() {
             return Err(Error::AlreadyMarkedAsDoubleSpend(address));
@@ -138,7 +138,7 @@ impl SpendStorage {
     /// and double spent attempts to be missed (as the validation and adding
     /// could otherwise happen in parallel in different threads.)
     pub(crate) async fn try_add_double(
-        &mut self,
+        &self,
         a_spend: &SignedSpend,
         b_spend: &SignedSpend,
     ) -> Result<()> {
@@ -177,7 +177,7 @@ impl SpendStorage {
         Ok(())
     }
 
-    async fn add(&mut self, signed_spend: &SignedSpend) -> Result<()> {
+    async fn add(&self, signed_spend: &SignedSpend) -> Result<()> {
         let addr = dbc_address(signed_spend.dbc_id());
         let filepath = self.address_to_filepath(&addr, &self.valid_spends_path)?;
 
@@ -250,7 +250,7 @@ impl SpendStorage {
     }
 
     async fn try_store_double_spend(
-        &mut self,
+        &self,
         a_spend: &SignedSpend,
         b_spend: &SignedSpend,
     ) -> Result<()> {
@@ -300,7 +300,7 @@ mod tests {
     async fn write_and_read_100_spends() {
         // Test that a range of different spends can be stored and read as expected.
         let number_of_spends = 100;
-        let mut storage = init_file_store();
+        let storage = init_file_store();
 
         let key = MainKey::random();
         let dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
@@ -328,7 +328,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_add_is_idempotent() {
-        let mut storage = init_file_store();
+        let storage = init_file_store();
         let key = MainKey::random();
         let src_dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
 
@@ -350,7 +350,7 @@ mod tests {
     #[ignore = "We have temporarily disabled the punishment of double spends. NB it is still detected and hindered, just not punished."]
     #[tokio::test]
     async fn double_spend_attempt_is_detected() {
-        let mut storage = init_file_store();
+        let storage = init_file_store();
         let key = MainKey::random();
         let src_dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
 
@@ -402,7 +402,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_add_double_is_idempotent() {
-        let mut storage = init_file_store();
+        let storage = init_file_store();
         let key = MainKey::random();
         let src_dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
 
@@ -440,7 +440,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_add_fails_after_added_double_spend() {
-        let mut storage = init_file_store();
+        let storage = init_file_store();
         let key = MainKey::random();
         let src_dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
 

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -303,7 +303,7 @@ mod tests {
     use sn_dbc::MainKey;
 
     #[tokio::test]
-    async fn write_and_read_100_spends() {
+    async fn write_and_read_300_spends() {
         // Test that a range of different spends can be stored and read as expected.
         let number_of_spends = 100;
         let storage = init_file_store();
@@ -330,6 +330,42 @@ mod tests {
 
             assert_eq!(spend.to_bytes(), read_spend.to_bytes());
         }
+    }
+
+    #[tokio::test]
+    async fn concurrently_write_and_read_300_spends() {
+        // Test that a range of different spends can be stored and read as expected.
+        let number_of_spends = 300;
+        let storage = init_file_store();
+
+        let key = MainKey::random();
+        let dbc = create_first_dbc_from_key(&key).expect("First dbc creation to succeed.");
+        println!("Splitting into {number_of_spends} spends...");
+        let dbcs = split(&dbc, &key, number_of_spends).expect("Split to succeed.");
+        println!("Split finished.");
+        let spends: Vec<_> = dbcs
+            .into_iter()
+            .flat_map(|(dbc, _)| dbc.signed_spends)
+            .collect();
+
+        assert_eq!(spends.len(), number_of_spends);
+
+        let tasks = spends.into_iter().map(|spend| {
+            let store = storage.clone();
+            tokio::task::spawn(async move {
+                store.try_add(&spend).await.expect("Failed to write spend.");
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                let read_spend = store
+                    .get(&dbc_address(spend.dbc_id()))
+                    .await
+                    .expect("Failed to read spend.");
+
+                assert_eq!(spend.to_bytes(), read_spend.to_bytes());
+            })
+        });
+        let res = futures::future::join_all(tasks).await;
+
+        assert!(res.into_iter().all(|res| res.is_ok()))
     }
 
     #[tokio::test]

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -22,10 +22,12 @@ use bincode::{deserialize, serialize};
 use std::{
     fmt::{self, Display, Formatter},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 use tokio::{
     fs::{create_dir_all, read, remove_file, File},
     io::AsyncWriteExt,
+    sync::RwLock,
 };
 use tracing::trace;
 
@@ -40,6 +42,7 @@ const DOUBLE_SPENDS_STORE_DIR_NAME: &str = "double_spends";
 pub(crate) struct SpendStorage {
     valid_spends_path: PathBuf,
     double_spends_path: PathBuf,
+    sync: Arc<RwLock<()>>,
 }
 
 impl SpendStorage {
@@ -48,6 +51,7 @@ impl SpendStorage {
         Self {
             valid_spends_path: path.join(VALID_SPENDS_STORE_DIR_NAME),
             double_spends_path: path.join(DOUBLE_SPENDS_STORE_DIR_NAME),
+            sync: Arc::new(RwLock::new(())),
         }
     }
 
@@ -93,6 +97,7 @@ impl SpendStorage {
     /// and double spent attempts to be missed (as the validation and adding
     /// could otherwise happen in parallel in different threads.)
     pub(crate) async fn validate(&self, signed_spend: &SignedSpend) -> Result<()> {
+        let _ = self.sync.write().await;
         let address = dbc_address(signed_spend.dbc_id());
         if self.try_get_double_spend(&address).await.is_ok() {
             return Err(Error::AlreadyMarkedAsDoubleSpend(address));
@@ -178,6 +183,7 @@ impl SpendStorage {
     }
 
     async fn add(&self, signed_spend: &SignedSpend) -> Result<()> {
+        let _ = self.sync.write().await;
         let addr = dbc_address(signed_spend.dbc_id());
         let filepath = self.address_to_filepath(&addr, &self.valid_spends_path)?;
 

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -57,9 +57,9 @@ use xor_name::XorName;
 pub(crate) const CLOSE_GROUP_SIZE: usize = 8;
 
 // Timeout for requests sent/received through the request_response behaviour.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3*10);
 // Sets the keep-alive timeout of idle connections.
-const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(3*10);
 
 /// Majority of a given group (i.e. > 1/2).
 #[inline]

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -272,16 +272,17 @@ impl Node {
                         let result = if ok_results.len() >= close_group_majority() {
                             Ok(())
                         } else {
-                            Err(ProtocolError::InternalProcessing(
-                                "Less than majority of close group peers returned an OK response."
-                                    .to_string(),
-                            ))
+                            Err(ProtocolError::InternalProcessing(format!(
+                                "Only {} out of required {} peers returned an OK response.",
+                                ok_results.len(),
+                                close_group_majority()
+                            )))
                         };
 
                         CmdResponse::NodePong(result)
                     }
                     Err(err) => {
-                        warn!("Failed to send ping closest peers: {err:?}");
+                        warn!("Failed to send ping to closest peers: {err:?}");
                         CmdResponse::NodePong(Err(ProtocolError::InternalProcessing(
                             err.to_string(),
                         )))

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -92,7 +92,7 @@ impl Node {
             .await
             .map_err(|e| Error::CouldNotLoadWallet(e.to_string()))?;
 
-        let mut node = Self {
+        let node = Self {
             network: network.clone(),
             registers: RegisterStorage::new(root_dir),
             transfers: Transfers::new(root_dir, node_id, node_wallet),
@@ -122,9 +122,7 @@ impl Node {
         })
     }
 
-    // **** Private helpers *****
-
-    async fn handle_network_event(&mut self, event: NetworkEvent) -> Result<()> {
+    async fn handle_network_event(&self, event: NetworkEvent) -> Result<()> {
         match event {
             NetworkEvent::RequestReceived { req, channel } => {
                 self.handle_request(req, channel).await?
@@ -160,7 +158,7 @@ impl Node {
     }
 
     async fn handle_request(
-        &mut self,
+        &self,
         request: Request,
         response_channel: MsgResponder,
     ) -> Result<()> {
@@ -198,7 +196,7 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_query(&mut self, query: Query) -> QueryResponse {
+    async fn handle_query(&self, query: Query) -> QueryResponse {
         match query {
             Query::Register(query) => self.registers.read(&query, User::Anyone).await,
             Query::GetChunk(address) => {

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -222,7 +222,7 @@ impl Node {
                         // The client is asking for the fee to spend a specific dbc, and including the id of that dbc.
                         // The required fee content is encrypted to that dbc id, and so only the holder of the dbc secret
                         // key can unlock the contents.
-                        let required_fee = self.transfers.get_required_fee(dbc_id, priority);
+                        let required_fee = self.transfers.get_required_fee(dbc_id, priority).await;
                         QueryResponse::GetFees(Ok(required_fee))
                     }
                     SpendQuery::GetDbcSpend(address) => {
@@ -239,7 +239,7 @@ impl Node {
         }
     }
 
-    async fn handle_cmd(&mut self, cmd: Cmd) -> CmdResponse {
+    async fn handle_cmd(&self, cmd: Cmd) -> CmdResponse {
         match cmd {
             Cmd::NodePing(cmd) => {
                 let result = match self.network.node_get_closest_peers(cmd).await {

--- a/safenode/src/protocol/messages/cmd.rs
+++ b/safenode/src/protocol/messages/cmd.rs
@@ -30,6 +30,10 @@ use std::collections::BTreeMap;
 #[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, custom_debug::Debug)]
 pub enum Cmd {
+    /// A ping sent from a node to close group nodes of the given xorname.
+    NodePing(xor_name::XorName),
+    /// A ping sent from a client to close group nodes of the given xorname.
+    ClientPing(xor_name::XorName),
     /// [`Chunk`] write operation.
     ///
     /// [`Chunk`]: crate::domain::storage::Chunk
@@ -60,6 +64,8 @@ impl Cmd {
     /// Used to send a cmd to the close group of the address.
     pub fn dst(&self) -> DataAddress {
         match self {
+            Cmd::NodePing(name) => DataAddress::PingPong(*name),
+            Cmd::ClientPing(name) => DataAddress::PingPong(*name),
             Cmd::StoreChunk(chunk) => DataAddress::Chunk(ChunkAddress::new(*chunk.name())),
             Cmd::Register(cmd) => DataAddress::Register(cmd.dst()),
             Cmd::SpendDbc { signed_spend, .. } => {
@@ -72,6 +78,12 @@ impl Cmd {
 impl std::fmt::Display for Cmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Cmd::NodePing(name) => {
+                write!(f, "Cmd::NodePing({name:?})")
+            }
+            Cmd::ClientPing(name) => {
+                write!(f, "Cmd::ClientPing({name:?})")
+            }
             Cmd::StoreChunk(chunk) => {
                 write!(f, "Cmd::StoreChunk({:?})", chunk.name())
             }

--- a/safenode/src/protocol/messages/response.rs
+++ b/safenode/src/protocol/messages/response.rs
@@ -75,6 +75,8 @@ pub enum QueryResponse {
 /// The response to a Cmd, containing the query result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CmdResponse {
+    /// Response to Cmd::NodePing _and_ Cmd::ClientPing,
+    NodePong(Result<()>),
     //
     // ===== Dbc Spends =====
     //

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -56,9 +56,10 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
         .collect();
 
     if ok_results.len() >= close_group_majority() {
+        println!("Yay! {} out of the required {} peers returned an OK response.", ok_results.len(), close_group_majority());
         Ok(())
     } else {
-        panic!("Less than majority of close group peers returned an OK response.");
+        panic!("Only {} out of required {} peers returned an OK response.", ok_results.len(), close_group_majority());
     }
 }
 

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -34,7 +34,7 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
 
     trace!("Adding a small delay to allow the client to find enough nodes.");
     // Some sleep is required to allow the client to find enough nodes.
-    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
     trace!("Sending ping to closest nodes...");
 
     let results = match client

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -56,10 +56,18 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
         .collect();
 
     if ok_results.len() >= close_group_majority() {
-        println!("Yay! {} out of the required {} peers returned an OK response.", ok_results.len(), close_group_majority());
+        println!(
+            "Yay! {} out of the required {} peers returned an OK response.",
+            ok_results.len(),
+            close_group_majority()
+        );
         Ok(())
     } else {
-        panic!("Only {} out of required {} peers returned an OK response.", ok_results.len(), close_group_majority());
+        panic!(
+            "Only {} out of required {} peers returned an OK response.",
+            ok_results.len(),
+            close_group_majority()
+        );
     }
 }
 

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -38,7 +38,7 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
     trace!("Sending ping to closest nodes...");
 
     let results = match client
-        .send_to_closest(Request::Cmd(Cmd::ClientPing(random_dst)))
+        .send_to_local_closest(Request::Cmd(Cmd::ClientPing(random_dst)))
         .await
     {
         Ok(results) => results,

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -34,7 +34,7 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
 
     trace!("Adding a small delay to allow the client to find enough nodes.");
     // Some sleep is required to allow the client to find enough nodes.
-    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
     trace!("Sending ping to closest nodes...");
 
     let results = match client

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -23,6 +23,7 @@ use eyre::Result;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
+    let _log_appender_guard = crate::log::init_node_logging(&None)?;
     use crate::{
         network::close_group_majority,
         protocol::messages::{Cmd, CmdResponse, Request, Response},
@@ -30,6 +31,11 @@ async fn node_many_to_many_ping_pong_succeeds() -> Result<()> {
 
     let client = get_client();
     let random_dst = rand::random();
+
+    trace!("Adding a small delay to allow the client to find enough nodes.");
+    // Some sleep is required to allow the client to find enough nodes.
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+    trace!("Sending ping to closest nodes...");
 
     let results = match client
         .send_to_closest(Request::Cmd(Cmd::ClientPing(random_dst)))


### PR DESCRIPTION
For demonstrating this issue. Not for merge (at least not now).

A client sends a `ClientPing` to close group nodes of a given name.
Those nodes send a `NodePing` to close group nodes of the hash of the original name.
A node that receives a `NodePing`, will return `NodePong(Ok(()))` if it considers itself to be among the close group nodes of the given name.

The nodes receiving a `ClientPing`, will return a `NodePong(Ok(()))` if a majority of the nodes they queried, returned a `NodePong(Ok(()))`.

The test will succeed if the client receives a majority of `NodePong(Ok(()))`.