### PR TITLE
feat(node): node to broadcast storage events for Chunks, Registers and DBC Spends

### DIFF
--- a/safenode/src/bin/safenode/main.rs
+++ b/safenode/src/bin/safenode/main.rs
@@ -167,6 +167,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
         loop {
             match node_events_rx.recv().await {
                 Ok(NodeEvent::ConnectedToNetwork) => info!("Connected to the Network"),
+                Ok(_) => { /* we ignore other evvents */ }
                 Err(RecvError::Closed) => {
                     if let Err(err) = ctrl_tx
                         .send(NodeCtrl::Stop {

--- a/safenode/src/node/event.rs
+++ b/safenode/src/node/event.rs
@@ -6,6 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::domain::storage::{ChunkAddress, RegisterAddress};
+
+use sn_dbc::DbcId;
 use tokio::sync::broadcast;
 
 /// Channel where users of the public API can listen to events broadcasted by the node.
@@ -41,4 +44,12 @@ impl NodeEventsChannel {
 pub enum NodeEvent {
     /// The node has been connected to the network
     ConnectedToNetwork,
+    /// A Chunk has been stored in local storage
+    ChunkStored(ChunkAddress),
+    /// A Register has been created in local storage
+    RegisterCreated(RegisterAddress),
+    /// A Register edit operation has been applied in local storage
+    RegisterEdited(RegisterAddress),
+    /// A DBC Spend has been stored in local storage
+    SpendStored(DbcId),
 }


### PR DESCRIPTION
Example output when using the `safenode_rpc_client` example app:
 ```
$ cargo run --release --example safenode_rpc_client 127.0.0.1:12001 events
Starting logging to stdout
Listening to node events... (press Ctrl+C to exit)
New event received: Event-ChunkStored(ChunkAddress(e984d3(11101001)..))
New event received: Event-ChunkStored(ChunkAddress(6b4456(01101011)..))
New event received: Event-ChunkStored(ChunkAddress(ad80db(10101101)..))
New event received: Event-RegisterCreated(RegisterAddress { name: 90d3af(10010000).., tag: 5000 })
New event received: Event-RegisterEdited(RegisterAddress { name: 90d3af(10010000).., tag: 5000 })
New event received: Event-RegisterEdited(RegisterAddress { name: 90d3af(10010000).., tag: 5000 })
New event received: Event-ChunkStored(ChunkAddress(679629(01100111)..))
New event received: Event-ChunkStored(ChunkAddress(4fe0d8(01001111)..))
New event received: Event-RegisterCreated(RegisterAddress { name: 86fa6d(10000110).., tag: 7302 })
```