### PR TITLE
chore: remove node msg handling mut access

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -45,7 +45,7 @@ impl Client {
             events_channel,
             signer,
         };
-        let mut client_clone = client.clone();
+        let client_clone = client.clone();
 
         let _swarm_driver = spawn({
             trace!("Starting up client swarm_driver");
@@ -71,7 +71,7 @@ impl Client {
         Ok(client)
     }
 
-    fn handle_network_event(&mut self, event: NetworkEvent) -> Result<()> {
+    fn handle_network_event(&self, event: NetworkEvent) -> Result<()> {
         match event {
             // Clients do not handle requests.
             NetworkEvent::RequestReceived { .. } => {}

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -211,7 +211,7 @@ impl SpendStorage {
         file.write_all(&bytes).await?;
         // Sync up OS data to disk to reduce the chances of
         // concurrent reading failing by reading an empty/incomplete file.
-        file.sync_data().await?;
+        file.sync_all().await?;
 
         trace!("Stored new spend {addr:?}.");
 

--- a/safenode/src/domain/storage/spends.rs
+++ b/safenode/src/domain/storage/spends.rs
@@ -360,7 +360,7 @@ mod tests {
         let tasks = spends.into_iter().map(|spend| {
             let store = storage.clone();
             tokio::task::spawn(async move {
-                store.try_add(&spend).await.expect("Failed to write spend.");
+                let _ = store.try_add(&spend).await.expect("Failed to write spend.");
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                 let read_spend = store
                     .get(&dbc_address(spend.dbc_id()))

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -222,7 +222,7 @@ impl Node {
                         // The client is asking for the fee to spend a specific dbc, and including the id of that dbc.
                         // The required fee content is encrypted to that dbc id, and so only the holder of the dbc secret
                         // key can unlock the contents.
-                        let required_fee = self.transfers.get_required_fee(dbc_id, priority);
+                        let required_fee = self.transfers.get_required_fee(dbc_id, priority).await;
                         QueryResponse::GetFees(Ok(required_fee))
                     }
                     SpendQuery::GetDbcSpend(address) => {
@@ -239,7 +239,7 @@ impl Node {
         }
     }
 
-    async fn handle_cmd(&mut self, cmd: Cmd) -> CmdResponse {
+    async fn handle_cmd(&self, cmd: Cmd) -> CmdResponse {
         match cmd {
             Cmd::StoreChunk(chunk) => {
                 let addr = *chunk.address();

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -92,7 +92,7 @@ impl Node {
             .await
             .map_err(|e| Error::CouldNotLoadWallet(e.to_string()))?;
 
-        let mut node = Self {
+        let node = Self {
             network: network.clone(),
             registers: RegisterStorage::new(root_dir),
             transfers: Transfers::new(root_dir, node_id, node_wallet),
@@ -122,9 +122,7 @@ impl Node {
         })
     }
 
-    // **** Private helpers *****
-
-    async fn handle_network_event(&mut self, event: NetworkEvent) -> Result<()> {
+    async fn handle_network_event(&self, event: NetworkEvent) -> Result<()> {
         match event {
             NetworkEvent::RequestReceived { req, channel } => {
                 self.handle_request(req, channel).await?
@@ -159,11 +157,7 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_request(
-        &mut self,
-        request: Request,
-        response_channel: MsgResponder,
-    ) -> Result<()> {
+    async fn handle_request(&self, request: Request, response_channel: MsgResponder) -> Result<()> {
         trace!("Handling request: {request:?}");
         let response = match request {
             Request::Cmd(cmd) => Response::Cmd(self.handle_cmd(cmd).await),
@@ -198,7 +192,7 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_query(&mut self, query: Query) -> QueryResponse {
+    async fn handle_query(&self, query: Query) -> QueryResponse {
         match query {
             Query::Register(query) => self.registers.read(&query, User::Anyone).await,
             Query::GetChunk(address) => {


### PR DESCRIPTION
This should decrease the cases of sequential access or deadlocks, which may have contributed to [this issue](https://github.com/maidsafe/safe_network/issues/207).

Although tests on this PR shows that the issues persist.

Nevertheless, it should be better to push down any locking further down, to decrease the amount of calls/logic that get serialized.