### PR TITLE
refactor: impl canonical network key

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -17,6 +17,7 @@ use crate::{
     protocol::{
         messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response, SpendQuery},
         storage::{dbc_address, dbc_name, Chunk, ChunkAddress},
+        NetworkKey,
     },
 };
 
@@ -111,16 +112,13 @@ impl Client {
             NetworkEvent::PeerAdded(peer_id) => {
                 self.events_channel
                     .broadcast(ClientEvent::ConnectedToNetwork);
-                let target = {
-                    let mut rng = rand::thread_rng();
-                    XorName::random(&mut rng)
-                };
 
+                let key = NetworkKey::from_peer(peer_id);
                 let network = self.network.clone();
                 let _handle = spawn(async move {
-                    trace!("On PeerAdded({peer_id:?}) Getting closest peers for target {target:?}");
-                    let result = network.client_get_closest_peers(target).await;
-                    trace!("For target {target:?}, get closest peers {result:?}");
+                    trace!("On PeerAdded({peer_id:?}) Getting closest peers for target {key:?}");
+                    let result = network.client_get_closest_peers(&key).await;
+                    trace!("For target {key:?}, get closest peers {result:?}");
                 });
             }
         }
@@ -214,17 +212,6 @@ impl Client {
         }
     }
 
-    /// This is for network testing only
-    pub async fn get_closest(&self, dst: XorName) -> Vec<PeerId> {
-        match self.network.client_get_closest_peers(dst).await {
-            Ok(peers) => peers,
-            Err(err) => {
-                warn!("Failed to get_closest of {dst:?} with error {err:?}");
-                vec![]
-            }
-        }
-    }
-
     pub(crate) async fn send_to_closest(&self, request: Request) -> Result<Vec<Result<Response>>> {
         let responses = self
             .network
@@ -238,11 +225,10 @@ impl Client {
 
     pub(crate) async fn expect_closest_majority_ok(&self, spend: SpendRequest) -> Result<()> {
         let dbc_id = spend.signed_spend.dbc_id();
-        trace!("Getting the closest peers to {dbc_id:?}.");
-        let closest_peers = self
-            .network
-            .client_get_closest_peers(dbc_name(dbc_id))
-            .await?;
+        let key = NetworkKey::from_name(dbc_name(dbc_id));
+
+        trace!("Getting the closest peers to {dbc_id:?} / {key:?}.");
+        let closest_peers = self.network.client_get_closest_peers(&key).await?;
 
         let cmd = Cmd::SpendDbc {
             signed_spend: Box::new(spend.signed_spend),
@@ -293,12 +279,10 @@ impl Client {
     }
 
     pub(crate) async fn expect_closest_majority_same(&self, dbc_id: &DbcId) -> Result<SignedSpend> {
-        trace!("Getting the closest peers to {dbc_id:?}.");
+        let key = NetworkKey::from_name(dbc_name(dbc_id));
+        trace!("Getting the closest peers to {dbc_id:?} / {key:?}.");
         let address = dbc_address(dbc_id);
-        let closest_peers = self
-            .network
-            .client_get_closest_peers(*address.name())
-            .await?;
+        let closest_peers = self.network.client_get_closest_peers(&key).await?;
 
         let query = Query::Spend(SpendQuery::GetDbcSpend(address));
         trace!("Sending {:?} to the closest peers.", query);

--- a/safenode/src/domain/client_transfers/online.rs
+++ b/safenode/src/domain/client_transfers/online.rs
@@ -151,7 +151,7 @@ async fn select_inputs(
                         .reward_address
                         .random_dbc_id_src(&mut rand::thread_rng());
                     recipients.push((*fee, dbc_id_src));
-                    let _ = node_fees.insert(*node_id, (required_fee.clone(), dbc_id_src));
+                    let _ = node_fees.insert(node_id.clone(), (required_fee.clone(), dbc_id_src));
                 });
 
             let _ = node_fees_per_input.insert(dbc_id, node_fees);
@@ -425,7 +425,7 @@ fn fee_ciphers(
         // Encrypt the amount to the _derived key_ (i.e. new dbc id).
         let amount_cipher = revealed_amount.encrypt(&dbc_id);
         let _ = input_fee_ciphers.insert(
-            *node_id,
+            node_id.clone(),
             FeeCiphers::new(amount_cipher, derivation_index_cipher),
         );
     }

--- a/safenode/src/domain/node_transfers/mod.rs
+++ b/safenode/src/domain/node_transfers/mod.rs
@@ -79,7 +79,7 @@ impl Transfers {
         let reward_address_sig = self.node_wallet.sign(&content.to_bytes());
         let required_fee = RequiredFee::new(content, reward_address_sig);
 
-        (self.node_id, required_fee)
+        (self.node_id.clone(), required_fee)
     }
 
     /// Get the current fee for the specified spend priority.
@@ -169,7 +169,7 @@ impl Transfers {
         dst_tx: &DbcTransaction,
         fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
     ) -> Result<Token> {
-        let fee_paid = decipher_fee(&self.node_wallet, dst_tx, self.node_id, fee_ciphers)?;
+        let fee_paid = decipher_fee(&self.node_wallet, dst_tx, &self.node_id, fee_ciphers)?;
 
         let spend_q_snapshot = self.spend_queue.snapshot();
         let spend_q_stats = spend_q_snapshot.stats();
@@ -236,13 +236,13 @@ fn validate_parent_spends(
 fn decipher_fee(
     node_wallet: &LocalWallet,
     dst_tx: &DbcTransaction,
-    node_id: NodeId,
+    node_id: &NodeId,
     fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
 ) -> Result<Token> {
     use super::wallet::SigningWallet;
     let fee_ciphers = fee_ciphers
-        .get(&node_id)
-        .ok_or(Error::MissingFeeCiphers(node_id))?;
+        .get(node_id)
+        .ok_or(Error::MissingFeeCiphers(node_id.clone()))?;
     let (dbc_id, revealed_amount) = node_wallet
         .decrypt(fee_ciphers)
         .map_err(|e| Error::FeeCipherDecryptionFailed(e.to_string()))?;
@@ -252,7 +252,7 @@ fn decipher_fee(
         .find(|proof| proof.dbc_id() == &dbc_id)
     {
         Some(proof) => proof,
-        None => return Err(Error::MissingFee((node_id, dbc_id))),
+        None => return Err(Error::MissingFee((node_id.clone(), dbc_id))),
     };
 
     let blinded_amount = revealed_amount.blinded_amount(&sn_dbc::PedersenGens::default());

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -10,7 +10,10 @@ use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
 
 use crate::{
     network::error::Result,
-    protocol::messages::{QueryResponse, Request, Response},
+    protocol::{
+        messages::{QueryResponse, Request, Response},
+        NetworkKey,
+    },
 };
 
 use libp2p::{
@@ -20,7 +23,6 @@ use libp2p::{
 };
 use std::collections::{hash_map, HashSet};
 use tokio::sync::oneshot;
-use xor_name::XorName;
 
 /// Commands to send to the Swarm
 #[derive(Debug)]
@@ -40,7 +42,7 @@ pub enum SwarmCmd {
         sender: oneshot::Sender<Result<()>>,
     },
     GetClosestPeers {
-        xor_name: XorName,
+        key: NetworkKey,
         sender: oneshot::Sender<HashSet<PeerId>>,
     },
     SendRequest {
@@ -128,10 +130,12 @@ impl SwarmDriver {
                     let _ = sender.send(Err(Error::AlreadyDialingPeer(peer_id)));
                 }
             }
-
-            SwarmCmd::GetClosestPeers { xor_name, sender } => {
-                let key = xor_name.0.to_vec();
-                let query_id = self.swarm.behaviour_mut().kademlia.get_closest_peers(key);
+            SwarmCmd::GetClosestPeers { key, sender } => {
+                let query_id = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .get_closest_peers(key.as_bytes());
                 let _ = self
                     .pending_get_closest_peers
                     .insert(query_id, (sender, Default::default()));

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -24,15 +24,18 @@ use self::{
     msg::{MsgCodec, MsgProtocol},
 };
 
-use crate::protocol::messages::{QueryResponse, Request, Response};
+use crate::protocol::{
+    messages::{QueryResponse, Request, Response},
+    NetworkKey,
+};
 
 use futures::{future::select_all, StreamExt};
 use libp2p::{
     core::muxing::StreamMuxerBox,
     identity,
     kad::{
-        record::store::MemoryStore, store::MemoryStoreConfig, KBucketKey, Kademlia, KademliaConfig,
-        QueryId, Record, RecordKey,
+        record::store::MemoryStore, store::MemoryStoreConfig, Kademlia, KademliaConfig, QueryId,
+        Record, RecordKey,
     },
     mdns,
     multiaddr::Protocol,
@@ -49,7 +52,6 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use xor_name::XorName;
 
 /// The maximum number of peers to return in a `GetClosestPeers` response.
 /// This is the group size used in safe network protocol to be responsible for
@@ -171,10 +173,6 @@ impl SwarmDriver {
         let peer_id = PeerId::from(keypair.public());
 
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
-        info!(
-            "PeerId converted to XorName: {peer_id} - {:?}",
-            XorName::from_content(&peer_id.to_bytes())
-        );
 
         // RequestResponse configuration
         let mut req_res_config = RequestResponseConfig::default();
@@ -329,14 +327,14 @@ impl Network {
 
     /// Returns the closest peers to the given `XorName`, sorted by their distance to the xor_name.
     /// Excludes the client's `PeerId` while calculating the closest peers.
-    pub async fn client_get_closest_peers(&self, xor_name: XorName) -> Result<Vec<PeerId>> {
-        self.get_closest_peers(xor_name, true).await
+    pub async fn client_get_closest_peers(&self, key: &NetworkKey) -> Result<Vec<PeerId>> {
+        self.get_closest_peers(key, true).await
     }
 
-    /// Returns the closest peers to the given `XorName`, sorted by their distance to the xor_name.
+    /// Returns the closest peers to the given `NetworkKey`, sorted by their distance to the key.
     /// Includes our node's `PeerId` while calculating the closest peers.
-    pub async fn node_get_closest_peers(&self, xor_name: XorName) -> Result<Vec<PeerId>> {
-        self.get_closest_peers(xor_name, false).await
+    pub async fn node_get_closest_peers(&self, key: &NetworkKey) -> Result<Vec<PeerId>> {
+        self.get_closest_peers(key, false).await
     }
 
     /// Send `Request` to the closest peers. If `self` is among the closest_peers, the `Request` is
@@ -346,9 +344,9 @@ impl Network {
     pub async fn node_send_to_closest(&self, request: &Request) -> Result<Vec<Result<Response>>> {
         info!(
             "Sending {request:?} with dst {:?} to the closest peers.",
-            request.dst().name()
+            request.dst().key()
         );
-        let closest_peers = self.node_get_closest_peers(*request.dst().name()).await?;
+        let closest_peers = self.node_get_closest_peers(&request.dst().key()).await?;
 
         Ok(self
             .send_and_get_responses(closest_peers, request, true)
@@ -362,9 +360,9 @@ impl Network {
     pub async fn fire_and_forget_to_closest(&self, request: &Request) -> Result<()> {
         info!(
             "Sending {request:?} with dst {:?} to the closest peers.",
-            request.dst().name()
+            request.dst().key()
         );
-        let closest_peers = self.node_get_closest_peers(*request.dst().name()).await?;
+        let closest_peers = self.node_get_closest_peers(&request.dst().key()).await?;
         for peer in closest_peers {
             self.fire_and_forget(request.clone(), peer).await?;
         }
@@ -375,9 +373,9 @@ impl Network {
     pub async fn client_send_to_closest(&self, request: &Request) -> Result<Vec<Result<Response>>> {
         info!(
             "Sending {request:?} with dst {:?} to the closest peers.",
-            request.dst().name()
+            request.dst().key()
         );
-        let closest_peers = self.client_get_closest_peers(*request.dst().name()).await?;
+        let closest_peers = self.client_get_closest_peers(&request.dst().key()).await?;
 
         Ok(self
             .send_and_get_responses(closest_peers, request, true)
@@ -447,11 +445,14 @@ impl Network {
 
     /// Returns the closest peers to the given `XorName`, sorted by their distance to the xor_name.
     /// If `client` is false, then include `self` among the `closest_peers`
-    async fn get_closest_peers(&self, xor_name: XorName, client: bool) -> Result<Vec<PeerId>> {
-        debug!("Getting the closest peers to {xor_name:?}");
+    async fn get_closest_peers(&self, key: &NetworkKey, client: bool) -> Result<Vec<PeerId>> {
+        debug!("Getting the closest peers to {key:?}");
         let (sender, receiver) = oneshot::channel();
-        self.send_swarm_cmd(SwarmCmd::GetClosestPeers { xor_name, sender })
-            .await?;
+        self.send_swarm_cmd(SwarmCmd::GetClosestPeers {
+            key: key.clone(),
+            sender,
+        })
+        .await?;
         let k_bucket_peers = receiver.await?;
 
         // Count self in if among the CLOSE_GROUP_SIZE closest and sort the result
@@ -459,16 +460,15 @@ impl Network {
         if !client {
             closest_peers.push(self.peer_id);
         }
-        self.sort_peers_by_key(closest_peers, xor_name.0.to_vec())
+        self.sort_peers_by_key(closest_peers, key)
     }
 
     /// Sort the provided peers by their distance to the given key.
-    fn sort_peers_by_key(&self, mut peers: Vec<PeerId>, key: Vec<u8>) -> Result<Vec<PeerId>> {
-        let target = KBucketKey::new(key);
+    fn sort_peers_by_key(&self, mut peers: Vec<PeerId>, key: &NetworkKey) -> Result<Vec<PeerId>> {
         peers.sort_by(|a, b| {
-            let a = KBucketKey::new(a.to_bytes());
-            let b = KBucketKey::new(b.to_bytes());
-            target.distance(&a).cmp(&target.distance(&b))
+            let a = NetworkKey::from_peer(*a);
+            let b = NetworkKey::from_peer(*b);
+            key.distance(&a).cmp(&key.distance(&b))
         });
         let peers: Vec<PeerId> = peers.iter().take(CLOSE_GROUP_SIZE).cloned().collect();
 
@@ -521,8 +521,11 @@ mod tests {
         log::init_test_logger,
         network::{MsgResponder, NetworkEvent},
         protocol::{
-            messages::{Cmd, CmdResponse, Request, Response},
-            storage::Chunk,
+            NetworkKey,
+            {
+                messages::{Cmd, CmdResponse, Request, Response},
+                storage::Chunk,
+            },
         },
     };
 
@@ -564,8 +567,7 @@ mod tests {
 
         // Check the closest nodes to the following random_data
         let mut rng = thread_rng();
-        let random_data = XorName::random(&mut rng);
-        let random_data_key = KBucketKey::from(random_data.0.to_vec());
+        let random_data = NetworkKey::from_name(XorName::random(&mut rng));
 
         tokio::time::sleep(Duration::from_secs(5)).await;
         let our_net = networks_list
@@ -594,7 +596,7 @@ mod tests {
             }
         }
         let expected_from_table = table
-            .closest_keys(&random_data_key)
+            .closest_keys(&random_data.as_kbucket_key())
             .map(|key| {
                 key_to_peer_id
                     .get(&key)
@@ -606,7 +608,7 @@ mod tests {
         info!("Got Closest from table {:?}", expected_from_table.len());
 
         // Ask the other nodes for the closest_peers.
-        let closest = our_net.get_closest_peers(random_data, false).await?;
+        let closest = our_net.get_closest_peers(&random_data, false).await?;
 
         assert_lists(closest, expected_from_table);
         Ok(())

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -23,6 +23,7 @@ use crate::{
             Request, Response, SpendQuery,
         },
         storage::{dbc_address, registers::User, DbcAddress},
+        NetworkKey,
     },
 };
 
@@ -38,7 +39,6 @@ use std::{
     path::Path,
 };
 use tokio::{sync::mpsc, task::spawn};
-use xor_name::XorName;
 
 #[derive(Debug)]
 pub(super) struct TransferAction {
@@ -154,16 +154,12 @@ impl Node {
             }
             NetworkEvent::PeerAdded(peer) => {
                 self.events_channel.broadcast(NodeEvent::ConnectedToNetwork);
-                let target = {
-                    let mut rng = rand::thread_rng();
-                    XorName::random(&mut rng)
-                };
-
+                let key = NetworkKey::from_peer(peer);
                 let network = self.network.clone();
                 let _handle = spawn(async move {
-                    trace!("On PeerAdded({peer:?}) Getting closest peers for target {target:?}");
-                    let result = network.node_get_closest_peers(target).await;
-                    trace!("For target {target:?}, get closest peers {result:?}");
+                    trace!("On PeerAdded({peer:?}) Getting closest peers for target {key:?}...");
+                    let result = network.node_get_closest_peers(&key).await;
+                    trace!("Closest peers to {key:?} got: {result:?}.");
                 });
             }
             NetworkEvent::NewListenAddr(_) => {

--- a/safenode/src/protocol/error/mod.rs
+++ b/safenode/src/protocol/error/mod.rs
@@ -29,4 +29,7 @@ pub enum Error {
     /// Errors in node transfer handling.
     #[error("Transfer error: {0:?}")]
     Transfers(#[from] TransferError),
+    /// Error when converting a NodeId back to a PeerId.
+    #[error("The network key could not be cast to a peer id: {0:?}")]
+    NotAPeerId(Vec<u8>),
 }

--- a/safenode/src/protocol/error/mod.rs
+++ b/safenode/src/protocol/error/mod.rs
@@ -29,7 +29,10 @@ pub enum Error {
     /// Errors in node transfer handling.
     #[error("Transfer error: {0:?}")]
     Transfers(#[from] TransferError),
-    /// Error when converting a NodeId back to a PeerId.
-    #[error("The network key could not be cast to a peer id: {0:?}")]
-    NotAPeerId(Vec<u8>),
+    /// Error when converting to a PeerId.
+    #[error("Could not convert to a PeerId: {0:?}")]
+    NotAPeerId(String),
+    /// Error when converting to an XorName.
+    #[error("Could not convert to an XorName: {0:?}")]
+    NotAnXorName(String),
 }

--- a/safenode/src/protocol/messages/node_id.rs
+++ b/safenode/src/protocol/messages/node_id.rs
@@ -6,27 +6,31 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::protocol::error::{Error, Result};
+
 use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
-use xor_name::XorName;
 
 /// A unique identifier for a node in the network,
 /// by which we can know their location in the xor space.
-#[derive(
-    Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
-)]
-pub struct NodeId(XorName);
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct NodeId(Vec<u8>);
 
 impl NodeId {
-    /// Returns a `NodeId` representation of the `PeerId` by hashing its bytes.
+    /// Returns a `NodeId` representation of the `PeerId` by encapsulating its bytes.
     pub fn from(peer_id: PeerId) -> Self {
-        Self(XorName::from_content(&peer_id.to_bytes()))
+        Self(peer_id.to_bytes())
     }
 
     /// Returns this NodeId as bytes
     pub fn as_bytes(&self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    /// Returns this NodeId as PeerId
+    pub fn as_peer_id(&self) -> Result<PeerId> {
+        PeerId::from_bytes(&self.0).map_err(|_| Error::NotAPeerId(self.0.clone()))
     }
 }
 

--- a/safenode/src/protocol/messages/node_id.rs
+++ b/safenode/src/protocol/messages/node_id.rs
@@ -30,7 +30,7 @@ impl NodeId {
 
     /// Returns this NodeId as PeerId
     pub fn as_peer_id(&self) -> Result<PeerId> {
-        PeerId::from_bytes(&self.0).map_err(|_| Error::NotAPeerId(self.0.clone()))
+        PeerId::from_bytes(&self.0).map_err(|err| Error::NotAPeerId(err.to_string()))
     }
 }
 

--- a/safenode/src/protocol/mod.rs
+++ b/safenode/src/protocol/mod.rs
@@ -10,5 +10,66 @@
 pub mod error;
 /// Messages types
 pub mod messages;
+
+use libp2p::{
+    kad::{kbucket::Distance, KBucketKey as Key},
+    PeerId,
+};
+use xor_name::XorName;
+
+/// This is the key in the network by which proximity/distance
+/// to other items (wether nodes or data chunks) are calculated.
+///
+/// This is the mapping from the XOR name used
+/// by for example self encryption, or the libp2p PeerId,
+/// to the key used in the Kademlia DHT.
+/// All our xorname calculations shall be replaced with the KBucketKey calculations,
+/// for getting proximity/distance to other items (wether nodes or data chunks).
+pub enum NetworkKey {
+    /// The NetworkKey is representing a PeerId.
+    PeerId(Vec<u8>),
+    /// The NetworkKey is representing an XorName.
+    XorName(Vec<u8>),
+}
+
+impl NetworkKey {
+    /// Returns a `NetworkKey` representation of the `XorName` by encapsulating its bytes.
+    pub fn from_name(name: XorName) -> Self {
+        NetworkKey::XorName(name.0.to_vec())
+    }
+
+    /// Returns a `NetworkKey` representation of the `PeerId` by encapsulating its bytes.
+    pub fn from_peer_id(peer_id: PeerId) -> Self {
+        NetworkKey::PeerId(peer_id.to_bytes())
+    }
+
+    /// Return the encapsulated bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            NetworkKey::PeerId(bytes) => bytes.to_vec(),
+            NetworkKey::XorName(bytes) => bytes.to_vec(),
+        }
+    }
+
+    /// Return the encapsulated bytes as a `KBucketKey`.
+    pub fn as_kbucket_key(&self) -> Key<Vec<u8>> {
+        Key::new(self.as_bytes())
+    }
+
+    /// Computes the distance of the keys according to the XOR metric.
+    pub fn distance<U>(&self, other: &NetworkKey) -> Distance {
+        self.as_kbucket_key().distance(&other.as_kbucket_key())
+    }
+
+    // NB: Leaving this here as to demonstrate what we can do with this.
+    // /// Returns the uniquely determined key with the given distance to `self`.
+    // ///
+    // /// This implements the following equivalence:
+    // ///
+    // /// `self xor other = distance <==> other = self xor distance`
+    // pub fn for_distance(&self, d: Distance) -> libp2p::kad::kbucket::KeyBytes {
+    //     self.as_kbucket_key().for_distance(d)
+    // }
+}
 /// Storage types for spends, chunks and registers.
 pub mod storage;

--- a/safenode/src/protocol/mod.rs
+++ b/safenode/src/protocol/mod.rs
@@ -11,39 +11,43 @@ pub mod error;
 /// Messages types
 pub mod messages;
 
+use self::error::{Error, Result};
+
 use libp2p::{
     kad::{kbucket::Distance, KBucketKey as Key},
     PeerId,
 };
-use xor_name::XorName;
+use serde::{Deserialize, Serialize};
+use xor_name::{XorName, XOR_NAME_LEN};
 
 /// This is the key in the network by which proximity/distance
 /// to other items (wether nodes or data chunks) are calculated.
 ///
 /// This is the mapping from the XOR name used
-/// by for example self encryption, or the libp2p PeerId,
+/// by for example self encryption, or the libp2p `PeerId`,
 /// to the key used in the Kademlia DHT.
-/// All our xorname calculations shall be replaced with the KBucketKey calculations,
-/// for getting proximity/distance to other items (wether nodes or data chunks).
+/// All our xorname calculations shall be replaced with the `KBucketKey` calculations,
+/// for getting proximity/distance to other items (wether nodes or data).
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum NetworkKey {
     /// The NetworkKey is representing a PeerId.
     PeerId(Vec<u8>),
-    /// The NetworkKey is representing an XorName.
+    /// The NetworkKey is representing an XorName of some data.
     XorName(Vec<u8>),
 }
 
 impl NetworkKey {
-    /// Returns a `NetworkKey` representation of the `XorName` by encapsulating its bytes.
+    /// Return a `NetworkKey` representation of the `XorName` by encapsulating its bytes.
     pub fn from_name(name: XorName) -> Self {
         NetworkKey::XorName(name.0.to_vec())
     }
 
-    /// Returns a `NetworkKey` representation of the `PeerId` by encapsulating its bytes.
-    pub fn from_peer_id(peer_id: PeerId) -> Self {
+    /// Return a `NetworkKey` representation of the `PeerId` by encapsulating its bytes.
+    pub fn from_peer(peer_id: PeerId) -> Self {
         NetworkKey::PeerId(peer_id.to_bytes())
     }
 
-    /// Return the encapsulated bytes.
+    /// Return the encapsulated bytes of this `NetworkKey`.
     pub fn as_bytes(&self) -> Vec<u8> {
         match self {
             NetworkKey::PeerId(bytes) => bytes.to_vec(),
@@ -51,18 +55,50 @@ impl NetworkKey {
         }
     }
 
-    /// Return the encapsulated bytes as a `KBucketKey`.
+    /// Try to convert this `NetworkKey` to an `XorName`.
+    pub fn as_name(&self) -> Result<XorName> {
+        let bytes = match self {
+            NetworkKey::PeerId(bytes) => {
+                return Err(Error::NotAnXorName(format!("Not an xorname: {bytes:?}")))
+            }
+            NetworkKey::XorName(bytes) => bytes,
+        };
+        let mut xor = [0u8; XOR_NAME_LEN];
+        xor.copy_from_slice(&bytes[..XOR_NAME_LEN]);
+        Ok(XorName(xor))
+    }
+
+    /// Try to convert this `NetworkKey` to a `PeerId`.
+    pub fn as_peer(&self) -> Result<PeerId> {
+        let bytes = match self {
+            NetworkKey::PeerId(bytes) => bytes.to_vec(),
+            NetworkKey::XorName(bytes) => {
+                return Err(Error::NotAPeerId(format!("Not a peer id: {bytes:?}")))
+            }
+        };
+        match PeerId::from_bytes(&bytes) {
+            Ok(peer_id) => Ok(peer_id),
+            Err(err) => Err(Error::NotAPeerId(format!("Invalid peer id bytes: {err}"))),
+        }
+    }
+
+    /// Return the `KBucketKey` representation of this `NetworkKey`.
+    ///
+    /// The `KBucketKey` is used for calculating proximity/distance to other items (wether nodes or data).
+    /// Important to note is that it will always SHA256 hash any bytes it receives.
+    /// Therefore, the canonical use of distance/proximity calculations in the network
+    /// is via the `KBucketKey`, or the convenience methods of `NetworkKey`.
     pub fn as_kbucket_key(&self) -> Key<Vec<u8>> {
         Key::new(self.as_bytes())
     }
 
-    /// Computes the distance of the keys according to the XOR metric.
-    pub fn distance<U>(&self, other: &NetworkKey) -> Distance {
+    /// Compute the distance of the keys according to the XOR metric.
+    pub fn distance(&self, other: &NetworkKey) -> Distance {
         self.as_kbucket_key().distance(&other.as_kbucket_key())
     }
 
     // NB: Leaving this here as to demonstrate what we can do with this.
-    // /// Returns the uniquely determined key with the given distance to `self`.
+    // /// Return the uniquely determined key with the given distance to `self`.
     // ///
     // /// This implements the following equivalence:
     // ///

--- a/safenode/src/protocol/storage/address/mod.rs
+++ b/safenode/src/protocol/storage/address/mod.rs
@@ -10,6 +10,8 @@ mod chunk;
 mod dbc;
 mod register;
 
+use crate::protocol::NetworkKey;
+
 pub use self::{
     chunk::ChunkAddress,
     dbc::{dbc_address, dbc_name, DbcAddress},
@@ -22,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 /// An address of data on the network.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DataAddress {
     ///
     Chunk(ChunkAddress),
@@ -30,15 +32,18 @@ pub enum DataAddress {
     Register(RegisterAddress),
     ///
     Spend(DbcAddress),
+    /// The new general identifier for a items in the network.
+    Network(NetworkKey),
 }
 
 impl DataAddress {
     /// The xorname.
-    pub fn name(&self) -> &XorName {
+    pub fn key(&self) -> NetworkKey {
         match self {
-            Self::Chunk(address) => address.name(),
-            Self::Register(address) => address.name(),
-            Self::Spend(address) => address.name(),
+            Self::Chunk(address) => NetworkKey::from_name(*address.name()),
+            Self::Register(address) => NetworkKey::from_name(*address.name()),
+            Self::Spend(address) => NetworkKey::from_name(*address.name()),
+            Self::Network(key) => key.clone(),
         }
     }
 
@@ -64,6 +69,7 @@ impl std::fmt::Display for DataAddress {
             DataAddress::Chunk(addr) => write!(f, "{addr:?}"),
             DataAddress::Register(addr) => write!(f, "{addr:?}"),
             DataAddress::Spend(addr) => write!(f, "{addr:?}"),
+            DataAddress::Network(key) => write!(f, "Network({key:?})"),
         }
     }
 }

--- a/safenode/src/protocol/storage/address/mod.rs
+++ b/safenode/src/protocol/storage/address/mod.rs
@@ -32,7 +32,7 @@ pub enum DataAddress {
     Register(RegisterAddress),
     ///
     Spend(DbcAddress),
-    /// The new general identifier for a items in the network.
+    /// The new general identifier for items in the network.
     Network(NetworkKey),
 }
 


### PR DESCRIPTION
This was originally part of PR #212, but can be broken out to its own PR.

We've been keeping our `XorName` closeness logic in parallel with the kad closeness, i.e. mapping `PeerId` to our concept of id. We did some hashing that seems it would lead to us having one view of what is close peer, while kad had another view of it. 
Maybe it wasn't actually happening, but the two logics are there side by side, and there is not so much clarity there.

As I was looking at data replication, I got more clarity there, and I found what I believe to be the way to use only the kad closeness logic, and introducing some simplification and type safety.

This PR is an intermediate step and further clarity can be reached.

***

The closeness logic exists in `libp2p::kad::KadBucketKey`. It does all that work that we had our custom code for. We already use it for close calc, but there was not so much type safety to ensure we use only that, and a bit confusing where `XorName` is used, why and how - and how closeness of `PeerId` fits into closeness of `XorName`.

`KadBucketKey` (in this PR aliased as `Key`) works on a bit vector - which is also what `PeerId` is a wrapping type for, and it has a `preimage` which is what we pass in, and it has a key which is the `SHA256 digest` of the `preimage`.

So in this PR a canonical `NetworkKey` is implemented for cohesion. It holds the bit vector of either `PeerId` or XorName, without any modifications to it.
So it has two enum variants, `PeerId` and `XorName`. And it means we leave all bit vectors untouched before they get mapped to `KBucketKey`. 

The `NetworkKey` is now what is passed around in the paths where we use dst/distance/closeness metrics.

This should keep the distance metrics of all our items the same, and also clear up when to use what, how they relate etc.