### PR TITLE
feat(node): add AlreadyDialingPeer as error

### DIFF
--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -20,7 +20,6 @@ use libp2p::{
 };
 use std::collections::{hash_map, HashSet};
 use tokio::sync::oneshot;
-use tracing::warn;
 use xor_name::XorName;
 
 /// Commands to send to the Swarm
@@ -113,7 +112,7 @@ impl SwarmDriver {
                         }
                     }
                 } else {
-                    warn!("Already dialing peer.");
+                    let _ = sender.send(Err(Error::AlreadyDialingPeer(peer_id)));
                 }
             }
 

--- a/safenode/src/network/error.rs
+++ b/safenode/src/network/error.rs
@@ -47,6 +47,9 @@ pub enum Error {
     #[error("Dial Error")]
     DialError(#[from] DialError),
 
+    #[error("This peer is already being dialed: {0}")]
+    AlreadyDialingPeer(libp2p::PeerId),
+
     #[error("Outbound Error")]
     OutboundError(#[from] OutboundFailure),
 


### PR DESCRIPTION
Without returning this error, the receiver will get an error because we
drop the sender without sending anything on the oneshot channel.
