### PR TITLE
fix: avoid deadlock during spend dbc

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -258,6 +258,142 @@ jobs:
         if: failure()
         continue-on-error: true
 
+  spend_test_ubuntu:
+    name: dbc spend tests on ubuntu
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
+
+      - name: install ripgrep ubuntu
+        run: sudo apt-get install ripgrep
+
+      - name: Build sn bins
+        run: cargo build --release --bins
+        timeout-minutes: 30
+
+      - name: Start a local network
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        id: section-startup
+        env:
+          RUST_LOG: "safenode,safe=trace"
+        timeout-minutes: 10
+
+      - name: execute the dbc spend test
+        run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
+        id: client-spend-dbc
+        env:
+          RUST_LOG: "safenode,safe=trace"
+        timeout-minutes: 10
+
+      - name: Kill all nodes
+        shell: bash
+        timeout-minutes: 1
+        if: failure()
+        continue-on-error: true
+        run: |
+          pkill safenode
+          echo "$(pgrep safenode | wc -l) nodes still running"
+
+      - name: Tar log files
+        shell: bash
+        continue-on-error: true
+        run: find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@main
+        with:
+          name: sn_node_logs_dbc_${{matrix.os}}
+          path: log_files.tar.gz
+        if: failure()
+        continue-on-error: true
+
+  spend_test_windows:
+    name: dbc spend tests on windows
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
+
+      - name: install ripgrep windows
+        run: choco install ripgrep
+
+      - name: Build sn bins
+        run: cargo build --release --bins
+        timeout-minutes: 30
+
+      - name: Start a local network
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        id: section-startup
+        env:
+          RUST_LOG: "safenode,safe=trace"
+        timeout-minutes: 10
+
+      - name: execute the dbc spend test
+        run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
+        id: client-spend-dbc
+        env:
+          RUST_LOG: "safenode,safe=trace"
+        timeout-minutes: 10
+
+      - name: Kill all nodes
+        shell: bash
+        timeout-minutes: 1
+        if: failure()
+        continue-on-error: true
+        run: |
+          pkill safenode
+          echo "$(pgrep safenode | wc -l) nodes still running"
+
+      - name: Tar log files
+        shell: bash
+        continue-on-error: true
+        run: find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@main
+        with:
+          name: sn_node_logs_dbc_${{matrix.os}}
+          path: log_files.tar.gz
+        if: failure()
+        continue-on-error: true
+
   churn:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Network churning tests

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -259,6 +259,7 @@ jobs:
         continue-on-error: true
 
   spend_test:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
     name: dbc spend tests against network
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -258,12 +258,12 @@ jobs:
         if: failure()
         continue-on-error: true
 
-  spend_test_ubuntu:
-    name: dbc spend tests on ubuntu
+  spend_test:
+    name: dbc spend tests against network
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -284,77 +284,22 @@ jobs:
 
       - name: install ripgrep ubuntu
         run: sudo apt-get install ripgrep
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: install ripgrep mac
+        run: brew install ripgrep
+        if: matrix.os == 'macos-latest'
+
+      - name: install ripgrep windows
+        run: choco install ripgrep
+        if: matrix.os == 'windows-latest'
 
       - name: Build sn bins
         run: cargo build --release --bins
         timeout-minutes: 30
 
-      - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
-        id: section-startup
-        env:
-          RUST_LOG: "safenode,safe=trace"
-        timeout-minutes: 10
-
-      - name: execute the dbc spend test
-        run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
-        id: client-spend-dbc
-        env:
-          RUST_LOG: "safenode,safe=trace"
-        timeout-minutes: 10
-
-      - name: Kill all nodes
-        shell: bash
-        timeout-minutes: 1
-        if: failure()
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files
-        shell: bash
-        continue-on-error: true
-        run: find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure()
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
-        with:
-          name: sn_node_logs_dbc_${{matrix.os}}
-          path: log_files.tar.gz
-        if: failure()
-        continue-on-error: true
-
-  spend_test_windows:
-    name: dbc spend tests on windows
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-        continue-on-error: true
-        with:
-          cache-on-failure: true
-          sharedKey: ${{github.run_id}}
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-
-      - name: Build sn bins
-        run: cargo build --release --bins
+      - name: Build testing executable
+        run: cargo test --release multiple_sequential_transfers_succeed --no-run
         timeout-minutes: 30
 
       - name: Start a local network

--- a/safenode/examples/registers.rs
+++ b/safenode/examples/registers.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use safenode::client::{Client, ClientEvent, Error};
+use safenode::client::{Client, Error};
 
 use bls::SecretKey;
 use clap::Parser;
@@ -39,18 +39,8 @@ async fn main() -> Result<()> {
     let signer = SecretKey::random();
 
     println!("Starting SAFE client...");
-    let client = Client::new(signer, None)?;
+    let client = Client::new(signer, None).await?;
     println!("SAFE client signer public key: {:?}", client.signer_pk());
-
-    // Let's wait till we are connected to the network before proceeding further
-    let mut client_events_rx = client.events_channel();
-    loop {
-        if let Ok(ClientEvent::ConnectedToNetwork) = client_events_rx.recv().await {
-            println!("Connected to the Network!");
-            println!();
-            break;
-        }
-    }
 
     // we'll retrieve (or create if not found) a Register, and write on it
     // in offline mode, syncing with the network periodically.

--- a/safenode/src/bin/safe/mod.rs
+++ b/safenode/src/bin/safe/mod.rs
@@ -16,7 +16,7 @@ use self::cli::{files_cmds, register_cmds, wallet_cmds, Opt, SubCmd};
 use clap::Parser;
 use eyre::{eyre, Result};
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
-use safenode::client::{Client, ClientEvent};
+use safenode::client::Client;
 use safenode::log::init_node_logging;
 use std::path::PathBuf;
 
@@ -35,16 +35,7 @@ async fn main() -> Result<()> {
     let secret_key = bls::SecretKey::random();
     let peers = parse_peer_multiaddresses(&opt.peers)?;
 
-    let client = Client::new(secret_key, Some(peers))?;
-
-    let mut client_events_rx = client.events_channel();
-    if let Ok(event) = client_events_rx.recv().await {
-        match event {
-            ClientEvent::ConnectedToNetwork => {
-                println!("Client connected to the Network");
-            }
-        }
-    }
+    let client = Client::new(secret_key, Some(peers)).await?;
 
     let root_dir = get_client_dir().await?;
 

--- a/safenode/src/bin/safe/mod.rs
+++ b/safenode/src/bin/safe/mod.rs
@@ -12,6 +12,7 @@ extern crate tracing;
 mod cli;
 
 use self::cli::{files_cmds, register_cmds, wallet_cmds, Opt, SubCmd};
+
 use clap::Parser;
 use eyre::{eyre, Result};
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
@@ -24,7 +25,6 @@ async fn main() -> Result<()> {
     let opt = Opt::parse();
     // For client, default to log to std::out
     // This is ruining the log output for the CLI. Needs to be fixed.
-
     let tmp_dir = std::env::temp_dir();
     let _log_appender_guard = init_node_logging(&Some(tmp_dir.join("safe-client.log")))?;
 

--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -94,7 +94,7 @@ impl Client {
             NetworkEvent::RequestReceived { .. } => {}
             // We do not listen on sockets.
             NetworkEvent::NewListenAddr(_) => {}
-            NetworkEvent::PeerAdded => {
+            NetworkEvent::PeerAdded(_) => {
                 self.events_channel
                     .broadcast(ClientEvent::ConnectedToNetwork);
             }

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -167,6 +167,7 @@ impl SwarmDriver {
                         .map_err(|_| Error::InternalMsgChannelDropped)?;
                 }
                 MsgResponder::FromPeer(channel) => {
+                    trace!("Sending response to peer");
                     self.swarm
                         .behaviour_mut()
                         .request_response

--- a/safenode/src/network/cmd.rs
+++ b/safenode/src/network/cmd.rs
@@ -167,7 +167,6 @@ impl SwarmDriver {
                         .map_err(|_| Error::InternalMsgChannelDropped)?;
                 }
                 MsgResponder::FromPeer(channel) => {
-                    trace!("Sending response to peer");
                     self.swarm
                         .behaviour_mut()
                         .request_response

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -255,23 +255,12 @@ impl SwarmDriver {
                 }
             }
             SwarmEvent::ConnectionClosed {
-                peer_id, endpoint, ..
+                peer_id,
+                endpoint,
+                cause,
+                ..
             } => {
-                // The connection closed due to no msg flow show as `endpoint::receiver`
-                // The connection closed due to peer dead show as `endpoint::dialer`
-                info!("Connection closed to Peer {peer_id} - {endpoint:?}");
-                // if endpoint.is_dialer() {
-                //     info!("Dead Peer {peer_id:?}");
-                //     if self
-                //         .swarm
-                //         .behaviour_mut()
-                //         .kademlia
-                //         .remove_address(&peer_id, endpoint.get_remote_address())
-                //         .is_some()
-                //     {
-                //         info!("Removed dead peer {peer_id:?} from RT");
-                //     }
-                // }
+                info!("Connection closed to Peer {peer_id} - {endpoint:?} - {cause:?}");
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 if let Some(peer_id) = peer_id {

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -91,7 +91,7 @@ pub enum NetworkEvent {
         channel: MsgResponder,
     },
     /// Emitted when the DHT is updated
-    PeerAdded,
+    PeerAdded(PeerId),
     /// Started listening on a new address
     NewListenAddr(Multiaddr),
 }
@@ -173,9 +173,13 @@ impl SwarmDriver {
                         // TODO: send an error response back?
                     }
                 }
-                KademliaEvent::RoutingUpdated { is_new_peer, .. } => {
+                KademliaEvent::RoutingUpdated {
+                    peer, is_new_peer, ..
+                } => {
                     if *is_new_peer {
-                        self.event_sender.send(NetworkEvent::PeerAdded).await?;
+                        self.event_sender
+                            .send(NetworkEvent::PeerAdded(*peer))
+                            .await?;
                     }
                 }
                 KademliaEvent::InboundRequest { request } => {

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -260,18 +260,18 @@ impl SwarmDriver {
                 // The connection closed due to no msg flow show as `endpoint::receiver`
                 // The connection closed due to peer dead show as `endpoint::dialer`
                 info!("Connection closed to Peer {peer_id} - {endpoint:?}");
-                if endpoint.is_dialer() {
-                    info!("Dead Peer {peer_id:?}");
-                    if self
-                        .swarm
-                        .behaviour_mut()
-                        .kademlia
-                        .remove_address(&peer_id, endpoint.get_remote_address())
-                        .is_some()
-                    {
-                        info!("Removed dead peer {peer_id:?} from RT");
-                    }
-                }
+                // if endpoint.is_dialer() {
+                //     info!("Dead Peer {peer_id:?}");
+                //     if self
+                //         .swarm
+                //         .behaviour_mut()
+                //         .kademlia
+                //         .remove_address(&peer_id, endpoint.get_remote_address())
+                //         .is_some()
+                //     {
+                //         info!("Removed dead peer {peer_id:?} from RT");
+                //     }
+                // }
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 if let Some(peer_id) = peer_id {

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
 use self::{
     cmd::SwarmCmd,
     error::Result,
-    event::NodeBehaviour,
+    event::{NodeBehaviour, NodeEvent},
     msg::{MsgCodec, MsgProtocol},
 };
 
@@ -37,7 +37,7 @@ use libp2p::{
     mdns,
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
-    swarm::{Swarm, SwarmBuilder},
+    swarm::{Swarm, SwarmBuilder, SwarmEvent},
     Multiaddr, PeerId, Transport,
 };
 use std::{
@@ -167,6 +167,10 @@ impl SwarmDriver {
         let peer_id = PeerId::from(keypair.public());
 
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
+        info!(
+            "PeerId converted to XorName: {peer_id} - {:?}",
+            XorName::from_content(&peer_id.to_bytes())
+        );
 
         // RequestResponse configuration
         let mut req_res_config = RequestResponseConfig::default();
@@ -256,30 +260,63 @@ impl SwarmDriver {
     /// asynchronous tasks.
     pub async fn run(mut self) {
         loop {
-            trace!("Swarm on selection");
-            tokio::select! {
-                some_cmd = self.cmd_receiver.recv() => {
-                    trace!("received a swarm cmd {some_cmd:?}");
-                    match some_cmd {
-                        Some(cmd) => {
-                            if let Err(err) = self.handle_cmd(cmd).await {
-                                warn!("Error while handling cmd: {err}");
-                            }
-                        },
-                        None => continue,
+            let received_swarm = {
+                if let Ok(cmd) = self.cmd_receiver.try_recv() {
+                    Some(NetworkPollResult::SwarmCmd(cmd))
+                } else if let Ok(Some(event)) =
+                    tokio::time::timeout(Duration::from_millis(10), self.swarm.next()).await
+                {
+                    Some(NetworkPollResult::SwarmEvent(event))
+                } else {
+                    None
+                }
+            };
+
+            match received_swarm {
+                Some(NetworkPollResult::SwarmCmd(cmd)) => {
+                    if let Err(err) = self.handle_cmd(cmd).await {
+                        warn!("Error while handling cmd: {err}");
                     }
                     trace!("Handled swarm cmd");
-                },
-                some_event = self.swarm.next() => {
-                    if let Err(err) = self.handle_swarm_events(some_event.expect("Swarm stream to be infinite!")).await {
+                }
+                Some(NetworkPollResult::SwarmEvent(event)) => {
+                    if let Err(err) = self.handle_swarm_events(event).await {
                         warn!("Error while handling event: {err}");
                     }
                     trace!("Handled swarm event");
-                },
-                else => continue,
+                }
+                _ => continue,
             }
+
+            // tokio::select! {
+            //     some_cmd = self.cmd_receiver.recv() => {
+            //         trace!("received a swarm cmd {some_cmd:?}");
+            //         match some_cmd {
+            //             Some(cmd) => {
+            //                 if let Err(err) = self.handle_cmd(cmd).await {
+            //                     warn!("Error while handling cmd: {err}");
+            //                 }
+            //             },
+            //             None => continue,
+            //         }
+            //         trace!("Handled swarm cmd");
+            //     },
+            //     some_event = self.swarm.next() => {
+            //         trace!("received a swarm event {some_event:?}");
+            //         if let Err(err) = self.handle_swarm_events(some_event.expect("Swarm stream to be infinite!")).await {
+            //             warn!("Error while handling event: {err}");
+            //         }
+            //         trace!("Handled swarm event");
+            //     },
+            //     else => continue,
+            // }
         }
     }
+}
+
+enum NetworkPollResult<EventError: std::error::Error> {
+    SwarmCmd(SwarmCmd),
+    SwarmEvent(SwarmEvent<NodeEvent, EventError>),
 }
 
 #[derive(Clone)]

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -266,19 +266,15 @@ impl SwarmDriver {
                     if let Err(err) = self.handle_swarm_events(swarm_event).await {
                         warn!("Error while handling event: {err}");
                     }
-                    trace!("Handled swarm event");
                 },
-                some_cmd = self.cmd_receiver.recv() => {
-                    trace!("received a swarm cmd {some_cmd:?}");
-                    match some_cmd {
-                        Some(cmd) => {
-                            if let Err(err) = self.handle_cmd(cmd).await {
-                                warn!("Error while handling cmd: {err}");
-                            }
-                        },
-                        None => continue,
-                    }
-                    trace!("Handled swarm cmd");
+                some_cmd = self.cmd_receiver.recv() => match some_cmd {
+                    Some(cmd) => {
+                        trace!("received a swarm cmd {cmd:?}");
+                        if let Err(err) = self.handle_cmd(cmd).await {
+                            warn!("Error while handling cmd: {err}");
+                        }
+                    },
+                    None =>  continue,
                 },
             }
         }
@@ -439,9 +435,7 @@ impl Network {
 
     // Helper to send SwarmCmd
     async fn send_swarm_cmd(&self, cmd: SwarmCmd) -> Result<()> {
-        trace!("Sending cmd to swarm {cmd:?}");
         self.swarm_cmd_sender.send(cmd).await?;
-        trace!("Sent cmd to swarm");
         Ok(())
     }
 

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -262,14 +262,12 @@ impl SwarmDriver {
         loop {
             tokio::select! {
                 swarm_event = self.swarm.select_next_some() => {
-                    trace!("received a swarm event {swarm_event:?}");
                     if let Err(err) = self.handle_swarm_events(swarm_event).await {
                         warn!("Error while handling event: {err}");
                     }
                 },
                 some_cmd = self.cmd_receiver.recv() => match some_cmd {
                     Some(cmd) => {
-                        trace!("received a swarm cmd {cmd:?}");
                         if let Err(err) = self.handle_cmd(cmd).await {
                             warn!("Error while handling cmd: {err}");
                         }

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -13,16 +13,14 @@ use super::{
 };
 
 use crate::{
-    domain::{
-        dbc_genesis::is_genesis_parent_tx, node_transfers::Transfers, storage::RegisterStorage,
-        wallet::LocalWallet,
-    },
+    domain::{dbc_genesis::is_genesis_parent_tx, wallet::LocalWallet},
     network::{close_group_majority, MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState},
+    node::{RegisterStorage, Transfers},
     protocol::{
         error::{Error as ProtocolError, StorageError, TransferError},
         messages::{
-            Cmd, CmdResponse, Event, NodeId, Query, QueryResponse, RegisterCmd, Request, Response,
-            SpendQuery,
+            Cmd, CmdResponse, Event, FeeCiphers, NodeId, Query, QueryResponse, RegisterCmd,
+            Request, Response, SpendQuery,
         },
         storage::{dbc_address, registers::User, DbcAddress},
     },
@@ -34,9 +32,25 @@ use libp2p::{
     kad::{Record, RecordKey},
     Multiaddr, PeerId,
 };
-use std::{collections::BTreeSet, net::SocketAddr, path::Path};
-use tokio::task::spawn;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
+    path::Path,
+};
+use tokio::{
+    sync::mpsc::{self, error::TryRecvError},
+    task::spawn,
+};
 use xor_name::XorName;
+
+#[derive(Debug)]
+pub(super) struct TransferAction {
+    signed_spend: Box<SignedSpend>,
+    parent_tx: Box<DbcTransaction>,
+    fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
+    parent_spends: BTreeSet<SignedSpend>,
+    response_channel: MsgResponder,
+}
 
 /// Once a node is started and running, the user obtains
 /// a `NodeRunning` object which can be used to interact with it.
@@ -89,27 +103,39 @@ impl Node {
             .await
             .map_err(|e| Error::CouldNotLoadWallet(e.to_string()))?;
 
+        let (transfer_action_sender, mut transfer_action_receiver) = mpsc::channel(100);
+
         let mut node = Self {
             network: network.clone(),
             registers: RegisterStorage::new(root_dir),
             transfers: Transfers::new(root_dir, node_id, node_wallet),
             events_channel: node_events_channel.clone(),
             initial_peers,
+            transfer_actor: transfer_action_sender,
         };
 
         let _handle = spawn(swarm_driver.run());
         let _handle = spawn(async move {
             loop {
-                let event = match network_event_receiver.recv().await {
-                    Some(event) => event,
-                    None => {
-                        error!("The `NetworkEvent` channel has been closed");
-                        continue;
+                match network_event_receiver.try_recv() {
+                    Ok(event) => {
+                        if let Err(err) = node.handle_network_event(event).await {
+                            warn!("Error handling network event: {err}");
+                        }
                     }
+                    Err(TryRecvError::Disconnected) => {
+                        error!("The `NetworkEvent` channel is closed")
+                    }
+                    Err(_) => {}
                 };
-                if let Err(err) = node.handle_network_event(event).await {
-                    warn!("Error handling network event: {err}");
-                }
+                match transfer_action_receiver.try_recv() {
+                    Ok(action) => node.handle_transfer_action(action).await,
+                    Err(TryRecvError::Disconnected) => {
+                        error!("The `TransferAction` channel is closed")
+                    }
+                    Err(_) => {}
+                };
+                std::thread::sleep(std::time::Duration::from_millis(1));
             }
         });
 
@@ -126,7 +152,7 @@ impl Node {
             NetworkEvent::RequestReceived { req, channel } => {
                 self.handle_request(req, channel).await?
             }
-            NetworkEvent::PeerAdded => {
+            NetworkEvent::PeerAdded(peer) => {
                 self.events_channel.broadcast(NodeEvent::ConnectedToNetwork);
                 let target = {
                     let mut rng = rand::thread_rng();
@@ -135,7 +161,7 @@ impl Node {
 
                 let network = self.network.clone();
                 let _handle = spawn(async move {
-                    trace!("Getting closest peers for target {target:?}");
+                    trace!("On PeerAdded({peer:?}) Getting closest peers for target {target:?}");
                     let result = network.node_get_closest_peers(target).await;
                     trace!("For target {target:?}, get closest peers {result:?}");
                 });
@@ -162,9 +188,9 @@ impl Node {
         response_channel: MsgResponder,
     ) -> Result<()> {
         trace!("Handling request: {request:?}");
-        let response = match request {
-            Request::Cmd(cmd) => Response::Cmd(self.handle_cmd(cmd).await),
-            Request::Query(query) => Response::Query(self.handle_query(query).await),
+        match request {
+            Request::Cmd(cmd) => self.handle_cmd(cmd, response_channel).await,
+            Request::Query(query) => self.handle_query(query, response_channel).await,
             Request::Event(event) => {
                 match event {
                     Event::ValidSpendReceived {
@@ -177,26 +203,22 @@ impl Node {
                             .try_add(spend, parent_tx, fee_ciphers, parent_spends)
                             .await
                             .map_err(ProtocolError::Transfers)?;
-                        return Ok(());
                     }
                     Event::DoubleSpendAttempted { new, existing } => {
                         self.transfers
                             .try_add_double(new.as_ref(), existing.as_ref())
                             .await
                             .map_err(ProtocolError::Transfers)?;
-                        return Ok(());
                     }
                 };
             }
-        };
-
-        self.send_response(response, response_channel).await;
+        }
 
         Ok(())
     }
 
-    async fn handle_query(&mut self, query: Query) -> QueryResponse {
-        match query {
+    async fn handle_query(&mut self, query: Query, response_channel: MsgResponder) {
+        let resp = match query {
             Query::Register(query) => self.registers.read(&query, User::Anyone).await,
             Query::GetChunk(address) => {
                 match self
@@ -218,6 +240,7 @@ impl Node {
                         // The required fee content is encrypted to that dbc id, and so only the holder of the dbc secret
                         // key can unlock the contents.
                         let required_fee = self.transfers.get_required_fee(dbc_id, priority);
+                        trace!("Sending response back on query GetFees {dbc_id:?}");
                         QueryResponse::GetFees(Ok(required_fee))
                     }
                     SpendQuery::GetDbcSpend(address) => {
@@ -231,10 +254,12 @@ impl Node {
                     }
                 }
             }
-        }
+        };
+        self.send_response(Response::Query(resp), response_channel)
+            .await;
     }
 
-    async fn handle_cmd(&mut self, cmd: Cmd) -> CmdResponse {
+    async fn handle_cmd(&mut self, cmd: Cmd, response_channel: MsgResponder) {
         match cmd {
             Cmd::StoreChunk(chunk) => {
                 let addr = *chunk.address();
@@ -248,7 +273,7 @@ impl Node {
                     expires: None,
                 };
 
-                match self.network.put_data_as_record(record).await {
+                let resp = match self.network.put_data_as_record(record).await {
                     Ok(()) => {
                         self.events_channel.broadcast(NodeEvent::ChunkStored(addr));
                         CmdResponse::StoreChunk(Ok(()))
@@ -259,7 +284,9 @@ impl Node {
                             StorageError::ChunkNotStored(*addr.name()).into()
                         ))
                     }
-                }
+                };
+                self.send_response(Response::Cmd(resp), response_channel)
+                    .await;
             }
             Cmd::Register(cmd) => {
                 let result = self
@@ -269,7 +296,7 @@ impl Node {
                     .map_err(ProtocolError::Storage);
 
                 let xorname = cmd.dst();
-                match cmd {
+                let resp = match cmd {
                     RegisterCmd::Create(_) => {
                         self.events_channel
                             .broadcast(NodeEvent::RegisterCreated(xorname));
@@ -280,182 +307,108 @@ impl Node {
                             .broadcast(NodeEvent::RegisterEdited(xorname));
                         CmdResponse::EditRegister(result)
                     }
-                }
+                };
+                self.send_response(Response::Cmd(resp), response_channel)
+                    .await;
             }
             Cmd::SpendDbc {
                 signed_spend,
                 parent_tx,
                 fee_ciphers,
             } => {
-                // First we fetch all parent spends from the network.
-                // They shall naturally all exist as valid spends for this current
-                // spend attempt to be valid.
-                let parent_spends = match self.get_parent_spends(parent_tx.as_ref()).await {
-                    Ok(parent_spends) => parent_spends,
-                    Err(Error::Protocol(err)) => return CmdResponse::Spend(Err(err)),
-                    Err(error) => {
-                        return CmdResponse::Spend(Err(ProtocolError::Transfers(
-                            TransferError::SpendParentCloseGroupIssue(error.to_string()),
-                        )))
-                    }
-                };
+                let network = self.network.clone();
+                let transfer_actor = self.transfer_actor.clone();
 
-                // Then we try to add the spend to the transfers.
-                // This will validate all the necessary components of the spend.
-                let res = match self
-                    .transfers
-                    .try_add(
-                        signed_spend.clone(),
-                        parent_tx.clone(),
-                        fee_ciphers.clone(),
-                        parent_spends.clone(),
+                let _handler = spawn(async move {
+                    handle_spend_dbc(
+                        network,
+                        transfer_actor,
+                        response_channel,
+                        signed_spend,
+                        parent_tx,
+                        fee_ciphers,
                     )
                     .await
-                {
-                    Ok(()) => {
-                        let dbc_id = *signed_spend.dbc_id();
-                        trace!("Broadcasting valid spend: {dbc_id:?}");
+                });
+            }
+        }
+    }
 
-                        self.events_channel
-                            .broadcast(NodeEvent::SpendStored(dbc_id));
+    async fn handle_transfer_action(&mut self, action: TransferAction) {
+        let TransferAction {
+            signed_spend,
+            parent_tx,
+            fee_ciphers,
+            parent_spends,
+            response_channel,
+        } = action;
 
-                        let event = Event::ValidSpendReceived {
-                            spend: signed_spend,
-                            parent_tx,
-                            fee_ciphers,
-                            parent_spends,
-                        };
-                        match self
-                            .network
-                            .fire_and_forget_to_closest(&Request::Event(event))
-                            .await
-                        {
+        let result = self
+            .transfers
+            .try_add(
+                signed_spend.clone(),
+                parent_tx.clone(),
+                fee_ciphers.clone(),
+                parent_spends.clone(),
+            )
+            .await;
+
+        let network = self.network.clone();
+        let events_channel = self.events_channel.clone();
+
+        let _handler = spawn(async move {
+            let resp = match result {
+                Ok(()) => {
+                    let dbc_id = *signed_spend.dbc_id();
+                    trace!("Broadcasting valid spend: {dbc_id:?}");
+
+                    events_channel.broadcast(NodeEvent::SpendStored(dbc_id));
+
+                    let event = Event::ValidSpendReceived {
+                        spend: signed_spend,
+                        parent_tx,
+                        fee_ciphers,
+                        parent_spends,
+                    };
+                    match network
+                        .fire_and_forget_to_closest(&Request::Event(event))
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(err) => {
+                            warn!("Failed to send valid spend event to closest peers: {err:?}");
+                        }
+                    }
+
+                    Ok(())
+                }
+                Err(TransferError::Storage(StorageError::DoubleSpendAttempt { new, existing })) => {
+                    warn!("Double spend attempted! New: {new:?}. Existing:  {existing:?}");
+                    if let Ok(event) = Event::double_spend_attempt(new.clone(), existing.clone()) {
+                        match network.node_send_to_closest(&Request::Event(event)).await {
                             Ok(_) => {}
                             Err(err) => {
-                                warn!("Failed to send valid spend event to closest peers: {err:?}");
+                                warn!(
+                                    "Failed to send double spend event to closest peers: {err:?}"
+                                );
                             }
                         }
-
-                        Ok(())
                     }
-                    Err(TransferError::Storage(StorageError::DoubleSpendAttempt {
-                        new,
-                        existing,
-                    })) => {
-                        warn!("Double spend attempted! New: {new:?}. Existing:  {existing:?}");
-                        if let Ok(event) =
-                            Event::double_spend_attempt(new.clone(), existing.clone())
-                        {
-                            match self
-                                .network
-                                .node_send_to_closest(&Request::Event(event))
-                                .await
-                            {
-                                Ok(_) => {}
-                                Err(err) => {
-                                    warn!("Failed to send double spend event to closest peers: {err:?}");
-                                }
-                            }
-                        }
 
-                        Err(ProtocolError::Transfers(TransferError::Storage(
-                            StorageError::DoubleSpendAttempt { new, existing },
-                        )))
-                    }
-                    other => other.map_err(ProtocolError::Transfers),
-                };
-
-                CmdResponse::Spend(res)
-            }
-        }
-    }
-
-    // This call makes sure we get the same spend from all in the close group.
-    // If we receive a spend here, it is assumed to be valid. But we will verify
-    // that anyway, in the code right after this for loop.
-    async fn get_parent_spends(&self, parent_tx: &DbcTransaction) -> Result<BTreeSet<SignedSpend>> {
-        // These will be different spends, one for each input that went into
-        // creating the above spend passed in to this function.
-        let mut all_parent_spends = BTreeSet::new();
-
-        if is_genesis_parent_tx(parent_tx) {
-            return Ok(all_parent_spends);
-        }
-
-        // First we fetch all parent spends from the network.
-        // They shall naturally all exist as valid spends for this current
-        // spend attempt to be valid.
-        for parent_input in &parent_tx.inputs {
-            let parent_address = dbc_address(&parent_input.dbc_id());
-            // This call makes sure we get the same spend from all in the close group.
-            // If we receive a spend here, it is assumed to be valid. But we will verify
-            // that anyway, in the code right after this for loop.
-            let parent_spend = self.get_spend(parent_address).await?;
-            let _ = all_parent_spends.insert(parent_spend);
-        }
-
-        Ok(all_parent_spends)
-    }
-
-    /// Retrieve a `Spend` from the closest peers
-    async fn get_spend(&self, address: DbcAddress) -> Result<SignedSpend> {
-        let request = Request::Query(Query::Spend(SpendQuery::GetDbcSpend(address)));
-        let responses = self.network.node_send_to_closest(&request).await?;
-
-        // Get all Ok results of the expected response type `GetDbcSpend`.
-        let spends: Vec<_> = responses
-            .iter()
-            .flatten()
-            .flat_map(|resp| {
-                if let Response::Query(QueryResponse::GetDbcSpend(Ok(signed_spend))) = resp {
-                    Some(signed_spend.clone())
-                } else {
-                    None
+                    Err(ProtocolError::Transfers(TransferError::Storage(
+                        StorageError::DoubleSpendAttempt { new, existing },
+                    )))
                 }
-            })
-            .collect();
-
-        // As to not have a single rogue node deliver a bogus spend,
-        // and thereby have us fail the check here
-        // (we would have more than 1 spend in the BTreeSet), we must
-        // look for a majority of the same responses, and ignore any other responses.
-        if spends.len() >= close_group_majority() {
-            // Majority of nodes in the close group returned an Ok response.
-            use itertools::*;
-            if let Some(spend) = spends
-                .into_iter()
-                .map(|x| (x, 1))
-                .into_group_map()
-                .into_iter()
-                .filter(|(_, v)| v.len() >= close_group_majority())
-                .max_by_key(|(_, v)| v.len())
-                .map(|(k, _)| k)
-            {
-                // Majority of nodes in the close group returned the same spend.
-                return Ok(spend);
-            }
-        }
-
-        // The parent is not recognised by majority of peers in its close group.
-        // Thus, the parent is not valid.
-        info!("The spend could not be verified as valid: {address:?}");
-
-        // If not enough spends were gotten, we try error the first
-        // error to the expected query returned from nodes.
-        for resp in responses.iter().flatten() {
-            if let Response::Query(QueryResponse::GetDbcSpend(result)) = resp {
-                let _ = result.clone()?;
+                other => other.map_err(ProtocolError::Transfers),
             };
-        }
 
-        // If there were no success or fail to the expected query,
-        // we check if there were any send errors.
-        for resp in responses {
-            let _ = resp?;
-        }
-
-        // If there was none of the above, then we had unexpected responses.
-        Err(Error::UnexpectedResponses)
+            if let Err(err) = network
+                .send_response(Response::Cmd(CmdResponse::Spend(resp)), response_channel)
+                .await
+            {
+                warn!("Error while sending response: {err:?}");
+            }
+        });
     }
 
     async fn send_response(&self, resp: Response, response_channel: MsgResponder) {
@@ -463,4 +416,143 @@ impl Node {
             warn!("Error while sending response: {err:?}");
         }
     }
+}
+
+// Node handling of SpendDbc request
+async fn handle_spend_dbc(
+    network: Network,
+    transfer_actor: mpsc::Sender<TransferAction>,
+    response_channel: MsgResponder,
+    signed_spend: Box<SignedSpend>,
+    parent_tx: Box<DbcTransaction>,
+    fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
+) {
+    // First we fetch all parent spends from the network.
+    // They shall naturally all exist as valid spends for this current
+    // spend attempt to be valid.
+    let parent_spends = match get_parent_spends(network.clone(), &parent_tx).await {
+        Ok(parent_spends) => parent_spends,
+        Err(error) => {
+            let resp = if let Error::Protocol(err) = &error {
+                CmdResponse::Spend(Err(err.clone()))
+            } else {
+                CmdResponse::Spend(Err(ProtocolError::Transfers(
+                    TransferError::SpendParentCloseGroupIssue(error.to_string()),
+                )))
+            };
+
+            if let Err(err) = network
+                .send_response(Response::Cmd(resp), response_channel)
+                .await
+            {
+                warn!("Error while sending response: {err:?}");
+            }
+            return;
+        }
+    };
+
+    let transfer_action = TransferAction {
+        signed_spend,
+        parent_tx,
+        fee_ciphers,
+        parent_spends,
+        response_channel,
+    };
+
+    // Then we try to add the spend to the transfers.
+    // This will validate all the necessary components of the spend.
+    if let Err(err) = transfer_actor.send(transfer_action).await {
+        warn!("Failed to send transfer action with {err:?}");
+    }
+}
+
+// This call makes sure we get the same spend from all in the close group.
+// If we receive a spend here, it is assumed to be valid. But we will verify
+// that anyway, in the code right after this for loop.
+async fn get_parent_spends(
+    network: Network,
+    parent_tx: &DbcTransaction,
+) -> Result<BTreeSet<SignedSpend>> {
+    // These will be different spends, one for each input that went into
+    // creating the above spend passed in to this function.
+    let mut all_parent_spends = BTreeSet::new();
+
+    if is_genesis_parent_tx(parent_tx) {
+        return Ok(all_parent_spends);
+    }
+
+    // First we fetch all parent spends from the network.
+    // They shall naturally all exist as valid spends for this current
+    // spend attempt to be valid.
+    for parent_input in &parent_tx.inputs {
+        let parent_address = dbc_address(&parent_input.dbc_id());
+        // This call makes sure we get the same spend from all in the close group.
+        // If we receive a spend here, it is assumed to be valid. But we will verify
+        // that anyway, in the code right after this for loop.
+        let parent_spend = get_spend(network.clone(), parent_address).await?;
+        let _ = all_parent_spends.insert(parent_spend);
+    }
+
+    Ok(all_parent_spends)
+}
+
+/// Retrieve a `Spend` from the closest peers
+async fn get_spend(network: Network, address: DbcAddress) -> Result<SignedSpend> {
+    let request = Request::Query(Query::Spend(SpendQuery::GetDbcSpend(address)));
+    let responses = network.node_send_to_closest(&request).await?;
+
+    // Get all Ok results of the expected response type `GetDbcSpend`.
+    let spends: Vec<_> = responses
+        .iter()
+        .flatten()
+        .flat_map(|resp| {
+            if let Response::Query(QueryResponse::GetDbcSpend(Ok(signed_spend))) = resp {
+                Some(signed_spend.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // As to not have a single rogue node deliver a bogus spend,
+    // and thereby have us fail the check here
+    // (we would have more than 1 spend in the BTreeSet), we must
+    // look for a majority of the same responses, and ignore any other responses.
+    if spends.len() >= close_group_majority() {
+        // Majority of nodes in the close group returned an Ok response.
+        use itertools::*;
+        if let Some(spend) = spends
+            .into_iter()
+            .map(|x| (x, 1))
+            .into_group_map()
+            .into_iter()
+            .filter(|(_, v)| v.len() >= close_group_majority())
+            .max_by_key(|(_, v)| v.len())
+            .map(|(k, _)| k)
+        {
+            // Majority of nodes in the close group returned the same spend.
+            return Ok(spend);
+        }
+    }
+
+    // The parent is not recognised by majority of peers in its close group.
+    // Thus, the parent is not valid.
+    info!("The spend could not be verified as valid: {address:?}");
+
+    // If not enough spends were gotten, we try error the first
+    // error to the expected query returned from nodes.
+    for resp in responses.iter().flatten() {
+        if let Response::Query(QueryResponse::GetDbcSpend(result)) = resp {
+            let _ = result.clone()?;
+        };
+    }
+
+    // If there were no success or fail to the expected query,
+    // we check if there were any send errors.
+    for resp in responses {
+        let _ = resp?;
+    }
+
+    // If there was none of the above, then we had unexpected responses.
+    Err(Error::UnexpectedResponses)
 }

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -135,7 +135,7 @@ impl Node {
                     }
                     Err(_) => {}
                 };
-                std::thread::sleep(std::time::Duration::from_millis(1));
+                std::thread::sleep(std::time::Duration::from_millis(3));
             }
         });
 
@@ -430,6 +430,7 @@ async fn handle_spend_dbc(
     // First we fetch all parent spends from the network.
     // They shall naturally all exist as valid spends for this current
     // spend attempt to be valid.
+    trace!("handle_spend_dbc");
     let parent_spends = match get_parent_spends(network.clone(), &parent_tx).await {
         Ok(parent_spends) => parent_spends,
         Err(error) => {
@@ -450,6 +451,8 @@ async fn handle_spend_dbc(
             return;
         }
     };
+
+    trace!("got parent_spends for handle_spend_dbc");
 
     let transfer_action = TransferAction {
         signed_spend,
@@ -478,6 +481,7 @@ async fn get_parent_spends(
     let mut all_parent_spends = BTreeSet::new();
 
     if is_genesis_parent_tx(parent_tx) {
+        trace!("Return with empty parent_spends for genesis");
         return Ok(all_parent_spends);
     }
 
@@ -489,7 +493,9 @@ async fn get_parent_spends(
         // This call makes sure we get the same spend from all in the close group.
         // If we receive a spend here, it is assumed to be valid. But we will verify
         // that anyway, in the code right after this for loop.
+        trace!("getting parent_spend for {:?}", parent_address.name());
         let parent_spend = get_spend(network.clone(), parent_address).await?;
+        trace!("got parent_spend for {:?}", parent_address.name());
         let _ = all_parent_spends.insert(parent_spend);
     }
 

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -430,7 +430,7 @@ async fn handle_spend_dbc(
     // First we fetch all parent spends from the network.
     // They shall naturally all exist as valid spends for this current
     // spend attempt to be valid.
-    trace!("handle_spend_dbc");
+    trace!("Handle spend dbc bearing parent_tx {:?}", parent_tx.hash());
     let parent_spends = match get_parent_spends(network.clone(), &parent_tx).await {
         Ok(parent_spends) => parent_spends,
         Err(error) => {
@@ -452,7 +452,7 @@ async fn handle_spend_dbc(
         }
     };
 
-    trace!("got parent_spends for handle_spend_dbc");
+    trace!("Got parent_spends for {:?}", parent_tx.hash());
 
     let transfer_action = TransferAction {
         signed_spend,

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -15,12 +15,15 @@ pub use self::{
     event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
 };
 
+use self::api::TransferAction;
+
 use crate::{
     domain::{node_transfers::Transfers, storage::RegisterStorage},
     network::Network,
 };
 
 use libp2p::{Multiaddr, PeerId};
+use tokio::sync::mpsc;
 
 /// `Node` represents a single node in the distributed network. It handles
 /// network events, processes incoming requests, interacts with the data
@@ -32,4 +35,5 @@ pub struct Node {
     events_channel: NodeEventsChannel,
     /// Peers that are dialed at startup of node.
     initial_peers: Vec<(PeerId, Multiaddr)>,
+    transfer_actor: mpsc::Sender<TransferAction>,
 }

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -21,10 +21,9 @@ use sn_dbc::Token;
 use assert_fs::TempDir;
 use eyre::Result;
 
-#[ignore = "Not yet finished."]
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_sequential_transfers_succeed() -> Result<()> {
-    // let _log_appender_guard = crate::log::init_node_logging(&None)?;
+    let _log_appender_guard = crate::log::init_node_logging(&None)?;
 
     let first_wallet_dir = TempDir::new()?;
     let first_wallet_balance = Token::from_nano(1_000_000_000);

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -33,6 +33,7 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
     println!("Getting {first_wallet_balance} tokens from the faucet...");
     let tokens =
         get_tokens_from_faucet(first_wallet_balance, first_wallet.address(), &client).await;
+    std::thread::sleep(std::time::Duration::from_secs(2));
     println!("Verifying the transfer from faucet...");
     client.verify(&tokens).await?;
     first_wallet.deposit(vec![tokens]);
@@ -53,6 +54,7 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
         &client,
     )
     .await;
+    std::thread::sleep(std::time::Duration::from_secs(5));
     println!("Verifying the transfer from first wallet...");
     client.verify(&tokens).await?;
     second_wallet.deposit(vec![tokens]);

--- a/safenode/src/tests_e2e/mod.rs
+++ b/safenode/src/tests_e2e/mod.rs
@@ -29,7 +29,7 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
     let first_wallet_balance = Token::from_nano(1_000_000_000);
 
     let mut first_wallet = get_wallet(first_wallet_dir.path()).await;
-    let client = get_client();
+    let client = get_client().await;
     println!("Getting {first_wallet_balance} tokens from the faucet...");
     let tokens =
         get_tokens_from_faucet(first_wallet_balance, first_wallet.address(), &client).await;
@@ -71,9 +71,11 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
     Ok(())
 }
 
-fn get_client() -> Client {
+async fn get_client() -> Client {
     let secret_key = bls::SecretKey::random();
-    Client::new(secret_key, None).expect("Client shall be successfully created.")
+    Client::new(secret_key, None)
+        .await
+        .expect("Client shall be successfully created.")
 }
 
 async fn get_wallet(root_dir: &Path) -> LocalWallet {


### PR DESCRIPTION
This PR contains the work trying to resolve the deadlock issue during the dbc spend process.
Which shall get the `multiple_sequential_transfers_succeed` test starts passing

Closes https://github.com/maidsafe/safe_network/pull/218