### PR TITLE
feat: enable otel tracing for the node

### DIFF
--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -17,6 +17,14 @@ path = "src/bin/safe/mod.rs"
 name = "faucet"
 path = "src/bin/faucet.rs"
 
+[features]
+otlp = [
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "opentelemetry-semantic-conventions",
+    "tracing-opentelemetry",
+]
+
 [dependencies]
 async-trait = "0.1"
 bincode = "1.3.1"
@@ -35,6 +43,9 @@ itertools = "~0.10.1"
 lazy_static = "~1.4.0"
 libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "mdns", "quic", "request-response",] }
 libp2p-quic = { version = "0.7.0-alpha.3", features = ["tokio"] }
+opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.10", optional = true }
+opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 priority-queue = "~0.7.0"
 prost = { version = "0.9" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -49,9 +60,10 @@ tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lo
 tokio-stream = { version = "~0.1.12" }
 tonic = { version = "0.6.2" }
 tracing = { version = "~0.1.26" }
-tracing-subscriber = "0.3.16"
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
+tracing-opentelemetry = { version = "0.17", optional = true }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 walkdir = "2.3.1"
 xor_name = "5.0.0"
 

--- a/safenode/src/log/error.rs
+++ b/safenode/src/log/error.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+/// Internal error.
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[cfg(feature = "otlp")]
+    #[error("OpenTelemetry Tracing error: {0}")]
+    OpenTelemetryTracing(#[from] opentelemetry::trace::TraceError),
+    #[error("Could not configure OTLP logging: {0}")]
+    OtlpConfigurationError(String),
+}

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -96,6 +96,8 @@ impl SwarmDriver {
         &mut self,
         event: SwarmEvent<NodeEvent, EventError>,
     ) -> Result<()> {
+        let span = info_span!("Handling a swarm event");
+        let _ = span.enter();
         match event {
             SwarmEvent::Behaviour(NodeEvent::MsgReceived(event)) => {
                 if let Err(e) = self.handle_msg(event).await {


### PR DESCRIPTION
- 5a6f6a7 **feat: enable otel tracing for the node**

  Enables Open Telemetry tracing for the node so we can start getting traces in Opensearch. The
  configuration is almost identical to the old node. As with the old setup, `otlp` is a feature that
  needs to be enabled, and it will also be toggled by use of the `OTEL_EXPORTER_OTLP_ENDPOINT`
  environment variable.

  I also made a change so that logging for the service always goes to stdout, even when a file is
  specified for logs to go to. This is useful for quick debugging when the node is running as a
  service, which it does in the remote setup. You can use `journalctl` to tail or dump out the logs,
  and that would apply even if logs to file weren't enabled.

  Traces are only submitted to the telemetry collector service when spans are used, so to get things
  started, one span was added for swarm events; more can be added on an ad-hoc basis when needed.

- bd7fc04 **chore: make the `--root-dir` argument optional**

  The usage of this argument was a bit confusing, because it was specified as optional, but then the
  code asserted that a value had to be provided. This time it's changed to actually be optional and
  the default value is indicated by the doc comments.

  I took the opportunity to elaborate the documentation for the other arguments.