### PR TITLE
Remove fees per input

### DIFF
--- a/safenode/src/domain/client_transfers/mod.rs
+++ b/safenode/src/domain/client_transfers/mod.rs
@@ -39,16 +39,13 @@ pub(crate) use self::{
     online::create_transfer as create_online_transfer,
 };
 
-use crate::protocol::messages::{FeeCiphers, NodeId, RequiredFee};
+use crate::protocol::messages::{FeeCiphers, NodeId};
 
 use sn_dbc::{
-    Dbc, DbcId, DbcIdSource, DbcTransaction, DerivedKey, PublicAddress, RevealedAmount,
-    SignedSpend, Token,
+    Dbc, DbcIdSource, DbcTransaction, DerivedKey, PublicAddress, RevealedAmount, SignedSpend, Token,
 };
 
 use std::collections::BTreeMap;
-
-type NodeFeesPerInput = BTreeMap<DbcId, BTreeMap<NodeId, (RequiredFee, DbcIdSource)>>;
 
 /// The input details necessary to
 /// carry out a transfer of tokens.
@@ -61,11 +58,6 @@ pub struct Inputs {
     pub recipients: Vec<(Token, DbcIdSource)>,
     /// Any surplus amount after spending the necessary input dbcs.
     pub change: (Token, PublicAddress),
-    /// This is the set of input dbc keys, each having a set of
-    /// node ids and their respective fees to be paid, and the
-    /// dbc id source to generate the dbc the fees shall be paid to.
-    /// Used to produce the fee ciphers for the spends.
-    pub node_fees_per_input: NodeFeesPerInput,
 }
 
 /// The created dbcs and change dbc from a transfer

--- a/safenode/src/domain/client_transfers/offline.rs
+++ b/safenode/src/domain/client_transfers/offline.rs
@@ -106,7 +106,6 @@ fn select_inputs(
         dbcs_to_spend,
         recipients,
         change: (change_amount, change_to),
-        node_fees_per_input: BTreeMap::new(),
     })
 }
 

--- a/safenode/src/domain/client_transfers/online.rs
+++ b/safenode/src/domain/client_transfers/online.rs
@@ -221,7 +221,6 @@ async fn select_inputs(
         dbcs_to_spend,
         recipients,
         change: (change_amount, change_to),
-        node_fees_per_input,
     })
 }
 
@@ -244,7 +243,6 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
         dbcs_to_spend,
         recipients,
         change: (change, change_to),
-        node_fees_per_input,
     } = selected_inputs;
 
     let mut inputs = vec![];
@@ -313,16 +311,13 @@ fn create_transfer_with(selected_inputs: Inputs) -> Result<Outputs> {
             "Missing source dbc tx of {dbc_id:?}!"
         )))?;
 
-        let node_fees = node_fees_per_input
-            .get(dbc_id)
-            .ok_or(Error::DbcReissueFailed(format!(
-                "Missing source dbc tx of {dbc_id:?}!"
-            )))?;
+        // NB TODO no fees for now, but we might add some later
+        let node_fees = BTreeMap::new();
 
         let spend_requests = SpendRequest {
             signed_spend: signed_spend.clone(),
             parent_tx: parent_tx.clone(),
-            fee_ciphers: fee_ciphers(&outputs, node_fees)?,
+            fee_ciphers: fee_ciphers(&outputs, &node_fees)?,
         };
 
         all_spend_requests.push(spend_requests);


### PR DESCRIPTION
This PR removes the fees per input design, which is an economically unviable design. 

Example scenario:
- each input has a fee, so for my 5$ input I will need a fee, let's say the smallest unit is 1$. 
- then I spend my 5$ and 1$ is fee, so far so good.
- now farmer nodes accumulate lots of small fee DBCs, in order for them to spend them, they need a fee
- to spend a 1$ DBC they will need a 1$ fee

In this system, eventually, all money on the network will turn into unuseable, value-less penny-DBCs

A viable alternative would be fee per Tx like bitcoin does. 