### PR TITLE
feat(storage): implement DiskBackedRecordStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1409,13 +1409,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1509,6 +1509,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -2285,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -2300,9 +2310,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 
 [[package]]
 name = "libm"
@@ -2689,9 +2699,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -3618,6 +3628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "quinn-proto"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,7 +3783,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -3775,7 +3796,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "yasna",
 ]
 
@@ -3970,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -4053,7 +4074,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "chrono",
- "clap 4.2.5",
+ "clap 4.2.7",
  "crdts",
  "custom_debug",
  "dirs-next",
@@ -4070,6 +4091,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "proptest",
  "prost",
+ "quickcheck",
  "rand 0.8.5",
  "rayon",
  "rmp-serde",
@@ -4190,18 +4212,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4221,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c95a500e3923258f7fc3a16bf29934e403aef5ca1096e184d85e3b1926675e8"
+checksum = "2b2931818f5d80d6bbe619cc30edd53b822fac51e1f6833cd4659072d701721b"
 dependencies = [
  "serde",
 ]
@@ -4614,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -4626,15 +4648,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4857,7 +4879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.20",
+ "time 0.3.21",
  "tracing-subscriber",
 ]
 
@@ -5331,7 +5353,7 @@ dependencies = [
  "sha2 0.10.6",
  "stun",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
  "tokio",
  "turn",
  "url",
@@ -5802,7 +5824,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -5820,7 +5842,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -5843,7 +5865,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,6 +4075,7 @@ dependencies = [
  "rmp-serde",
  "self_encryption",
  "serde",
+ "smallvec",
  "sn_dbc",
  "thiserror",
  "tiny-keccak",

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -18,12 +18,7 @@ name = "faucet"
 path = "src/bin/faucet.rs"
 
 [features]
-otlp = [
-    "opentelemetry",
-    "opentelemetry-otlp",
-    "opentelemetry-semantic-conventions",
-    "tracing-opentelemetry",
-]
+otlp = ["opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tracing-opentelemetry"]
 
 [dependencies]
 async-trait = "0.1"
@@ -65,6 +60,7 @@ tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 walkdir = "2.3.1"
 xor_name = "5.0.0"
+smallvec = "1.10.0"
 
 [dev-dependencies]
 assert_fs = "1.0.0"

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -66,6 +66,7 @@ smallvec = "1.10.0"
 assert_fs = "1.0.0"
 assert_matches = "1.5.0"
 proptest = { version = "1.0.0" }
+quickcheck = "1.0.3"
 
 [build-dependencies]
 tonic-build = { version = "0.6.2" }

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -1,0 +1,318 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+// This was forked from the
+// use super::*;
+
+use libp2p::identity::PeerId;
+use libp2p::kad::{kbucket, K_VALUE};
+use smallvec::SmallVec;
+
+use libp2p::kad::{
+    record::{Key, ProviderRecord, Record},
+    store::{Error, RecordStore, Result},
+};
+use std::borrow::Cow;
+use std::collections::{hash_map, hash_set, HashMap, HashSet};
+use std::iter;
+
+/// In-memory implementation of a `RecordStore`.
+pub(crate) struct DiskBackedRecordStore {
+    /// The identity of the peer owning the store.
+    local_key: kbucket::Key<PeerId>,
+    /// The configuration of the store.
+    config: DiskBackedRecordStoreConfig,
+    /// The stored (regular) records.
+    records: HashMap<Key, Record>,
+    /// The stored provider records.
+    providers: HashMap<Key, SmallVec<[ProviderRecord; K_VALUE.get()]>>,
+    /// The set of all provider records for the node identified by `local_key`.
+    ///
+    /// Must be kept in sync with `providers`.
+    provided: HashSet<ProviderRecord>,
+}
+
+/// Configuration for a `DiskBackedRecordStore`.
+#[derive(Debug, Clone)]
+pub(crate) struct DiskBackedRecordStoreConfig {
+    /// The maximum number of records.
+    pub(crate) max_records: usize,
+    /// The maximum size of record values, in bytes.
+    pub(crate) max_value_bytes: usize,
+    /// The maximum number of providers stored for a key.
+    ///
+    /// This should match up with the chosen replication factor.
+    pub(crate) max_providers_per_key: usize,
+    /// The maximum number of provider records for which the
+    /// local node is the provider.
+    pub(crate) max_provided_keys: usize,
+}
+
+impl Default for DiskBackedRecordStoreConfig {
+    fn default() -> Self {
+        Self {
+            max_records: 1024,
+            max_value_bytes: 65 * 1024,
+            max_provided_keys: 1024,
+            max_providers_per_key: K_VALUE.get(),
+        }
+    }
+}
+
+impl DiskBackedRecordStore {
+    /// Creates a new `DiskBackedStore` with a default configuration.
+    pub(crate) fn new(local_id: PeerId) -> Self {
+        Self::with_config(local_id, Default::default())
+    }
+
+    /// Creates a new `DiskBackedStore` with the given configuration.
+    pub(crate) fn with_config(local_id: PeerId, config: DiskBackedRecordStoreConfig) -> Self {
+        DiskBackedRecordStore {
+            local_key: kbucket::Key::from(local_id),
+            config,
+            records: HashMap::default(),
+            provided: HashSet::default(),
+            providers: HashMap::default(),
+        }
+    }
+
+    /// Retains the records satisfying a predicate.
+    pub(crate) fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&Key, &mut Record) -> bool,
+    {
+        self.records.retain(f);
+    }
+}
+
+impl RecordStore for DiskBackedRecordStore {
+    type RecordsIter<'a> =
+        iter::Map<hash_map::Values<'a, Key, Record>, fn(&'a Record) -> Cow<'a, Record>>;
+
+    type ProvidedIter<'a> = iter::Map<
+        hash_set::Iter<'a, ProviderRecord>,
+        fn(&'a ProviderRecord) -> Cow<'a, ProviderRecord>,
+    >;
+
+    fn get(&self, k: &Key) -> Option<Cow<'_, Record>> {
+        self.records.get(k).map(Cow::Borrowed)
+    }
+
+    fn put(&mut self, r: Record) -> Result<()> {
+        if r.value.len() >= self.config.max_value_bytes {
+            return Err(Error::ValueTooLarge);
+        }
+
+        let num_records = self.records.len();
+
+        match self.records.entry(r.key.clone()) {
+            hash_map::Entry::Occupied(mut e) => {
+                e.insert(r);
+            }
+            hash_map::Entry::Vacant(e) => {
+                if num_records >= self.config.max_records {
+                    return Err(Error::MaxRecords);
+                }
+                e.insert(r);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn remove(&mut self, k: &Key) {
+        self.records.remove(k);
+    }
+
+    fn records(&self) -> Self::RecordsIter<'_> {
+        self.records.values().map(Cow::Borrowed)
+    }
+
+    fn add_provider(&mut self, record: ProviderRecord) -> Result<()> {
+        let num_keys = self.providers.len();
+
+        // Obtain the entry
+        let providers = match self.providers.entry(record.key.clone()) {
+            e @ hash_map::Entry::Occupied(_) => e,
+            e @ hash_map::Entry::Vacant(_) => {
+                if self.config.max_provided_keys == num_keys {
+                    return Err(Error::MaxProvidedKeys);
+                }
+                e
+            }
+        }
+        .or_insert_with(Default::default);
+
+        if let Some(i) = providers.iter().position(|p| p.provider == record.provider) {
+            // In-place update of an existing provider record.
+            providers.as_mut()[i] = record;
+        } else {
+            // It is a new provider record for that key.
+            let local_key = self.local_key.clone();
+            let key = kbucket::Key::new(record.key.clone());
+            let provider = kbucket::Key::from(record.provider);
+            if let Some(i) = providers.iter().position(|p| {
+                let pk = kbucket::Key::from(p.provider);
+                provider.distance(&key) < pk.distance(&key)
+            }) {
+                // Insert the new provider.
+                if local_key.preimage() == &record.provider {
+                    self.provided.insert(record.clone());
+                }
+                providers.insert(i, record);
+                // Remove the excess provider, if any.
+                if providers.len() > self.config.max_providers_per_key {
+                    if let Some(p) = providers.pop() {
+                        self.provided.remove(&p);
+                    }
+                }
+            } else if providers.len() < self.config.max_providers_per_key {
+                // The distance of the new provider to the key is larger than
+                // the distance of any existing provider, but there is still room.
+                if local_key.preimage() == &record.provider {
+                    self.provided.insert(record.clone());
+                }
+                providers.push(record);
+            }
+        }
+        Ok(())
+    }
+
+    fn providers(&self, key: &Key) -> Vec<ProviderRecord> {
+        self.providers
+            .get(key)
+            .map_or_else(Vec::new, |ps| ps.clone().into_vec())
+    }
+
+    fn provided(&self) -> Self::ProvidedIter<'_> {
+        self.provided.iter().map(Cow::Borrowed)
+    }
+
+    fn remove_provider(&mut self, key: &Key, provider: &PeerId) {
+        if let hash_map::Entry::Occupied(mut e) = self.providers.entry(key.clone()) {
+            let providers = e.get_mut();
+            if let Some(i) = providers.iter().position(|p| &p.provider == provider) {
+                let p = providers.remove(i);
+                self.provided.remove(&p);
+            }
+            if providers.is_empty() {
+                e.remove();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p_core::multihash::{Code, Multihash};
+    use quickcheck::*;
+    use rand::Rng;
+
+    fn random_multihash() -> Multihash {
+        Multihash::wrap(Code::Sha2_256.into(), &rand::thread_rng().gen::<[u8; 32]>()).unwrap()
+    }
+
+    fn distance(r: &ProviderRecord) -> kbucket::Distance {
+        kbucket::Key::new(r.key.clone()).distance(&kbucket::Key::from(r.provider))
+    }
+
+    #[test]
+    fn put_get_remove_record() {
+        fn prop(r: Record) {
+            let mut store = DiskBackedRecordStore::new(PeerId::random());
+            assert!(store.put(r.clone()).is_ok());
+            assert_eq!(Some(Cow::Borrowed(&r)), store.get(&r.key));
+            store.remove(&r.key);
+            assert!(store.get(&r.key).is_none());
+        }
+        quickcheck(prop as fn(_))
+    }
+
+    #[test]
+    fn add_get_remove_provider() {
+        fn prop(r: ProviderRecord) {
+            let mut store = DiskBackedRecordStore::new(PeerId::random());
+            assert!(store.add_provider(r.clone()).is_ok());
+            assert!(store.providers(&r.key).contains(&r));
+            store.remove_provider(&r.key, &r.provider);
+            assert!(!store.providers(&r.key).contains(&r));
+        }
+        quickcheck(prop as fn(_))
+    }
+
+    #[test]
+    fn providers_ordered_by_distance_to_key() {
+        fn prop(providers: Vec<kbucket::Key<PeerId>>) -> bool {
+            let mut store = DiskBackedRecordStore::new(PeerId::random());
+            let key = Key::from(random_multihash());
+
+            let mut records = providers
+                .into_iter()
+                .map(|p| ProviderRecord::new(key.clone(), p.into_preimage(), Vec::new()))
+                .collect::<Vec<_>>();
+
+            for r in &records {
+                assert!(store.add_provider(r.clone()).is_ok());
+            }
+
+            records.sort_by_key(distance);
+            records.truncate(store.config.max_providers_per_key);
+
+            records == store.providers(&key).to_vec()
+        }
+
+        quickcheck(prop as fn(_) -> _)
+    }
+
+    #[test]
+    fn provided() {
+        let id = PeerId::random();
+        let mut store = DiskBackedRecordStore::new(id);
+        let key = random_multihash();
+        let rec = ProviderRecord::new(key, id, Vec::new());
+        assert!(store.add_provider(rec.clone()).is_ok());
+        assert_eq!(
+            vec![Cow::Borrowed(&rec)],
+            store.provided().collect::<Vec<_>>()
+        );
+        store.remove_provider(&rec.key, &id);
+        assert_eq!(store.provided().count(), 0);
+    }
+
+    #[test]
+    fn update_provider() {
+        let mut store = DiskBackedRecordStore::new(PeerId::random());
+        let key = random_multihash();
+        let prv = PeerId::random();
+        let mut rec = ProviderRecord::new(key, prv, Vec::new());
+        assert!(store.add_provider(rec.clone()).is_ok());
+        assert_eq!(vec![rec.clone()], store.providers(&rec.key).to_vec());
+        rec.expires = Some(Instant::now());
+        assert!(store.add_provider(rec.clone()).is_ok());
+        assert_eq!(vec![rec.clone()], store.providers(&rec.key).to_vec());
+    }
+
+    #[test]
+    fn max_provided_keys() {
+        let mut store = DiskBackedRecordStore::new(PeerId::random());
+        for _ in 0..store.config.max_provided_keys {
+            let key = random_multihash();
+            let prv = PeerId::random();
+            let rec = ProviderRecord::new(key, prv, Vec::new());
+            let _ = store.add_provider(rec);
+        }
+        let key = random_multihash();
+        let prv = PeerId::random();
+        let rec = ProviderRecord::new(key, prv, Vec::new());
+        match store.add_provider(rec) {
+            Err(Error::MaxProvidedKeys) => {}
+            _ => panic!("Unexpected result"),
+        }
+    }
+}

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::network::CLOSE_GROUP_SIZE;
 use libp2p::{
     identity::PeerId,
     kad::{
@@ -15,33 +14,17 @@ use libp2p::{
         store::{Error, RecordStore, Result},
     },
 };
-use smallvec::SmallVec;
-use std::{
-    borrow::Cow,
-    collections::{hash_map, HashMap, HashSet},
-    fs,
-    path::PathBuf,
-    vec,
-};
-
-// The maximum number of providers stored for a key. This value should be equal to our chosen
-// CLOSE_GROUP_SIZE (kad::replication_factor).
-const MAX_PROVIDERS_PER_KEY: usize = CLOSE_GROUP_SIZE;
+use std::{borrow::Cow, collections::HashSet, fs, path::PathBuf, vec};
 
 /// A `RecordStore` that stores records on disk.
 pub(crate) struct DiskBackedRecordStore {
     /// The identity of the peer owning the store.
+    #[allow(dead_code)]
     local_key: KBucketKey<PeerId>,
     /// The configuration of the store.
     config: DiskBackedRecordStoreConfig,
     /// A set of keys, each corresponding to a data `Record` stored on disk.
-    disk_backed_records: HashSet<Key>,
-    /// The stored provider records.
-    providers: HashMap<Key, SmallVec<[ProviderRecord; MAX_PROVIDERS_PER_KEY]>>,
-    /// The set of all provider records for the node identified by `local_key`.
-    ///
-    /// Must be kept in sync with `providers`.
-    provided: HashSet<ProviderRecord>,
+    records: HashSet<Key>,
 }
 
 /// Configuration for a `DiskBackedRecordStore`.
@@ -53,18 +36,14 @@ pub(crate) struct DiskBackedRecordStoreConfig {
     pub(crate) max_records: usize,
     /// The maximum size of record values, in bytes.
     pub(crate) max_value_bytes: usize,
-    /// The maximum number of provider records for which the
-    /// local node is the provider.
-    pub(crate) max_provided_keys: usize,
 }
 
 impl Default for DiskBackedRecordStoreConfig {
     fn default() -> Self {
         Self {
+            storage_dir: std::env::temp_dir(),
             max_records: 1024,
             max_value_bytes: 65 * 1024,
-            max_provided_keys: 1024,
-            storage_dir: std::env::temp_dir(),
         }
     }
 }
@@ -81,9 +60,7 @@ impl DiskBackedRecordStore {
         DiskBackedRecordStore {
             local_key: KBucketKey::from(local_id),
             config,
-            disk_backed_records: HashSet::default(),
-            provided: HashSet::default(),
-            providers: HashMap::default(),
+            records: HashSet::default(),
         }
     }
 
@@ -94,7 +71,7 @@ impl DiskBackedRecordStore {
         F: Fn(&Key) -> bool,
     {
         let to_be_removed = self
-            .disk_backed_records
+            .records
             .iter()
             .filter(|k| !predicate(k))
             .cloned()
@@ -123,7 +100,7 @@ impl RecordStore for DiskBackedRecordStore {
         // with the record. Thus a node can be bombarded with GET reqs for random keys. These can be safely
         // ignored if we don't have the record locally.
         trace!("GET request for Record key: {k:?}");
-        if !self.disk_backed_records.contains(k) {
+        if !self.records.contains(k) {
             trace!("Record not found locally");
             return None;
         }
@@ -170,7 +147,7 @@ impl RecordStore for DiskBackedRecordStore {
         // todo: the key is not tied to the value it contains, hence the value can be overwritten
         // (incase of dbc double spends etc), hence need to deal with those.
         // Maybe implement a RecordHeader to store the type of data we're storing?
-        if self.disk_backed_records.contains(&r.key) {
+        if self.records.contains(&r.key) {
             debug!(
                 "Record with key {:?} already exists, not overwriting.",
                 r.key
@@ -178,7 +155,7 @@ impl RecordStore for DiskBackedRecordStore {
             return Ok(());
         }
 
-        let num_records = self.disk_backed_records.len();
+        let num_records = self.records.len();
         if num_records >= self.config.max_records {
             warn!("Record not stored. Maximum number of records reached. Current num_records: {num_records}");
             return Err(Error::MaxRecords);
@@ -189,7 +166,7 @@ impl RecordStore for DiskBackedRecordStore {
         match fs::write(file_path, r.value) {
             Ok(_) => {
                 trace!("Wrote record to disk! filename: {filename}");
-                let _ = !self.disk_backed_records.insert(r.key);
+                let _ = !self.records.insert(r.key);
                 Ok(())
             }
             Err(err) => {
@@ -200,12 +177,13 @@ impl RecordStore for DiskBackedRecordStore {
     }
 
     fn remove(&mut self, k: &Key) {
+        let _ = self.records.remove(k);
+
         let filename = Self::key_to_hex(k);
         let file_path = self.config.storage_dir.join(&filename);
         match fs::remove_file(file_path) {
             Ok(_) => {
                 trace!("Removed record from disk! filename: {filename}");
-                let _ = self.disk_backed_records.remove(k);
             }
             Err(err) => {
                 error!("Error while removing file. filename: {filename}, error: {err:?}");
@@ -215,7 +193,7 @@ impl RecordStore for DiskBackedRecordStore {
 
     fn records(&self) -> Self::RecordsIter<'_> {
         let mut records = Vec::new();
-        for key in self.disk_backed_records.iter() {
+        for key in self.records.iter() {
             if let Some(record) = self.get(key) {
                 records.push(record);
             }
@@ -223,81 +201,20 @@ impl RecordStore for DiskBackedRecordStore {
         records.into_iter()
     }
 
-    fn add_provider(&mut self, record: ProviderRecord) -> Result<()> {
-        let num_keys = self.providers.len();
-
-        // Obtain the entry
-        let providers = match self.providers.entry(record.key.clone()) {
-            e @ hash_map::Entry::Occupied(_) => e,
-            e @ hash_map::Entry::Vacant(_) => {
-                if self.config.max_provided_keys == num_keys {
-                    return Err(Error::MaxProvidedKeys);
-                }
-                e
-            }
-        }
-        .or_insert_with(Default::default);
-
-        if let Some(i) = providers.iter().position(|p| p.provider == record.provider) {
-            // In-place update of an existing provider record.
-            providers.as_mut()[i] = record;
-        } else {
-            // It is a new provider record for that key.
-            let local_key = self.local_key.clone();
-            let key = KBucketKey::new(record.key.clone());
-            let provider = KBucketKey::from(record.provider);
-            if let Some(i) = providers.iter().position(|p| {
-                let pk = KBucketKey::from(p.provider);
-                provider.distance(&key) < pk.distance(&key)
-            }) {
-                // Insert the new provider.
-                if local_key.preimage() == &record.provider {
-                    let _ = self.provided.insert(record.clone());
-                }
-                providers.insert(i, record);
-                // Remove the excess provider, if any.
-                if providers.len() > MAX_PROVIDERS_PER_KEY {
-                    if let Some(p) = providers.pop() {
-                        let _ = self.provided.remove(&p);
-                    }
-                }
-            } else if providers.len() < MAX_PROVIDERS_PER_KEY {
-                // The distance of the new provider to the key is larger than
-                // the distance of any existing provider, but there is still room.
-                if local_key.preimage() == &record.provider {
-                    let _ = self.provided.insert(record.clone());
-                }
-                providers.push(record);
-            }
-        }
-        Ok(())
+    fn add_provider(&mut self, _record: ProviderRecord) -> Result<()> {
+        todo!("ProviderRecords are not used currently.")
     }
 
-    fn providers(&self, key: &Key) -> Vec<ProviderRecord> {
-        self.providers
-            .get(key)
-            .map_or_else(Vec::new, |ps| ps.clone().into_vec())
+    fn providers(&self, _key: &Key) -> Vec<ProviderRecord> {
+        todo!("ProviderRecords are not used currently.")
     }
 
     fn provided(&self) -> Self::ProvidedIter<'_> {
-        self.provided
-            .iter()
-            .map(Cow::Borrowed)
-            .collect::<Vec<_>>()
-            .into_iter()
+        todo!("ProviderRecords are not used currently.")
     }
 
-    fn remove_provider(&mut self, key: &Key, provider: &PeerId) {
-        if let hash_map::Entry::Occupied(mut e) = self.providers.entry(key.clone()) {
-            let providers = e.get_mut();
-            if let Some(i) = providers.iter().position(|p| &p.provider == provider) {
-                let p = providers.remove(i);
-                let _ = self.provided.remove(&p);
-            }
-            if providers.is_empty() {
-                let _ = e.remove();
-            }
-        }
+    fn remove_provider(&mut self, _key: &Key, _provider: &PeerId) {
+        todo!("ProviderRecords are not used currently.")
     }
 }
 
@@ -305,13 +222,8 @@ impl RecordStore for DiskBackedRecordStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libp2p::{
-        core::multihash::Multihash,
-        kad::kbucket::{Distance, Key as KBucketKey},
-    };
+    use libp2p::{core::multihash::Multihash, kad::kbucket::Key as KBucketKey};
     use quickcheck::*;
-    use rand::Rng;
-    use std::time::Instant;
 
     const MULITHASH_CODE: u64 = 0x12;
 
@@ -376,15 +288,6 @@ mod tests {
         }
     }
 
-    fn random_multihash() -> Multihash {
-        Multihash::wrap(MULITHASH_CODE, &rand::thread_rng().gen::<[u8; 32]>())
-            .expect("Failed to gen random_multihash")
-    }
-
-    fn distance(r: &ProviderRecord) -> Distance {
-        KBucketKey::new(r.key.clone()).distance(&KBucketKey::from(r.provider))
-    }
-
     #[test]
     fn put_get_remove_record() {
         fn prop(r: ArbitraryRecord) {
@@ -396,88 +299,5 @@ mod tests {
             assert!(store.get(&r.key).is_none());
         }
         quickcheck(prop as fn(_))
-    }
-
-    #[test]
-    fn add_get_remove_provider() {
-        fn prop(r: ArbitraryProviderRecord) {
-            let r = r.0;
-            let mut store = DiskBackedRecordStore::new(PeerId::random());
-            assert!(store.add_provider(r.clone()).is_ok());
-            assert!(store.providers(&r.key).contains(&r));
-            store.remove_provider(&r.key, &r.provider);
-            assert!(!store.providers(&r.key).contains(&r));
-        }
-        quickcheck(prop as fn(_))
-    }
-
-    #[test]
-    fn providers_ordered_by_distance_to_key() {
-        fn prop(providers: Vec<ArbitraryKBucketKey>) -> bool {
-            let mut store = DiskBackedRecordStore::new(PeerId::random());
-            let key = Key::from(random_multihash());
-
-            let mut records = providers
-                .into_iter()
-                .map(|p| ProviderRecord::new(key.clone(), p.0.into_preimage(), Vec::new()))
-                .collect::<Vec<_>>();
-
-            for r in &records {
-                assert!(store.add_provider(r.clone()).is_ok());
-            }
-
-            records.sort_by_key(distance);
-            records.truncate(MAX_PROVIDERS_PER_KEY);
-
-            records == store.providers(&key).to_vec()
-        }
-
-        quickcheck(prop as fn(_) -> _)
-    }
-
-    #[test]
-    fn provided() {
-        let id = PeerId::random();
-        let mut store = DiskBackedRecordStore::new(id);
-        let key = random_multihash();
-        let rec = ProviderRecord::new(key, id, Vec::new());
-        assert!(store.add_provider(rec.clone()).is_ok());
-        assert_eq!(
-            vec![Cow::Borrowed(&rec)],
-            store.provided().collect::<Vec<_>>()
-        );
-        store.remove_provider(&rec.key, &id);
-        assert_eq!(store.provided().count(), 0);
-    }
-
-    #[test]
-    fn update_provider() {
-        let mut store = DiskBackedRecordStore::new(PeerId::random());
-        let key = random_multihash();
-        let prv = PeerId::random();
-        let mut rec = ProviderRecord::new(key, prv, Vec::new());
-        assert!(store.add_provider(rec.clone()).is_ok());
-        assert_eq!(vec![rec.clone()], store.providers(&rec.key).to_vec());
-        rec.expires = Some(Instant::now());
-        assert!(store.add_provider(rec.clone()).is_ok());
-        assert_eq!(vec![rec.clone()], store.providers(&rec.key).to_vec());
-    }
-
-    #[test]
-    fn max_provided_keys() {
-        let mut store = DiskBackedRecordStore::new(PeerId::random());
-        for _ in 0..store.config.max_provided_keys {
-            let key = random_multihash();
-            let prv = PeerId::random();
-            let rec = ProviderRecord::new(key, prv, Vec::new());
-            let _ = store.add_provider(rec);
-        }
-        let key = random_multihash();
-        let prv = PeerId::random();
-        let rec = ProviderRecord::new(key, prv, Vec::new());
-        match store.add_provider(rec) {
-            Err(Error::MaxProvidedKeys) => {}
-            _ => panic!("Unexpected result"),
-        }
     }
 }

--- a/safenode/src/domain/storage/mod.rs
+++ b/safenode/src/domain/storage/mod.rs
@@ -6,10 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod disk_backed_record_store;
 mod registers;
 mod spends;
 
 pub(crate) use self::{
+    disk_backed_record_store::{DiskBackedRecordStore, DiskBackedRecordStoreConfig},
     registers::{RegisterReplica, RegisterStorage},
     spends::SpendStorage,
 };

--- a/safenode/src/network/error.rs
+++ b/safenode/src/network/error.rs
@@ -71,7 +71,6 @@ pub enum Error {
     #[error("Could not get CLOSE_GROUP_SIZE number of peers.")]
     NotEnoughPeers,
 
-    /// We failed to retrieve data from our local record storage
-    #[error("Provider record was not found locally")]
+    #[error("Record was not found locally")]
     RecordNotFound,
 }

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -18,8 +18,10 @@ use crate::protocol::{
     storage::Chunk,
 };
 
+use crate::domain::storage::DiskBackedRecordStore;
+
 use libp2p::{
-    kad::{store::MemoryStore, GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
+    kad::{GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
     mdns,
     multiaddr::Protocol,
     request_response::{self, ResponseChannel as PeerResponseChannel},
@@ -34,7 +36,7 @@ use tracing::{info, warn};
 #[behaviour(out_event = "NodeEvent")]
 pub(super) struct NodeBehaviour {
     pub(super) request_response: request_response::Behaviour<MsgCodec>,
-    pub(super) kademlia: Kademlia<MemoryStore>,
+    pub(super) kademlia: Kademlia<DiskBackedRecordStore>,
     pub(super) mdns: mdns::tokio::Behaviour,
     pub(super) identify: libp2p::identify::Behaviour,
 }

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -11,15 +11,14 @@ use super::{
     msg::MsgCodec,
     SwarmDriver,
 };
-
-use crate::network::IDENTIFY_AGENT_STR;
-use crate::protocol::{
-    messages::{QueryResponse, Request, Response},
-    storage::Chunk,
+use crate::{
+    domain::storage::DiskBackedRecordStore,
+    network::IDENTIFY_AGENT_STR,
+    protocol::{
+        messages::{QueryResponse, Request, Response},
+        storage::Chunk,
+    },
 };
-
-use crate::domain::storage::DiskBackedRecordStore;
-
 use libp2p::{
     kad::{GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
     mdns,

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -24,16 +24,13 @@ use self::{
     msg::{MsgCodec, MsgProtocol},
 };
 
+use crate::domain::storage::{DiskBackedRecordStore, DiskBackedRecordStoreConfig};
 use crate::protocol::messages::{QueryResponse, Request, Response};
-
 use futures::{future::select_all, StreamExt};
 use libp2p::{
     core::muxing::StreamMuxerBox,
     identity,
-    kad::{
-        record::store::MemoryStore, store::MemoryStoreConfig, KBucketKey, Kademlia, KademliaConfig,
-        QueryId, Record, RecordKey,
-    },
+    kad::{KBucketKey, Kademlia, KademliaConfig, QueryId, Record, RecordKey},
     mdns,
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
@@ -196,7 +193,7 @@ impl SwarmDriver {
 
         // Configures the memory store to be able to hold larger
         // records than by default
-        let memory_store_cfg = MemoryStoreConfig {
+        let memory_store_cfg = DiskBackedRecordStoreConfig {
             max_value_bytes: 1024 * 1024,
             max_providers_per_key: CLOSE_GROUP_SIZE,
             ..Default::default()
@@ -206,7 +203,7 @@ impl SwarmDriver {
         // to outbound-only mode and don't listen on any address
         let kademlia = Kademlia::with_config(
             peer_id,
-            MemoryStore::with_config(peer_id, memory_store_cfg),
+            DiskBackedRecordStore::with_config(peer_id, memory_store_cfg),
             kad_cfg,
         );
 

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -111,8 +111,6 @@ impl SwarmDriver {
             // how often a node will replicate records that it has stored, aka copying the key-value pair to other nodes
             // this is a heavier operation than publication, so it is done less frequently
             .set_replication_interval(Some(Duration::from_secs(20)))
-            // how often a node will announce that it is providing a value for a specific key
-            .set_provider_publication_interval(Some(Duration::from_secs(10)))
             // how often a node will publish a record key, aka telling the others it exists
             .set_publication_interval(Some(Duration::from_secs(5)))
             // 1mb packet size

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -87,7 +87,7 @@ impl Node {
         initial_peers: Vec<(PeerId, Multiaddr)>,
         root_dir: &Path,
     ) -> Result<RunningNode> {
-        let (network, mut network_event_receiver, swarm_driver) = SwarmDriver::new(addr)?;
+        let (network, mut network_event_receiver, swarm_driver) = SwarmDriver::new(addr, root_dir)?;
         let node_events_channel = NodeEventsChannel::default();
 
         let (transfer_action_sender, mut transfer_action_receiver) = mpsc::channel(100);

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -244,7 +244,7 @@ impl Node {
                         CmdResponse::StoreChunk(Ok(()))
                     }
                     Err(err) => {
-                        error!("Failed to register node as chunk provider: {err:?}");
+                        error!("Failed to StoreChunk: {err:?}");
                         CmdResponse::StoreChunk(Err(
                             StorageError::ChunkNotStored(*addr.name()).into()
                         ))


### PR DESCRIPTION
- This allows KAD to store the `Records` to fs instead of memory.
- Only data `Records` are stored to disk, `ProviderRecords` are still stored in memory

closes #242 