### PR TITLE
Wallet cli ux

### DIFF
--- a/safenode/src/bin/safe/cli/files.rs
+++ b/safenode/src/bin/safe/cli/files.rs
@@ -6,10 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use safenode::{
-    client::{Client, Files},
-    protocol::storage::ChunkAddress,
-};
+use crate::{get_client, Multiaddr};
+use safenode::{client::Files, protocol::storage::ChunkAddress};
 
 use bytes::Bytes;
 use clap::Parser;
@@ -38,7 +36,12 @@ pub enum FilesCmds {
     },
 }
 
-pub(crate) async fn files_cmds(cmds: FilesCmds, client: Client, root_dir: &Path) -> Result<()> {
+pub(crate) async fn files_cmds(
+    cmds: FilesCmds,
+    peers: Vec<Multiaddr>,
+    root_dir: &Path,
+) -> Result<()> {
+    let client = get_client(peers).await?;
     let file_api: Files = Files::new(client);
     match cmds {
         FilesCmds::Upload { path } => upload_files(path, &file_api, root_dir).await?,

--- a/safenode/src/bin/safe/cli/register.rs
+++ b/safenode/src/bin/safe/cli/register.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::{get_client, Multiaddr};
 use safenode::client::{Client, Error as ClientError};
 
 use clap::Subcommand;
@@ -35,11 +36,12 @@ pub enum RegisterCmds {
     },
 }
 
-pub(crate) async fn register_cmds(cmds: RegisterCmds, client: &Client) -> Result<()> {
+pub(crate) async fn register_cmds(cmds: RegisterCmds, peers: Vec<Multiaddr>) -> Result<()> {
+    let client = get_client(peers).await?;
     match cmds {
-        RegisterCmds::Create { name } => create_register(name, client).await?,
-        RegisterCmds::Edit { name, entry } => edit_register(name, entry, client).await?,
-        RegisterCmds::Get { names } => get_registers(names, client).await?,
+        RegisterCmds::Create { name } => create_register(name, &client).await?,
+        RegisterCmds::Edit { name, entry } => edit_register(name, entry, &client).await?,
+        RegisterCmds::Get { names } => get_registers(names, &client).await?,
     }
     Ok(())
 }

--- a/safenode/src/bin/safe/cli/wallet.rs
+++ b/safenode/src/bin/safe/cli/wallet.rs
@@ -20,8 +20,6 @@ use std::path::Path;
 
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
-    /// Print the address of the wallet.
-    Address,
     /// Print the balance of the wallet.
     Balance,
     /// Deposit `Dbc`s to the local wallet.
@@ -31,15 +29,17 @@ pub enum WalletCmds {
     /// that dir, for example by choosing that path when downloading
     /// the dbc file from email or browser.
     Deposit,
+    /// Send from the wallet to a `PublicAddress`.
     Send {
-        /// This shall be the number of nanos to send.
-        /// Necessary if the `to` argument has been given.
+        /// The number of nanos to send.
         #[clap(name = "amount")]
         amount: String,
-        /// This must be a hex-encoded `PublicAddress`.
+        /// Hex-encoded `PublicAddress`.
         #[clap(name = "to")]
         to: String,
     },
+    /// Print the `PublicAddress` of the wallet.
+    Receive,
 }
 
 pub(crate) async fn wallet_cmds(
@@ -48,15 +48,15 @@ pub(crate) async fn wallet_cmds(
     root_dir: &Path,
 ) -> Result<()> {
     match cmds {
-        WalletCmds::Address => address(root_dir).await?,
         WalletCmds::Balance => balance(root_dir).await?,
         WalletCmds::Deposit => deposit(root_dir).await?,
         WalletCmds::Send { amount, to } => send(amount, to, peers, root_dir).await?,
+        WalletCmds::Receive => receive(root_dir).await?,
     }
     Ok(())
 }
 
-async fn address(root_dir: &Path) -> Result<()> {
+async fn receive(root_dir: &Path) -> Result<()> {
     let wallet = LocalWallet::load_from(root_dir).await?;
     let address_hex = hex::encode(wallet.address().to_bytes());
     println!("{address_hex}");


### PR DESCRIPTION
This is a tidy up for wallet ux in the cli

* Remove `safe wallet deposit` since it has no way to be used, there's no way to export a dbc for later being imported. My feeling is this functionality will be enabled later anyhow with something like wallet backups such as `safe wallet import|export`. The `deposit` functionality is still retained in the code since it's used for genesis dbc.

* `safe wallet address` is a local-only operation, but was trying to connect to the network. This is fixed by instantiating the client object later in the cli process, rather than immediately at the start. This allows commands that run locally to avoid creating the client and contacting the network.

* Rename `safe wallet address` to `safe wallet receive` to be a pair with `send|receive`.

In the future it would be nice to also have some extra features, but are beyond the scope of this PR:

* wallet backup via `safe wallet export|import` which packages the whole wallet into a zip file (tx history, dbcs, name metadata etc)

*  use EIP2333 derivation with BIP39 mnemonics exposed via `safe wallet mnemonic show|load` (is this ergonomic?)

* encrypt all secrets on disk with a password. Enter the password before signing txs or any other use of secret keys

* cleaner separation of tx creation and signing, as a path to offline / hardware wallet transaction signing