### PR TITLE
feat: only trigger replication when peer churning in close range

### DIFF
--- a/safenode/src/domain/storage/mod.rs
+++ b/safenode/src/domain/storage/mod.rs
@@ -11,7 +11,9 @@ mod registers;
 mod spends;
 
 pub(crate) use self::{
-    disk_backed_record_store::{DiskBackedRecordStore, DiskBackedRecordStoreConfig},
+    disk_backed_record_store::{
+        DiskBackedRecordStore, DiskBackedRecordStoreConfig, REPLICATION_INTERVAL,
+    },
     registers::{RegisterReplica, RegisterStorage},
     spends::SpendStorage,
 };

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -67,6 +67,13 @@ pub(crate) const CLOSE_GROUP_SIZE: usize = 8;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 // Sets the keep-alive timeout of idle connections.
 const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+// Duration of the period during which counting the number of times a peer
+// emmits `OutgoingConnectionError` error.
+// This value and the correspendent `DEAD_PEER_DETECTION_THRESHOLD`,
+// will be affected by the data/requests transmission among the network.
+const DEAD_PEER_DETECTION_PERIOD: Duration = Duration::from_secs(10);
+// Number of entries to be held in the dead peer dectection LRU cache.
+const DEAD_PEER_DETECTION_CAPACITY: usize = 50;
 
 /// Our agent string has as a prefix that we can match against.
 pub const IDENTIFY_AGENT_STR: &str = "safe/node/";
@@ -290,8 +297,8 @@ impl SwarmDriver {
             pending_requests: Default::default(),
             pending_query: Default::default(),
             potential_dead_peers: LruCache::with_expiry_duration_and_capacity(
-                Duration::from_secs(10),
-                50,
+                DEAD_PEER_DETECTION_PERIOD,
+                DEAD_PEER_DETECTION_CAPACITY,
             ),
         };
 


### PR DESCRIPTION
This PR contains the work of only trigger replication when close range peer is churning.
This is aim to reduce the replication workload.

There are two timing spots that replication shall be triggered: 
a newly added peer falls into our close range; one of our close range peer dropped out

Depends on PR https://github.com/maidsafe/safe_network/pull/264

Related to issue https://github.com/maidsafe/safe_network/issues/260