### PR TITLE
feat: dead peer detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,6 +2763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru_time_cache"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,6 +4114,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libp2p-quic",
+ "lru_time_cache",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -45,6 +45,7 @@ itertools = "~0.10.1"
 lazy_static = "~1.4.0"
 libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "request-response", "identify"] }
 libp2p-quic = { version = "0.7.0-alpha.3", features = ["tokio"] }
+lru_time_cache = "0.11.11"
 opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.10", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }


### PR DESCRIPTION
This PR contains the work of detection dead peers and remove it from the kad.

Note: this relies on `flying requests among nodes`. i.e. the detection only works when there is data/requests being exchanged among the network.
A quiet network, say startup a network of 25 nodes locally, then kill one of it, won't trigger the detection. 