### PR TITLE
fix(client): Register retrieval API was expecting incorrect error type

### DIFF
--- a/safenode/src/client/register/offline_replica.rs
+++ b/safenode/src/client/register/offline_replica.rs
@@ -308,7 +308,7 @@ impl RegisterOffline {
 
         // If no register was gotten, we will return the first error sent to us.
         for resp in responses.iter().flatten() {
-            if let Response::Query(QueryResponse::GetChunk(result)) = resp {
+            if let Response::Query(QueryResponse::GetRegister(result)) = resp {
                 let _ = result.clone()?;
             };
         }

--- a/safenode/src/network/error.rs
+++ b/safenode/src/network/error.rs
@@ -68,8 +68,8 @@ pub enum Error {
     #[error("The oneshot::sender has been dropped")]
     SenderDropped(#[from] oneshot::error::RecvError),
 
-    #[error("Could not get CLOSE_GROUP_SIZE number of peers.")]
-    NotEnoughPeers,
+    #[error("Could no get enough peers ({required}) to satisfy the request, found {found}")]
+    NotEnoughPeers { found: usize, required: usize },
 
     #[error("Record was not found locally")]
     RecordNotFound,

--- a/safenode/src/network/error.rs
+++ b/safenode/src/network/error.rs
@@ -68,7 +68,7 @@ pub enum Error {
     #[error("The oneshot::sender has been dropped")]
     SenderDropped(#[from] oneshot::error::RecvError),
 
-    #[error("Could no get enough peers ({required}) to satisfy the request, found {found}")]
+    #[error("Could not get enough peers ({required}) to satisfy the request, found {found}")]
     NotEnoughPeers { found: usize, required: usize },
 
     #[error("Record was not found locally")]

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -497,7 +497,10 @@ impl Network {
 
         if CLOSE_GROUP_SIZE > peers.len() {
             warn!("Not enough peers in the k-bucket to satisfy the request");
-            return Err(Error::NotEnoughPeers);
+            return Err(Error::NotEnoughPeers {
+                found: peers.len(),
+                required: CLOSE_GROUP_SIZE,
+            });
         }
         Ok(peers)
     }


### PR DESCRIPTION
- Register retrieval API was not handling error responses correctly, thus when no success response was received it was reporting always the same `Error::UnexpectedResponses` variant.
- Also adding context info to `Network::Error::NotEnoughPeers` variant.