### PR TITLE
feat: stop node process in case sub event channel closed

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -168,7 +168,7 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Build sn bins
-        run: cargo build --release --bins 
+        run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
 
       - name: Start a local network

--- a/safenode/src/bin/safenode/main.rs
+++ b/safenode/src/bin/safenode/main.rs
@@ -201,8 +201,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
         loop {
             match node_events_rx.recv().await {
                 Ok(NodeEvent::ConnectedToNetwork) => info!("Connected to the Network"),
-                Ok(_) => { /* we ignore other evvents */ }
-                Err(RecvError::Closed) => {
+                Ok(NodeEvent::ChannelClosed) | Err(RecvError::Closed) => {
                     if let Err(err) = ctrl_tx
                         .send(NodeCtrl::Stop {
                             delay: Duration::from_secs(1),
@@ -215,6 +214,10 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                         );
                         break;
                     }
+                }
+                Ok(event) => {
+                    /* we ignore other events */
+                    info!("Currently ignored node event {event:?}");
                 }
                 Err(RecvError::Lagged(n)) => {
                     warn!("Skipped {n} node events!");

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -212,7 +212,7 @@ impl SwarmDriver {
                 match *iden {
                     libp2p::identify::Event::Received { peer_id, info } => {
                         if info.agent_version.starts_with(IDENTIFY_AGENT_STR) {
-                            info!("Adding peer to routing table, based on received identify info from {peer_id:?}: {info:?}");
+                            info!("{:?} Adding peer to routing table, based on received identify info from {peer_id:?}: {info:?}", self.self_peer_id);
                             for multiaddr in info.listen_addrs {
                                 let _routing_update = self
                                     .swarm

--- a/safenode/src/node/event.rs
+++ b/safenode/src/node/event.rs
@@ -52,4 +52,6 @@ pub enum NodeEvent {
     RegisterEdited(RegisterAddress),
     /// A DBC Spend has been stored in local storage
     SpendStored(DbcId),
+    /// One of the sub event channel closed and unrecoverable.
+    ChannelClosed,
 }


### PR DESCRIPTION
Stop the node process when sub event channel closed.
This is to avoid the log files to be polluted by the unrecoverable error.