### PR TITLE
feat: use reviewpad:summary marker instead of spamming comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+## Description
+
+reviewpad:summary 

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -20,16 +20,6 @@ labels:
 # A workflow is a list of actions that will be executed based on the defined rules.
 # For more details see https://docs.reviewpad.com/guides/syntax#workflow.
 workflows:
-  # This workflow calls Reviewpad AI agent to summarize the pull request.
-  - name: summarize
-    description: Summarize the pull request
-    always-run: true
-    if:
-      # Summarize the pull requests when pull requests are opened or synchronized.
-      - rule: ($eventType() == "synchronize" || $eventType() == "opened") && $state() == "open"
-        extra-actions:
-          - $summarize()
-
   # This workflow assigns the most relevant reviewer to pull requests.
   # This helps guarantee that pull requests are reviewed by at least one person.
   - name: reviewer-assignment


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 May 23 13:27 UTC
This pull request contains two patches. The first one removes automatic summarization from reviewpad.yml. The second one adds a PULL_REQUEST_TEMPLATE file to the .github directory.
<!-- reviewpad:summarize:end -->


This pull request updates Reviewpad so that instead of putting a new comment with a new summary on every instance, it will update a comment in the actual PR description. The initial summary is triggered with the marker.