### PR TITLE
fix: remove issue message issue

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -62,10 +62,6 @@ workflows:
     description: Validate best practices for pull request management
     always-run: true
     if:
-      # Warn pull requests that do not have an associated GitHub issue.
-      - rule: $hasLinkedIssues() == false
-        extra-actions:
-          - $warn("Please link an issue to the pull request")
       # Warn pull requests if their description is empty.
       - rule: $description() == ""
         extra-actions:


### PR DESCRIPTION
## Description

Gets rid of:

Reviewpad Report

⚠️ Warnings

Please link an issue to the pull request



<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 May 23 02:20 UTC
This pull request fixes an issue where an unnecessary warning message was displayed when a pull request did not have an associated GitHub issue. The issue message has been removed.
<!-- reviewpad:summarize:end --> 
