### PR TITLE
fix: ci churn tests.

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -53,7 +53,9 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: |
+          ll ~/.safe/local-test-network/safenode-1/
+          echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/local-test-network/safenode-1/* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Check contact peer
         shell: bash

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -48,11 +48,12 @@ jobs:
         env:
           RUST_LOG: "safenode,safe=trace"
         timeout-minutes: 10
-
+        
       - name: Set contact env var node.
         shell: bash
-        # get all nodes listen ports
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        # Get safenode-1 local listen addr
+        # node-1 will _not_ be churned
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Check contact peer
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -182,12 +182,14 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: |
+          ll ~/.safe/local-test-network/safenode-1/
+          echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/local-test-network/safenode-1/* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Check contact peer
         shell: bash
         run: echo "Peer is $SAFE_PEERS"
-      
+  
       
       - name: Start a client to upload files
         run: cargo run --bin safe --release -- files upload -- "./resources"
@@ -314,7 +316,7 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/local-test-network/safenode-1/* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
   
       - name: execute the dbc spend test
         run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
@@ -403,7 +405,7 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/local-test-network/safenode-1/* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Start a client to upload chunks
         

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -180,8 +180,9 @@ jobs:
 
       - name: Set contact env var node.
         shell: bash
-        # get all nodes listen ports
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        # Get safenode-1 local listen addr
+        # node-1 will _not_ be churned
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Check contact peer
         shell: bash
@@ -294,22 +295,29 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+        run: cargo build --release --bins
         timeout-minutes: 30
 
+        
       - name: Build testing executable
         run: cargo test --release multiple_sequential_transfers_succeed --no-run
         timeout-minutes: 30
-
+        
       - name: Start a local network
         run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup
         env:
           RUST_LOG: "safenode,safe=trace"
-        timeout-minutes: 10
-
+          timeout-minutes: 10
+          
+      - name: Set contact env var node.
+        shell: bash
+        # Get safenode-1 local listen addr
+        # node-1 will _not_ be churned
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+  
       - name: execute the dbc spend test
-        run: cargo test --release --features="local-discovery" multiple_sequential_transfers_succeed  -- --nocapture
+        run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
         id: client-spend-dbc
         env:
           RUST_LOG: "safenode,safe=trace"
@@ -377,7 +385,7 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+        run: cargo build --release --bins
         timeout-minutes: 30
 
       - name: Build rpc client
@@ -391,31 +399,34 @@ jobs:
           RUST_LOG: "safenode,safe=trace"
         timeout-minutes: 10
 
+      - name: Set contact env var node.
+        shell: bash
+        # Get safenode-1 local listen addr
+        # node-1 will _not_ be churned
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+
       - name: Start a client to upload chunks
         
-        run: cargo run --bin safe --release --features="local-discovery" -- files upload -- "./resources"
+        run: cargo run --bin safe --release -- files upload -- "./resources"
         id: client-file-upload
         env:
           RUST_LOG: "safenode,safe=trace"
-        timeout-minutes: 10
+        timeout-minutes: 5
 
       - name: Start network churning
-        
         shell: bash
         run: ./resources/scripts/network_churning.sh
-        timeout-minutes: 20
+        timeout-minutes: 5
 
         
       - name: Start a client to confirm chunk still retained
-        
-        run: cargo run --bin safe --features local-discovery --release -- files download
+        run: cargo run --bin safe --release -- files download
         id: client-file-download
         env:
           RUST_LOG: "safenode,safe=trace"
-        timeout-minutes: 15
+        timeout-minutes: 5
 
-      - name: Downloaded file is same as the original
-        
+      - name: Downloaded finetwork_churnin.sh le is same as the original
         shell: bash
         timeout-minutes: 1
         run: |
@@ -424,7 +435,6 @@ jobs:
           cmp --silent $old $new
       
       - name: Verify restart of nodes using rg
-        
         shell: bash
         timeout-minutes: 1
         # get the counts, then the specific line, and then the digit count only

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -182,7 +182,7 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Check contact peer
         shell: bash
@@ -314,7 +314,7 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
   
       - name: execute the dbc spend test
         run: cargo test --release multiple_sequential_transfers_succeed  -- --nocapture
@@ -403,7 +403,7 @@ jobs:
         shell: bash
         # Get safenode-1 local listen addr
         # node-1 will _not_ be churned
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.log* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/safenode-1/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
 
       - name: Start a client to upload chunks
         

--- a/resources/scripts/network_churning.sh
+++ b/resources/scripts/network_churning.sh
@@ -14,7 +14,10 @@ echo "Number of existing nodes: $nodes_count"
 
 sleep 5
 
-count=0
+# start at 1 so we never restert node-1
+count=1
+
+echo "safenode-1 will not be restarted. This should enable continuity of SAFE_PEERS for the other nodes/clients"
 while (( $count != $nodes_count ))
 do
     ((count++))


### PR DESCRIPTION
Reduce use of local-discovery in CI.
Ensures node-1 does not churn so we can use that specifically for our SAFE_PEER and it's vaild over churn calls.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 May 23 21:25 UTC
This pull request fixes issue with CI churn tests, reducing the use of local-discovery and ensuring node-1 does not churn so it can be used specifically for SAFE_PEER. The changes include modifications to scripts and workflows.
<!-- reviewpad:summarize:end --> 
