### PR TITLE
feat(client): add a network redial feature; to redial if there's no activity.

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -87,35 +87,36 @@ impl Client {
                 }
 
                 info!("Client waiting for a network event");
-
-                tokio::select! {
-                    event = network_event_receiver.recv() => {
+                match tokio::time::timeout(INACTIVITY_TIMEOUT, network_event_receiver.recv()).await
+                {
+                    Ok(event) => {
                         let the_event = match event {
                             Some(the_event) => the_event,
                             None => {
                                 error!("The `NetworkEvent` channel has been closed");
                                 continue;
                             }
-
                         };
                         trace!("Client recevied a network event {the_event:?}");
                         if let Err(err) = client_clone.handle_network_event(the_event) {
                             warn!("Error handling network event: {err}");
                         }
 
-                        continue
+                        continue;
                     }
-                    _ = tokio::time::sleep(INACTIVITY_TIMEOUT) => {
+                    Err(_elapse_err) => {
                         if cfg!(feature = "inactive-client-redials") {
                             must_dial_network = true;
                             info!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
                             println!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
+                        } else if let Err(error) = client_clone
+                            .events_channel
+                            .broadcast(ClientEvent::InactiveClient(INACTIVITY_TIMEOUT))
+                        {
+                            error!("Error broadcasting inactive client event: {error}");
                         }
-                        else {
-                            client_clone.events_channel.broadcast(ClientEvent::InactiveClient(INACTIVITY_TIMEOUT));
-                        }
-                       continue
 
+                        continue;
                     }
                 }
             }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -69,8 +69,8 @@ impl Client {
                     if must_dial_network {
                         let network = network.clone();
                         let _handle = spawn(async move {
-                            trace!("Client dialing network");
                             for (peer_id, addr) in peers {
+                                trace!("Client dialing network peer {peer_id} at {addr:?}");
                                 let _ = network.add_to_routing_table(peer_id, addr.clone()).await;
                                 if let Err(err) = network.dial(peer_id, addr.clone()).await {
                                     tracing::error!("Failed to dial {peer_id}: {err:?}");
@@ -83,16 +83,32 @@ impl Client {
                 }
 
                 info!("Client waiting for a network event");
-                let event = match network_event_receiver.recv().await {
-                    Some(event) => event,
-                    None => {
-                        error!("The `NetworkEvent` channel has been closed");
-                        continue;
+                let inactivity_timeout = tokio::time::Duration::from_secs(10);
+
+                tokio::select! {
+                    event = network_event_receiver.recv() => {
+                        let the_event = match event {
+                            Some(the_event) => the_event,
+                            None => {
+                                error!("The `NetworkEvent` channel has been closed");
+                                continue;
+                            }
+
+                        };
+                        trace!("Client recevied a network event {the_event:?}");
+                        if let Err(err) = client_clone.handle_network_event(the_event) {
+                            warn!("Error handling network event: {err}");
+                        }
+
+                        continue
                     }
-                };
-                trace!("Client recevied a network event {event:?}");
-                if let Err(err) = client_clone.handle_network_event(event) {
-                    warn!("Error handling network event: {err}");
+                    _ = tokio::time::sleep(inactivity_timeout) => {
+                       must_dial_network = true;
+                        info!("Inactive client, will attempt to dial the network again");
+                        println!("Inactive client, will attempt to dial the network again");
+                       continue
+
+                    }
                 }
             }
         });

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -30,6 +30,9 @@ use tokio::task::spawn;
 use tracing::trace;
 use xor_name::XorName;
 
+/// The timeout duration for the client to receive any response from the network.
+const INACTIVITY_TIMEOUT: std::time::Duration = tokio::time::Duration::from_secs(10);
+
 impl Client {
     /// Instantiate a new client.
     pub async fn new(signer: SecretKey, peers: Option<Vec<(PeerId, Multiaddr)>>) -> Result<Self> {
@@ -63,6 +66,7 @@ impl Client {
             trace!("Starting up client swarm_driver");
             swarm_driver.run()
         });
+
         let _event_handler = spawn(async move {
             loop {
                 if let Some(peers) = peers.clone() {
@@ -83,7 +87,6 @@ impl Client {
                 }
 
                 info!("Client waiting for a network event");
-                let inactivity_timeout = tokio::time::Duration::from_secs(10);
 
                 tokio::select! {
                     event = network_event_receiver.recv() => {
@@ -102,10 +105,15 @@ impl Client {
 
                         continue
                     }
-                    _ = tokio::time::sleep(inactivity_timeout) => {
-                       must_dial_network = true;
-                        info!("Inactive client, will attempt to dial the network again");
-                        println!("Inactive client, will attempt to dial the network again");
+                    _ = tokio::time::sleep(INACTIVITY_TIMEOUT) => {
+                        if cfg!(feature = "inactive-client-redials") {
+                            must_dial_network = true;
+                            info!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
+                            println!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
+                        }
+                        else {
+                            client_clone.events_channel.broadcast(ClientEvent::InactiveClient(INACTIVITY_TIMEOUT));
+                        }
                        continue
 
                     }
@@ -118,6 +126,10 @@ impl Client {
                 ClientEvent::ConnectedToNetwork => {
                     info!("Client connected to the Network.");
                     println!("Client successfully connected to the Network.");
+                }
+                ClientEvent::InactiveClient(timeout) => {
+                    error!("Inactive client for {timeout:?}, inactive-client-redial is not set, and so shutting down");
+                    return Err(Error::InactiveClient(timeout));
                 }
             }
         }

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -10,6 +10,7 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
 use sn_protocol::storage::registers::{Entry, EntryHash};
 use std::collections::BTreeSet;
+use std::time::Duration;
 use thiserror::Error;
 
 use super::ClientEvent;
@@ -40,6 +41,10 @@ pub enum Error {
     /// A general error when verifying a transfer validity in the network.
     #[error("Failed to verify transfer validity in the network {0}")]
     CouldNotVerifyTransfer(String),
+
+    /// After attempting to dial, the client received no network activity for a given duration.
+    #[error("Client received no network activity for {0:?}")]
+    InactiveClient(Duration),
 
     #[error("Chunks error {0}.")]
     Chunks(#[from] super::chunks::Error),

--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -39,6 +39,9 @@ impl ClientEventsChannel {
 pub enum ClientEvent {
     /// The client has been connected to the network
     ConnectedToNetwork,
+    /// No network activity has been received for a given duration
+    /// we should error out
+    InactiveClient(std::time::Duration),
 }
 
 /// Receiver Channel where users of the public API can listen to events broadcasted by the client.

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin/faucet.rs"
 [features]
 default=[]
 local-discovery=["sn_networking/local-discovery"]
+inactive-client-redials=[]
+otlp = ["sn_logging/otlp"]
 
 [dependencies]
 async-trait = "0.1"

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -206,7 +206,7 @@ fn nodes_info_from_logs(path: &Path) -> Result<BTreeMap<u32, NodeInfo>> {
                 .expect("Failed to get parent dir")
                 .to_path_buf();
 
-            lines.filter_map(|item| item.ok()).for_each(|line| {
+            lines.map_while(|item| item.ok()).for_each(|line| {
                 if let Some(cap) = re.captures_iter(&line).next() {
                     let pid = cap[1].parse().expect("Failed to parse PID from node log");
                     let peer_id =


### PR DESCRIPTION
Clients coudl hang if for some reason the initial dial did not go through.

Here we redial if there has been no network activity

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 May 23 02:17 UTC
This pull request adds a network redial feature if there is no activity from the network. It also error outs if the `inactive-client-redials` feature is not enabled and there is inactivity from the network.
<!-- reviewpad:summarize:end --> 
