### PR TITLE
fix: prevent client hangs

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -107,7 +107,7 @@ impl Client {
             NetworkEvent::NewListenAddr(_) => {}
             NetworkEvent::PeerAdded(peer_id) => {
                 self.events_channel
-                    .broadcast(ClientEvent::ConnectedToNetwork);
+                    .broadcast(ClientEvent::ConnectedToNetwork)?;
                 debug!("PeerAdded: {peer_id}");
             }
         }

--- a/safenode/src/client/error.rs
+++ b/safenode/src/client/error.rs
@@ -13,6 +13,8 @@ use crate::protocol::storage::registers::{Entry, EntryHash};
 use std::collections::BTreeSet;
 use thiserror::Error;
 
+use super::ClientEvent;
+
 /// Internal error.
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
@@ -25,6 +27,9 @@ pub enum Error {
 
     #[error("Events receiver error {0}.")]
     EventsReceiver(#[from] tokio::sync::broadcast::error::RecvError),
+
+    #[error("Events sender error {0}.")]
+    EventsSender(#[from] tokio::sync::broadcast::error::SendError<ClientEvent>),
 
     #[error("ResponseTimeout.")]
     ResponseTimeout(#[from] tokio::time::error::Elapsed),

--- a/safenode/src/client/event.rs
+++ b/safenode/src/client/event.rs
@@ -28,10 +28,9 @@ impl ClientEventsChannel {
     }
 
     // Broadcast a new event, meant to be a helper only used by the client's internals.
-    pub(crate) fn broadcast(&self, event: ClientEvent) {
-        if let Err(err) = self.0.send(event.clone()) {
-            trace!("Error occurred when trying to broadcast a client event ({event:?}): {err}");
-        }
+    pub(crate) fn broadcast(&self, event: ClientEvent) -> Result<()> {
+        let _subscriber_count = self.0.send(event)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 May 23 01:51 UTC
This pull request fixes two issues related to the client event channel. It ensures that the broadcast function returns an error if we cannot broadcast on the client events channel. Moreover, it fixes intermittent client hangs by ensuring that we subscribe to the client events channel immediately after client initialization.
<!-- reviewpad:summarize:end --> 
