### PR TITLE
test: remove closest peer test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -110,11 +110,6 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release -p safenode -- network
 
-      - name: Run network tests with local discovery enabled
-        # Only run on PRs w/ ubuntu
-        timeout-minutes: 25
-        run: cargo test --release -p safenode --features="local-discovery" -- network
-
       - name: Run protocol tests
         # Only run on PRs w/ ubuntu
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,11 +168,6 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release -p safenode -- network
 
-      - name: Run network tests with local discovery enabled
-        # Only run on PRs w/ ubuntu
-        timeout-minutes: 25
-        run: cargo test --release -p safenode --features="local-discovery" -- network
-
       - name: Run protocol tests
         timeout-minutes: 25
         run: cargo test --release -p safenode -- protocol


### PR DESCRIPTION
This is essentially testing a kad feature, but one that requires a live network and discovery to funciton properly.

This has been very brittle, and if the underlying kad implementation is good, this should be fine.

So I think we can remove this test entirely

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 May 23 03:14 UTC
This pull request removes a test that required a live network and discovery to function properly, as it was considered brittle and unnecessary.
<!-- reviewpad:summarize:end --> 
