### PR TITLE
fix(node): implementation of RecordStore::records() libp2p trait fn w…

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -110,11 +110,6 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release -p safenode -- network
 
-      - name: Run network tests with local discovery enabled
-        # Only run on PRs w/ ubuntu
-        timeout-minutes: 25
-        run: cargo test --release -p safenode --features="local-discovery" -- network
-
       - name: Run protocol tests
         # Only run on PRs w/ ubuntu
         timeout-minutes: 25

--- a/resources/scripts/network_churning.sh
+++ b/resources/scripts/network_churning.sh
@@ -8,6 +8,7 @@ fi
 log_dir=~/.safe/node/local-test-network
 
 nodes_count=$(ls $log_dir | wc -l)
+nodes_count=3
 
 echo
 echo "Number of existing nodes: $nodes_count"
@@ -22,6 +23,7 @@ do
 
     echo Iteration $count
     echo Restarting node on port $target_port
+    rm -rf ~/.safe/node/local-test-network/safenode-$count
     cargo run --release --example safenode_rpc_client -- "127.0.0.1:$target_port" restart 1
 	sleep 5
 done

--- a/resources/scripts/network_churning.sh
+++ b/resources/scripts/network_churning.sh
@@ -24,7 +24,7 @@ do
     echo Restarting node on port $target_port
     rm -rf ~/.safe/node/local-test-network/safenode-$count
     cargo run --release --example safenode_rpc_client -- "127.0.0.1:$target_port" restart 1
-	sleep 30
+	sleep 5
 done
 
 export SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '') && echo "SAFE_PEERS now set to: $SAFE_PEERS"

--- a/resources/scripts/network_churning.sh
+++ b/resources/scripts/network_churning.sh
@@ -8,7 +8,6 @@ fi
 log_dir=~/.safe/node/local-test-network
 
 nodes_count=$(ls $log_dir | wc -l)
-nodes_count=3
 
 echo
 echo "Number of existing nodes: $nodes_count"
@@ -25,5 +24,7 @@ do
     echo Restarting node on port $target_port
     rm -rf ~/.safe/node/local-test-network/safenode-$count
     cargo run --release --example safenode_rpc_client -- "127.0.0.1:$target_port" restart 1
-	sleep 25
+	sleep 30
 done
+
+export SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe/**/*.lo* -u | rg '/ip4.*$' -m1 -o | rg '"' -r '') && echo "SAFE_PEERS now set to: $SAFE_PEERS"

--- a/resources/scripts/network_churning.sh
+++ b/resources/scripts/network_churning.sh
@@ -25,5 +25,5 @@ do
     echo Restarting node on port $target_port
     rm -rf ~/.safe/node/local-test-network/safenode-$count
     cargo run --release --example safenode_rpc_client -- "127.0.0.1:$target_port" restart 1
-	sleep 5
+	sleep 25
 done

--- a/safenode/Cargo.toml
+++ b/safenode/Cargo.toml
@@ -18,7 +18,7 @@ name = "faucet"
 path = "src/bin/faucet.rs"
 
 [features]
-default=[]
+default=["local-discovery"]
 local-discovery=["libp2p/mdns"]
 otlp = [
     "opentelemetry",

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -26,8 +26,8 @@ use std::{
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
-pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(180);
-pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(10);
+pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(8*60);
+pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(60);
 
 /// A `RecordStore` that stores records on disk.
 pub(crate) struct DiskBackedRecordStore {

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -26,8 +26,8 @@ use std::{
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
-pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(18 * 60);
-pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(3 * 60);
+pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(60 * 60);
+pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(20 * 60);
 
 /// A `RecordStore` that stores records on disk.
 pub(crate) struct DiskBackedRecordStore {

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -26,8 +26,8 @@ use std::{
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
-pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(18*60);
-pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(3*60);
+pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(18 * 60);
+pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(3 * 60);
 
 /// A `RecordStore` that stores records on disk.
 pub(crate) struct DiskBackedRecordStore {

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -6,11 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::network::CLOSE_GROUP_SIZE;
 use libp2p::{
     identity::PeerId,
     kad::{
-        kbucket::Key as KBucketKey,
+        kbucket::{Distance, Key as KBucketKey},
         record::{Key, ProviderRecord, Record},
         store::{Error, RecordStore, Result},
     },
@@ -24,9 +23,6 @@ use std::{
     time::{Duration, Instant},
     vec,
 };
-
-// Control the random replication factor, which means `one in x` copies got replicated each time.
-const RANDOM_REPLICATION_FACTOR: usize = CLOSE_GROUP_SIZE / 2;
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
@@ -42,8 +38,6 @@ pub(crate) struct DiskBackedRecordStore {
     config: DiskBackedRecordStoreConfig,
     /// A set of keys, each corresponding to a data `Record` stored on disk.
     records: HashSet<Key>,
-    /// Records for the next replication.
-    replication_records: Vec<Key>,
     /// Time that replication triggered.
     replication_start: Instant,
 }
@@ -90,7 +84,6 @@ impl DiskBackedRecordStore {
             local_key: KBucketKey::from(local_id),
             config,
             records: Default::default(),
-            replication_records: Default::default(),
             replication_start: Instant::now(),
         }
     }
@@ -111,32 +104,21 @@ impl DiskBackedRecordStore {
         to_be_removed.iter().for_each(|key| self.remove(key));
     }
 
-    /// Trigger a future replication
-    pub(crate) fn trigger_replication(&mut self) {
+    /// Returns the list of keys that within the distance to the target
+    pub(crate) fn entries_to_be_replicated(
+        &mut self,
+        target: KBucketKey<Vec<u8>>,
+        distance_bar: Distance,
+    ) -> Vec<Key> {
         self.replication_start = Instant::now();
-        if !self.replication_records.is_empty() {
-            // Do nothing if replication already triggered.
-            return;
-        }
-
-        let mut index: usize = {
-            let mut rng = rand::thread_rng();
-            rng.gen_range(0..RANDOM_REPLICATION_FACTOR)
-        };
-
-        for key in self.records.iter() {
-            if index % RANDOM_REPLICATION_FACTOR == 0 {
-                self.replication_records.push(key.clone());
-            }
-            index += 1;
-        }
-    }
-
-    /// Cleanup the replication cache when expired, i.e. replication shall got carried out.
-    pub(crate) fn try_clean_replication_cache(&mut self) {
-        if self.replication_start + self.config.replication_interval < Instant::now() {
-            self.replication_records.clear();
-        }
+        self.records
+            .iter()
+            .filter(|key| {
+                let record_key = KBucketKey::from(key.to_vec());
+                target.distance(&record_key) < distance_bar
+            })
+            .cloned()
+            .collect()
     }
 
     // Converts a Key into a Hex string.
@@ -149,7 +131,11 @@ impl DiskBackedRecordStore {
         hex_string
     }
 
-    fn read_from_disk<'a>(key: &Key, storage_dir: &Path) -> Option<Cow<'a, Record>> {
+    pub(crate) fn storage_dir(&self) -> PathBuf {
+        self.config.storage_dir.clone()
+    }
+
+    pub(crate) fn read_from_disk<'a>(key: &Key, storage_dir: &Path) -> Option<Cow<'a, Record>> {
         let filename = Self::key_to_hex(key);
         let file_path = storage_dir.join(&filename);
 
@@ -169,6 +155,10 @@ impl DiskBackedRecordStore {
                 None
             }
         }
+    }
+
+    pub(crate) fn write_to_local(&mut self, record: Record) -> Result<()> {
+        self.put(record)
     }
 }
 
@@ -246,10 +236,13 @@ impl RecordStore for DiskBackedRecordStore {
         }
     }
 
+    // A backstop replication shall only trigger within pre-defined interval
     fn records(&self) -> Self::RecordsIter<'_> {
         RecordsIterator {
             keys: self.records.iter(),
             storage_dir: self.config.storage_dir.clone(),
+            is_triggered: self.replication_start + self.config.replication_interval
+                < Instant::now(),
         }
     }
 
@@ -278,12 +271,16 @@ impl RecordStore for DiskBackedRecordStore {
 pub(crate) struct RecordsIterator<'a> {
     keys: hash_set::Iter<'a, Key>,
     storage_dir: PathBuf,
+    is_triggered: bool,
 }
 
 impl<'a> Iterator for RecordsIterator<'a> {
     type Item = Cow<'a, Record>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if !self.is_triggered {
+            return None;
+        }
         for key in self.keys.by_ref() {
             let record = DiskBackedRecordStore::read_from_disk(key, &self.storage_dir);
             if record.is_some() {

--- a/safenode/src/domain/storage/disk_backed_record_store.rs
+++ b/safenode/src/domain/storage/disk_backed_record_store.rs
@@ -26,8 +26,8 @@ use std::{
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
-pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(8*60);
-pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(60);
+pub(crate) const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(18*60);
+pub(crate) const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(3*60);
 
 /// A `RecordStore` that stores records on disk.
 pub(crate) struct DiskBackedRecordStore {

--- a/safenode/src/domain/storage/mod.rs
+++ b/safenode/src/domain/storage/mod.rs
@@ -12,7 +12,8 @@ mod spends;
 
 pub(crate) use self::{
     disk_backed_record_store::{
-        DiskBackedRecordStore, DiskBackedRecordStoreConfig, REPLICATION_INTERVAL,
+        DiskBackedRecordStore, DiskBackedRecordStoreConfig, REPLICATION_INTERVAL_LOWER_BOUND,
+        REPLICATION_INTERVAL_UPPER_BOUND,
     },
     registers::{RegisterReplica, RegisterStorage},
     spends::SpendStorage,

--- a/safenode/src/network/event.rs
+++ b/safenode/src/network/event.rs
@@ -13,9 +13,9 @@ use super::{
 };
 use crate::{
     domain::storage::DiskBackedRecordStore,
-    network::IDENTIFY_AGENT_STR,
+    network::{sort_peers_by_address, sort_peers_by_key, CLOSE_GROUP_SIZE, IDENTIFY_AGENT_STR},
     protocol::{
-        messages::{QueryResponse, Request, Response},
+        messages::{Cmd, QueryResponse, ReplicatedData, Request, Response},
         storage::Chunk,
         NetworkAddress,
     },
@@ -25,7 +25,7 @@ use crate::{
 use libp2p::mdns;
 
 use libp2p::{
-    kad::{GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
+    kad::{kbucket::Key as KBucketKey, GetRecordOk, Kademlia, KademliaEvent, QueryResult, K_VALUE},
     multiaddr::Protocol,
     request_response::{self, ResponseChannel as PeerResponseChannel},
     swarm::{NetworkBehaviour, SwarmEvent},
@@ -41,6 +41,11 @@ use tracing::{info, warn};
 // If higher than this number of times detected,
 // the peer is counted as dropped out from the network.
 const DEAD_PEER_DETECTION_THRESHOLD: usize = 3;
+
+// Defines how close that a node will trigger repliation.
+// That is, the node has to be among the REPLICATION_RANGE closest to data,
+// to carry out the replication.
+const REPLICATION_RANGE: usize = 2;
 
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "NodeEvent")]
@@ -197,7 +202,7 @@ impl SwarmDriver {
                         self.event_sender
                             .send(NetworkEvent::PeerAdded(*peer))
                             .await?;
-                        self.try_trigger_replication(peer);
+                        self.try_trigger_replication(peer, false);
                     }
                 }
                 KademliaEvent::InboundRequest { request } => {
@@ -287,14 +292,6 @@ impl SwarmDriver {
                 ..
             } => {
                 info!("Connection closed to Peer {peer_id} - {endpoint:?} - {cause:?}");
-
-                // This is most periodically called due to connection time out.
-                // Hence using it as a point to cleanup the replication cache.
-                self.swarm
-                    .behaviour_mut()
-                    .kademlia
-                    .store_mut()
-                    .try_clean_replication_cache();
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 warn!("Having OutgoingConnectionError {peer_id:?} - {error:?}");
@@ -310,7 +307,7 @@ impl SwarmDriver {
                         *value += 1;
                         if *value > DEAD_PEER_DETECTION_THRESHOLD {
                             trace!("Detected dead peer {peer_id:?}");
-                            self.try_trigger_replication(&peer_id);
+                            self.try_trigger_replication(&peer_id, true);
                             let _ = self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
                         }
                     } else {
@@ -325,11 +322,8 @@ impl SwarmDriver {
         Ok(())
     }
 
-    fn try_trigger_replication(&mut self, peer: &PeerId) {
-        // Replication is triggered when the newly added peer is among our closest,
-        // or the dead peer was among our closest.
-        // As the record retaining is undertaken by libp2p directly,
-        // all holding records are supposed to be replicated once triggered.
+    // Replication is triggered when the newly added peer or the dead peer was among our closest.
+    fn try_trigger_replication(&mut self, peer: &PeerId, is_dead_peer: bool) {
         let our_address = NetworkAddress::from_peer(self.self_peer_id);
         // Fetch from local shall be enough.
         let closest_peers: Vec<_> = self
@@ -340,11 +334,89 @@ impl SwarmDriver {
             .collect();
         let target = NetworkAddress::from_peer(*peer).as_kbucket_key();
         if closest_peers.iter().any(|key| *key == target) {
-            self.swarm
+            let mut all_peers: Vec<PeerId> = vec![];
+            for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
+                for entry in kbucket.iter() {
+                    all_peers.push(entry.node.key.clone().into_preimage());
+                }
+            }
+            let churned_peer_address = NetworkAddress::from_peer(*peer);
+            // Only nearby peers (two times of the CLOSE_GROUP_SIZE) may affect the later on
+            // calculation of `closest peers to each entry`.
+            // Hecence to reduce the computation work, no need to take all peers.
+            let sorted_peers: Vec<PeerId> =
+                if let Ok(sorted_peers) = sort_peers_by_address(all_peers, &churned_peer_address) {
+                    sorted_peers
+                        .iter()
+                        .take(2 * CLOSE_GROUP_SIZE)
+                        .cloned()
+                        .collect()
+                } else {
+                    return;
+                };
+            if sorted_peers.len() <= CLOSE_GROUP_SIZE {
+                return;
+            }
+
+            let distance_bar = NetworkAddress::from_peer(sorted_peers[CLOSE_GROUP_SIZE])
+                .distance(&churned_peer_address);
+
+            // The fetched entries are records that supposed to be held by the churned_peer.
+            let entries_to_be_replicated = self
+                .swarm
                 .behaviour_mut()
                 .kademlia
                 .store_mut()
-                .trigger_replication();
+                .entries_to_be_replicated(churned_peer_address.as_kbucket_key(), distance_bar);
+            let storage_dir = self
+                .swarm
+                .behaviour_mut()
+                .kademlia
+                .store_mut()
+                .storage_dir();
+
+            for key in entries_to_be_replicated.iter() {
+                let record_key = KBucketKey::from(key.to_vec());
+                let closest_peers: Vec<_> = if let Ok(sorted_peers) =
+                    sort_peers_by_key(sorted_peers.clone(), &record_key)
+                {
+                    sorted_peers
+                        .iter()
+                        .take(CLOSE_GROUP_SIZE + 1)
+                        .cloned()
+                        .collect()
+                } else {
+                    continue;
+                };
+
+                // Only carry out replication when self within REPLICATION_RANGE
+                let replicate_range = NetworkAddress::from_peer(closest_peers[REPLICATION_RANGE]);
+                if our_address.as_kbucket_key().distance(&record_key)
+                    >= replicate_range.as_kbucket_key().distance(&record_key)
+                {
+                    continue;
+                }
+
+                let dst = if is_dead_peer {
+                    // If the churned peer is a dead peer, then the replication target
+                    // shall be: the `CLOSE_GROUP_SIZE`th closest node to each data entry.
+                    if !closest_peers.iter().any(|p| *p == *peer) {
+                        continue;
+                    }
+                    closest_peers[CLOSE_GROUP_SIZE]
+                } else {
+                    *peer
+                };
+                if let Some(record) = DiskBackedRecordStore::read_from_disk(key, &storage_dir) {
+                    let chunk = Chunk::new(record.value.clone().into());
+                    let request = Request::Cmd(Cmd::Replicate(ReplicatedData::Chunk(chunk)));
+                    let _ = self
+                        .swarm
+                        .behaviour_mut()
+                        .request_response
+                        .send_request(&dst, request);
+                }
+            }
         }
     }
 }

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -29,7 +29,7 @@ use crate::domain::storage::{
     REPLICATION_INTERVAL_UPPER_BOUND,
 };
 use crate::protocol::{
-    messages::{QueryResponse, Request, Response},
+    messages::{QueryResponse, ReplicatedData, Request, Response},
     NetworkAddress,
 };
 
@@ -40,7 +40,7 @@ use libp2p::mdns;
 use libp2p::{
     core::muxing::StreamMuxerBox,
     identity,
-    kad::{Kademlia, KademliaConfig, QueryId, Record, RecordKey},
+    kad::{kbucket::Key as KBucketKey, Kademlia, KademliaConfig, QueryId, Record, RecordKey},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{Swarm, SwarmBuilder},
@@ -355,6 +355,37 @@ impl SwarmDriver {
     }
 }
 
+/// Sort the provided peers by their distance to the given `NetworkAddress`.
+pub(crate) fn sort_peers_by_address(
+    peers: Vec<PeerId>,
+    address: &NetworkAddress,
+) -> Result<Vec<PeerId>> {
+    sort_peers_by_key(peers, &address.as_kbucket_key())
+}
+
+/// Sort the provided peers by their distance to the given `KBucketKey`.
+pub(crate) fn sort_peers_by_key<T>(
+    mut peers: Vec<PeerId>,
+    key: &KBucketKey<T>,
+) -> Result<Vec<PeerId>> {
+    peers.sort_by(|a, b| {
+        let a = NetworkAddress::from_peer(*a);
+        let b = NetworkAddress::from_peer(*b);
+        key.distance(&a.as_kbucket_key())
+            .cmp(&key.distance(&b.as_kbucket_key()))
+    });
+    let peers: Vec<PeerId> = peers.iter().take(CLOSE_GROUP_SIZE).cloned().collect();
+
+    if CLOSE_GROUP_SIZE > peers.len() {
+        warn!("Not enough peers in the k-bucket to satisfy the request");
+        return Err(Error::NotEnoughPeers {
+            found: peers.len(),
+            required: CLOSE_GROUP_SIZE,
+        });
+    }
+    Ok(peers)
+}
+
 #[derive(Clone)]
 /// API to interact with the underlying Swarm
 pub struct Network {
@@ -477,6 +508,17 @@ impl Network {
             .await
     }
 
+    /// Store replicated data to local
+    /// The `chunk_storage` is currently held by `swarm_driver` within `network` instance.
+    /// Hence has to carry out this notification.
+    pub async fn store_replicated_data_to_local(
+        &self,
+        replicated_data: ReplicatedData,
+    ) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::StoreReplicatedData { replicated_data })
+            .await
+    }
+
     /// Send `Request` to the the given `PeerId` and await for the response. If `self` is the recipient,
     /// then the `Request` is forwarded to itself and handled, and a corresponding `Response` is created
     /// and returned to itself. Hence the flow remains the same and there is no branching at the upper
@@ -533,30 +575,7 @@ impl Network {
         if !client {
             closest_peers.push(self.peer_id);
         }
-        self.sort_peers_by_key(closest_peers, key)
-    }
-
-    /// Sort the provided peers by their distance to the given key.
-    fn sort_peers_by_key(
-        &self,
-        mut peers: Vec<PeerId>,
-        key: &NetworkAddress,
-    ) -> Result<Vec<PeerId>> {
-        peers.sort_by(|a, b| {
-            let a = NetworkAddress::from_peer(*a);
-            let b = NetworkAddress::from_peer(*b);
-            key.distance(&a).cmp(&key.distance(&b))
-        });
-        let peers: Vec<PeerId> = peers.iter().take(CLOSE_GROUP_SIZE).cloned().collect();
-
-        if CLOSE_GROUP_SIZE > peers.len() {
-            warn!("Not enough peers in the k-bucket to satisfy the request");
-            return Err(Error::NotEnoughPeers {
-                found: peers.len(),
-                required: CLOSE_GROUP_SIZE,
-            });
-        }
-        Ok(peers)
+        sort_peers_by_address(closest_peers, key)
     }
 
     // Send a `Request` to the provided set of peers and wait for their responses concurrently.

--- a/safenode/src/network/mod.rs
+++ b/safenode/src/network/mod.rs
@@ -617,13 +617,10 @@ mod tests {
     use super::SwarmDriver;
     use crate::{
         log::init_test_logger,
-        network::{MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE},
+        network::{MsgResponder, NetworkEvent},
         protocol::{
-            NetworkAddress,
-            {
-                messages::{Cmd, CmdResponse, Request, Response},
-                storage::{Chunk, ChunkAddress},
-            },
+            messages::{Cmd, CmdResponse, Request, Response},
+            storage::Chunk,
         },
     };
     use assert_matches::assert_matches;
@@ -632,102 +629,7 @@ mod tests {
     use rand::{thread_rng, Rng};
     use std::{net::SocketAddr, time::Duration};
 
-    #[cfg(feature = "local-discovery")]
-    use libp2p::kad::kbucket::{Entry, InsertResult, KBucketsTable, NodeStatus};
-    #[cfg(feature = "local-discovery")]
-    use libp2p::PeerId;
-    #[cfg(feature = "local-discovery")]
-    use std::collections::{BTreeMap, HashMap};
-    #[cfg(feature = "local-discovery")]
-    use std::fmt;
-    #[cfg(feature = "local-discovery")]
-    use xor_name::XorName;
-
     use std::path::Path;
-
-    #[tokio::test(flavor = "multi_thread")]
-    // Enable mDNS for peer discovery here
-    #[cfg(feature = "local-discovery")]
-    async fn closest() -> Result<()> {
-        init_test_logger();
-        let mut networks_list = Vec::new();
-        let mut network_events_recievers = BTreeMap::new();
-        for _ in 1..25 {
-            let (net, event_rx, driver) = SwarmDriver::new(
-                "0.0.0.0:0"
-                    .parse::<SocketAddr>()
-                    .expect("0.0.0.0:0 should parse into a valid `SocketAddr`"),
-                Path::new(""),
-            )?;
-            let _handle = tokio::spawn(driver.run());
-
-            let _ = network_events_recievers.insert(net.peer_id, event_rx);
-            networks_list.push(net);
-        }
-
-        tokio::time::sleep(Duration::from_secs(5)).await;
-
-        // Generate some rounds of random query to allow nodes populate its RT
-        let mut rng = thread_rng();
-        for net in networks_list.iter() {
-            // Do twice to reduce the possibility of missing a node knowledge.
-            let random_data =
-                NetworkAddress::from_chunk_address(ChunkAddress::new(XorName::random(&mut rng)));
-            let _ = net.get_closest_peers(&random_data, false).await?;
-            let random_data =
-                NetworkAddress::from_chunk_address(ChunkAddress::new(XorName::random(&mut rng)));
-            let _ = net.get_closest_peers(&random_data, false).await?;
-        }
-
-        // Get the expected list of closest peers by creating a `KBucketsTable` with all the peers
-        // inserted inside it.
-        // The `KBucketsTable::local_key` is considered to be random since the `local_key` will not
-        // be part of the `closest_peers`. Since our implementation of `get_closest_peers` returns
-        // `self`, we'd want to insert `our_net` into the table as well.
-        let mut table = KBucketsTable::<_, ()>::new(
-            NetworkAddress::from_peer(PeerId::random()).as_kbucket_key(),
-            Duration::from_secs(5),
-        );
-        let mut key_to_peer_id = HashMap::new();
-        for net in networks_list.iter() {
-            let key = NetworkAddress::from_peer(net.peer_id).as_kbucket_key();
-            let _ = key_to_peer_id.insert(key.clone(), net.peer_id);
-
-            if let Entry::Absent(e) = table.entry(&key) {
-                match e.insert((), NodeStatus::Connected) {
-                    InsertResult::Inserted => {}
-                    _ => continue,
-                }
-            } else {
-                return Err(eyre!("Table entry should be absent"));
-            }
-        }
-
-        // Check the closest nodes to the following random_data
-        let random_data =
-            NetworkAddress::from_chunk_address(ChunkAddress::new(XorName::random(&mut rng)));
-        let expected_from_table = table
-            .closest_keys(&random_data.as_kbucket_key())
-            .map(|key| {
-                key_to_peer_id
-                    .get(&key)
-                    .cloned()
-                    .ok_or_else(|| eyre::eyre!("Key should be present"))
-            })
-            .take(CLOSE_GROUP_SIZE)
-            .collect::<Result<Vec<_>>>()?;
-        info!("Got Closest from table {:?}", expected_from_table);
-
-        // Ask the other nodes for the closest_peers.
-        let our_net = networks_list
-            .get(0)
-            .ok_or_else(|| eyre!("networks_list is not empty"))?;
-        let closest = our_net.get_closest_peers(&random_data, false).await?;
-        info!("Got Closest from network {:?}", closest);
-
-        assert_lists(closest, expected_from_table);
-        Ok(())
-    }
 
     #[tokio::test]
     async fn msg_to_self_should_not_error_out() -> Result<()> {
@@ -781,30 +683,5 @@ mod tests {
                 return Ok(());
             }
         }
-    }
-
-    #[cfg(feature = "local-discovery")]
-    /// Test utility
-    fn assert_lists<I, J, K>(a: I, b: J)
-    where
-        K: fmt::Debug + Eq,
-        I: IntoIterator<Item = K>,
-        J: IntoIterator<Item = K>,
-    {
-        let vec1: Vec<_> = a.into_iter().collect();
-        let mut vec2: Vec<_> = b.into_iter().collect();
-
-        assert_eq!(vec1.len(), vec2.len());
-
-        for item1 in &vec1 {
-            let idx2 = vec2
-                .iter()
-                .position(|item2| item1 == item2)
-                .expect("Item not found in second list");
-
-            let _ = vec2.swap_remove(idx2);
-        }
-
-        assert_eq!(vec2.len(), 0);
     }
 }

--- a/safenode/src/node/api.rs
+++ b/safenode/src/node/api.rs
@@ -285,6 +285,16 @@ impl Node {
                 self.send_response(Response::Cmd(resp), response_channel)
                     .await;
             }
+            Cmd::Replicate(replicated_data) => {
+                debug!(
+                    "That's a replicated data in for :{:?}",
+                    replicated_data.name()
+                );
+                let _ = self
+                    .network
+                    .store_replicated_data_to_local(replicated_data)
+                    .await;
+            }
             Cmd::Register(cmd) => {
                 let result = self
                     .registers

--- a/safenode/src/protocol/messages/cmd.rs
+++ b/safenode/src/protocol/messages/cmd.rs
@@ -11,7 +11,7 @@ use crate::protocol::{
     NetworkAddress,
 };
 
-use super::RegisterCmd;
+use super::{RegisterCmd, ReplicatedData};
 
 use sn_dbc::{DbcTransaction, SignedSpend};
 
@@ -46,6 +46,10 @@ pub enum Cmd {
         #[debug(skip)]
         parent_tx: Box<DbcTransaction>,
     },
+    /// [`ReplicatedData`] write operation.
+    ///
+    /// [`ReplicatedData`]: crate::protocol::messages::ReplicatedData
+    Replicate(ReplicatedData),
 }
 
 impl Cmd {
@@ -59,6 +63,7 @@ impl Cmd {
             Cmd::SpendDbc { signed_spend, .. } => {
                 NetworkAddress::from_dbc_address(DbcAddress::from_dbc_id(signed_spend.dbc_id()))
             }
+            Cmd::Replicate(replicated_data) => replicated_data.dst(),
         }
     }
 }
@@ -74,6 +79,9 @@ impl std::fmt::Display for Cmd {
             }
             Cmd::SpendDbc { signed_spend, .. } => {
                 write!(f, "Cmd::SpendDbc({:?})", signed_spend.dbc_id())
+            }
+            Cmd::Replicate(replicated_data) => {
+                write!(f, "Cmd::Replicate({:?})", replicated_data.name())
             }
         }
     }


### PR DESCRIPTION
…as not returning all records## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 May 23 06:19 UTC
This pull request modifies various parts of the safenode network. It includes changes to a bash script that restarts a node on a specific port, modifications to the `Cmd` enum in `safenode/src/protocol/messages/cmd.rs`, changes to the `Command` module, modifications to the `DiskBackedRecordStore` struct, updates to `.github/workflows/merge.yml`, alterations to the `Node` struct's `Cmd` enum, updates to the `Cargo.toml` file, and changes to the `NodeBehaviour` struct in `safenode/src/network/event.rs`.
<!-- reviewpad:summarize:end --> 
