### PR TITLE
feat: refactor replication flow to using pull model

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -343,18 +343,18 @@ jobs:
         run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
 
-      - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
-
-      - name: Build churn tests 
+      - name: Build churn tests
         run: cargo test --release -p sn_node --features="local-discovery" --no-run
         timeout-minutes: 30
         # new output folder to avoid linker issues w/ windows
         env:
           CARGO_TARGET_DIR: "./churn-target"
+
+      - name: Start a local network
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
 
       - name: Chunks data integrity during nodes churn (during 10min)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -322,6 +322,10 @@ jobs:
         run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
 
+      - name: Build churn tests 
+        run: cargo test --release -p sn_node --features="local-discovery" --no-run
+        timeout-minutes: 30
+
       - name: Start a local network
         run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "libp2p",
  "quickcheck",
  "rand 0.8.5",
+ "sn_protocol",
  "tracing",
 ]
 

--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -8,6 +8,7 @@
 
 use std::io;
 use thiserror::Error;
+use xor_name::XorName;
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -55,12 +56,14 @@ pub enum Error {
         maximum: usize,
     },
 
-    #[error("Not all chunks were retrieved, expected {expected}, retrieved {retrieved}.")]
+    #[error("Not all chunks were retrieved, expected {expected}, retrieved {retrieved}, missing {missing_chunks:?}.")]
     NotEnoughChunksRetrieved {
         /// Number of Chunks expected to be retrieved
         expected: usize,
         /// Number of Chunks retrieved
         retrieved: usize,
+        /// Missing chunks
+        missing_chunks: Vec<XorName>,
     },
 
     #[error("Not all data was chunked, expected {expected}, but we have {chunked}.)")]

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -266,9 +266,22 @@ impl Files {
         }
 
         if expected_count > retrieved_chunks.len() {
+            let missing_chunks: Vec<XorName> = chunks_info
+                .iter()
+                .filter_map(|expected_info| {
+                    if !retrieved_chunks.iter().any(|retrieved_chunk| {
+                        XorName::from_content(&retrieved_chunk.content) == expected_info.dst_hash
+                    }) {
+                        None
+                    } else {
+                        Some(expected_info.dst_hash)
+                    }
+                })
+                .collect();
             Err(Error::NotEnoughChunksRetrieved {
                 expected: expected_count,
                 retrieved: retrieved_chunks.len(),
+                missing_chunks,
             })?
         } else {
             Ok(retrieved_chunks)

--- a/sn_networking/src/circular_vec.rs
+++ b/sn_networking/src/circular_vec.rs
@@ -1,3 +1,10 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
 #[derive(Debug)]
 pub struct CircularVec<T> {
     inner: std::collections::VecDeque<T>,

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -1,0 +1,134 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::PeerId;
+use sn_protocol::NetworkAddress;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
+
+// Max parallel fetches can be undertaken at the same time.
+const MAX_PARALLEL_FETCH: usize = 8;
+
+// The duration after which a peer will be considered failed to fetch data from,
+// if no response got from that peer.
+const FETCH_FAILED_DURATION: Duration = Duration::from_secs(10);
+
+// Status of the data fetching progroess from the holder.
+#[derive(PartialEq)]
+pub(crate) enum HolderStatus {
+    Pending,
+    OnGoing,
+    Failed,
+}
+
+#[derive(Default)]
+pub(crate) struct ReplicationFetcher {
+    to_be_fetched: BTreeMap<NetworkAddress, BTreeMap<PeerId, (Instant, HolderStatus)>>,
+    on_going_fetches: usize,
+}
+
+impl ReplicationFetcher {
+    // Add a list of keys of a holder.
+    // Return with a list of keys to fetch, if presents.
+    pub(crate) fn add_keys(
+        &mut self,
+        peer_id: PeerId,
+        keys: Vec<NetworkAddress>,
+    ) -> Vec<(PeerId, NetworkAddress)> {
+        for key in keys {
+            self.add_holder(key, peer_id);
+        }
+        self.next_to_fetch()
+    }
+
+    // Notify the fetch result of a key from a holder.
+    // Return with a list of keys to fetch, if presents.
+    pub(crate) fn notify_fetch_result(
+        &mut self,
+        peer_id: &PeerId,
+        key: &NetworkAddress,
+        result: bool,
+    ) -> Vec<(PeerId, NetworkAddress)> {
+        self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
+
+        if result {
+            let _ = self.to_be_fetched.remove(key);
+        } else if let Some(holders) = self.to_be_fetched.get_mut(key) {
+            if let Some(status) = holders.get_mut(peer_id) {
+                status.1 = HolderStatus::Failed;
+            }
+        }
+        self.next_to_fetch()
+    }
+
+    // Returns a list of keys to fetch
+    fn next_to_fetch(&mut self) -> Vec<(PeerId, NetworkAddress)> {
+        let mut keys_to_fetch = vec![];
+        if self.on_going_fetches >= MAX_PARALLEL_FETCH {
+            return keys_to_fetch;
+        }
+
+        let len = MAX_PARALLEL_FETCH - self.on_going_fetches;
+        let mut all_failed_entries = vec![];
+        for (key, holders) in self.to_be_fetched.iter_mut() {
+            let mut failed_counter = 0;
+            if holders.values().any(|status| {
+                HolderStatus::OnGoing == status.1
+                    && status.0 + FETCH_FAILED_DURATION > Instant::now()
+            }) {
+                continue;
+            }
+            for (peer_id, status) in holders.iter_mut() {
+                match status.1 {
+                    HolderStatus::Pending => {
+                        status.0 = Instant::now();
+                        status.1 = HolderStatus::OnGoing;
+                        self.on_going_fetches += 1;
+                        keys_to_fetch.push((*peer_id, key.clone()));
+                        break;
+                    }
+                    HolderStatus::OnGoing => {
+                        trace!("Marking failed {key:?} on {peer_id:?}",);
+                        status.1 = HolderStatus::Failed;
+                        failed_counter += 1;
+                        self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
+                    }
+                    HolderStatus::Failed => failed_counter += 1,
+                }
+            }
+
+            if keys_to_fetch.len() >= len {
+                break;
+            }
+
+            if failed_counter == holders.len() {
+                warn!(
+                    "Failed to fetch copies of {key:?} from all {:?} holders",
+                    holders.len()
+                );
+                // TODO: fire `get_record` instead?
+                all_failed_entries.push(key.clone());
+            }
+        }
+
+        for failed_key in all_failed_entries {
+            let _ = self.to_be_fetched.remove(&failed_key);
+        }
+
+        keys_to_fetch
+    }
+
+    fn add_holder(&mut self, key: NetworkAddress, peer_id: PeerId) {
+        let holders = self.to_be_fetched.entry(key).or_insert(Default::default());
+        let _ = holders
+            .entry(peer_id)
+            .or_insert((Instant::now(), HolderStatus::Pending));
+    }
+}

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -44,7 +44,7 @@ const CHURN_CYCLES: u32 = 1;
 const CHUNK_CREATION_RATIO_TO_CHURN: u32 = 5;
 const REGISTER_CREATION_RATIO_TO_CHURN: u32 = 5;
 
-const CHUNKS_SIZE: usize = 1024;
+const CHUNKS_SIZE: usize = 1000 * 1000;
 
 const CONTENT_QUERY_RATIO_TO_CHURN: u32 = 12;
 const MAX_NUM_OF_QUERY_ATTEMPTS: u8 = 5;
@@ -189,7 +189,7 @@ async fn data_availability_during_churn() -> Result<()> {
     // the original holders churned out.
     // i.e. the test may pass even without any replication
     // Hence, we carry out a final round of query all data to confirm storage.
-    println!("Final querying content of content");
+    println!("Final querying confirmation of content");
     let mut content_queried_count = 0;
 
     // take one read lock to avoid holding the lock for the whole loop
@@ -197,11 +197,10 @@ async fn data_availability_during_churn() -> Result<()> {
     let content = content.read().await;
     let uploaded_content_count = content.len();
     for net_addr in content.iter() {
+        let result = final_retry_query_content(&client, net_addr, churn_period).await;
         assert!(
-            final_retry_query_content(&client, net_addr, churn_period)
-                .await
-                .is_ok(),
-            "Failed to query content at {net_addr:?}"
+            result.is_ok(),
+            "Failed to query content at {net_addr:?} with error {result:?}"
         );
 
         content_queried_count += 1;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -6,9 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::storage::{
-    registers::{EntryHash, User},
-    ChunkAddress, DbcAddress, RegisterAddress,
+use crate::{
+    storage::{
+        registers::{EntryHash, User},
+        ChunkAddress, DbcAddress, RegisterAddress,
+    },
+    NetworkAddress,
 };
 
 use serde::{Deserialize, Serialize};
@@ -26,6 +29,14 @@ pub enum Error {
     /// Chunk not found.
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(ChunkAddress),
+    /// Replication not found.
+    #[error("Peer {holder:?} cann't find ReplicatedData {address:?}")]
+    ReplicatedDataNotFound {
+        /// Holder that being contacted
+        holder: NetworkAddress,
+        /// Address of the missing data
+        address: NetworkAddress,
+    },
     /// We failed to store chunk
     #[error("Chunk was not stored w/ xorname {0:?}")]
     ChunkNotStored(XorName),

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -42,6 +42,18 @@ pub enum Query {
     /// [`SignedSpend`]: sn_dbc::SignedSpend
     /// [`GetDbcSpend`]: super::QueryResponse::GetDbcSpend
     GetSpend(DbcAddress),
+    /// Retrieve a [`ReplicatedData`] at the given address.
+    ///
+    /// This should eventually lead to a [`GetReplicatedData`] response.
+    ///
+    /// [`ReplicatedData`]:  crate::messages::ReplicatedData
+    /// [`GetReplicatedData`]: super::QueryResponse::GetReplicatedData
+    GetReplicatedData {
+        /// Sender of the query
+        requester: NetworkAddress,
+        /// Address of the data to be fetched
+        address: NetworkAddress,
+    },
 }
 
 impl Query {
@@ -51,6 +63,7 @@ impl Query {
             Query::GetChunk(address) => NetworkAddress::from_chunk_address(*address),
             Query::Register(query) => NetworkAddress::from_register_address(query.dst()),
             Query::GetSpend(address) => NetworkAddress::from_dbc_address(*address),
+            Query::GetReplicatedData { address, .. } => address.clone(),
         }
     }
 }
@@ -66,6 +79,12 @@ impl std::fmt::Display for Query {
             }
             Query::GetSpend(address) => {
                 write!(f, "Query::GetSpend({address:?})")
+            }
+            Query::GetReplicatedData { requester, address } => {
+                write!(
+                    f,
+                    "Query::GetReplicatedData({requester:?} querying {address:?})"
+                )
             }
         }
     }

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -8,10 +8,12 @@
 
 use crate::{
     error::Result,
+    messages::ReplicatedData,
     storage::{
         registers::{Entry, EntryHash, Permissions, Policy, Register, User},
         Chunk,
     },
+    NetworkAddress,
 };
 
 #[allow(unused_imports)] // needed by rustdocs links
@@ -43,6 +45,13 @@ pub enum QueryResponse {
     ///
     /// [`GetChunk`]: crate::messages::Query::GetChunk
     GetChunk(Result<Chunk>),
+    //
+    // ===== ReplicatedData =====
+    //
+    /// Response to [`GetReplicatedData`]
+    ///
+    /// [`GetReplicatedData`]: crate::messages::Query::GetReplicatedData
+    GetReplicatedData(Result<(NetworkAddress, ReplicatedData)>),
     //
     // ===== Register Data =====
     //

--- a/sn_record_store/Cargo.toml
+++ b/sn_record_store/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 [dependencies]
 libp2p = { version="0.51", features = ["tokio","kad", "macros"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
+sn_protocol = { path = "../sn_protocol", version = "0.1.0" }
 tracing = { version = "~0.1.26" }
 
 

--- a/sn_record_store/src/lib.rs
+++ b/sn_record_store/src/lib.rs
@@ -17,6 +17,7 @@ use libp2p::{
     },
 };
 use rand::Rng;
+use sn_protocol::NetworkAddress;
 use std::{
     borrow::Cow,
     collections::{hash_set, HashSet},
@@ -135,6 +136,13 @@ impl DiskBackedRecordStore {
 
     pub fn storage_dir(&self) -> PathBuf {
         self.config.storage_dir.clone()
+    }
+
+    pub fn record_addresses(&self) -> HashSet<NetworkAddress> {
+        self.records
+            .iter()
+            .map(|record_key| NetworkAddress::from_record_key(record_key.clone()))
+            .collect()
     }
 
     pub fn read_from_disk<'a>(key: &Key, storage_dir: &Path) -> Option<Cow<'a, Record>> {


### PR DESCRIPTION
## Description

This PR contains the work to refactor replication flow to using pull model as described within th e issue https://github.com/maidsafe/safe_network/issues/294.
This will reduce the communication traffic a lot, with a much safer coverage, and flatten the peak traffic/mem usage via controlling the parallel fetching threads.

It also contains a work of refactor dead peer detection, which now is more deterministic.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 May 23 13:23 UTC
This pull request includes various changes across different files. The changes include updates to enums, new modules, additions to dependencies, and several code cleanups. The changes also introduce a `ReplicationFetcher` module for fetching data from holders on the network. Additionally, a new variant called `ReplicatedDataNotFound` was added to the `StorageError` enum. Finally, a new variant called `GetReplicatedData` was added to the `Query` and `QueryResponse` enums to allow clients to retrieve replicated data from the network.
<!-- reviewpad:summarize:end --> 

Closes https://github.com/maidsafe/safe_network/issues/294