### PR TITLE
ci: reenable windows churn tests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -350,10 +350,15 @@ jobs:
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features="local-discovery" --no-run
         timeout-minutes: 30
+        # new output folder to avoid linker issues w/ windows
+        env:
+          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Chunks data integrity during nodes churn (during 10min)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
           CHUNKS_ONLY: true
           TEST_DURATION_MINS: 10
           SN_LOG: "all"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -315,10 +315,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # windows currently has a linker fail... 
-        # TODO: reenable
-        os: [ubuntu-latest, macos-latest]
-        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -317,11 +317,16 @@ jobs:
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features="local-discovery" --no-run
         timeout-minutes: 30
+        # new output folder to avoid linker issues w/ windows
+        env:
+          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Chunks data integrity during nodes churn (during 10min) (in theory)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
         id: data_availability_during_churn
         env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
           CHUNKS_ONLY: true
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -277,10 +277,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # windows currently has a linker fail... 
-        # TODO: reenable
-        os: [ubuntu-latest, macos-latest]
-        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
ahead of #306 