### PR TITLE
fix(node): correct dead peer detection

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -373,6 +373,12 @@ jobs:
         run : |
           restart_count=$(rg "Node is restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
+          detected_dead_peer=$(rg "Detected dead peer" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+          echo "Detected dead peer $detected_dead_peer times"
+          if [ $detected_dead_peer -lt $restart_count ]; then
+            echo "Detected dead peer times of: $detected_dead_peer is less than the restart count of: $restart_count"
+            exit 1
+          fi
           node_count=$(ls $log_dir | wc -l)
           if [ $restart_count -lt $node_count ]; then
             echo "Restart count of: $restart_count is less than the node count of: $node_count"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -341,8 +341,14 @@ jobs:
         # TODO: make this use an env var, or relate to testnet size
         run : |
           restart_count=$(rg "Node is restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
-          node_count=$(ls $log_dir | wc -l)
           echo "Restart $restart_count nodes"
+          detected_dead_peer=$(rg "Detected dead peer" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+          echo "Detected dead peer $detected_dead_peer times"
+          if [ $detected_dead_peer -lt $restart_count ]; then
+            echo "Detected dead peer times of: $detected_dead_peer is less than the restart count of: $restart_count"
+            exit 1
+          fi
+          node_count=$(ls $log_dir | wc -l)
           if [ $restart_count -lt $node_count ]; then
             echo "Restart count of: $restart_count is less than the node count of: $node_count"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,12 +2753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru_time_cache"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,7 +4436,6 @@ dependencies = [
  "futures",
  "itertools",
  "libp2p",
- "lru_time_cache",
  "rand 0.8.5",
  "rmp-serde",
  "serde",
@@ -4476,7 +4469,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libp2p",
- "lru_time_cache",
  "prost",
  "rand 0.8.5",
  "rayon",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -21,7 +21,6 @@ eyre = "0.6.8"
 futures = "~0.3.13"
 itertools = "~0.10.1"
 libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "request-response", "identify", "autonat", "mplex", "noise", "tcp", "yamux"] }
-lru_time_cache = "0.11.11"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -38,7 +38,6 @@ hex = "~0.4.3"
 itertools = "~0.10.1"
 lazy_static = "~1.4.0"
 libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "autonat"] }
-lru_time_cache = "0.11.11"
 prost = { version = "0.9" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -39,8 +39,8 @@ mod safenode_proto {
 
 const NODE_COUNT: u32 = 25;
 
+const EXTRA_CHURN_COUNT: u32 = 5;
 const CHURN_CYCLES: u32 = 1;
-// const CHURN_PERIOD_MILLIS: u64 = 10_000;
 const CHUNK_CREATION_RATIO_TO_CHURN: u32 = 5;
 const REGISTER_CREATION_RATIO_TO_CHURN: u32 = 5;
 
@@ -85,7 +85,8 @@ async fn data_availability_during_churn() -> Result<()> {
         let cycles = str.parse::<u32>()?;
         test_duration / (cycles * NODE_COUNT)
     } else {
-        test_duration / (CHURN_CYCLES * NODE_COUNT)
+        // Ensure at least some nodes got churned twice.
+        test_duration / std::cmp::max(CHURN_CYCLES * NODE_COUNT, NODE_COUNT + EXTRA_CHURN_COUNT)
     };
 
     println!("Nodes will churn every {:?}", churn_period);

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -15,22 +15,6 @@ default=[]
 local-discovery=[]
 
 [dependencies]
-# async-trait = "0.1"
-# bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.8"
-# futures = "~0.3.13"
-# itertools = "~0.10.1"
 libp2p = { version="0.51", features = [] }
-# lru_time_cache = "0.11.11"
-# rand = { version = "~0.8.5", features = ["small_rng"] }
-# rmp-serde = "1.1.1"
-# serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_domain = { path = "../sn_domain", version = "0.1.0" }
-# sn_logging = { path = "../sn_logging", features = ["test-utils"], version = "0.1.0" }
-# sn_protocol = { path = "../sn_protocol", version = "0.1.0" }
-# thiserror = "1.0.23"
-# tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
-
-# [dev-dependencies]
-# assert_matches = "1.5.0"


### PR DESCRIPTION
The previous DialError was obsoleted, hence the dead peer detection needs to be refactored for a more solid error.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 May 23 10:53 UTC
This pull request fixes the dead peer detection in the node, which was using an obsolete DialError and required refactoring. The patch removes unused dependencies and decreases the replication range to improve the performance and ensures a corrected partially targeted replication.
<!-- reviewpad:summarize:end --> 
