### PR TITLE
Revert "fix: client wait till RT filled with enough peers"

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -25,11 +25,7 @@ use sn_transfers::client_transfers::SpendRequest;
 use bls::{PublicKey, SecretKey, Signature};
 use futures::future::select_all;
 use itertools::Itertools;
-use libp2p::{
-    kad::{RecordKey, K_VALUE},
-    Multiaddr, PeerId,
-};
-use std::num::NonZeroUsize;
+use libp2p::{kad::RecordKey, Multiaddr, PeerId};
 use tokio::task::spawn;
 use tracing::trace;
 use xor_name::XorName;
@@ -55,7 +51,6 @@ impl Client {
             network: network.clone(),
             events_channel,
             signer,
-            peers_added: 0,
         };
 
         // subscribe to our events channel first, so we don't have intermittent
@@ -152,18 +147,9 @@ impl Client {
             // We are not doing AutoNAT and don't care about our status.
             NetworkEvent::NatStatusChanged(_) => {}
             NetworkEvent::PeerAdded(peer_id) => {
+                self.events_channel
+                    .broadcast(ClientEvent::ConnectedToNetwork)?;
                 debug!("PeerAdded: {peer_id}");
-                // In case client running in non-local-discovery mode,
-                // it may take some time to fillup the RT.
-                // To avoid such delay may fail the query with RecordNotFound,
-                // wait till certain amount of peers populated into RT
-                if let Some(peers_added) = NonZeroUsize::new(self.peers_added) {
-                    if peers_added >= K_VALUE {
-                        self.events_channel
-                            .broadcast(ClientEvent::ConnectedToNetwork)?;
-                    }
-                }
-                self.peers_added += 1;
             }
         }
 

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -37,5 +37,4 @@ pub struct Client {
     network: Network,
     events_channel: ClientEventsChannel,
     signer: bls::SecretKey,
-    peers_added: usize,
 }


### PR DESCRIPTION
This reverts commit b615aedf332996254a5a08feb9934af7fb9bce0e.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 04:24 UTC
This pull request reverts a previous commit (b615aedf332996254a5a08feb9934af7fb9bce0e) that fixed an issue with clients waiting until enough peers were filled into the Routing Table (RT), and switches back to the original behavior. The code changes remove unnecessary imports and use the events_channel to broadcast ClientEvent when a peer is added to the network.
<!-- reviewpad:summarize:end --> 
