### PR TITLE
chore: Bump sn_dbc version to 19 for simpler signedspend debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a1f15118076c41687b7d3b2978d5c3080148f54b6090a266e496e97a0ebb9a"
+checksum = "5f36153809a2d29a0a7b5e8c1f8f048a64c086a41d8848dd9baf5c49f3c16594"
 dependencies = [
  "bincode",
  "blsttc",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -26,7 +26,7 @@ hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 sn_build_info= { path="../sn_build_info", version="0.1.0" }
 sn_client = { path = "../sn_client", version = "0.85.0" }
-sn_dbc = { version = "18.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.1.0" }
 sn_logging = { path = "../sn_logging", version = "0.1.0" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -25,7 +25,7 @@ libp2p = { version="0.51", features = ["identify"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "18.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.1.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.0" }
 sn_registers = { path = "../sn_registers", version = "0.1.0" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -48,7 +48,7 @@ self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info= { path="../sn_build_info", version="0.1.0" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
-sn_dbc = { version = "18.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.0" }
 sn_logging = { path = "../sn_logging", version = "0.1.0" }
 sn_networking = { path = "../sn_networking", version = "0.1.0" }

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -16,6 +16,6 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "18.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.0", features = ["serdes"] }
 thiserror = "1.0.23"
 xor_name = "5.0.0"

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -19,7 +19,7 @@ hex = "~0.4.3"
 lazy_static = "~1.4.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "18.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.1.0" }
 tokio = { version = "1.17.0" }
 tracing = { version = "~0.1.26" }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 05:31 UTC
This pull request updates sn_dbc version to 19, which includes simpler signed spend debug. There are also minor changes across six files, with 7 insertions and 7 deletions.
<!-- reviewpad:summarize:end --> 
