### PR TITLE
fix(client): carry out client random query when inactivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,6 +4351,7 @@ dependencies = [
  "futures",
  "itertools",
  "libp2p",
+ "rand 0.8.5",
  "rayon",
  "self_encryption",
  "serde",

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -22,6 +22,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 futures = "~0.3.13"
 itertools = "~0.10.1"
 libp2p = { version="0.51", features = ["identify"] }
+rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -37,6 +37,9 @@ use xor_name::XorName;
 /// The timeout duration for the client to receive any response from the network.
 const INACTIVITY_TIMEOUT: std::time::Duration = tokio::time::Duration::from_secs(10);
 
+/// The initial rounds of `get_random` allowing client to fill up the RT.
+const INITIAL_GET_RANDOM_ROUNDS: usize = 5;
+
 impl Client {
     /// Instantiate a new client.
     pub async fn new(signer: SecretKey, peers: Option<Vec<(PeerId, Multiaddr)>>) -> Result<Self> {
@@ -106,36 +109,44 @@ impl Client {
                         if let Err(err) = client_clone.handle_network_event(the_event) {
                             warn!("Error handling network event: {err}");
                         }
-
-                        continue;
                     }
                     Err(_elapse_err) => {
-                        if cfg!(feature = "inactive-client-redials") {
-                            must_dial_network = true;
-                            info!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
-                            println!("Inactive client for {INACTIVITY_TIMEOUT:?}, will attempt to dial the network again");
-                        } else if let Err(error) = client_clone
+                        if let Err(error) = client_clone
                             .events_channel
                             .broadcast(ClientEvent::InactiveClient(INACTIVITY_TIMEOUT))
                         {
                             error!("Error broadcasting inactive client event: {error}");
                         }
-
-                        continue;
                     }
                 }
             }
         });
 
-        if let Ok(event) = client_events_rx.recv().await {
-            match event {
-                ClientEvent::ConnectedToNetwork => {
+        let mut rng = rand::thread_rng();
+        // Carry out 5 rounds of random get to fill up the RT at the begginning.
+        for _ in 0..INITIAL_GET_RANDOM_ROUNDS {
+            let random_target = ChunkAddress::new(XorName::random(&mut rng));
+            let _ = client.get_chunk(random_target).await;
+        }
+
+        loop {
+            match client_events_rx.recv().await {
+                Ok(ClientEvent::ConnectedToNetwork) => {
                     info!("Client connected to the Network.");
                     println!("Client successfully connected to the Network.");
+                    break;
                 }
-                ClientEvent::InactiveClient(timeout) => {
-                    error!("Inactive client for {timeout:?}, inactive-client-redial is not set, and so shutting down");
-                    return Err(Error::InactiveClient(timeout));
+                Ok(ClientEvent::InactiveClient(timeout)) => {
+                    let random_target = ChunkAddress::new(XorName::random(&mut rng));
+                    debug!("No ClientEvent activity in the past {timeout:?}, performing a random get_chunk query to target: {random_target:?}");
+                    println!("Client not having enough peers detected after {timeout:?}, performing one more round of network scanning");
+                    let _ = client.get_chunk(random_target).await;
+                    continue;
+                }
+                Err(err) => {
+                    error!("Unexpected error during client startup {err:?}");
+                    println!("Unexpected error during client startup {err:?}");
+                    return Err(err);
                 }
             }
         }
@@ -161,6 +172,11 @@ impl Client {
                     if peers_added >= K_VALUE {
                         self.events_channel
                             .broadcast(ClientEvent::ConnectedToNetwork)?;
+                    } else {
+                        println!(
+                            "Client waiting for fully connected to newtork, progression ({}/{})",
+                            self.peers_added, K_VALUE
+                        );
                     }
                 }
                 self.peers_added += 1;

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/bin/faucet.rs"
 [features]
 default=[]
 local-discovery=["sn_networking/local-discovery"]
-inactive-client-redials=[]
 otlp = ["sn_logging/otlp"]
 
 [dependencies]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 10:40 UTC
This pull request adds a client feature that carries out random queries when the client has been inactive for too long. It uses the `rand` crate and performs a random get_chunk query to target: {random_target}. The patch also includes updates to the Cargo and sn_client files.
<!-- reviewpad:summarize:end --> 

Close https://github.com/maidsafe/safe_network/pull/322
