### PR TITLE
chore: initial changelogs for new crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: release
 
-on:
-  push:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -4,10 +4,10 @@ name: Version Bump
 concurrency:
   group: "version-bumping"
 
-on:
-  push:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,61 @@
+[workspace]
+allow_dirty = false
+changelog_update = true
+dependencies_update = false
+git_release_enable = false
+publish_allow_dirty = false
+semver_check = false
+
+[[package]]
+name = "sn_build_info"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_client"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_logging"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_networking"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_peers_acquisition"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_protocol"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_record_store"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_registers"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_transfers"
+changelog_update = true
+git_release_enable = false
+publish = true

--- a/sn_build_info/CHANGELOG.md
+++ b/sn_build_info/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_build_info-v0.1.0) - 2023-06-04
+
+### Fixed
+- local-discovery deps

--- a/sn_logging/CHANGELOG.md
+++ b/sn_logging/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_logging-v0.1.0) - 2023-06-04
+
+### Added
+- add registers and transfers crates, deprecate domain
+- *(logs)* add 'all' log shorthand
+- add build_info crate
+
+### Fixed
+- add missing safenode/safe trace to  logs
+- local-discovery deps
+- remove unused deps, fix doc comment
+
+### Other
+- accommodate new workspace
+- extract logging and networking crates

--- a/sn_networking/CHANGELOG.md
+++ b/sn_networking/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_networking-v0.1.0) - 2023-06-04
+
+### Added
+- record based DBC Spends
+- *(record_store)* extract record_store into its own crate
+
+### Fixed
+- expand channel capacity
+- *(node)* correct dead peer detection
+- *(node)* increase replication range to 5.
+- add in init to potential_dead_peers.
+- remove unused deps after crate reorg
+- *(networking)* clippy
+- local-discovery deps
+- remove unused deps, fix doc comment
+
+### Other
+- increase networking channel size
+- *(CI)* mem check against large file and churn test
+- fixup after rebase
+- extract logging and networking crates

--- a/sn_peers_acquisition/CHANGELOG.md
+++ b/sn_peers_acquisition/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_peers_acquisition-v0.1.0) - 2023-06-04
+
+### Fixed
+- *(node)* correct dead peer detection
+- local-discovery deps

--- a/sn_protocol/CHANGELOG.md
+++ b/sn_protocol/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_protocol-v0.1.0) - 2023-06-04
+
+### Added
+- store double spends when we detect them
+- record based DBC Spends
+
+### Fixed
+- remove unused deps, fix doc comment
+
+### Other
+- bump sn_dbc version to 19 for simpler signedspend debug
+- accommodate new workspace
+- extract new sn_protocol crate

--- a/sn_record_store/CHANGELOG.md
+++ b/sn_record_store/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_record_store-v0.1.0) - 2023-06-04
+
+### Added
+- *(record_store)* extract record_store into its own crate
+
+### Fixed
+- remove unused deps after crate reorg

--- a/sn_registers/CHANGELOG.md
+++ b/sn_registers/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jacderida/safe_network/releases/tag/sn_registers-v0.1.0) - 2023-06-04
+
+### Added
+- add registers and transfers crates, deprecate domain


### PR DESCRIPTION
The `release-plz` tool has been used to generate the initial changelogs for new crates.

The configuration for the tool has also been added, which is mostly just intended to prevent Github Releases for non-binary crates. In this configuration, Github Releases have been prevented globally so that we can use the tool to do the initial crate releases without partially incomplete Github Releases without enormous changelogs.

Also disables the current version bumping and release workflows from running on push to main. These are going to be modified shortly.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jun 23 20:32 UTC
This pull request adds initial changelogs for new crates using the `release-plz` tool and also adds the necessary configuration to prevent Github Releases for non-binary crates. Additionally, it disables the current version bumping and release workflows from running on push to main. Finally, changelogs have been added to various crates and some dependencies have been removed after crate reorganization.
<!-- reviewpad:summarize:end --> 
