### PR TITLE
fix(build): ensure to pull GIT_HASH via `env` call in apps directly

### DIFF
--- a/sn_build_info/src/lib.rs
+++ b/sn_build_info/src/lib.rs
@@ -5,12 +5,19 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+use std::process::Command;
 
-/// The git commit pulled from the env var GIT_HASH (which is set during build at build.rs)
-pub fn git_hash() -> String {
-    if let Ok(git_hash) = std::env::var("GIT_HASH") {
-        git_hash
-    } else {
-        "---- No git commit hash found ----".to_string()
-    }
+/// set GIT_HASH env var to current commit
+pub fn pre_build_set_git_commit_env() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("Failed to execute git command");
+
+    let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
+
+    // Set the Git hash as an environment variable
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+    Ok(())
 }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -27,7 +27,6 @@ color-eyre = "~0.6"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
-sn_build_info= { path="../sn_build_info", version="0.1.0" }
 sn_client = { path = "../sn_client", version = "0.85.0" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.1.0" }
@@ -39,3 +38,6 @@ tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"
 walkdir = "2.3.1"
 xor_name = "5.0.0"
+
+[build-dependencies]
+sn_build_info = { path="../sn_build_info", version="0.1.0" }

--- a/sn_cli/build.rs
+++ b/sn_cli/build.rs
@@ -5,18 +5,9 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-use std::process::Command;
+use sn_build_info::pre_build_set_git_commit_env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .expect("Failed to execute git command");
-
-    let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
-
-    // Set the Git hash as an environment variable
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
-
+    pre_build_set_git_commit_env()?;
     Ok(())
 }

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -14,7 +14,6 @@ mod subcommands;
 
 use crate::cli::Opt;
 use crate::subcommands::{files::files_cmds, register::register_cmds, wallet::wallet_cmds, SubCmd};
-use sn_build_info::git_hash;
 use sn_client::Client;
 use sn_logging::init_logging;
 #[cfg(feature = "metrics")]
@@ -43,7 +42,8 @@ async fn main() -> Result<()> {
 
     info!("Full client logs will be written to {:?}", tmp_dir);
     println!("Instantiating a SAFE client...");
-    println!("Current build's git commit hash: {}", git_hash());
+    println!("Current build's git commit hash: {}", env!("GIT_HASH"));
+    debug!("Current build's git commit hash: {}", env!("GIT_HASH"));
 
     let secret_key = bls::SecretKey::random();
     let peers = peers_from_opts_or_env(&opt.peers)?;

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -35,3 +35,4 @@ thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
+

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -46,7 +46,6 @@ rmp-serde = "1.1.1"
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_build_info= { path="../sn_build_info", version="0.1.0" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.0" }
@@ -74,3 +73,4 @@ assert_fs = "1.0.0"
 
 [build-dependencies]
 tonic-build = { version = "0.6.2" }
+sn_build_info = { path="../sn_build_info", version="0.1.0" }

--- a/sn_node/build.rs
+++ b/sn_node/build.rs
@@ -5,7 +5,11 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+// use sn_build_info::pre_build_set_git_commit_env;
+use sn_build_info::pre_build_set_git_commit_env;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("./src/protocol/safenode_proto/safenode.proto")?;
+    pre_build_set_git_commit_env()?;
     Ok(())
 }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -11,7 +11,6 @@ extern crate tracing;
 
 mod rpc;
 
-use sn_build_info::git_hash;
 use sn_logging::init_logging;
 #[cfg(feature = "metrics")]
 use sn_logging::metrics::init_metrics;
@@ -125,7 +124,7 @@ fn main() -> Result<()> {
         (rt, guard)
     };
 
-    debug!("Current build's git commit hash: {}", git_hash());
+    debug!("Current build's git commit hash: {}", env!("GIT_HASH"));
 
     let root_dir = get_root_dir_path(opt.root_dir)?;
     let log_dir = if let Some(path) = opt.log_dir {


### PR DESCRIPTION
abstracting this call to the build_info lib meant that it was trying to fetch an actual env var at runtime, as opposed to the one supplied at build time

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jun 23 00:04 UTC
This pull request fixes a build issue where the build_info library was fetching an actual env var at runtime instead of the one supplied at build time. The solution is to abstract the call to the build_info lib. The GIT_HASH is now pulled via `env` call in apps directly.
<!-- reviewpad:summarize:end --> 
