### PR TITLE
chore: fix some wording around client connectivity

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -173,7 +173,7 @@ impl Client {
                             .broadcast(ClientEvent::ConnectedToNetwork)?;
                     } else {
                         println!(
-                            "Client waiting for fully connected to network, progression ({}/{})",
+                            "Waiting for sufficient peer connections ({}/{})",
                             self.peers_added, K_VALUE
                         );
                     }

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -15,7 +15,7 @@ use libp2p::{
     TransportError,
 };
 use sn_protocol::messages::Response;
-use std::io;
+use std::{io, path::PathBuf};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
@@ -36,6 +36,12 @@ pub enum Error {
 
     #[error("Outgoing response has been dropped due to a conn being closed or timeout: {0}")]
     OutgoingResponseDropped(Response),
+
+    #[error("Could not create storage dir: {path:?}, error: {source}")]
+    FailedToCreateRecordStoreDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -237,7 +237,12 @@ impl SwarmDriver {
         let kademlia = {
             // Configures the disk_store to store records under the provided path and increase the max record size
             let storage_dir = disk_store_path.unwrap_or(std::env::temp_dir());
-            std::fs::create_dir_all(&storage_dir)?;
+            if let Err(error) = std::fs::create_dir_all(&storage_dir) {
+                return Err(Error::FailedToCreateRecordStoreDir {
+                    path: storage_dir,
+                    source: error,
+                });
+            }
 
             let store_cfg = DiskBackedRecordStoreConfig {
                 max_value_bytes: 1024 * 1024,


### PR DESCRIPTION
## Description

fixes #302 as much as perm issues can be

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jun 23 03:45 UTC
This pull request includes two chore changes. The first one changes the wording in a log message to make it clearer, while the second one adds proper error handling when failing to create a storage directory in node initialization.
<!-- reviewpad:summarize:end --> 
