### PR TITLE
fix: typo fixing

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -173,7 +173,7 @@ impl Client {
                             .broadcast(ClientEvent::ConnectedToNetwork)?;
                     } else {
                         println!(
-                            "Client waiting for fully connected to newtork, progression ({}/{})",
+                            "Client waiting for fully connected to network, progression ({}/{})",
                             self.peers_added, K_VALUE
                         );
                     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jun 23 09:47 UTC
This pull request fixes a simple typo in the `sn_client/src/api.rs` file. The word `newtork` has been corrected to `network`.
<!-- reviewpad:summarize:end --> 
