### PR TITLE
chore: emit git info with vergen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "sn_build_info"
 version = "0.1.1"
+dependencies = [
+ "vergen",
+]
 
 [[package]]
 name = "sn_cli"
@@ -5539,6 +5542,17 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time 0.3.21",
+]
 
 [[package]]
 name = "version_check"

--- a/sn_build_info/Cargo.toml
+++ b/sn_build_info/Cargo.toml
@@ -9,3 +9,6 @@ name = "sn_build_info"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.1.1"
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }

--- a/sn_build_info/build.rs
+++ b/sn_build_info/build.rs
@@ -5,9 +5,17 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-use sn_build_info::pre_build_set_git_commit_env;
+use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    pre_build_set_git_commit_env()?;
+    EmitBuilder::builder()
+        // Emit the short SHA-1 hash of the current commit
+        .git_sha(true)
+        // Emit the current branch name
+        .git_branch()
+        // Emit the annotated tag of the current commit, or fall back to abbreviated commit object.
+        .git_describe(true, false, None)
+        .emit()?;
+
     Ok(())
 }

--- a/sn_build_info/src/lib.rs
+++ b/sn_build_info/src/lib.rs
@@ -5,19 +5,29 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-use std::process::Command;
 
-/// set GIT_HASH env var to current commit
-pub fn pre_build_set_git_commit_env() -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .expect("Failed to execute git command");
+/// Git information separated by slashes: `<sha> / <branch> / <describe>`
+pub fn git_info() -> &'static str {
+    concat!(
+        env!("VERGEN_GIT_SHA"),
+        " / ",
+        env!("VERGEN_GIT_BRANCH"),
+        " / ",
+        env!("VERGEN_GIT_DESCRIBE")
+    )
+}
 
-    let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
+/// Annotated tag description, or fall back to abbreviated commit object.
+pub fn git_describe() -> &'static str {
+    env!("VERGEN_GIT_DESCRIBE")
+}
 
-    // Set the Git hash as an environment variable
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+/// Current git branch.
+pub fn git_branch() -> &'static str {
+    env!("VERGEN_GIT_BRANCH")
+}
 
-    Ok(())
+/// Shortened SHA-1 hash.
+pub fn git_sha() -> &'static str {
+    env!("VERGEN_GIT_SHA")
 }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -28,6 +28,7 @@ color-eyre = "~0.6"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
+sn_build_info = { path="../sn_build_info", version = "0.1.1" }
 sn_client = { path = "../sn_client", version = "0.85.3" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
@@ -39,6 +40,3 @@ tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"
 walkdir = "2.3.1"
 xor_name = "5.0.0"
-
-[build-dependencies]
-sn_build_info = { path="../sn_build_info", version = "0.1.1" }

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -40,9 +40,10 @@ async fn main() -> Result<()> {
     #[cfg(feature = "metrics")]
     tokio::spawn(init_metrics(std::process::id()));
 
-    println!("Current build's git commit hash: {}", env!("GIT_HASH"));
-    debug!("Current build's git commit hash: {}", env!("GIT_HASH"));
+    debug!("Built with git version: {}", sn_build_info::git_info());
+    println!("Built with git version: {}", sn_build_info::git_info());
     info!("Full client logs will be written to {:?}", tmp_dir);
+    println!("Instantiating a SAFE client...");
 
     let secret_key = bls::SecretKey::random();
     let peers = peers_from_opts_or_env(&opt.peers)?;

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -46,6 +46,7 @@ rmp-serde = "1.1.1"
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
+sn_build_info = { path="../sn_build_info", version = "0.1.1" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.3" }
@@ -72,4 +73,3 @@ assert_fs = "1.0.0"
 
 [build-dependencies]
 tonic-build = { version = "0.6.2" }
-sn_build_info = { path="../sn_build_info", version = "0.1.1" }

--- a/sn_node/build.rs
+++ b/sn_node/build.rs
@@ -6,10 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 // use sn_build_info::pre_build_set_git_commit_env;
-use sn_build_info::pre_build_set_git_commit_env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("./src/protocol/safenode_proto/safenode.proto")?;
-    pre_build_set_git_commit_env()?;
     Ok(())
 }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -126,7 +126,7 @@ fn main() -> Result<()> {
         (rt, guard)
     };
 
-    debug!("Current build's git commit hash: {}", env!("GIT_HASH"));
+    debug!("Built with git version: {}", sn_build_info::git_info());
 
     let root_dir = get_root_dir_path(opt.root_dir)?;
     let log_dir = if let Some(path) = opt.log_dir {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 08:53 UTC
This pull request adds the `vergen` dependency and emits git information with it. It also updates the `sn_build_info` and `sn_cli` workspaces.
<!-- reviewpad:summarize:end --> 
