### PR TITLE
feat: bail out if empty list of addreses is provided for payment proof generation

### DIFF
--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -14,7 +14,19 @@ use crate::subcommands::SubCmd;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub(crate) struct Opt {
-    /// Nodes we dial at start to help us get connected to the network. Can be specified multiple times.
+    /// Provide a peer to connect to a public network, using the MultiAddr format.
+    ///
+    /// The MultiAddr format looks like so:
+    ///
+    /// /ip4/13.40.152.226/udp/12000/quic-v1/p2p/12D3KooWRi6wF7yxWLuPSNskXc6kQ5cJ6eaymeMbCRdTnMesPgFx
+    ///
+    /// Noteworthy are the second, fourth, and last parts.
+    ///
+    /// Those are the IP address and UDP port the peer is listening on, and its peer ID, respectively.
+    ///
+    /// Many peers can be provided by using the argument multiple times.
+    ///
+    /// If none are provided, a connection will be attempted to a local network.
     #[clap(long = "peer", global = true)]
     pub peers: Vec<Multiaddr>,
 

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -15,7 +15,7 @@ use crate::subcommands::SubCmd;
 #[command(author, version, about, long_about = None)]
 pub(crate) struct Opt {
     /// Nodes we dial at start to help us get connected to the network. Can be specified multiple times.
-    #[clap(long = "peer")]
+    #[clap(long = "peer", global = true)]
     pub peers: Vec<Multiaddr>,
 
     /// Available sub commands.

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -8,7 +8,6 @@
 
 use sn_client::{Client, Files, WalletClient};
 use sn_dbc::{Dbc, Token};
-use sn_protocol::{storage::ChunkAddress, NetworkAddress};
 use sn_transfers::{
     payment_proof::PaymentProofsMap,
     wallet::{parse_public_address, LocalWallet},
@@ -153,9 +152,7 @@ pub(super) async fn pay_for_storage(
             let bytes = Bytes::from(file);
             // we need all chunks addresses not just the data-map addr
             let (_, chunks) = file_api.chunk_bytes(bytes)?;
-            chunks.iter().for_each(|c| {
-                chunks_addrs.push(NetworkAddress::ChunkAddress(ChunkAddress::new(*c.name())))
-            });
+            chunks.iter().for_each(|c| chunks_addrs.push(*c.name()));
         }
     }
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 
-use sn_protocol::NetworkAddress;
+use sn_dbc::{Dbc, PublicAddress, Token};
 use sn_transfers::{
     client_transfers::TransferOutputs,
     payment_proof::{build_payment_proofs, PaymentProofsMap},
@@ -17,9 +17,8 @@ use sn_transfers::{
 
 use bls::SecretKey;
 use futures::future::join_all;
-use sn_dbc::{Dbc, PublicAddress, Token};
-
 use std::iter::Iterator;
+use xor_name::XorName;
 
 /// A wallet client can be used to send and
 /// receive tokens to/from other wallets.
@@ -72,7 +71,7 @@ impl WalletClient {
     /// Send tokens to nodes closest to the data we want to make storage payment for.
     pub async fn pay_for_storage(
         &mut self,
-        content_addrs: impl Iterator<Item = &NetworkAddress>,
+        content_addrs: impl Iterator<Item = &XorName>,
     ) -> Result<(Dbc, PaymentProofsMap)> {
         // TODO: calculate the amount to pay to each node, perhaps just 1 nano to begin with.
         let amount = Token::from_nano(1);

--- a/sn_transfers/src/payment_proof/error.rs
+++ b/sn_transfers/src/payment_proof/error.rs
@@ -15,8 +15,8 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    /// Failed to build the payment prooff tree
-    #[error("Failed to build the payment prooff tree: {0}")]
+    /// Failed to build the payment proof tree
+    #[error("Failed to build the payment proof tree: {0}")]
     ProofTree(String),
     /// Failed to generate the audit trail for an item
     #[error("Failed to generate the audit trail for leaf item #{index}: {reason}")]

--- a/sn_transfers/src/payment_proof/mod.rs
+++ b/sn_transfers/src/payment_proof/mod.rs
@@ -231,7 +231,7 @@ mod tests {
         .map(XorName)
         .collect::<Vec<_>>();
 
-        for i in 0..addrs.len() {
+        for i in 1..addrs.len() {
             let (_, payment_proofs) = build_payment_proofs(addrs.iter().take(i))?;
             assert_eq!(payment_proofs.len(), i);
         }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 17:58 UTC
This pull request adds a feature that makes the code bail out if an empty list of addresses is provided for payment proof generation. The patch contains changes in multiple files to implement this feature.
<!-- reviewpad:summarize:end --> 
