### PR TITLE
ci: release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: release
 
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 env:
+  RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.11/release-plz-x86_64-unknown-linux-gnu.tar.gz
+  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -38,8 +40,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      # It's quite slow to install just by building it, but here we need a cross-platform solution.
       - shell: bash
-        run: make gha-build-${{ matrix.target }}
+        run: cargo install just
+      - shell: bash
+        run: just build-release-artifacts "${{ matrix.target }}"
       - uses: actions/upload-artifact@main
         with:
           name: safe_network-${{ matrix.target }}
@@ -54,7 +59,7 @@ jobs:
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Release Failed"
 
-  gh_release:
+  release:
     if: |
       github.repository_owner == 'maidsafe' &&
       startsWith(github.event.head_commit.message, 'chore(release):')
@@ -62,7 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
@@ -90,157 +98,37 @@ jobs:
           name: safe_network-aarch64-unknown-linux-musl
           path: artifacts/prod/aarch64-unknown-linux-musl/release
 
-      - shell: bash
-        name: package artifacts for release
-        run: |
-          make prepare-deploy
-          make safenode-package-version-artifacts-for-release
-          make safe-package-version-artifacts-for-release
-
-      - shell: bash
-        id: versioning
-        run: |
-          ./resources/scripts/output_versioning_info.sh
-
-      - name: generate release description first pass
+      # It's possible to `cargo install` these tools, but it's very slow to compile on GHA infra.
+      # Therefore we just pull some binaries from the Github Releases.
+      - name: install tools
         shell: bash
         run: |
-          ./resources/scripts/get_release_description.sh > release_description.md
+          curl -L -O $RELEASE_PLZ_BIN_URL
+          tar xvf release-plz-x86_64-unknown-linux-gnu.tar.gz
+          rm release-plz-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv release-plz /usr/local/bin
 
-      # The second pass uses Python to extract the changelog entries for this version.
-      # Python can easily do a string replace and avoid all the pain with newlines you get in Bash.
-      # The script operates on the release_description.md that was generated in the previous step.
-      - name: generate release description second pass
-        shell: bash
-        run: |
-          pip install toml
-          ./resources/scripts/insert_changelog_entry.py
-
-      - name: create github release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.versioning.outputs.gh_release_tag_name }}
-          release_name: ${{ steps.versioning.outputs.gh_release_name }}
-          draft: false
-          prerelease: false
-          body_path: release_description.md
-
-      # There's an action you can use for uploading an asset to a release, but because there are so
-      # many assets, using the 'gh' CLI is much more concise. The 'gh' tool should be on an Actions
-      # build agent by default.
-      - name: upload artifacts as assets
-        shell: bash
-        run: |
-          (
-            cd deploy/prod/safenode
-            ls | xargs gh release upload ${{ steps.versioning.outputs.gh_release_tag_name }}
-          )
-          (
-            cd deploy/prod/safe
-            ls | xargs gh release upload ${{ steps.versioning.outputs.gh_release_tag_name }}
-          )
-
-      - uses: shallwefootball/s3-upload-action@master
-        name: upload safenode artifacts to s3
-        with:
-          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: safenode
-          source_dir: deploy/prod/safenode
-          destination_dir: ""
-
-      - uses: shallwefootball/s3-upload-action@master
-        name: upload safe artifacts to s3
-        with:
-          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: safe
-          source_dir: deploy/prod/safe
-          destination_dir: ""
-
-      # Now repackage and upload the artifacts using 'latest' for the version.
+          curl -L -O $JUST_BIN_URL
+          mkdir just
+          tar xvf just-1.13.0-x86_64-unknown-linux-musl.tar.gz -C just
+          rm just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+          sudo mv just/just /usr/local/bin
+          rm -rf just
       - shell: bash
-        name: package artifacts for release
         run: |
-          make prepare-deploy
-          make safenode-package-version-artifacts-for-release \
-            SAFENODE_VERSION=latest DEPLOY_PATH=deploy
-          make safe-package-version-artifacts-for-release SAFE_VERSION=latest DEPLOY_PATH=deploy
-
-      - uses: shallwefootball/s3-upload-action@master
-        name: upload safenode artifacts to s3
-        with:
-          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: safenode
-          source_dir: deploy/prod/safenode
-          destination_dir: ""
-
-      - uses: shallwefootball/s3-upload-action@master
-        name: upload safe artifacts to s3
-        with:
-          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: safe
-          source_dir: deploy/prod/safe
-          destination_dir: ""
-      - name: post notification to slack on failure
-        if: ${{ failure() }}
-        uses: bryannice/gitactions-slack-notification@2.0.0
-        env:
-          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-          SLACK_TITLE: "Release Failed"
-
-  # publish:
-  #   name: publish
-  #   runs-on: ubuntu-latest
-  #   needs: [gh_release]
-  #   if: |
-  #     github.repository_owner == 'maidsafe' &&
-  #     startsWith(github.event.head_commit.message, 'chore(release):')
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: "0"
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #     - shell: bash
-  #       id: versioning
-  #       run: |
-  #         ./resources/scripts/output_versioning_info.sh
-  #     # - name: cargo login
-  #     #   run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-  #     ## We will probably need this one later
-  #     # - name: publish sn_updater
-  #     #   run: |
-  #     #     commit_message="${{ github.event.head_commit.message }}"
-  #     #     if [[ $commit_message == *"sn_updater"* ]]; then
-  #     #       # The sn_updater crate doesn't have any dependencies so we can go ahead and publish.
-  #     #       cd sn_updater && cargo publish --allow-dirty
-  #     #     fi
-  #     - name: publish safenode
-  #       run: |
-  #         commit_message="${{ github.event.head_commit.message }}"
-  #         if [[ $commit_message == *"safenode"* ]]; then
-  #           ./resources/scripts/publish_crate_with_retries.sh "safenode"
-  #         fi
-  #     - name: publish safe
-  #       run: |
-  #         commit_message="${{ github.event.head_commit.message }}"
-  #         if [[ $commit_message == *"safe-"* ]]; then
-  #           ./resources/scripts/publish_crate_with_retries.sh "safe"
-  #         fi
-  #     - name: post notification to slack on failure
-  #       if: ${{ failure() }}
-  #       uses: bryannice/gitactions-slack-notification@2.0.0
-  #       env:
-  #         SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-  #         SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-  #         SLACK_TITLE: "Release Failed"
+          cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          release-plz release --git-token ${{ secrets.GITHUB_TOKEN }}
+          just package-release-assets "safe"
+          just package-release-assets "safenode"
+          just package-release-assets "testnet"
+          just upload-release-assets
+          just upload-release-assets-to-s3 "safe"
+          just upload-release-assets-to-s3 "safenode"
+          just upload-release-assets-to-s3 "testnet"
+          # Now repackage and upload the artifacts to S3 using 'latest' for the version.
+          just package-release-assets "safe" "latest"
+          just package-release-assets "safenode" "latest"
+          just package-release-assets "testnet" "latest"
+          just upload-release-assets-to-s3 "safe"
+          just upload-release-assets-to-s3 "safenode"
+          just upload-release-assets-to-s3 "testnet"

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -4,12 +4,13 @@ name: Version Bump
 concurrency:
   group: "version-bumping"
 
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 env:
+  RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.11/release-plz-x86_64-unknown-linux-gnu.tar.gz
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -33,11 +34,18 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-      - shell: bash
-        run: cargo install cargo-smart-release
+      # It's possible to `cargo install` release-plz, but it's very slow to compile on GHA infra.
+      # Therefore we just pull the binary from the Github Release.
+      - name: install release-plz
+        shell: bash
+        run: |
+          curl -L -O $RELEASE_PLZ_BIN_URL
+          tar xvf release-plz-x86_64-unknown-linux-gnu.tar.gz
+          rm release-plz-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv release-plz /usr/local/bin
       - shell: bash
         run: ./resources/scripts/bump_version.sh
-      - name: push version bump commit and tags
+      - name: push version bump commit
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,185 @@
+#!/usr/bin/env just --justfile
+
+release_repo := "maidsafe/safe_network"
+
+build-release-artifacts arch:
+  #!/usr/bin/env bash
+  set -e
+
+  arch="{{arch}}"
+  supported_archs=(
+    "x86_64-pc-windows-msvc"
+    "x86_64-apple-darwin"
+    "x86_64-unknown-linux-musl"
+    "arm-unknown-linux-musleabi"
+    "armv7-unknown-linux-musleabihf"
+    "aarch64-unknown-linux-musl"
+  )
+
+  arch_supported=false
+  for supported_arch in "${supported_archs[@]}"; do
+    if [[ "$arch" == "$supported_arch" ]]; then
+      arch_supported=true
+      break
+    fi
+  done
+
+  if [[ "$arch_supported" == "false" ]]; then
+    echo "$arch is not supported."
+    exit 1
+  fi
+
+  if [[ "$arch" == "x86_64-unknown-linux-musl" ]]; then
+    if [[ "$(grep -E '^NAME="Ubuntu"' /etc/os-release)" ]]; then
+      # This is intended for use on a fresh Github Actions agent
+      sudo apt update -y
+      sudo apt install -y musl-tools
+    fi
+    rustup target add x86_64-unknown-linux-musl
+  fi
+
+  rm -rf artifacts
+  mkdir artifacts
+  cargo clean
+  if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
+    cargo install cross
+    cross build --release --target $arch --bin safe
+    cross build --release --target $arch --bin safenode
+    cross build --release --target $arch --bin testnet
+  else
+    cargo build --release --target $arch --bin safe
+    cargo build --release --target $arch --bin safenode
+    cargo build --release --target $arch --bin testnet
+  fi
+
+  find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+  rm -f artifacts/.cargo-lock
+
+package-release-assets bin version="":
+  #!/usr/bin/env bash
+  set -e
+
+  architectures=(
+    "x86_64-pc-windows-msvc"
+    "x86_64-apple-darwin"
+    "x86_64-unknown-linux-musl"
+    "arm-unknown-linux-musleabi"
+    "armv7-unknown-linux-musleabihf"
+    "aarch64-unknown-linux-musl"
+  )
+
+  bin="{{bin}}"
+  case "$bin" in
+    safe)
+      crate="sn_cli"
+      ;;
+    safenode)
+      crate="sn_node"
+      ;;
+    testnet)
+      crate="sn_testnet"
+      ;;
+    *)
+      echo "The only supported binaries are safe, safenode or testnet."
+      exit 1
+      ;;
+  esac
+
+  if [[ -z "{{version}}" ]]; then
+    version=$(grep "^version" < $crate/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  else
+    version="{{version}}"
+  fi
+
+  rm -rf deploy/$bin
+  find artifacts/ -name "$bin" -exec chmod +x '{}' \;
+  for arch in "${architectures[@]}" ; do
+    echo "Packaging for $arch..."
+    if [[ $arch == *"windows"* ]]; then bin_name="${bin}.exe"; else bin_name=$bin; fi
+    zip -j $bin-$version-$arch.zip artifacts/$arch/release/$bin_name
+    tar -C artifacts/$arch/release -zcvf $bin-$version-$arch.tar.gz $bin_name
+  done
+
+  mkdir -p deploy/$bin
+  mv *.tar.gz deploy/$bin
+  mv *.zip deploy/$bin
+
+upload-release-assets:
+  #!/usr/bin/env bash
+  set -e
+
+  binary_crates=(
+    "sn_cli"
+    "sn_node"
+    "sn_testnet"
+  )
+
+  commit_msg=$(git log -1 --pretty=%B)
+  # Remove 'chore(release): ' prefix
+  commit_msg=${commit_msg#*: }
+
+  IFS='/' read -ra crates_with_versions <<< "$commit_msg"
+  declare -a crate_names
+  for crate_with_version in "${crates_with_versions[@]}"; do
+    crate=$(echo "$crate_with_version" | awk -F'-v' '{print $1}')
+    crates+=("$crate")
+  done
+
+  for crate in "${crates[@]}"; do
+    for binary_crate in "${binary_crates[@]}"; do
+        if [[ "$crate" == "$binary_crate" ]]; then
+            case "$crate" in
+              sn_cli)
+                bin_name="safe"
+                ;;
+              sn_node)
+                bin_name="safenode"
+                ;;
+              sn_testnet)
+                bin_name="testnet"
+                ;;
+              *)
+                echo "The only supported binaries are safe, safenode or testnet."
+                exit 1
+                ;;
+            esac
+            # The crate_with_version variable will correspond to the tag name of the release.
+            # However, only binary crates have releases, so we need to skip any tags that don't
+            # correspond to a binary.
+            for crate_with_version in "${crates_with_versions[@]}"; do
+              if [[ $crate_with_version == $crate-v* ]]; then
+                (
+                  echo "Uploading $bin_name assets to $crate_with_version release..."
+                  cd deploy/$bin_name
+                  ls | xargs gh release upload $crate_with_version --repo {{release_repo}}
+                )
+              fi
+            done
+        fi
+    done
+  done
+
+upload-release-assets-to-s3 bin_name:
+  #!/usr/bin/env bash
+  set -e
+
+  case "{{bin_name}}" in
+    safe)
+      bucket="sn-cli"
+      ;;
+    safenode)
+      bucket="sn-node"
+      ;;
+    testnet)
+      bucket="sn-testnet"
+      ;;
+    *)
+      echo "The only supported binaries are safe, safenode or testnet"
+      exit 1
+      ;;
+  esac
+
+  cd deploy/{{bin_name}}
+  for file in *.zip *.tar.gz; do
+    aws s3 cp "$file" "s3://$bucket/$file" --acl public-read
+  done

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,7 @@
 allow_dirty = false
 changelog_update = true
 dependencies_update = false
-git_release_enable = false
+git_release_enable = true
 publish_allow_dirty = false
 semver_check = false
 


### PR DESCRIPTION
The release process now uses the `release-plz` tool.

The version bumping workflow uses a small script that runs `release-plz update` and parses its output to determine which crates had version bumps. A commit is then generated based on that. Unlike `smart-release`, `release-plz update` doesn't create a commit or tags. So now the version bumping is only producing the commit and pushing that to `main`.

The release workflow is then kicked off, which builds the binaries, then uses the `release-plz release` command to publish crates that were bumped using `update`. The same command also performs Github Releases for the binary crates and creates tags for every crate that was published.

Finally, the binary assets are attached to the releases and uploaded to S3.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 18:44 UTC
This pull request introduces various changes, including additions and updates to GitHub Actions workflows and release processes. It adds new environment variables, updates 'on' triggers, and modifies the release-plz.toml file. Additionally, it introduces a new `Justfile` with tasks for building and releasing artifacts across different platforms.
<!-- reviewpad:summarize:end --> 
