### PR TITLE
feat: include output DBC within payment proof for Chunks storage

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -11,9 +11,8 @@ use super::wallet::pay_for_storage;
 use bytes::Bytes;
 use clap::Parser;
 use color_eyre::Result;
-use sn_client::{Client, Files};
+use sn_client::{Client, Files, PaymentProofsMap};
 use sn_protocol::storage::ChunkAddress;
-use sn_transfers::payment_proof::PaymentProofsMap;
 
 use std::{
     fs,
@@ -90,8 +89,7 @@ async fn upload_files(
 
     // We make the payment for Chunks storage only if requested by the user
     let payment_proofs = if pay {
-        let (_dbc, payment_proofs) = pay_for_storage(&client, root_dir, &files_path).await?;
-        payment_proofs
+        pay_for_storage(&client, root_dir, &files_path).await?
     } else {
         PaymentProofsMap::default()
     };

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -6,12 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_client::{Client, Files, WalletClient};
-use sn_dbc::{Dbc, Token};
-use sn_transfers::{
-    payment_proof::PaymentProofsMap,
-    wallet::{parse_public_address, LocalWallet},
-};
+use sn_client::{Client, Files, PaymentProofsMap, WalletClient};
+use sn_dbc::Token;
+use sn_transfers::wallet::{parse_public_address, LocalWallet};
 
 use bytes::Bytes;
 use clap::Parser;
@@ -142,7 +139,7 @@ pub(super) async fn pay_for_storage(
     client: &Client,
     root_dir: &Path,
     files_path: &Path,
-) -> Result<(Dbc, PaymentProofsMap)> {
+) -> Result<PaymentProofsMap> {
     let wallet = LocalWallet::load_from(root_dir).await?;
     let mut wallet_client = WalletClient::new(client.clone(), wallet);
     let file_api: Files = Files::new(client.clone());
@@ -175,5 +172,5 @@ pub(super) async fn pay_for_storage(
     wallet.store_created_dbc(new_dbc.clone()).await?;
     println!("Successfully stored new dbc ({dbc_id:?}) to wallet dir. It can now be sent to the storage nodes when uploading paid chunks.");
 
-    Ok((new_dbc, proofs))
+    Ok(proofs)
 }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -9,11 +9,11 @@
 use super::{
     chunks::{to_chunk, DataMapLevel, Error, LargeFile, SmallFile},
     error::Result,
+    wallet::PaymentProofsMap,
     Client,
 };
 
 use sn_protocol::storage::{Chunk, ChunkAddress};
-use sn_transfers::payment_proof::PaymentProofsMap;
 
 use bincode::deserialize;
 use bytes::Bytes;

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::{
     faucet::{get_tokens_from_faucet, load_faucet_wallet},
     file_apis::Files,
     register::{Register, RegisterOffline},
-    wallet::{send, WalletClient},
+    wallet::{send, PaymentProofsMap, WalletClient},
 };
 
 use self::event::ClientEventsChannel;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -699,7 +699,7 @@ mod tests {
     use rand::{thread_rng, Rng};
     use sn_logging::init_test_logger;
     use sn_protocol::{
-        messages::{Cmd, CmdResponse, Hash, PaymentProof, Request, Response},
+        messages::{CmdResponse, Query, Request, Response},
         storage::Chunk,
     };
     use std::{net::SocketAddr, path::Path, time::Duration};
@@ -731,17 +731,12 @@ mod tests {
             }
         });
 
-        // Send a request to store a random chunk to `self`.
+        // Send a request to query a random chunk to `self`.
         let mut random_data = [0u8; 128];
         thread_rng().fill(&mut random_data);
-        let req = Request::Cmd(Cmd::StoreChunk {
-            chunk: Chunk::new(Bytes::copy_from_slice(&random_data)),
-            payment: Some(PaymentProof {
-                reason_hash: Hash::hash(&random_data),
-                audit_trail: vec![],
-                path: vec![],
-            }),
-        });
+        let req = Request::Query(Query::GetChunk(
+            *Chunk::new(Bytes::copy_from_slice(&random_data)).address(),
+        ));
         // Send the request to `self` and wait for a response.
         let now = tokio::time::Instant::now();
         loop {

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -19,7 +19,9 @@ use sn_networking::{
 };
 use sn_protocol::{
     error::Error as ProtocolError,
-    messages::{Cmd, CmdResponse, Query, QueryResponse, RegisterCmd, Request, Response},
+    messages::{
+        Cmd, CmdResponse, PaymentProof, Query, QueryResponse, RegisterCmd, Request, Response,
+    },
     storage::{registers::User, Chunk, DbcAddress},
     NetworkAddress,
 };
@@ -248,9 +250,17 @@ impl Node {
                 debug!("That's a store chunk in for :{addr_name:?}");
 
                 // TODO: temporarily payment proof is optional
-                if let Some(payment_proof) = payment {
+                if let Some(PaymentProof {
+                    reason_hash,
+                    audit_trail,
+                    path,
+                    ..
+                }) = &payment
+                {
                     // Let's make sure the payment proof is valid for the chunk's name
-                    if let Err(err) = validate_payment_proof(addr_name, &payment_proof) {
+                    if let Err(err) =
+                        validate_payment_proof(addr_name, reason_hash, audit_trail, path)
+                    {
                         debug!("Chunk payment proof deemed invalid: {err:?}");
                         let resp =
                             CmdResponse::StoreChunk(Err(ProtocolError::InvalidPaymentProof {

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -14,7 +14,7 @@ use crate::{
 use super::RegisterCmd;
 
 // TODO: remove this dependency and define these types herein.
-pub use sn_dbc::{Hash, SignedSpend};
+pub use sn_dbc::{Dbc, Hash, SignedSpend};
 
 use serde::{Deserialize, Serialize};
 
@@ -103,11 +103,14 @@ pub type MerkleTreeNodesType = [u8; 32];
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct PaymentProof {
+    // Output DBC for nodes to check the Chunk payment is valid and inputs have
+    // been effectivelly spent on the network.
+    pub dbc: Dbc,
     // Reason-hash value set in the input/parent DBCs spent for this storage payment.
-    // TOOD: pass the output DBC instead, nodes can check input/parent DBCs' reason-hash among other pending validations.
+    // TODO: remove it since nodes should get this from the input/parent spent DBC/s
     pub reason_hash: Hash,
     // Merkletree audit trail to prove the Chunk has been paid by the
-    // given DBC (using the DBC's 'reason' field)
+    // given DBC (using DBC's parent/s 'reason' field)
     pub audit_trail: Vec<MerkleTreeNodesType>,
     // Path of the audit trail
     pub path: Vec<usize>,


### PR DESCRIPTION
Resolves #342 

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 14:35 UTC
This pull request includes various changes across multiple files related to the `PaymentProofsMap` type. It adds new fields and modifies the return types of some functions. It also removes some unused imports and changes imports from one module to another. Additionally, it updates the `CmdResponse::StoreChunk` function in the `sn_protocol` module to accept payment proofs. Finally, it modifies the `PaymentProof` struct in the `sn_protocol` module to add a new field `dbc` and update the `audit_trail` field.
<!-- reviewpad:summarize:end --> 
