### PR TITLE
chore: upgrade `sn_transfers` to 0.9.0

### DIFF
--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_transfers"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.0"
+version = "0.9.0"
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
It turned out we already had an `sn_transfers` crate that was over two years old, so it was a mistake to initially version this crate at 0.1.0.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 17:48 UTC
This pull request upgrades the `sn_transfers` crate to version 0.9.0, replacing the over two-year-old 0.1.0 version.
<!-- reviewpad:summarize:end --> 
