### PR TITLE
ci: workflow for building release artifacts

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,0 +1,51 @@
+name: build release artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to build.
+        type: string
+        required: true
+        default: main
+
+jobs:
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      # It's quite slow to install just by building it, but here we need a cross-platform solution.
+      - shell: bash
+        run: cargo install just
+      - shell: bash
+        run: just build-release-artifacts "${{ matrix.target }}"
+      - uses: actions/upload-artifact@main
+        with:
+          name: safe_network-${{ matrix.target }}
+          path: |
+            artifacts
+            !artifacts/.cargo-lock


### PR DESCRIPTION
Provides a workflow that can be triggered manually for building release artifacts from either the current `main` or a specified branch, for whatever reason you need at the time.

My particular use case is that I can use the artifacts to perform a 'manual' release run without having a release commit, which can sometimes be useful for resolving situations in which releases or crate publishing have went bad.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 19:55 UTC
This pull request adds a workflow for building release artifacts on specified branches or current `main`. It includes installation of necessary tools and uploading the resulting artifacts. This workflow aims to provide a way to generate release artifacts without the need of a release commit, which can be useful for resolving problems during releases or crate publishing.
<!-- reviewpad:summarize:end --> 
