### PR TITLE
chore: manually update references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "sn_transfers"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "assert_fs",
  "async-trait",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -30,7 +30,7 @@ hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 sn_client = { path = "../sn_client", version = "0.85.2" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
-sn_transfers = { path = "../sn_transfers", version = "0.1.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 sn_logging = { path = "../sn_logging", version = "0.1.1" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.1" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -31,7 +31,7 @@ sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.1.1" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
 sn_registers = { path = "../sn_registers", version = "0.1.1" }
-sn_transfers = { path = "../sn_transfers", version = "0.1.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -53,7 +53,7 @@ sn_logging = { path = "../sn_logging", version = "0.1.1" }
 sn_networking = { path = "../sn_networking", version = "0.1.1" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
 sn_registers = { path = "../sn_registers", version = "0.1.1" }
-sn_transfers = { path = "../sn_transfers", version = "0.1.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-stream = { version = "~0.1.12" }


### PR DESCRIPTION
The new `sn_transfers` crate at `v0.9.0` has now been published, but these other crates needed manually pointed to the new version.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 20:21 UTC
This pull request updates the reference to the `sn_transfers` crate to version 0.9.0 in the `sn_cli`, `sn_client`, and `sn_node` packages and updates the corresponding `Cargo.lock` file. This is necessary since the crate has now been published and these packages were still pointing to the previous version.
<!-- reviewpad:summarize:end --> 
