### PR TITLE
ci: use the release access token on checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.RELEASE_PAT }}
       - uses: actions/download-artifact@master
         with:
           name: safe_network-x86_64-pc-windows-msvc


### PR DESCRIPTION
This may be what's causing the failure to push to the repository. The version bumping workflow uses a PAT on the checkout action, so hopefully this may resolve the issue.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 22:54 UTC
This pull request fixes an issue with the push to the repository during the version bumping workflow. The release access token is now used during checkout to resolve the problem.
<!-- reviewpad:summarize:end --> 
