### PR TITLE
ci: use correct paths for artifacts

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: main
 
+env:
+  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+
 jobs:
   build:
     name: build
@@ -49,3 +52,66 @@ jobs:
           path: |
             artifacts
             !artifacts/.cargo-lock
+
+  # This job isn't necessary, but it's useful for debugging the packaging process for the real release
+  # workflow, just in case any issues are ever encountered there.
+  package:
+    name: publish and release
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.RELEASE_PAT }}
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-pc-windows-msvc
+          path: artifacts/x86_64-pc-windows-msvc/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-unknown-linux-musl
+          path: artifacts/x86_64-unknown-linux-musl/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-apple-darwin
+          path: artifacts/x86_64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-arm-unknown-linux-musleabi
+          path: artifacts/arm-unknown-linux-musleabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-armv7-unknown-linux-musleabihf
+          path: artifacts/armv7-unknown-linux-musleabihf/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-aarch64-unknown-linux-musl
+          path: artifacts/aarch64-unknown-linux-musl/release
+      # It's possible to `cargo install` just, but it's very slow to compile on GHA infra.
+      # Therefore we just pull the binary from the Github Release.
+      - name: install just
+        shell: bash
+        run: |
+          curl -L -O $JUST_BIN_URL
+          mkdir just
+          tar xvf just-1.13.0-x86_64-unknown-linux-musl.tar.gz -C just
+          rm just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+          sudo mv just/just /usr/local/bin
+          rm -rf just
+          sudo apt-get install -y tree
+      - name: package artifacts
+        shell: bash
+        run: |
+          tree artifacts
+          just package-release-assets "safe"
+          just package-release-assets "safenode"
+          just package-release-assets "testnet"
+      - uses: actions/upload-artifact@main
+        with:
+          name: packaged_binaries
+          path: deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,27 +79,27 @@ jobs:
       - uses: actions/download-artifact@master
         with:
           name: safe_network-x86_64-pc-windows-msvc
-          path: artifacts/prod/x86_64-pc-windows-msvc/release
+          path: artifacts/x86_64-pc-windows-msvc/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-x86_64-unknown-linux-musl
-          path: artifacts/prod/x86_64-unknown-linux-musl/release
+          path: artifacts/x86_64-unknown-linux-musl/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-x86_64-apple-darwin
-          path: artifacts/prod/x86_64-apple-darwin/release
+          path: artifacts/x86_64-apple-darwin/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-arm-unknown-linux-musleabi
-          path: artifacts/prod/arm-unknown-linux-musleabi/release
+          path: artifacts/arm-unknown-linux-musleabi/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-armv7-unknown-linux-musleabihf
-          path: artifacts/prod/armv7-unknown-linux-musleabihf/release
+          path: artifacts/armv7-unknown-linux-musleabihf/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-aarch64-unknown-linux-musl
-          path: artifacts/prod/aarch64-unknown-linux-musl/release
+          path: artifacts/aarch64-unknown-linux-musl/release
       - shell: bash
         run: |
           git config --local user.email "action@github.com"

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -14,12 +14,12 @@ use clap::Subcommand;
 #[derive(Subcommand, Debug)]
 pub(super) enum SubCmd {
     #[clap(name = "wallet", subcommand)]
-    /// Manage wallets on the SAFE Network
+    /// Commands for wallet management
     Wallet(wallet::WalletCmds),
     #[clap(name = "files", subcommand)]
-    /// Manage files on the SAFE Network
+    /// Commands for file management
     Files(files::FilesCmds),
     #[clap(name = "register", subcommand)]
-    /// Manage files on the SAFE Network
+    /// Commands for register management
     Register(register::RegisterCmds),
 }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -83,7 +83,9 @@ struct Opt {
     #[clap(long = "peer", value_name = "MultiAddr")]
     peers: Vec<Multiaddr>,
 
-    /// Enable the admin/ctrl RPC service by providing an IP and port for it to listen on.
+    /// Enable the admin/control RPC service by providing an IP and port for it to listen on.
+    ///
+    /// The RPC service can be used for querying information about the running node.
     #[clap(long)]
     rpc: Option<SocketAddr>,
 

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -51,7 +51,7 @@ struct Cmd {
     #[clap(long = "join", short = 'j', value_parser)]
     join_network: bool,
 
-    /// Optional location for a network contacts file.
+    /// Location for a network contacts file.
     ///
     /// This should only be used in conjunction with the 'join' command. You can supply it if you
     /// have an existing network contacts path and you want to launch nodes perhaps on another
@@ -62,7 +62,7 @@ struct Cmd {
     #[clap(long = "network-contacts-path", short = 'n', value_name = "FILE_PATH")]
     network_contacts_path: Option<PathBuf>,
 
-    /// Interval between node launches in ms. Defaults to 5000.
+    /// Interval between node launches in milliseconds. Defaults to 5000.
     #[clap(long = "interval", short = 'i')]
     node_launch_interval: Option<u64>,
 


### PR DESCRIPTION
- 9040884 **ci: use correct paths for artifacts**

  The `prod` in the artifacts path was removed as this was not expected to be in the artifacts
  directory.

  I've also added another job to the `build-release-artifacts` workflow to perform packaging of the
  build artifacts. This can be useful for debugging problems with packaging in the real release
  workflow.

- 450f1e3 **chore: provide clarity on command arguments**

  This has mainly been done just to change the text to force a release for testing the new release
  process.


## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 00:01 UTC
This pull request includes two patches. The first patch fixes the artifacts path and adds a job to generate packaging of build artifacts. The second patch provides clarity on command arguments for wallet, file and register management.
<!-- reviewpad:summarize:end --> 
