### PR TITLE
fix(replication): prevent dropped conns during replication

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -286,6 +286,11 @@ impl Node {
                     keys.len()
                 );
                 let _ = self.network.replication_keys_to_fetch(holder, keys).await;
+
+                // if we do not send a response, we can cause conneciton failures.
+                let resp = CmdResponse::Replicate(Ok(()));
+                self.send_response(Response::Cmd(resp), response_channel)
+                    .await;
             }
             Cmd::Register(cmd) => {
                 let result = self.registers.write(&cmd).await;

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -89,6 +89,8 @@ pub enum CmdResponse {
     CreateRegister(Result<()>),
     /// Response to RegisterCmd::Edit.
     EditRegister(Result<()>),
+    /// Response to ReplicateCmd
+    Replicate(Result<()>),
 }
 
 impl std::fmt::Display for QueryResponse {


### PR DESCRIPTION
We were seeing a lot of OutboundFialure and closed connections leading to dropped messages during data replication. This was turning up as UnexpectedEof errors when a connection was closed midway through send eg.

Seems like, due to _NOT_ responding to a request (using the protocol wrongly perhaps?) we were causing awaiting connections to error out as the receive stream was dropped unepectedly, causing a knock on to anything else in flight on that same connection.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 02:32 UTC
This pull request fixes dropped messages during data replication due to closed connections from outbound failures. The change includes adding a response to the ReplicateCmd to prevent connection failures and errors in awaiting connections.
<!-- reviewpad:summarize:end --> 
