### PR TITLE
ci: use personal access token for gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-2
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.RELEASE_PAT }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -34,7 +34,7 @@ sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 sn_logging = { path = "../sn_logging", version = "0.1.1" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,9 +28,9 @@ rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
-sn_networking = { path = "../sn_networking", version = "0.1.1" }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
-sn_registers = { path = "../sn_registers", version = "0.1.1" }
+sn_networking = { path = "../sn_networking", version = "0.1.2" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
+sn_registers = { path = "../sn_registers", version = "0.1.2" }
 sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_networking"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.1"
+version = "0.1.2"
 
 [features]
 default=["local-discovery"]
@@ -24,9 +24,9 @@ libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "request
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_record_store = { path = "../sn_record_store", version = "0.1.1" }
+sn_record_store = { path = "../sn_record_store", version = "0.1.2" }
 sn_logging = { path = "../sn_logging", features = ["test-utils"], version = "0.1.1" }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -51,9 +51,9 @@ sn_peers_acquisition= { path="../sn_peers_acquisition", version="0.1.0" }
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.3" }
 sn_logging = { path = "../sn_logging", version = "0.1.1" }
-sn_networking = { path = "../sn_networking", version = "0.1.1" }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
-sn_registers = { path = "../sn_registers", version = "0.1.1" }
+sn_networking = { path = "../sn_networking", version = "0.1.2" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
+sn_registers = { path = "../sn_registers", version = "0.1.2" }
 sn_transfers = { path = "../sn_transfers", version = "0.9.0" }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "sn_protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 bls = { package = "blsttc", version = "8.0.1" }

--- a/sn_record_store/Cargo.toml
+++ b/sn_record_store/Cargo.toml
@@ -8,15 +8,13 @@ license = "GPL-3.0"
 name = "sn_record_store"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.1"
-
+version = "0.1.2"
 
 [dependencies]
 libp2p = { version="0.51", features = ["tokio","kad", "macros"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
 tracing = { version = "~0.1.26" }
-
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_registers"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 bincode = "1.3.1"
@@ -16,7 +16,7 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
 tiny-keccak = "~2.0.2"
 tokio = { version = "1.17.0", features = ["fs"] }
 tracing = { version = "~0.1.26" }

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -21,7 +21,7 @@ merkletree = "~0.23.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_dbc = { version = "19.0.0", features = ["serdes"] }
-sn_protocol = { path = "../sn_protocol", version = "0.1.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.1.2" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt"] }
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"


### PR DESCRIPTION
- 2caff6b **ci: use personal access token for gh cli**

  It could be that `gh` can't upload assets to the release because the release was created using the
  `RELEASE_PAT` token.

  This should hopefully make it consistent.

- 0981578 **chore: manually change crate version**

  The version bumps were reverted for these crates and the idea was they it would be bumped again
  during the automated process, but for some reason that hasn't happened.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 20:42 UTC
This pull request includes two patches. The first patch updates the `GH_TOKEN` used for uploading assets to a Github release. The second patch manually changes the version of several crates to ensure they are correctly bumped during the automated process.
<!-- reviewpad:summarize:end --> 
