### PR TITLE
ci: upload release and s3 assets at the same time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,8 @@ jobs:
           just package-release-assets "safe"
           just package-release-assets "safenode"
           just package-release-assets "testnet"
+          # The versioned assets are uploaded to both the release and S3 in this target.
           just upload-release-assets
-          just upload-release-assets-to-s3 "safe"
-          just upload-release-assets-to-s3 "safenode"
-          just upload-release-assets-to-s3 "testnet"
           # Now repackage and upload the artifacts to S3 using 'latest' for the version.
           just package-release-assets "safe" "latest"
           just package-release-assets "safenode" "latest"

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -22,25 +22,28 @@ use std::{
 };
 use walkdir::WalkDir;
 
+// Please do not remove the blank lines in these doc comments.
+// They are used for inserting line breaks when the help menu is rendered in the UI.
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
     /// Print the address of the wallet.
     Address,
     /// Print the balance of the wallet.
     Balance,
-    /// Deposit `Dbc`s to the local wallet.
-    /// Tries to load any `Dbc`s from the `received_dbcs`
-    /// path in the wallet dir, and deposit it to the wallet.
-    /// The user has to manually place received dbc files to
-    /// that dir, for example by choosing that path when downloading
-    /// the dbc file from email or browser.
+    /// Deposit DBCs to the local wallet.
+    ///
+    /// Tries to load DBCs from the received DBCs path in the wallet directory and deposit them to
+    /// the wallet.
+    ///
+    /// Received DBCs must be placed in this directory manually.
     Deposit,
     Send {
-        /// This shall be the number of nanos to send.
-        /// Necessary if the `to` argument has been given.
+        /// The number of nanos to send.
+        ///
+        /// Necessary if the `to` argument is used.
         #[clap(name = "amount")]
         amount: String,
-        /// This must be a hex-encoded `PublicAddress`.
+        /// The hex-encoded public address for the recipient of the DBC.
         #[clap(name = "to")]
         to: String,
     },

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -89,7 +89,7 @@ struct Opt {
     #[clap(long)]
     rpc: Option<SocketAddr>,
 
-    /// Run the node in local network mode.
+    /// Run the node in local mode.
     ///
     /// When this flag is set, we will not filter out local addresses that we observe.
     #[clap(long)]

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -51,7 +51,7 @@ struct Cmd {
     #[clap(long = "join", short = 'j', value_parser)]
     join_network: bool,
 
-    /// Location for a network contacts file.
+    /// Location for the network contacts file.
     ///
     /// This should only be used in conjunction with the 'join' command. You can supply it if you
     /// have an existing network contacts path and you want to launch nodes perhaps on another


### PR DESCRIPTION
- 4f7f432 **ci: upload release and s3 assets at the same time**

  This is to make sure that the versioned assets are not overwritten by another build.

  Due to the way this process works, it's possible that all the binaries don't get updated for the
  same release. The `upload-release-assets` target is checking which binaries are released and will
  only upload the assets in the case of a release. The way it was setup previously, a new build would
  have overwritten the versioned artifacts that were on S3 because it was just uploading them all.
  Technically the build should be the same, but this just makes sure a versioned asset is not
  overwritten.

  We don't bother doing the same thing for the 'latest' release that goes to the S3 bucket, because
  those are only used for internal purposes.

- 5feffc5 **chore: improve documentation for cli commands**

  This is mainly just intended to force a release for testing the new release process.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jun 23 22:15 UTC
This pull request includes two patches: 

1. Changes to the release process to upload version-specific assets to both the release and an S3 bucket to prevent the overwriting of previous versions on S3.
2. Documentation improvements for CLI commands, primarily to test the new release process.
<!-- reviewpad:summarize:end --> 
