### PR TITLE
feat(node): move request handling off thread

### DIFF
--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -62,6 +62,7 @@ use sn_registers::RegisterStorage;
 /// `Node` represents a single node in the distributed network. It handles
 /// network events, processes incoming requests, interacts with the data
 /// storage, and broadcasts node-related events.
+#[derive(Clone)]
 pub struct Node {
     network: Network,
     registers: RegisterStorage,

--- a/sn_node/src/spendbook.rs
+++ b/sn_node/src/spendbook.rs
@@ -16,14 +16,15 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use libp2p::kad::{Record, RecordKey};
 use sn_dbc::{DbcTransaction, SignedSpend};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// The entitiy managing spends in a Node
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct SpendBook {
     /// This RW lock is here to prevent race conditions on spendbook querries
     /// that would enable double spends
-    rw_lock: RwLock<()>,
+    rw_lock: Arc<RwLock<()>>,
 }
 
 impl SpendBook {

--- a/sn_record_store/src/lib.rs
+++ b/sn_record_store/src/lib.rs
@@ -32,6 +32,9 @@ use std::{
 pub const REPLICATION_INTERVAL_UPPER_BOUND: Duration = Duration::from_secs(540);
 pub const REPLICATION_INTERVAL_LOWER_BOUND: Duration = Duration::from_secs(180);
 
+/// Max number of records a node can store
+const MAX_RECORDS_COUNT: usize = 2048;
+
 /// A `RecordStore` that stores records on disk.
 pub struct DiskBackedRecordStore {
     /// The identity of the peer owning the store.
@@ -67,7 +70,7 @@ impl Default for DiskBackedRecordStoreConfig {
 
         Self {
             storage_dir: std::env::temp_dir(),
-            max_records: 1024,
+            max_records: MAX_RECORDS_COUNT,
             max_value_bytes: 65 * 1024,
             replication_interval,
         }


### PR DESCRIPTION
make node cloneable## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Jun 23 01:37 UTC
This pull request includes two features: 

1. Moving request handling off thread and making node cloneable. 
2. Increasing the record storage capacity of the node by setting a higher max number of records that can be stored.
<!-- reviewpad:summarize:end --> 
