### PR TITLE
feat(node): log PID of node w/ metrics in debug

### DIFF
--- a/sn_logging/src/metrics.rs
+++ b/sn_logging/src/metrics.rs
@@ -9,7 +9,7 @@
 use serde::Serialize;
 use std::time::Duration;
 use sysinfo::{self, CpuExt, NetworkExt, Pid, PidExt, ProcessExt, System, SystemExt};
-use tracing::{error, trace};
+use tracing::{debug, error};
 
 const UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 const TO_MB: f32 = 1_000_000.0;
@@ -130,7 +130,7 @@ pub async fn init_metrics(pid: u32) {
             process,
         };
         match serde_json::to_string(&metrics) {
-            Ok(metrics) => trace!("{metrics}"),
+            Ok(metrics) => debug!("PID: {} {metrics}, ", std::process::id()),
             Err(err) => error!("Metrics error, could not serialize to JSON {err}"),
         }
 

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -26,6 +26,8 @@ use std::{
     time::Duration,
 };
 use tokio::{
+    fs::File,
+    io::AsyncWriteExt,
     runtime::Runtime,
     sync::{broadcast::error::RecvError, mpsc},
     time::sleep,
@@ -177,6 +179,12 @@ async fn start_node(
 
     info!("Starting node ...");
     let running_node = Node::run(node_socket_addr, peers, local, root_dir).await?;
+
+    // write the PID to the root dir
+    let pid = std::process::id();
+    let pid_file = root_dir.join("safenode.pid");
+    let mut file = File::create(&pid_file).await?;
+    file.write_all(pid.to_string().as_bytes()).await?;
 
     // Channel to receive node ctrl cmds from RPC service (if enabled), and events monitoring task
     let (ctrl_tx, mut ctrl_rx) = mpsc::channel::<NodeCtrl>(5);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Jun 23 03:59 UTC
This pull request adds the ability to log the PID of a node with metrics in debug mode. The change was made to the `metrics.rs` file and includes slight modifications to the `trace` and `debug` methods.
<!-- reviewpad:summarize:end --> 
