### PR TITLE
fix(sn_node): resolve OOM issue

### DIFF
--- a/sn_record_store/src/lib.rs
+++ b/sn_record_store/src/lib.rs
@@ -216,7 +216,11 @@ impl RecordStore for DiskBackedRecordStore {
         let num_records = self.records.len();
         if num_records >= self.config.max_records {
             warn!("Record not stored. Maximum number of records reached. Current num_records: {num_records}");
-            return Err(Error::MaxRecords);
+            // To avoid returning error causing libp2p holding un-necessary copy in cache,
+            // to achieve specified `quorumn::ALL` successes,
+            // which may result in OOM(Out Of Memory) issue under certain network circumstance.
+            // Here returning `OK` instead of `Error::MaxRecords`.
+            return Ok(());
         }
 
         let filename = Self::key_to_hex(&r.key);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jun 23 10:33 UTC
This pull request fixes an issue where returning an error could cause an OOM (Out Of Memory) issue under certain network circumstances by returning  `Ok(())` instead of `Error::MaxRecords`.
<!-- reviewpad:summarize:end --> 
