### PR TITLE
feat: nodes to verify input DBCs of Chunk payment proof were spent

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -291,6 +291,13 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 10
 
+      - name: execute the storage payment test
+        run: cargo test --release --features="local-discovery" storage_payment_succeeds -- --nocapture
+        env:
+          SN_LOG: "all"
+          CARGO_TARGET_DIR: "./transfer-target"
+        timeout-minutes: 10
+
       - name: Kill all nodes
         shell: bash
         timeout-minutes: 1

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -160,9 +160,9 @@ pub(super) async fn pay_for_storage(
     }
 
     println!("Making payment for {} Chunks...", chunks_addrs.len());
-    let (new_dbc, proofs) = wallet_client.pay_for_storage(chunks_addrs.iter()).await?;
+    let proofs = wallet_client.pay_for_storage(chunks_addrs.iter()).await?;
 
-    let mut wallet = wallet_client.into_wallet();
+    let wallet = wallet_client.into_wallet();
     let new_balance = wallet.balance();
 
     if let Err(err) = wallet.store().await {
@@ -171,9 +171,7 @@ pub(super) async fn pay_for_storage(
         println!("Successfully stored wallet with new balance {new_balance:?}.");
     }
 
-    let dbc_id = new_dbc.id();
-    wallet.store_created_dbc(new_dbc.clone()).await?;
-    println!("Successfully stored new dbc ({dbc_id:?}) to wallet dir. It can now be sent to the storage nodes when uploading paid chunks.");
+    println!("Successfully paid for storage and generated the proofs. They can now be sent to the storage nodes when uploading paid chunks.");
 
     Ok(proofs)
 }

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -98,7 +98,6 @@ impl WalletClient {
                         (
                             addr,
                             PaymentProof {
-                                reason_hash,
                                 dbc: dbc.clone(),
                                 audit_trail,
                                 path,

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -77,15 +77,17 @@ impl WalletClient {
         &mut self,
         content_addrs: impl Iterator<Item = &XorName>,
     ) -> Result<PaymentProofsMap> {
-        // TODO: calculate the amount to pay to each node, perhaps just 1 nano to begin with.
-        let amount = Token::from_nano(1);
-
-        // FIXME: calculate closest nodes to pay for storage, we are now just burning the output amount.
-        let to = vec![(amount, PublicAddress::new(SecretKey::random().public_key()))];
-
         // Let's build the payment proofs for list of content addresses
         let (reason_hash, audit_trail_info) = build_payment_proofs(content_addrs)
             .map_err(|err| Error::StoragePaymentReason(err.to_string()))?; // TODO: have a specific error type
+
+        // TODO: request an invoice to network which provides the amount to pay.
+        // For now, we just pay 1 nano per Chunk.
+        let num_of_addrs = audit_trail_info.len() as u64;
+        let amount = Token::from_nano(num_of_addrs);
+
+        // FIXME: calculate closest nodes to pay for storage, we are now just burning the output amount.
+        let to = vec![(amount, PublicAddress::new(SecretKey::random().public_key()))];
 
         let transfer = self.wallet.local_send(to, Some(reason_hash)).await?;
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -76,7 +76,7 @@ impl WalletClient {
     pub async fn pay_for_storage(
         &mut self,
         content_addrs: impl Iterator<Item = &XorName>,
-    ) -> Result<(Dbc, PaymentProofsMap)> {
+    ) -> Result<PaymentProofsMap> {
         // TODO: calculate the amount to pay to each node, perhaps just 1 nano to begin with.
         let amount = Token::from_nano(1);
 
@@ -91,14 +91,14 @@ impl WalletClient {
 
         match &transfer.created_dbcs[..] {
             [info, ..] => {
-                let dbc = info.dbc.clone();
+                let src_tx = &info.dbc.src_tx;
                 let payment_proofs = audit_trail_info
                     .into_iter()
                     .map(|(addr, (audit_trail, path))| {
                         (
                             addr,
                             PaymentProof {
-                                dbc: dbc.clone(),
+                                tx: src_tx.clone(),
                                 audit_trail,
                                 path,
                             },
@@ -106,7 +106,7 @@ impl WalletClient {
                     })
                     .collect();
 
-                Ok((dbc, payment_proofs))
+                Ok(payment_proofs)
             }
             [] => Err(Error::CouldNotSendTokens(
                 "No DBCs were returned from the wallet.".into(),

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -376,12 +376,7 @@ impl Node {
                     // TODO: self-verification of the signed spend?
 
                     if &signed_spend.spent_tx() != tx {
-                        // TODO: have a specific error type
-                        return Err(ProtocolError::InvalidPaymentProof {
-                            addr_name,
-                            reason: "DBC Tx doesn't match the retrieved SignedSpend's Tx"
-                                .to_string(),
-                        });
+                        return Err(ProtocolError::PaymentProofTxMismatch(addr_name));
                     }
 
                     reasons.push(signed_spend.reason());
@@ -394,19 +389,11 @@ impl Node {
         }
 
         match reasons.first() {
-            None => Err(ProtocolError::InvalidPaymentProof {
-                // TODO: have a specific error type
-                addr_name,
-                reason: "Payment DBC has no input DBCs".to_string(),
-            }),
+            None => Err(ProtocolError::PaymentProofWithoutInputs(addr_name)),
             Some(reason_hash) => {
                 // check all reasons are the same
                 if !reasons.iter().all(|r| r == reason_hash) {
-                    // TODO: have a specific error type
-                    return Err(ProtocolError::InvalidPaymentProof {
-                        addr_name,
-                        reason: "Not all input DBCs contain the same reason hash value".to_string(),
-                    });
+                    return Err(ProtocolError::PaymentProofInconsistentReason(addr_name));
                 }
 
                 // check the reason hash verifies the merkle-tree audit trail and path against the content address name

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -361,8 +361,8 @@ impl Node {
             path,
         }: &PaymentProof,
     ) -> Result<(), ProtocolError> {
-        // TODO: check the expected amount of tokens was paid by the Tx,
-        // i.e. one of the outputs is the predefined "burning address" and the sent (unblinded) amount matches.
+        // TODO: check the expected amount of tokens was paid by the Tx, i.e. the amount one of the
+        // outputs sent (unblinded) is the expected, and the paid address is the predefined "burning address"
 
         // We need to fetch the inputs of the DBC tx in order to obtain the reason-hash and
         // other info for verifications of valid payment.

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -65,6 +65,15 @@ pub enum Error {
         /// Reason why the payment proof was deemed invalid
         reason: String,
     },
+    /// At least one input of payment proof provided has a mismatching spend Tx
+    #[error("At least one input of payment proof provided for {0:?} has a mismatching spend Tx")]
+    PaymentProofTxMismatch(XorName),
+    /// Payment proof received has no inputs
+    #[error("Payment proof received for {0:?} has no inputs in its transaction")]
+    PaymentProofWithoutInputs(XorName),
+    /// Not all inputs in payment proof have the same 'reason' hash value
+    #[error("Not all inputs in payment proof for {0:?} have the same 'reason' hash value")]
+    PaymentProofInconsistentReason(XorName),
     /// Access denied for user
     #[error("Access denied for user: {0:?}")]
     AccessDenied(User),

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -13,9 +13,8 @@ use crate::{
 
 use super::RegisterCmd;
 
-use sn_dbc::DbcTransaction;
 // TODO: remove this dependency and define these types herein.
-pub use sn_dbc::{Dbc, Hash, SignedSpend};
+pub use sn_dbc::{DbcTransaction, Hash, SignedSpend};
 
 use serde::{Deserialize, Serialize};
 
@@ -104,9 +103,9 @@ pub type MerkleTreeNodesType = [u8; 32];
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct PaymentProof {
-    // Output DBC for nodes to check the storage payment is valid and inputs have
+    // DBC transaction for nodes to check the storage payment is valid and inputs have
     // been effectivelly spent on the network.
-    pub dbc: Dbc,
+    pub tx: DbcTransaction,
     // Merkletree audit trail to prove the content storage has been paid by the
     // given DBC (using DBC's parent/s 'reason' field)
     pub audit_trail: Vec<MerkleTreeNodesType>,

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -104,13 +104,10 @@ pub type MerkleTreeNodesType = [u8; 32];
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct PaymentProof {
-    // Output DBC for nodes to check the Chunk payment is valid and inputs have
+    // Output DBC for nodes to check the storage payment is valid and inputs have
     // been effectivelly spent on the network.
     pub dbc: Dbc,
-    // Reason-hash value set in the input/parent DBCs spent for this storage payment.
-    // TODO: remove it since nodes should get this from the input/parent spent DBC/s
-    pub reason_hash: Hash,
-    // Merkletree audit trail to prove the Chunk has been paid by the
+    // Merkletree audit trail to prove the content storage has been paid by the
     // given DBC (using DBC's parent/s 'reason' field)
     pub audit_trail: Vec<MerkleTreeNodesType>,
     // Path of the audit trail

--- a/sn_transfers/src/payment_proof/mod.rs
+++ b/sn_transfers/src/payment_proof/mod.rs
@@ -55,7 +55,7 @@
 //! DBC and tree, to the storage nodes upon uploading the Chunks for storing them on the network.
 //! ```
 
-mod error;
+pub(crate) mod error;
 mod hasher;
 
 use error::{Error, Result};

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     CreateTransfer(#[from] crate::client_transfers::Error),
     /// Could not build storage payment reason for content
     #[error("Could not build storage payment reason for content: {0}")]
-    StoragePaymentReason(String),
+    StoragePaymentReason(#[from] crate::payment_proof::error::Error),
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Jun 23 14:41 UTC
This pull request adds nodes to verify input DBCs for Chunk payment proofs were spent, making payment proof verification more robust. It also adds a new function to validate storage payments, a validation of the DBC's amounts and signatures, a retrieve of input DBC needed to get its reason-hash, and verifications of valid payment including expected beneficiaries.
<!-- reviewpad:summarize:end --> 
