### PR TITLE
fix: improve client upload speed

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -245,7 +245,7 @@ jobs:
         shell: bash
         env:
           CLIENT_PEAK_MEM_LIMIT_MB: "1000" # mb
-          CLIENT_AVG_MEM_LIMIT_MB: "600" # mb
+          CLIENT_AVG_MEM_LIMIT_MB: "700" # mb
         run: |
           peak_mem_usage=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "M" -r "")
           echo "Peak memory usage: $peak_mem_usage MB"

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -261,15 +261,31 @@ impl Client {
         RegisterOffline::create(self.clone(), xorname, tag)
     }
 
-    /// Store `Chunk` to its close group.
+    /// Store `Chunk` to spcified target.
     pub(super) async fn store_chunk(
         &self,
         chunk: Chunk,
         payment: Option<PaymentProof>,
+        closest_peers: Vec<PeerId>,
     ) -> Result<()> {
-        info!("Store chunk: {:?}", chunk.address());
+        let address = *chunk.name();
+        info!("Store chunk: {:?}", address);
         let request = Request::Cmd(Cmd::StoreChunk { chunk, payment });
-        let response = self.send_and_wait_till_first_rsp(request).await?;
+
+        // Result will be: just one with `StoreChunk(Ok(_))` response;
+        // or a vector of error responses, which only take the first into account.
+        let mut responses = self
+            .network
+            .send_and_get_responses(closest_peers, &request, false)
+            .await
+            .into_iter()
+            .map(|res| res.map_err(Error::Network))
+            .collect_vec();
+        let response = if let Some(response) = responses.pop() {
+            response?
+        } else {
+            return Err(Error::UnexpectedResponses);
+        };
 
         if matches!(response, Response::Cmd(CmdResponse::StoreChunk(Ok(_)))) {
             return Ok(());
@@ -281,6 +297,14 @@ impl Client {
 
         // If there were no store chunk errors, then we had unexpected responses.
         Err(Error::UnexpectedResponses)
+    }
+
+    /// Return the closest_peers to self, fetched from local.
+    pub(super) async fn get_closest_local_peers(&self) -> Result<Vec<PeerId>> {
+        Ok(self
+            .network
+            .get_closest_local_peers(&NetworkAddress::from_peer(self.network.peer_id))
+            .await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.
@@ -309,23 +333,6 @@ impl Client {
             .map(|res| res.map_err(Error::Network))
             .collect_vec();
         Ok(responses)
-    }
-
-    pub(crate) async fn send_and_wait_till_first_rsp(&self, request: Request) -> Result<Response> {
-        let mut responses = self
-            .network
-            .client_send_to_closest(&request, false)
-            .await?
-            .into_iter()
-            .map(|res| res.map_err(Error::Network))
-            .collect_vec();
-        // The responses will be just one OK response or a vector of error responses.
-        // In case of error responses, only need to return one.
-        if let Some(response) = responses.pop() {
-            response
-        } else {
-            Err(Error::UnexpectedResponses)
-        }
     }
 
     /// Send a `SpendDbc` request to the closest nodes to the dbc_id

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -492,6 +492,7 @@ impl Network {
 
     /// Returns the closest peers to the given `NetworkAddress` that is fetched from the local
     /// Routing Table. It is ordered by increasing distance of the peers
+    /// Note self peer_id is not included in the result.
     pub async fn get_closest_local_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetClosestLocalPeers {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Jun 23 16:22 UTC
This pull request contains client improvements including reduced memory usage during file uploading and improved upload speed. Changes were made in `sn_client/src/api.rs`, `sn_client/src/file_apis.rs`, `sn_networking/src/cmd.rs`, and `sn_networking/src/lib.rs`. In `sn_client/src/file_apis.rs`, the maximum batch size for chunk uploads was increased to 64, and uploading progress is now logged. In `sn_networking/src/lib.rs`, a new function was added to send requests to half of the closest peers.
<!-- reviewpad:summarize:end --> 
