### PR TITLE
add initial benchmarks for up/download

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -1,0 +1,114 @@
+name: PR Benchmarks
+
+on: pull_request
+
+
+env:
+  CARGO_INCREMENTAL: '0'
+  RUST_BACKTRACE: 1
+
+jobs:
+  benchmark:
+    name: Run and log benchmark results on gh-pages
+    # right now only ubuntu, running on multiple systems would require many pushes...\
+    # perhaps this can be done with one consolidation action in the future, pulling down all results and pushing
+    # once to the branch..
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - run: cargo install cargo-criterion
+
+      - name: ubuntu install ripgrep
+        run: sudo apt-get -y install ripgrep
+
+     
+      - name: Build sn bins
+        run: cargo build --release --bins
+        timeout-minutes: 30
+
+      - name: Start a local network
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Set contact env var node.
+        shell: bash
+        # get all nodes listen ports
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+
+      - name: Check contact peer
+        shell: bash
+        run: echo "Peer is $SAFE_PEERS"
+
+      ########################
+      ### Benchmark itself ###
+      ########################
+
+      - name: Bench `safe`
+        shell: bash
+        # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
+        # passes to tee which displays it in the terminal and writes to output.txt
+        run: cargo criterion --output-format bencher 2>&1 | tee -a output.txt
+
+     
+      #################################
+      ### Log any regression alerts ###
+      #################################
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'cargo'
+          # Where the output from the benchmark tool is stored
+          output-file-path: output.txt
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable alert commit comment
+          comment-on-alert: true
+          # 200% regression will result in alert
+          alert-threshold: '200%'
+          # Enable Job Summary for PRs
+          summary-always: true
+
+      ### CLEANUP ###
+      - name: Kill all nodes
+        shell: bash
+        timeout-minutes: 1
+        if: failure()
+        continue-on-error: true
+        run: |
+          pkill safenode
+          echo "$(pgrep safenode | wc -l) nodes still running"
+
+      - name: Tar log files
+        shell: bash
+        continue-on-error: true
+        run: |
+          find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@main
+        with:
+          name: safe_test_logs_e2e_${{matrix.os}}
+          path: log_files.tar.gz
+        if: failure()
+        continue-on-error: true

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -1,0 +1,131 @@
+name: Benchmark Chart Generation
+
+# Do not run this workflow on pull request since this workflow has permission to modify contents.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+env:
+  CARGO_INCREMENTAL: '0'
+  RUST_BACKTRACE: 1
+
+jobs:
+  benchmark:
+    name: Run and log benchmark results on gh-pages
+    # right now only ubuntu, running on multiple systems would require many pushes...\
+    # perhaps this can be done with one consolidation action in the future, pulling down all results and pushing
+    # once to the branch..
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - run: cargo install cargo-criterion
+
+      - name: ubuntu install ripgrep
+        run: sudo apt-get -y install ripgrep
+
+     
+      - name: Build sn bins
+        run: cargo build --release --bins
+        timeout-minutes: 30
+
+      - name: Start a local network
+        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Set contact env var node.
+        shell: bash
+        # get all nodes listen ports
+        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+
+      - name: Check contact peer
+        shell: bash
+        run: echo "Peer is $SAFE_PEERS"
+
+      ########################
+      ### Benchmark itself ###
+      ########################
+
+      - name: Bench `safe`
+        shell: bash
+        # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
+        # passes to tee which displays it in the terminal and writes to output.txt
+        run: cargo criterion --output-format bencher 2>&1 | tee -a output.txt
+
+
+      - name: Stop the network on fail
+        shell: bash
+        if: failure()
+        run: safe node killall || true && safe auth stop || true
+
+      - name: Failure logs
+        shell: bash
+        if: failure()
+        run: tail $HOME/.safe/node/local-test-network/*/*.log*
+
+      - name: Remove git hooks so gh-pages git commits will work
+        shell: bash
+        run: rm -rf .git/hooks/pre-commit
+
+      #################################
+      ### Log any regression alerts ###
+      #################################
+
+      # gh-pages branch is updated and pushed automatically with extracted benchmark data
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Safe Network Benchmarks
+          tool: 'cargo'
+          output-file-path: output.txt
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true
+          max-items-in-chart: 300
+
+
+        ### CLEANUP ###
+      - name: Kill all nodes
+        shell: bash
+        timeout-minutes: 1
+        if: failure()
+        continue-on-error: true
+        run: |
+            pkill safenode
+            echo "$(pgrep safenode | wc -l) nodes still running"
+
+      - name: Tar log files
+        shell: bash
+        continue-on-error: true
+        run: |
+            find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@main
+        with:
+            name: safe_test_logs_e2e_${{matrix.os}}
+            path: log_files.tar.gz
+        if: failure()
+        continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +790,33 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1025,6 +1064,42 @@ checksum = "6e30e1170960eddf5392c448ff5b190a49cfcb28d6c79f789f2b4e30b571f8f8"
 dependencies = [
  "serde",
  "tiny-keccak",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.3.0",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1919,6 +1994,12 @@ dependencies = [
  "tokio-util 0.7.8",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -3289,6 +3370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,6 +3604,34 @@ name = "platforms"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -4487,6 +4602,7 @@ dependencies = [
  "chrono",
  "clap 4.3.0",
  "color-eyre",
+ "criterion",
  "dirs-next",
  "hex",
  "libp2p",
@@ -4497,6 +4613,7 @@ dependencies = [
  "sn_peers_acquisition",
  "sn_protocol",
  "sn_transfers",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-core",
@@ -4926,15 +5043,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -14,6 +14,10 @@ version = "0.77.14"
 path="src/main.rs"
 name="safe"
 
+[[bench]]
+name = "files"
+harness = false
+
 [features]
 default = ["metrics"]
 metrics = ["sn_logging/process-metrics"]
@@ -40,3 +44,7 @@ tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"
 walkdir = "2.3.1"
 xor_name = "5.0.0"
+
+[dev-dependencies]
+criterion = "0.5.1"
+tempfile = "3.6.0"

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -1,0 +1,79 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::process::{exit, Command};
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn safe_files_upload(dir: &str) {
+    let output = Command::new("./target/release/safe")
+        .arg("files")
+        .arg("upload")
+        .arg(dir)
+        .output()
+        .expect("Failed to execute command");
+
+    if !output.status.success() {
+        panic!("Upload command executed with failing error code");
+    }
+}
+fn safe_files_download() {
+    let output = Command::new("./target/release/safe")
+        .arg("files")
+        .arg("download")
+        .output()
+        .expect("Failed to execute command");
+
+    if !output.status.success() {
+        panic!("Download command executed with failing error code");
+    }
+}
+
+fn create_file(size_mb: u64) -> tempfile::TempDir {
+    let dir = tempdir().expect("Failed to create temporary directory");
+    let file_path = dir.path().join("tempfile");
+
+    let mut file = File::create(file_path).expect("Failed to create file");
+    let data = vec![0u8; (size_mb * 1024 * 1024) as usize]; // Create a vector with size_mb MB of data
+    file.write_all(&data).expect("Failed to write to file");
+
+    dir
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Check if the binary exists
+    if !Path::new("./target/release/safe").exists() {
+        eprintln!("Error: Binary ./target/release/safe does not exist. Please make sure to compile your project first");
+        exit(1);
+    }
+
+    let sizes = vec![1, 10]; // File sizes in MB. Add more sizes as needed
+
+    for size in sizes {
+        let dir = create_file(size);
+        let dir_path = dir.path().to_str().unwrap();
+
+        let mut group = c.benchmark_group(format!("Upload Benchmark {}MB", size));
+        group.sample_size(50);
+        group.sampling_mode(criterion::SamplingMode::Flat);
+        group.measurement_time(Duration::from_secs(120));
+        group.warm_up_time(Duration::from_secs(10));
+
+        group.bench_function(BenchmarkId::new("safe files upload", size), |b| {
+            b.iter(|| safe_files_upload(dir_path))
+        });
+        group.finish();
+    }
+
+    // and now run downloads (will download everything we just uploaded)
+    let mut group = c.benchmark_group("Download Benchmark");
+    group.warm_up_time(Duration::from_secs(10));
+    group.sample_size(10);
+
+    group.bench_function("safe files download", |b| b.iter(safe_files_download));
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jun 23 01:31 UTC
This pull request includes changes to multiple files:
- The `replication_fetcher.rs` file has increased the `MAX_PARALLEL_FETCH` constant from 4 to 8.
- A new benchmarking file has been added, with functions to upload and download files using the project's command-line interface, and the results are outputted using the Criterion library.
- Several new packages have been added, including "anes", "cast", "ciborium", "criterion", "half", "oorandom", "plotters", and "tempfile". Some existing package versions have also been updated.
- A GitHub Actions workflow has been added that benchmarks Pull Requests against the main branch using cargo-criterion with rust-toolchain, logs it on the gh-pages branch, and checks for any regression alerts. If an alert occurs, a commit comment is made using the GitHub API. It also sets environmental variables for contact peer and uploads node logs in case of failures.
- A workflow file has been added, including several steps to install benchmarking packages, build binaries, run and log benchmarks in a criterion format, store and deploy benchmark results to the Github Pages branch with an access token, and cleanup and log node output in the event of a failure.
- The Cargo.toml file has been modified to include a new section for 'files' benchmarking, with two new dev-dependencies for benchmarking: criterion and tempfile.
<!-- reviewpad:summarize:end --> 
