### PR TITLE
fix: DBC transfers, fix e2e test, add double spend test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,9 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f36153809a2d29a0a7b5e8c1f8f048a64c086a41d8848dd9baf5c49f3c16594"
+checksum = "e1515911134d8d4aeac601bf6e5be0617d0b8e794b7bf038f6c87e3445b38120"
 dependencies = [
  "bincode",
  "blsttc",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -34,7 +34,7 @@ hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.85.9" }
-sn_dbc = { version = "19.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.1", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.9.3" }
 sn_logging = { path = "../sn_logging", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.1" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.1", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.1.9" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.4" }
 sn_registers = { path = "../sn_registers", version = "0.1.3" }
@@ -37,4 +37,3 @@ tiny-keccak = "~2.0.2"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
-

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -331,7 +331,7 @@ impl Client {
             .client_get_closest_peers(&network_address)
             .await?;
 
-        let cmd = Cmd::SpendDbc(spend.signed_spend);
+        let cmd = Cmd::SpendDbc(spend.signed_spend, spend.parent_tx);
 
         trace!(
             "Sending {:?} to the closest peers to store spend for {dbc_id:?}.",
@@ -371,11 +371,14 @@ impl Client {
             }
         }
 
-        Err(Error::CouldNotVerifyTransfer(format!(
+        let err = Err(Error::CouldNotVerifyTransfer(format!(
             "Not enough close group nodes accepted the spend for {dbc_id:?}. Got {}, required: {}.",
             ok_responses,
             close_group_majority()
-        )))
+        )));
+
+        warn!("Failed to store spend on the network: {:?}", err);
+        err
     }
 
     pub(crate) async fn expect_closest_majority_same(&self, dbc_id: &DbcId) -> Result<SignedSpend> {

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -173,7 +173,7 @@ impl Client {
             return Ok(());
         }
         Err(Error::CouldNotVerifyTransfer(
-            "The spends in network were not the same as the ones in the DBC.".into(),
+            "The spends in network were not the same as the ones in the DBC. The parents of this DBC are probably double spends.".into(),
         ))
     }
 }

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -57,9 +57,9 @@ impl WalletClient {
         let dbcs = transfer.created_dbcs.clone();
 
         // send to network
-        println!("Sending transfer to the network: {transfer:#?}");
+        trace!("Sending transfer to the network: {transfer:#?}");
         if let Err(error) = self.client.send(transfer.clone()).await {
-            println!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
+            warn!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
             self.unconfirmed_txs.push(transfer);
         }
 
@@ -140,6 +140,7 @@ impl Client {
     pub async fn send(&self, transfer: TransferOutputs) -> Result<()> {
         let mut tasks = Vec::new();
         for spend_request in &transfer.all_spend_requests {
+            trace!("sending spend request to the network: {spend_request:#?}");
             tasks.push(self.network_store_spend(spend_request.clone()));
         }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -74,7 +74,7 @@ pub(crate) const CLOSE_GROUP_SIZE: usize = 8;
 // Timeout for requests sent/received through the request_response behaviour.
 const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(30);
 // Sets the keep-alive timeout of idle connections.
-const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(100000);
 
 /// Our agent string has as a prefix that we can match against.
 pub const IDENTIFY_AGENT_STR: &str = "safe/node/";

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -74,7 +74,7 @@ pub(crate) const CLOSE_GROUP_SIZE: usize = 8;
 // Timeout for requests sent/received through the request_response behaviour.
 const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(30);
 // Sets the keep-alive timeout of idle connections.
-const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(100000);
+const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Our agent string has as a prefix that we can match against.
 pub const IDENTIFY_AGENT_STR: &str = "safe/node/";

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -48,7 +48,7 @@ self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.1" }
-sn_dbc = { version = "19.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.1", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.9" }
 sn_logging = { path = "../sn_logging", version = "0.1.2" }
 sn_networking = { path = "../sn_networking", version = "0.1.9" }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -22,7 +22,7 @@ use sn_protocol::{
     messages::{
         Cmd, CmdResponse, PaymentProof, Query, QueryResponse, RegisterCmd, Request, Response,
     },
-    storage::{registers::User, Chunk, DbcAddress},
+    storage::{registers::User, Chunk},
     NetworkAddress,
 };
 use sn_registers::RegisterStorage;
@@ -329,7 +329,6 @@ impl Node {
             }
             Cmd::SpendDbc(signed_spend, parent_tx) => {
                 let dbc_id = *signed_spend.dbc_id();
-                let dbc_addr = DbcAddress::from_dbc_id(&dbc_id);
 
                 let resp = match self
                     .spendbook
@@ -344,7 +343,7 @@ impl Node {
                     }
                     Err(err) => {
                         error!("Failed to StoreSpend: {err:?}");
-                        CmdResponse::Spend(Err(ProtocolError::FailedToStoreSpend(dbc_addr)))
+                        CmdResponse::Spend(Err(err))
                     }
                 };
 

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -327,11 +327,15 @@ impl Node {
                 self.send_response(Response::Cmd(resp), response_channel)
                     .await;
             }
-            Cmd::SpendDbc(signed_spend) => {
+            Cmd::SpendDbc(signed_spend, parent_tx) => {
                 let dbc_id = *signed_spend.dbc_id();
                 let dbc_addr = DbcAddress::from_dbc_id(&dbc_id);
 
-                let resp = match self.spendbook.spend_put(&self.network, signed_spend).await {
+                let resp = match self
+                    .spendbook
+                    .spend_put(&self.network, signed_spend, parent_tx)
+                    .await
+                {
                     Ok(addr) => {
                         debug!("Broadcasting valid spend: {dbc_id:?} at: {addr:?}");
                         self.events_channel

--- a/sn_node/src/spendbook.rs
+++ b/sn_node/src/spendbook.rs
@@ -89,10 +89,11 @@ impl SpendBook {
             Ok(()) => vec![signed_spend.clone()],
             Err(Error::DoubleSpendAttempt(one, two)) => vec![*one, *two],
             Err(e) => {
-                error!(
+                let err_str = format!(
                     "Failed to store spend for {dbc_id:?} because DBC verification failed: {e:?}"
                 );
-                return Err(Error::FailedToStoreSpend(dbc_addr));
+                error!("{:}", err_str);
+                return Err(Error::FailedToStoreSpend(err_str));
             }
         };
 
@@ -100,8 +101,11 @@ impl SpendBook {
         let signed_spends_bytes = match bincode::serialize(&signed_spends) {
             Ok(b) => b,
             Err(e) => {
-                error!("Failed to store spend for {dbc_id:?} because serialization failed: {e:?}");
-                return Err(Error::FailedToStoreSpend(dbc_addr));
+                let err_str = format!(
+                    "Failed to store spend for {dbc_id:?} because serialization failed: {e:?}"
+                );
+                error!("{:}", err_str);
+                return Err(Error::FailedToStoreSpend(err_str));
             }
         };
 
@@ -113,8 +117,9 @@ impl SpendBook {
             expires: None,
         };
         if let Err(e) = network.put_data_as_record(kademlia_record).await {
-            error!("Failed to store spend {dbc_id:?}: {e:?}");
-            return Err(Error::FailedToStoreSpend(dbc_addr));
+            let err_str = format!("Failed to store spend {dbc_id:?}: {e:?}");
+            error!("{:}", err_str);
+            return Err(Error::FailedToStoreSpend(err_str));
         }
 
         // if it was a double spend, report the error after having stored it

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -20,10 +20,11 @@ use assert_fs::TempDir;
 use eyre::Result;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "This test is ignored because it is not stable until we have DBCs stored as records."]
+// #[ignore = "This test is ignored because it is not stable until we have DBCs stored as records."]
 async fn multiple_sequential_transfers_succeed() -> Result<()> {
     let logging_targets = vec![
         ("safenode".to_string(), Level::INFO),
+        ("sn_client".to_string(), Level::TRACE),
         ("sn_transfers".to_string(), Level::INFO),
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -20,7 +20,6 @@ use assert_fs::TempDir;
 use eyre::Result;
 
 #[tokio::test(flavor = "multi_thread")]
-// #[ignore = "This test is ignored because it is not stable until we have DBCs stored as records."]
 async fn multiple_sequential_transfers_succeed() -> Result<()> {
     let logging_targets = vec![
         ("safenode".to_string(), Level::INFO),

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -16,6 +16,6 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.1", features = ["serdes"] }
 thiserror = "1.0.23"
 xor_name = "5.0.0"

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -110,16 +110,9 @@ pub enum Error {
     #[error("Spend parents are invalid: {0}")]
     InvalidSpendParents(String),
 
-    /// One or more parent spends of a requested spend had a different dst tx hash than the signed spend src tx hash.
-    #[error(
-        "The signed spend src tx ({signed_src_tx_hash:?}) did not match a valid parent's dst tx hash: {parent_dst_tx_hash:?}. The trail is invalid."
-    )]
-    TxTrailMismatch {
-        /// The signed spend src tx hash.
-        signed_src_tx_hash: Hash,
-        /// The dst hash of a parent signed spend.
-        parent_dst_tx_hash: Hash,
-    },
+    /// One or more parent spends of a requested spend has an invalid hash
+    #[error("Invalid parent spend hash: {0}")]
+    BadParentSpendHash(String),
     /// The provided source tx did not check out when verified with all supposed inputs to it (i.e. our spends parents).
     #[error(
         "The provided source tx (with hash {provided_src_tx_hash:?}) when verified with all supposed inputs to it (i.e. our spends parents).."

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -95,8 +95,8 @@ pub enum Error {
     #[error("Insufficient valid spends found: {0:?}")]
     InsufficientValidSpendsFound(DbcAddress),
     /// Node failed to store spend
-    #[error("Failed to store spend: {0:?}")]
-    FailedToStoreSpend(DbcAddress),
+    #[error("Failed to store spend: {0}")]
+    FailedToStoreSpend(String),
     /// Node failed to get spend
     #[error("Failed to get spend: {0:?}")]
     FailedToGetSpend(DbcAddress),

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use serde::{Deserialize, Serialize};
-use sn_dbc::{Hash, SignedSpend};
+use sn_dbc::SignedSpend;
 use thiserror::Error;
 use xor_name::XorName;
 
@@ -110,17 +110,13 @@ pub enum Error {
     #[error("Spend parents are invalid: {0}")]
     InvalidSpendParents(String),
 
+    /// The DBC we're trying to Spend came with an invalid parent Tx
+    #[error("Invalid Parent Tx: {0}")]
+    InvalidParentTx(String),
     /// One or more parent spends of a requested spend has an invalid hash
     #[error("Invalid parent spend hash: {0}")]
     BadParentSpendHash(String),
     /// The provided source tx did not check out when verified with all supposed inputs to it (i.e. our spends parents).
-    #[error(
-        "The provided source tx (with hash {provided_src_tx_hash:?}) when verified with all supposed inputs to it (i.e. our spends parents).."
-    )]
-    InvalidSourceTxProvided {
-        /// The signed spend src tx hash.
-        signed_src_tx_hash: Hash,
-        /// The hash of the provided source tx.
-        provided_src_tx_hash: Hash,
-    },
+    #[error("The provided source tx is invalid: {0}")]
+    InvalidSourceTxProvided(String),
 }

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use super::RegisterCmd;
 
+use sn_dbc::DbcTransaction;
 // TODO: remove this dependency and define these types herein.
 pub use sn_dbc::{Dbc, Hash, SignedSpend};
 
@@ -44,8 +45,8 @@ pub enum Cmd {
     ///
     /// [`SignedSpend`]: sn_dbc::SignedSpend
     /// The spend to be recorded.
-    /// It contains the transaction it is being spent in.
-    SpendDbc(SignedSpend),
+    /// As well as the parent_tx: the transaction this DBC was created in.
+    SpendDbc(SignedSpend, DbcTransaction),
     /// Write operation to notify peer fetch a list of [`NetworkAddress`] from the holder.
     ///
     /// [`NetworkAddress`]: crate::NetworkAddress
@@ -66,7 +67,7 @@ impl Cmd {
                 NetworkAddress::from_chunk_address(ChunkAddress::new(*chunk.name()))
             }
             Cmd::Register(cmd) => NetworkAddress::from_register_address(cmd.dst()),
-            Cmd::SpendDbc(signed_spend) => {
+            Cmd::SpendDbc(signed_spend, _) => {
                 NetworkAddress::from_dbc_address(DbcAddress::from_dbc_id(signed_spend.dbc_id()))
             }
             Cmd::Replicate { holder, .. } => holder.clone(),
@@ -83,7 +84,7 @@ impl std::fmt::Display for Cmd {
             Cmd::Register(cmd) => {
                 write!(f, "Cmd::Register({:?})", cmd.name()) // more qualification needed
             }
-            Cmd::SpendDbc(signed_spend) => {
+            Cmd::SpendDbc(signed_spend, _) => {
                 write!(f, "Cmd::SpendDbc({:?})", signed_spend.dbc_id())
             }
             Cmd::Replicate { holder, keys } => {

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -46,7 +46,7 @@ pub enum Cmd {
     /// [`SignedSpend`]: sn_dbc::SignedSpend
     /// The spend to be recorded.
     /// As well as the parent_tx: the transaction this DBC was created in.
-    SpendDbc(SignedSpend, DbcTransaction),
+    SpendDbc(SignedSpend, #[debug(skip)] DbcTransaction),
     /// Write operation to notify peer fetch a list of [`NetworkAddress`] from the holder.
     ///
     /// [`NetworkAddress`]: crate::NetworkAddress

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -14,14 +14,14 @@ version = "0.9.3"
 async-trait = "0.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
-dirs-next = "~2.0.0"
 custom_debug = "~0.5.0"
+dirs-next = "~2.0.0"
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
 merkletree = "~0.23.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.0.0", features = ["serdes"] }
+sn_dbc = { version = "19.0.1", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.1.4" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt"] }
 thiserror = "1.0.23"

--- a/sn_transfers/src/client_transfers/error.rs
+++ b/sn_transfers/src/client_transfers/error.rs
@@ -10,7 +10,7 @@ use sn_dbc::Error as DbcError;
 
 use thiserror::Error;
 
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error type returned by the API
 #[derive(Debug, Error)]

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -30,10 +30,8 @@
 mod error;
 mod transfer;
 
-pub(crate) use self::{
-    error::{Error, Result},
-    transfer::create_transfer,
-};
+pub(crate) use self::error::{Error, Result};
+pub use self::transfer::create_transfer;
 
 use sn_dbc::{
     Dbc, DbcIdSource, DbcTransaction, DerivedKey, PublicAddress, RevealedAmount, SignedSpend, Token,

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 /// The peers will validate each signed spend they receive, before accepting it.
 /// Once enough peers have accepted all the spends of the transaction, and serve
 /// them upon request, the transaction will be completed.
-pub(crate) fn create_transfer(
+pub fn create_transfer(
     available_dbcs: Vec<(Dbc, DerivedKey)>,
     recipients: Vec<(Token, DbcIdSource)>,
     change_to: PublicAddress,

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -56,6 +56,7 @@ lazy_static! {
     /// Load the genesis DBC.
     /// The genesis DBC is the first DBC in the network. It is created without
     /// a source transaction, as there was nothing before it.
+    #[derive(Debug)]
     pub static ref GENESIS_DBC: Dbc = match sn_dbc::Dbc::from_hex(GENESIS_DBC_HEX) {
         Ok(dbc) => dbc,
         Err(err) => panic!("Failed to read genesis DBC: {err:?}"),
@@ -68,14 +69,10 @@ pub fn is_genesis_parent_tx(parent_tx: &DbcTransaction) -> bool {
 }
 
 pub async fn load_genesis_wallet() -> LocalWallet {
-    println!("Loading genesis...");
+    info!("Loading genesis...");
     let mut genesis_wallet = create_genesis_wallet().await;
-    let genesis_balance = genesis_wallet.balance();
-    if genesis_balance.as_nano() > 0 {
-        println!("Genesis wallet balance: {genesis_balance}");
-        return genesis_wallet;
-    }
 
+    info!("Depositing genesis DBC: {:#?}", GENESIS_DBC.id());
     genesis_wallet.deposit(vec![GENESIS_DBC.clone()]);
     genesis_wallet
         .store()
@@ -83,7 +80,7 @@ pub async fn load_genesis_wallet() -> LocalWallet {
         .expect("Genesis wallet shall be stored successfully.");
 
     let genesis_balance = genesis_wallet.balance();
-    println!("Genesis wallet balance: {genesis_balance}");
+    info!("Genesis wallet balance: {genesis_balance}");
 
     genesis_wallet
 }

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -56,7 +56,6 @@ lazy_static! {
     /// Load the genesis DBC.
     /// The genesis DBC is the first DBC in the network. It is created without
     /// a source transaction, as there was nothing before it.
-    #[derive(Debug)]
     pub static ref GENESIS_DBC: Dbc = match sn_dbc::Dbc::from_hex(GENESIS_DBC_HEX) {
         Ok(dbc) => dbc,
         Err(err) => panic!("Failed to read genesis DBC: {err:?}"),

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::client_transfers::{create_transfer, TransferOutputs};
 
-use sn_dbc::{Dbc, DbcIdSource, Hash, MainKey, PublicAddress, Token};
+use sn_dbc::{Dbc, DbcIdSource, DerivedKey, Hash, MainKey, PublicAddress, Token};
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -154,17 +154,7 @@ impl LocalWallet {
         self.wallet.deposit(dbcs, &self.key);
     }
 
-    pub async fn local_send(
-        &mut self,
-        to: Vec<(Token, PublicAddress)>,
-        reason_hash: Option<Hash>,
-    ) -> Result<TransferOutputs> {
-        // create a unique key for each output
-        let to_unique_keys: Vec<_> = to
-            .into_iter()
-            .map(|(amount, address)| (amount, address.random_dbc_id_src(&mut rand::thread_rng())))
-            .collect();
-
+    pub fn available_dbcs(&self) -> Vec<(Dbc, DerivedKey)> {
         let mut available_dbcs = vec![];
         for dbc in self.wallet.available_dbcs.values() {
             if let Ok(derived_key) = dbc.derived_key(&self.key) {
@@ -176,6 +166,21 @@ impl LocalWallet {
                 );
             }
         }
+        available_dbcs
+    }
+
+    pub async fn local_send(
+        &mut self,
+        to: Vec<(Token, PublicAddress)>,
+        reason_hash: Option<Hash>,
+    ) -> Result<TransferOutputs> {
+        // create a unique key for each output
+        let to_unique_keys: Vec<_> = to
+            .into_iter()
+            .map(|(amount, address)| (amount, address.random_dbc_id_src(&mut rand::thread_rng())))
+            .collect();
+
+        let available_dbcs = self.available_dbcs();
         trace!("Available DBCs: {:#?}", available_dbcs);
 
         let reason_hash = reason_hash.unwrap_or_default();

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -170,12 +170,13 @@ impl LocalWallet {
             if let Ok(derived_key) = dbc.derived_key(&self.key) {
                 available_dbcs.push((dbc.clone(), derived_key));
             } else {
-                println!(
+                warn!(
                     "Skipping DBC {:?} because we don't have the key to spend it",
                     dbc.id()
                 );
             }
         }
+        trace!("Available DBCs: {:#?}", available_dbcs);
 
         let reason_hash = reason_hash.unwrap_or_default();
 


### PR DESCRIPTION
## Description

- fix issue in parent spends check
- add more `parent_tx` checks
- fix and reactivate `multiple_sequential_transfers_succeed`e2e test #311
- add a double spend e2e test

This PR makes DBC transfers work as well as 2 e2e tests to prove it. 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jun 23 05:38 UTC
This pull request involves multiple changes across various projects. Changes include updating dependencies, modifying error messages, adding new functions, and modifying logging statements. Specific changes include updating the sn_dbc version from 19.0.0 to 19.0.1 with the "serdes" feature still enabled, changing function visibility, modifying function parameters, adding new imports, and changing import statements. Additionally, modifications to logging statements to use proper logging macros can be found, along with changes to the default keep-alive timeout value.
<!-- reviewpad:summarize:end --> 
