### PR TITLE
fix: reduce client mem usage during uploading

### DIFF
--- a/sn_client/src/chunks/mod.rs
+++ b/sn_client/src/chunks/mod.rs
@@ -25,16 +25,6 @@ pub(crate) struct SmallFile {
     bytes: Bytes,
 }
 
-/// Data of size larger than or equal to [`MIN_ENCRYPTABLE_BYTES`] bytes.
-///
-/// A `LargeFile` is spread across multiple chunks in the network.
-/// This is done using self-encryption, which produces at least 4 chunks (3 for the contents, 1 for the `DataMap`).
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
-pub(crate) struct LargeFile {
-    bytes: Bytes,
-}
-
 impl SmallFile {
     /// Enforces size > 0 and size < [`MIN_ENCRYPTABLE_BYTES`] bytes.
     pub(crate) fn new(bytes: Bytes) -> Result<Self> {
@@ -45,25 +35,6 @@ impl SmallFile {
             })
         } else if bytes.is_empty() {
             Err(Error::EmptyFileProvided)
-        } else {
-            Ok(Self { bytes })
-        }
-    }
-
-    /// Returns the bytes.
-    pub(crate) fn bytes(&self) -> Bytes {
-        self.bytes.clone()
-    }
-}
-
-impl LargeFile {
-    /// Enforces size >= [`MIN_ENCRYPTABLE_BYTES`] bytes.
-    pub(crate) fn new(bytes: Bytes) -> Result<Self> {
-        if MIN_ENCRYPTABLE_BYTES > bytes.len() {
-            Err(Error::TooSmallForSelfEncryption {
-                size: bytes.len(),
-                minimum: MIN_ENCRYPTABLE_BYTES,
-            })
         } else {
             Ok(Self { bytes })
         }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jun 23 09:46 UTC
This pull request fixes a bug that reduces client memory usage when uploading files to the network. It removes the LargeFile struct and encrypts chunks based on file size. This is done by using self-encryption for files that are larger than or equal to `MIN_ENCRYPTABLE_BYTES`, and packages small files into a single chunk.
<!-- reviewpad:summarize:end --> 
