### PR TITLE
chore: `--version` argument for `safenode`

### DIFF
--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -37,7 +37,7 @@ use tracing_core::Level;
 // Please do not remove the blank lines in these doc comments.
 // They are used for inserting line breaks when the help menu is rendered in the UI.
 #[derive(Parser, Debug)]
-#[clap(name = "safenode cli")]
+#[clap(name = "safenode cli", version = env!("CARGO_PKG_VERSION"))]
 struct Opt {
     /// Specify the node's logging output directory.
     ///


### PR DESCRIPTION
At some point this was either removed, or it was never present.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jun 23 23:49 UTC
This pull request adds a `--version` argument to the `safenode` command-line program to print the current version. The new argument is added using the `clap` library and is pulled from the Cargo manifest.
<!-- reviewpad:summarize:end --> 
