### PR TITLE
fix: CLI is missing local-discovery feature

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 [features]
 default = ["metrics"]
 metrics = ["sn_logging/process-metrics"]
+local-discovery=["sn_client/local-discovery"]
 
 [dependencies]
 bincode = "1.3.1"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Jun 23 16:04 UTC
This pull request fixes an issue where the CLI is missing the local-discovery feature by adding it to the features and as a dependency in the Cargo.toml file.
<!-- reviewpad:summarize:end --> 
