### PR TITLE
ci: use `local-discovery` for released binaries

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,12 +43,12 @@ build-release-artifacts arch:
   cargo clean
   if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
     cargo install cross
-    cross build --release --target $arch --bin safe
-    cross build --release --target $arch --bin safenode
+    cross build --release --target $arch --bin safe --features local-discovery
+    cross build --release --target $arch --bin safenode --features local-discovery
     cross build --release --target $arch --bin testnet
   else
-    cargo build --release --target $arch --bin safe
-    cargo build --release --target $arch --bin safenode
+    cargo build --release --target $arch --bin safe --features local-discovery
+    cargo build --release --target $arch --bin safenode --features local-discovery
     cargo build --release --target $arch --bin testnet
   fi
 


### PR DESCRIPTION
It was pointed out by @willief that these features were not on the released binaries, so they couldn't be used to establish a connection.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jun 23 20:52 UTC
This pull request adds the `local-discovery` feature to the released binaries for establishing connections.
<!-- reviewpad:summarize:end --> 
