### PR TITLE
fix: ci chart generation using non-linux cmd

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -229,7 +229,7 @@ jobs:
           path: heaptrack.safe.*
         continue-on-error: true
 
-      - run: ll ./heaptrack.safe.txt 
+      - run: cat ./heaptrack.safe.txt 
         shell: bash
 
       - run: MEMORY_USAGE=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "M" -r "")


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Jun 23 05:28 UTC
This pull request fixes an issue with the CI chart generation using non-linux command by replacing ll with cat command.
<!-- reviewpad:summarize:end --> 
