### PR TITLE
ci: fix missing mb->kb change for client mem measurements

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -232,7 +232,7 @@ jobs:
       - run: cat ./heaptrack.safe.txt 
         shell: bash
 
-      - run: MEMORY_USAGE=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "K" -r "")
+      - run: rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "K" -r ""
         shell: bash
 
       - name: Check client memory usage
@@ -243,9 +243,9 @@ jobs:
         env:
           CLIENT_MEM_LIMIT_KB: "1024" # ~1mb (unit is kilobytes)
         run: |
-          MEMORY_USAGE=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "M" -r "")
+          MEMORY_USAGE=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "K" -r "")
           echo "Memory usage: $MEMORY_USAGE KB"
-          if (( $(echo "$MEMORY_USAGE > $CLIENT_MEM_LIMIT_UNIT" | bc -l) )); then
+          if (( $(echo "$MEMORY_USAGE > $CLIENT_MEM_LIMIT_KB" | bc -l) )); then
             echo "Client memory usage exceeded threshold: $CLIENT_MEM_LIMIT_KB KB"
             exit 1
           fi


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Jun 23 11:47 UTC
This pull request fixes a missing mb->kb change for client memory measurements in the .github/workflows/generate-benchmark-charts.yml file. The patch includes adjusting the run command to correctly get memory usage in KB and updating the environment variable for the client memory limit to be in KB as well.
<!-- reviewpad:summarize:end --> 
