### PR TITLE
chore: reduce some log levels to make 'debug' more useful

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -150,7 +150,7 @@ impl SwarmDriver {
             SwarmEvent::Behaviour(NodeEvent::Identify(iden)) => {
                 match *iden {
                     libp2p::identify::Event::Received { peer_id, info } => {
-                        info!(%peer_id, ?info, "identify: received info");
+                        debug!(%peer_id, ?info, "identify: received info");
 
                         // If we are not local, we care only for peers that we dialed and thus are reachable.
                         if (self.local || self.dialed_peers.contains(&peer_id))
@@ -173,7 +173,7 @@ impl SwarmDriver {
                                 .unique()
                                 .collect();
 
-                            info!(%peer_id, ?addrs, "identify: adding addresses to routing table");
+                            debug!(%peer_id, ?addrs, "identify: adding addresses to routing table");
                             for multiaddr in addrs.clone() {
                                 let _routing_update = self
                                     .swarm
@@ -198,9 +198,9 @@ impl SwarmDriver {
                             }
                         }
                     }
-                    libp2p::identify::Event::Sent { .. } => info!("identify: {iden:?}"),
-                    libp2p::identify::Event::Pushed { .. } => info!("identify: {iden:?}"),
-                    libp2p::identify::Event::Error { .. } => info!("identify: {iden:?}"),
+                    libp2p::identify::Event::Sent { .. } => trace!("identify: {iden:?}"),
+                    libp2p::identify::Event::Pushed { .. } => trace!("identify: {iden:?}"),
+                    libp2p::identify::Event::Error { .. } => trace!("identify: {iden:?}"),
                 }
             }
             #[cfg(feature = "local-discovery")]
@@ -300,7 +300,7 @@ impl SwarmDriver {
                 }
             }
             SwarmEvent::IncomingConnectionError { .. } => {}
-            SwarmEvent::Dialing(peer_id) => info!("Dialing {peer_id}"),
+            SwarmEvent::Dialing(peer_id) => trace!("Dialing {peer_id}"),
 
             SwarmEvent::Behaviour(NodeEvent::Autonat(event)) => match event {
                 autonat::Event::InboundProbe(e) => trace!("AutoNAT inbound probe: {e:?}"),
@@ -410,7 +410,7 @@ impl SwarmDriver {
                 }
             }
             other => {
-                debug!("KademliaEvent ignored: {other:?}");
+                trace!("KademliaEvent ignored: {other:?}");
             }
         }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -610,7 +610,7 @@ impl Network {
     /// Returns the closest peers to the given `XorName`, sorted by their distance to the xor_name.
     /// If `client` is false, then include `self` among the `closest_peers`
     async fn get_closest_peers(&self, key: &NetworkAddress, client: bool) -> Result<Vec<PeerId>> {
-        debug!("Getting the closest peers to {key:?}");
+        trace!("Getting the closest peers to {key:?}");
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetClosestPeers {
             key: key.clone(),


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 01:34 UTC
This pull request reduces some log levels in the sn_networking module to make 'debug' more useful. It changes the log level from 'info' to 'debug' for the identify event of SwarmEvent struct and changes the log level from 'info' to 'trace' for error, pushed, and sent events of identify. It also changes the log level from 'debug' to 'trace' for Dialing event of SwarmEvent struct and KademliaEvent. Moreover, it changes the log level from 'debug' to 'trace' for getting the closest peers of the Network struct.
<!-- reviewpad:summarize:end --> 
