### PR TITLE
ci: readd nohup for node.

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Start safenode with heaptrack
         run: |
           mkdir -p ~/.safe/heapnode
-          heaptrack ./target/release/safenode --root-dir ~/.safe/heapnode --log-dir ~/.safe/heapnode
+          heaptrack ./target/release/safenode --root-dir ~/.safe/heapnode --log-dir ~/.safe/heapnode &
           sleep 10
         env:
           SN_LOG: "all"
@@ -268,12 +268,12 @@ jobs:
           # Write the client memory usage to a file
           echo '[
               {
-                  "name": "Peak memory usage w/ ~1gb upload",
+                  "name": "Peak memory usage w/ ~450mb upload",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               },
               {
-                  "name": "Average memory usage w/ ~1gb upload",
+                  "name": "Average memory usage w/ ~450mb upload",
                   "value": '$average_mem',
                   "unit": "MB"
               }


### PR DESCRIPTION
Ups, That was removed thinking it was the client. That was wrong, and this would now hold up ci

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 02:10 UTC
This pull request readds nohup for node which was mistakenly removed, to hold up CI. The patch modifies `.github/workflows/generate-benchmark-charts.yml` file to include `nohup` with a following ampersand.
<!-- reviewpad:summarize:end --> 
