### PR TITLE
feat(sn_networking): Make it possible to pass in a keypair for PeerID

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -10,6 +10,7 @@ use super::{error::Result, event::NodeEventsChannel, Network, Node, NodeEvent};
 use crate::spendbook::SpendBook;
 use libp2p::{
     autonat::NatStatus,
+    identity::Keypair,
     kad::{Record, RecordKey},
     Multiaddr, PeerId,
 };
@@ -70,13 +71,14 @@ impl Node {
     ///
     /// Returns an error if there is a problem initializing the `SwarmDriver`.
     pub async fn run(
+        keypair: Option<Keypair>,
         addr: SocketAddr,
         initial_peers: Vec<(PeerId, Multiaddr)>,
         local: bool,
         root_dir: &Path,
     ) -> Result<RunningNode> {
         let (network, mut network_event_receiver, swarm_driver) =
-            SwarmDriver::new(addr, local, root_dir)?;
+            SwarmDriver::new(keypair, addr, local, root_dir)?;
         let node_events_channel = NodeEventsChannel::default();
 
         let mut node = Self {

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -168,8 +168,13 @@ async fn start_node(
 ) -> Result<()> {
     let started_instant = std::time::Instant::now();
 
+    // TODO: Pull this keypair from _somewhere_.
+    // This is used for our PeerId...
+    // where/how should we store this on disk?
+    let keypair = None;
+
     info!("Starting node ...");
-    let running_node = Node::run(node_socket_addr, peers, local, root_dir).await?;
+    let running_node = Node::run(keypair, node_socket_addr, peers, local, root_dir).await?;
 
     // write the PID to the root dir
     let pid = std::process::id();


### PR DESCRIPTION
makes changes up the stack so nodes could restart and maintain peerId, clients simply ignore this and provide None as they have a separate Signer used for client ops. Their PeerId is not relevant or used in kad at all

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 03:47 UTC
This pull request adds the ability to pass in a keypair for PeerID, allowing for nodes to maintain their PeerID even after restarting. Clients can still ignore this and provide None, as they have a separate signer for client operations and their PeerID is not used in Kademlia. Additionally, the PR generates a new keypair if none is provided, though it currently does not have a storage mechanism for the generated keypair.
<!-- reviewpad:summarize:end --> 
