### PR TITLE
feat(node): trigger replication when inactivity

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -550,6 +550,17 @@ impl Network {
         Ok(())
     }
 
+    /// Send `Request` to the closest peers to self
+    pub async fn send_req_no_reply_to_self_closest(&self, request: &Request) -> Result<()> {
+        info!("Sending {request:?} to self closest peers.");
+        // Using `client_get_closest_peers` to filter self out.
+        let closest_peers = self.client_get_closest_peers(&request.dst()).await?;
+        for peer in closest_peers {
+            self.send_req_ignore_reply(request.clone(), peer).await?;
+        }
+        Ok(())
+    }
+
     /// Send `Request` to the closest peers. `Self` is not present among the recipients.
     pub async fn client_send_to_closest(
         &self,

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -52,6 +52,10 @@ pub enum Cmd {
         #[debug(skip)]
         keys: Vec<NetworkAddress>,
     },
+    /// Notify peer to send back a replication list
+    ///
+    /// [`NetworkAddress`]: crate::NetworkAddress
+    RequestReplication(NetworkAddress),
 }
 
 impl Cmd {
@@ -66,6 +70,7 @@ impl Cmd {
                 NetworkAddress::from_dbc_address(DbcAddress::from_dbc_id(signed_spend.dbc_id()))
             }
             Cmd::Replicate { holder, .. } => holder.clone(),
+            Cmd::RequestReplication(sender) => sender.clone(),
         }
     }
 }
@@ -89,6 +94,9 @@ impl std::fmt::Display for Cmd {
                     holder.as_peer_id(),
                     keys.len()
                 )
+            }
+            Cmd::RequestReplication(sender) => {
+                write!(f, "Cmd::RequestReplication({:?})", sender.as_peer_id(),)
             }
         }
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 15:19 UTC
This pull request adds a feature to trigger replication to the closest peers when there is inactivity by adding a new `SwarmCmd` called `RequestReplication`. The change allows an inactivity peer to request for a replication flow to be triggered, considering the requester as a newly added peer.
<!-- reviewpad:summarize:end --> 
