### PR TITLE
feat: send and verify storage cost payment made to special network-owned output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array",
 ]
 
@@ -665,26 +664,6 @@ checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "bulletproofs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e698f1df446cc6246afd823afbe2d121134d089c9102c1dd26d1264991ba32"
-dependencies = [
- "byteorder",
- "clear_on_drop",
- "curve25519-dalek-ng",
- "digest 0.9.0",
- "merlin",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "serde_derive",
- "sha3",
- "subtle-ng",
- "thiserror",
 ]
 
 [[package]]
@@ -927,15 +906,6 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
-
-[[package]]
-name = "clear_on_drop"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "color-eyre"
@@ -1226,20 +1196,6 @@ dependencies = [
  "packed_simd_2",
  "platforms",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "serde",
- "subtle-ng",
  "zeroize",
 ]
 
@@ -2415,15 +2371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,18 +2937,6 @@ dependencies = [
  "serde",
  "tempfile",
  "typenum",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
 ]
 
 [[package]]
@@ -4531,18 +4466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,17 +4574,14 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "19.1.0"
+version = "19.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6abdb4e8c544e472933800639e2fcb540a472de382e9948e70c90bc7d5441923"
+checksum = "d46704477d95233cf8daefb6e1601eebdf755a9fd6cd35e6d4d4dc3f6e0dc946"
 dependencies = [
  "bincode",
  "blsttc",
- "bulletproofs",
- "curve25519-dalek-ng",
  "custom_debug",
  "hex",
- "merlin",
  "serde",
  "thiserror",
  "tiny-keccak",
@@ -4982,12 +4902,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
- "aes 0.8.2",
+ "aes 0.8.3",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -171,6 +171,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -204,15 +210,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -256,9 +262,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asn1-rs"
@@ -273,7 +279,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -289,7 +295,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -362,9 +368,9 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.22",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -396,18 +402,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -448,15 +454,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -514,6 +520,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -758,13 +770,13 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "time 0.1.45",
  "wasm-bindgen",
@@ -833,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
@@ -845,24 +857,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.0",
+ "clap_derive 4.3.2",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex 0.5.0",
  "strsim",
 ]
@@ -882,14 +893,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -964,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "core-foundation"
@@ -995,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -1045,7 +1056,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.0",
+ "clap 4.3.10",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -1095,22 +1106,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -1422,7 +1433,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1462,9 +1473,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+checksum = "c904bbebf8a5ecde84d81e5d3e5fe085104462a4bec7888608a4b408b117fecf"
 
 [[package]]
 name = "ecdsa"
@@ -1649,9 +1660,9 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bbc4024961e78784ed5e2b98e2411f75c7be0594c0e7a416ebcede13608b1c"
+checksum = "ddf221ceec4517f3cb764dae3541b2bd87666fc8832e51322fbb97250b468c71"
 dependencies = [
  "chrono",
  "flate2",
@@ -1670,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1690,9 +1701,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1781,7 +1792,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1854,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1880,14 +1891,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug",
- "polyval 0.6.0",
+ "polyval 0.6.1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -1914,7 +1925,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -1934,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -1992,15 +2003,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -2107,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2122,7 +2124,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2143,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2183,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2318,31 +2320,30 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.3",
  "widestring",
- "winapi",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
 
@@ -2357,15 +2358,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "c0aa48fab2893d8a49caa94082ae8488f4e1050d73b367881dcd2198f4199fd8"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2378,9 +2379,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libm"
@@ -2403,7 +2404,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-autonat",
@@ -2547,7 +2548,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "zeroize",
 ]
@@ -2572,7 +2573,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "smallvec",
  "thiserror",
  "uint",
@@ -2595,7 +2596,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -2647,7 +2648,7 @@ dependencies = [
  "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "snow",
  "static_assertions",
  "thiserror",
@@ -2737,7 +2738,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "log",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
 ]
 
@@ -2817,10 +2818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
+name = "linux-raw-sys"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2828,18 +2835,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -2915,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -2947,15 +2951,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -2965,14 +2960,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3041,7 +3035,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "unsigned-varint",
 ]
 
@@ -3110,7 +3104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "libc",
  "netlink-packet-core 0.4.2",
@@ -3124,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "libc",
  "netlink-packet-core 0.5.0",
@@ -3177,7 +3171,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -3257,11 +3251,20 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -3273,9 +3276,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -3300,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -3366,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -3390,7 +3393,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -3401,7 +3404,7 @@ checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -3441,15 +3444,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3478,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -3494,29 +3497,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -3542,9 +3545,9 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -3555,15 +3558,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -3575,7 +3578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -3609,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3757,7 +3760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -3882,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -3954,7 +3957,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -4007,7 +4010,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.21",
+ "time 0.3.22",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -4020,7 +4023,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.21",
+ "time 0.3.22",
  "yasna",
 ]
 
@@ -4030,7 +4033,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4039,7 +4042,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4048,18 +4051,18 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -4215,15 +4218,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -4354,7 +4370,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1010ea71bdf29522bd1940b645c79b805d83f1f9f07f194ed1132348fe448043"
 dependencies = [
- "aes 0.8.2",
+ "aes 0.8.3",
  "bincode",
  "brotli",
  "bytes",
@@ -4379,29 +4395,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -4410,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.163"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100168a8017b89fd4bcbeb8d857d95a8cfcbde829a7147c09cc82d3ab8d8cb41"
+checksum = "4747ace0742036c7ee087583e68eef757556616b92c0a82cd8efd999559f812a"
 dependencies = [
  "serde",
 ]
@@ -4456,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4523,7 +4539,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "chrono",
- "clap 4.3.0",
+ "clap 4.3.10",
  "color-eyre",
  "criterion",
  "dirs-next",
@@ -4643,7 +4659,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "chrono",
- "clap 4.3.0",
+ "clap 4.3.10",
  "crdts",
  "custom_debug",
  "dirs-next",
@@ -4690,7 +4706,7 @@ dependencies = [
 name = "sn_peers_acquisition"
 version = "0.1.3"
 dependencies = [
- "clap 4.3.0",
+ "clap 4.3.10",
  "eyre",
  "libp2p",
  "tracing",
@@ -4806,7 +4822,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "subtle",
 ]
 
@@ -4818,6 +4834,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4867,7 +4893,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4917,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f1dc6930a439cc5d154221b5387d153f8183529b07c19aca24ea31e0a167e1"
+checksum = "5bcd0346f90b6bc83526c7b180039a8acd26a5c848cc556d457f6472eb148122"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4958,7 +4984,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4989,7 +5015,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.22",
  "windows-sys 0.48.0",
 ]
 
@@ -5031,7 +5057,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -5066,11 +5092,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -5127,11 +5155,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -5139,7 +5168,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -5162,7 +5191,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -5309,19 +5338,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.21",
+ "time 0.3.22",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -5429,7 +5458,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -5583,12 +5612,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 
@@ -5600,11 +5629,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -5615,13 +5644,13 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vergen"
-version = "8.2.1"
+version = "8.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+checksum = "ce38fc503fa57441ac2539c3e723b5adf76601eb4f1ad24025c6660d27f355b7"
 dependencies = [
  "anyhow",
  "rustversion",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -5672,11 +5701,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -5700,9 +5728,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5710,24 +5738,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5735,28 +5763,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5805,10 +5833,10 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
  "tokio",
  "turn",
  "url",
@@ -5868,7 +5896,7 @@ dependencies = [
  "sec1",
  "serde",
  "sha1",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "signature",
  "subtle",
  "thiserror",
@@ -5910,7 +5938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -5977,7 +6005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "cc",
  "ipnet",
@@ -6004,9 +6032,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -6058,7 +6086,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -6076,7 +6104,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -6096,9 +6124,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -6225,11 +6253,12 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6279,7 +6308,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -6297,7 +6326,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -6334,7 +6363,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -6354,5 +6383,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,6 +4654,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libp2p",
+ "proptest",
  "prost",
  "rand 0.8.5",
  "rayon",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -35,7 +35,7 @@ hex = "~0.4.3"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.85.37" }
-sn_dbc = { version = "19.1.0", features = ["serdes"] }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.10.3" }
 sn_logging = { path = "../sn_logging", version = "0.1.4" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.3" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.0", features = ["serdes"] }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.3.8" }
 sn_protocol = { path = "../sn_protocol", version = "0.1.11" }
 sn_registers = { path = "../sn_registers", version = "0.1.10" }

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -18,7 +18,7 @@ pub async fn load_faucet_wallet(client: &Client) -> LocalWallet {
     let mut faucet_wallet = create_faucet_wallet().await;
 
     let faucet_balance = faucet_wallet.balance();
-    if faucet_balance.as_nano() > 0 {
+    if !faucet_balance.is_zero() {
         println!("Faucet wallet balance: {faucet_balance}");
         return faucet_wallet;
     }
@@ -26,7 +26,7 @@ pub async fn load_faucet_wallet(client: &Client) -> LocalWallet {
     // Transfer to faucet. We will transfer almost all of the genesis wallet's
     // balance to the faucet,.
 
-    let faucet_balance = Token::from_nano(genesis_wallet.balance().as_nano());
+    let faucet_balance = genesis_wallet.balance();
     println!("Sending {faucet_balance} from genesis to faucet wallet..");
     let tokens = send(
         genesis_wallet,

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -64,7 +64,7 @@ impl WalletClient {
 
         // return created DBCs even if network part failed???
         match &dbcs[..] {
-            [info, ..] => Ok(info.dbc.clone()),
+            [info, ..] => Ok(info.clone()),
             [] => Err(Error::CouldNotSendTokens(
                 "No DBCs were returned from the wallet.".into(),
             )),

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -98,13 +98,15 @@ impl WalletClient {
             return Err(error);
         }
 
+        let spent_ids: Vec<_> = transfer.tx.inputs.iter().map(|i| i.dbc_id()).collect();
+
         let payment_proofs = audit_trail_info
             .into_iter()
             .map(|(addr, (audit_trail, path))| {
                 (
                     addr,
                     PaymentProof {
-                        tx: transfer.tx.clone(),
+                        spent_ids: spent_ids.clone(),
                         audit_trail,
                         path,
                     },

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -77,7 +77,7 @@ impl WalletClient {
         content_addrs: impl Iterator<Item = &XorName>,
     ) -> Result<PaymentProofsMap> {
         // Let's build the payment proofs for list of content addresses
-        let (reason_hash, audit_trail_info) = build_payment_proofs(content_addrs)?;
+        let (root_hash, audit_trail_info) = build_payment_proofs(content_addrs)?;
 
         // TODO: request an invoice to network which provides the amount to pay.
         // For now, we just pay 1 nano per Chunk.
@@ -87,7 +87,7 @@ impl WalletClient {
 
         let transfer = self
             .wallet
-            .local_send_storage_payment(storage_cost, reason_hash)
+            .local_send_storage_payment(storage_cost, root_hash, None)
             .await?;
 
         // send to network

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -48,7 +48,7 @@ self_encryption = "~0.28.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.3" }
-sn_dbc = { version = "19.1.0", features = ["serdes"] }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.85.37" }
 sn_logging = { path = "../sn_logging", version = "0.1.4" }
 sn_networking = { path = "../sn_networking", version = "0.3.8" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -71,6 +71,7 @@ strum = { version = "0.25.0", features = ["derive"] }
 
 [dev-dependencies]
 assert_fs = "1.0.0"
+proptest = { version = "1.0.0" }
 
 [build-dependencies]
 tonic-build = { version = "0.6.2" }

--- a/sn_node/proptest-regressions/put_validation.txt
+++ b/sn_node/proptest-regressions/put_validation.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 25d53332493e12982b6e06b9218b2f56a328cdd3132c88a74e05e8487ead91a6 # shrinks to num_of_addrs = 2

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -295,7 +295,7 @@ impl Node {
                 // exit early, potentially logging false connection woes
             }
             other => {
-                error!("handle_response not implemented for {other:?}");
+                warn!("handle_response not implemented for {other:?}");
                 return Ok(());
             }
         };

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -465,6 +465,7 @@ impl Node {
 // how an output DBC Id works for regular outputs.
 fn verify_fee_output_id(spent_tx: &DbcTransaction) -> Result<(), ProtocolError> {
     let fee = &spent_tx.fee;
+    info!(">>>> FEE: {fee:?}");
     if !fee.is_free() {
         let mut fee_id_bytes = fee.root_hash.slice().to_vec();
         spent_tx

--- a/sn_node/src/spends.rs
+++ b/sn_node/src/spends.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use itertools::Itertools;
-use sn_dbc::{DbcId, DbcTransaction, SignedSpend, TransactionVerifier};
+use sn_dbc::{DbcId, DbcTransaction, SignedSpend};
 use sn_networking::Network;
 use sn_protocol::{
     error::{Error, Result},
@@ -157,7 +157,10 @@ fn validate_parent_spends(
     }
 
     // Here we check that the DBC we're trying to spend was created in a valid tx
-    if let Err(e) = TransactionVerifier::verify(&signed_spend.spend.dbc_creation_tx, &parent_spends)
+    if let Err(e) = signed_spend
+        .spend
+        .dbc_creation_tx
+        .verify_against_inputs_spent(&parent_spends)
     {
         return Err(Error::InvalidParentTx(format!(
             "verification failed for parent tx for {:?}: {e:?}",

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_client::{get_tokens_from_faucet, Client};
+use sn_transfers::wallet::LocalWallet;
+
+use eyre::Result;
+use sn_dbc::Token;
+use std::path::Path;
+
+pub async fn get_client() -> Client {
+    let secret_key = bls::SecretKey::random();
+    Client::new(secret_key, None, None)
+        .await
+        .expect("Client shall be successfully created.")
+}
+
+pub async fn get_wallet(root_dir: &Path) -> LocalWallet {
+    LocalWallet::load_from(root_dir)
+        .await
+        .expect("Wallet shall be successfully created.")
+}
+
+pub async fn get_client_and_wallet(root_dir: &Path, amount: u64) -> Result<(Client, LocalWallet)> {
+    let wallet_balance = Token::from_nano(amount);
+
+    let mut local_wallet = get_wallet(root_dir).await;
+    let client = get_client().await;
+    println!("Getting {wallet_balance} tokens from the faucet...");
+    let tokens = get_tokens_from_faucet(wallet_balance, local_wallet.address(), &client).await;
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    println!("Verifying the transfer from faucet...");
+    client.verify(&tokens).await?;
+    local_wallet.deposit(vec![tokens]);
+    assert_eq!(local_wallet.balance(), wallet_balance);
+    println!("Tokens deposited to the wallet that'll pay for storage: {wallet_balance}.");
+
+    Ok((client, local_wallet))
+}

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -149,16 +149,8 @@ async fn double_spend_transfers_fail() -> Result<()> {
     // check the DBCs, it should fail
     std::thread::sleep(std::time::Duration::from_secs(5));
     println!("Verifying the transfers from first wallet...");
-    let dbcs_for_2: Vec<_> = transfer_to_2
-        .created_dbcs
-        .iter()
-        .map(|d| d.dbc.clone())
-        .collect();
-    let dbcs_for_3: Vec<_> = transfer_to_3
-        .created_dbcs
-        .iter()
-        .map(|d| d.dbc.clone())
-        .collect();
+    let dbcs_for_2: Vec<_> = transfer_to_2.created_dbcs.clone();
+    let dbcs_for_3: Vec<_> = transfer_to_3.created_dbcs.clone();
     let should_err1 = client.verify(&dbcs_for_2[0]).await;
     let should_err2 = client.verify(&dbcs_for_3[0]).await;
     println!("Verifying at least one fails: {should_err1:?} {should_err2:?}");

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use sn_client::{get_tokens_from_faucet, send, Client, WalletClient};
 
-use sn_dbc::Token;
+use sn_dbc::{random_derivation_index, rng, Token};
 use sn_transfers::{client_transfers::create_transfer, wallet::LocalWallet};
 use tracing_core::Level;
 
@@ -129,8 +129,11 @@ async fn double_spend_transfers_fail() -> Result<()> {
 
     let some_dbcs = first_wallet.available_dbcs();
     let same_dbcs = some_dbcs.clone();
-    let to2_unique_key = (amount, to2.random_dbc_id_src(&mut rand::thread_rng()));
-    let to3_unique_key = (amount, to3.random_dbc_id_src(&mut rand::thread_rng()));
+
+    let mut rng = rng::thread_rng();
+
+    let to2_unique_key = (amount, to2, random_derivation_index(&mut rng));
+    let to3_unique_key = (amount, to3, random_derivation_index(&mut rng));
     let reason_hash: sn_dbc::Hash = None.unwrap_or_default();
 
     let transfer_to_2 = create_transfer(some_dbcs, vec![to2_unique_key], to1, reason_hash).unwrap();

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod common;
+
+use common::get_client_and_wallet;
+
+use sn_client::WalletClient;
+use sn_dbc::{Hash, Token};
+use sn_transfers::wallet::Error;
+
+use assert_fs::TempDir;
+use eyre::Result;
+use rand::Rng;
+use tracing_core::Level;
+use xor_name::XorName;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_payment_succeeds() -> Result<()> {
+    let logging_targets = vec![
+        ("safenode".to_string(), Level::INFO),
+        ("sn_client".to_string(), Level::TRACE),
+        ("sn_transfers".to_string(), Level::INFO),
+        ("sn_networking".to_string(), Level::INFO),
+        ("sn_node".to_string(), Level::INFO),
+    ];
+    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None, false)?;
+
+    let paying_wallet_balance = 500_000;
+    let paying_wallet_dir = TempDir::new()?;
+
+    let (client, paying_wallet) =
+        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+    let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
+
+    // generate a random number (between 50 and 100) of random addresses
+    let mut rng = rand::thread_rng();
+    let random_content_addrs = (0..rng.gen_range(50..100))
+        .collect::<Vec<_>>()
+        .iter()
+        .map(|_| XorName::random(&mut rng))
+        .collect::<Vec<_>>();
+    println!(
+        "Paying for {} random addresses...",
+        random_content_addrs.len()
+    );
+
+    let proofs = wallet_client
+        .pay_for_storage(random_content_addrs.iter())
+        .await?;
+
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
+    let cost = proofs.len() as u64; // 1 nano per addr
+    let new_balance = Token::from_nano(paying_wallet_balance - cost);
+    println!("Verifying new balance on paying wallet is {new_balance} ...");
+    let paying_wallet = wallet_client.into_wallet();
+    assert_eq!(paying_wallet.balance(), new_balance);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_payment_fails() -> Result<()> {
+    let logging_targets = vec![
+        ("safenode".to_string(), Level::INFO),
+        ("sn_client".to_string(), Level::TRACE),
+        ("sn_transfers".to_string(), Level::INFO),
+        ("sn_networking".to_string(), Level::INFO),
+        ("sn_node".to_string(), Level::INFO),
+    ];
+    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None, false)?;
+
+    let wallet_dir = TempDir::new()?;
+    let (client, mut wallet_client) = get_client_and_wallet(wallet_dir.path(), 15_000).await?;
+
+    // generate a random number (between 50 and 100) of random addresses
+    let random_num_of_addrs = rand::thread_rng().gen_range(50..100);
+    let storage_cost = Token::from_nano(random_num_of_addrs);
+
+    let mut transfer = wallet_client
+        .local_send_storage_payment(storage_cost, Hash::default(), None)
+        .await?;
+
+    // let's corrupt the generated spend in any way
+    let mut invalid_signed_spend = transfer.all_spend_requests[0].signed_spend.clone();
+    invalid_signed_spend.spend.spent_tx.fee.token = Token::from_nano(random_num_of_addrs + 1);
+    transfer.all_spend_requests[0].signed_spend = invalid_signed_spend;
+
+    let failed_send = client.send(transfer).await;
+
+    assert!(matches!(failed_send, Err(Error::CouldNotSendTokens(_))));
+
+    Ok(())
+}

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -17,7 +17,7 @@ custom_debug = "~0.5.0"
 libp2p = { version="0.51", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.0", features = ["serdes"] }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_registers = { path = "../sn_registers", version = "0.1.10" }
 thiserror = "1.0.23"
 xor_name = "5.0.0"

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -11,7 +11,7 @@ use crate::{
     NetworkAddress,
 };
 use serde::{Deserialize, Serialize};
-use sn_dbc::SignedSpend;
+use sn_dbc::{Hash, SignedSpend};
 use thiserror::Error;
 use xor_name::XorName;
 
@@ -38,15 +38,19 @@ pub enum Error {
     #[error("Register is Invalid: {0}")]
     RegisterError(#[from] sn_registers::Error),
 
+    /// The amount paid by payment proof is not the required for the received content
+    #[error("The amount paid by payment proof is not the required for the received content, paid {paid}, expected {expected}")]
+    PaymentProofInsufficientAmount { paid: usize, expected: usize },
     /// At least one input of payment proof provided has a mismatching spend Tx
     #[error("At least one input of payment proof provided for {0:?} has a mismatching spend Tx")]
     PaymentProofTxMismatch(XorName),
     /// Payment proof received has no inputs
     #[error("Payment proof received for {0:?} has no inputs in its transaction")]
     PaymentProofWithoutInputs(XorName),
-    /// Not all inputs in payment proof have the same 'reason' hash value
-    #[error("Not all inputs in payment proof for {0:?} have the same 'reason' hash value")]
-    PaymentProofInconsistentReason(XorName),
+    /// The id of the fee output found in a storage payment proof is invalid
+    #[error("The id of the fee output found in a storage payment proof is invalid: {}", .0.to_hex())]
+    PaymentProofInvalidFeeOutput(Hash),
+
     /// Cannot add another entry since the register entry cap has been reached.
     #[error("Cannot add another entry since the register entry cap has been reached: {0}")]
     TooManyEntries(usize),

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 // TODO: remove this dependency and define these types herein.
-pub use sn_dbc::{DbcTransaction, Hash, SignedSpend};
+pub use sn_dbc::{DbcId, DbcTransaction, Hash, SignedSpend};
 
 /// Data and Dbc cmds - recording spends or creating, updating, and removing data.
 ///
@@ -107,9 +107,9 @@ pub type MerkleTreeNodesType = [u8; 32];
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct PaymentProof {
-    // DBC transaction for nodes to check the storage payment is valid and inputs have
+    // Ids of the DBCs spent, for nodes to check the storage payment is valid and inputs have
     // been effectivelly spent on the network.
-    pub tx: DbcTransaction,
+    pub spent_ids: Vec<DbcId>,
     // Merkletree audit trail to prove the content storage has been paid by the
     // given DBC (using DBC's parent/s 'reason' field)
     pub audit_trail: Vec<MerkleTreeNodesType>,

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "~1.4.0"
 merkletree = "~0.23.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.0", features = ["serdes"] }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.1.11" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt"] }
 thiserror = "1.0.23"

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -58,7 +58,7 @@ pub struct TransferOutputs {
     /// The dbcs that were created containing
     /// the tokens sent to respective recipient.
     #[debug(skip)]
-    pub created_dbcs: Vec<CreatedDbc>,
+    pub created_dbcs: Vec<Dbc>,
     /// The dbc holding surplus tokens after
     /// spending the necessary input dbcs.
     #[debug(skip)]
@@ -75,14 +75,4 @@ pub struct SpendRequest {
     /// The dbc transaction that the spent dbc was created in.
     #[debug(skip)]
     pub parent_tx: DbcTransaction,
-}
-
-/// A resulting dbc from a token transfer.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct CreatedDbc {
-    /// The dbc that was created.
-    pub dbc: Dbc,
-    /// This is useful for the sender to know how much they sent to each recipient.
-    /// They can't know this from the dbc itself, as the amount is encrypted.
-    pub amount: Token,
 }

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -31,7 +31,7 @@ mod error;
 mod transfer;
 
 pub(crate) use self::error::{Error, Result};
-pub use self::transfer::create_transfer;
+pub use self::transfer::{create_storage_payment_transfer, create_transfer};
 
 use sn_dbc::{
     Dbc, DbcIdSource, DbcTransaction, DerivedKey, PublicAddress, RevealedAmount, SignedSpend, Token,

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -33,9 +33,7 @@ mod transfer;
 pub(crate) use self::error::{Error, Result};
 pub use self::transfer::{create_storage_payment_transfer, create_transfer};
 
-use sn_dbc::{
-    Dbc, DbcIdSource, DbcTransaction, DerivedKey, PublicAddress, RevealedAmount, SignedSpend, Token,
-};
+use sn_dbc::{Dbc, DbcTransaction, DerivationIndex, DerivedKey, PublicAddress, SignedSpend, Token};
 
 /// The input details necessary to
 /// carry out a transfer of tokens.
@@ -45,7 +43,7 @@ pub struct Inputs {
     /// to transfer the below specified amount of tokens to each recipients.
     pub dbcs_to_spend: Vec<(Dbc, DerivedKey)>,
     /// The amounts and dbc ids for the dbcs that will be created to hold the transferred tokens.
-    pub recipients: Vec<(Token, DbcIdSource)>,
+    pub recipients: Vec<(Token, PublicAddress, DerivationIndex)>,
     /// Any surplus amount after spending the necessary input dbcs.
     pub change: (Token, PublicAddress),
 }
@@ -54,10 +52,9 @@ pub struct Inputs {
 /// of tokens from one or more dbcs, into one or more new dbcs.
 #[derive(custom_debug::Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TransferOutputs {
-    /// This is the hash of the transaction
-    /// where all the below spends were made
-    /// and dbcs created.
-    pub tx_hash: sn_dbc::Hash,
+    /// This is the transaction where all the below
+    /// spends were made and dbcs created.
+    pub tx: sn_dbc::DbcTransaction,
     /// The dbcs that were created containing
     /// the tokens sent to respective recipient.
     #[debug(skip)]
@@ -87,5 +84,5 @@ pub struct CreatedDbc {
     pub dbc: Dbc,
     /// This is useful for the sender to know how much they sent to each recipient.
     /// They can't know this from the dbc itself, as the amount is encrypted.
-    pub amount: RevealedAmount,
+    pub amount: Token,
 }

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{CreatedDbc, Error, Inputs, Result, SpendRequest, TransferOutputs};
+use super::{Error, Inputs, Result, SpendRequest, TransferOutputs};
 
 use sn_dbc::{
     random_derivation_index, rng, Dbc, DerivationIndex, DerivedKey, FeeOutput, Hash, Input,
@@ -103,7 +103,7 @@ fn select_inputs(
         let dbc_balance = match dbc.token() {
             Ok(token) => token,
             Err(err) => {
-                warn!("Ignoring input Dbc (id: {input_key:?}) due to not having correct derived key: {err:?}");
+                warn!("Ignoring input Dbc (id: {input_key:?}) due to missing an output: {err:?}");
                 continue;
             }
         };
@@ -240,13 +240,13 @@ fn create_transfer_with(
         .map_err(Box::new)
         .map_err(Error::Dbcs)?
         .into_iter()
-        .map(|(dbc, amount)| CreatedDbc { dbc, amount })
+        .map(|(dbc, _)| dbc)
         .collect();
 
     let mut change_dbc = None;
     created_dbcs.retain(|created| {
-        if created.dbc.id() == change_id {
-            change_dbc = Some(created.dbc.clone());
+        if created.id() == change_id {
+            change_dbc = Some(created.clone());
             false
         } else {
             true

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -9,10 +9,13 @@
 use super::wallet::LocalWallet;
 
 #[cfg(test)]
-use sn_dbc::{random_derivation_index, rng, Hash, Input, Token, TransactionBuilder};
+use sn_dbc::{random_derivation_index, rng};
 
-use sn_dbc::{Dbc, DbcTransaction, Error as DbcError, MainKey};
+use sn_dbc::{
+    Dbc, DbcTransaction, Error as DbcError, Hash, Input, MainKey, Token, TransactionBuilder,
+};
 
+use bls::SecretKey;
 use lazy_static::lazy_static;
 use std::{fmt::Debug, path::PathBuf};
 use thiserror::Error;
@@ -21,15 +24,12 @@ use thiserror::Error;
 /// At the inception of the Network 30 % of total supply - i.e. 1,288,490,189 - whole tokens will be created.
 /// Each whole token can be subdivided 10^9 times,
 /// thus creating a total of 1,288,490,189,000,000,000 available units.
-#[cfg(test)]
 pub(super) const GENESIS_DBC_AMOUNT: u64 = (0.3 * TOTAL_SUPPLY as f64) as u64;
 
 /// A specialised `Result` type for dbc_genesis crate.
-#[cfg(test)]
 pub(super) type GenesisResult<T> = Result<T, Error>;
 
 /// Total supply of tokens that will eventually exist in the network: 4,294,967,295 * 10^9 = 4,294,967,295,000,000,000.
-#[cfg(test)]
 const TOTAL_SUPPLY: u64 = u32::MAX as u64 * u64::pow(10, 9);
 
 /// The secret key for the genesis DBC.
@@ -37,7 +37,6 @@ const TOTAL_SUPPLY: u64 = u32::MAX as u64 * u64::pow(10, 9);
 /// This key is public for auditing purposes. Hard coding its value means all nodes will be able to
 /// validate it.
 const GENESIS_DBC_SK: &str = "5f15ae2ea589007e1474e049bbc32904d583265f12ce1f8153f955076a9af49b";
-const GENESIS_DBC_HEX: &str = "000000000000000049dff9aaca1dc4720c0b0d3311e95ca7cabf564d494c160573b2f3142d46fa25e9e34ca90982e4f35ad18fa8fc9126044deb21fb1ad88b77541e9c63b83fa932369f1a93f8139482b52f65dbb80c5c1c696cf30875bf3894022dd61ccdc1d88da83a50b3ce1f8fa29ba65c72b767f7b878055ee4ac31e78ca8188bb1f406557eb427816d5cdd023a0000000000000028aa8317bec2db715282ed641758a43cd899d6b144ea57670afaaa8b06058fadfd5d12ad5aef0c2da90fc8c4cab83796aaf7f940ce7b2c90b35fbc774c71724b4b507b6e6bba497f0e66cfb875e48f94df10669deae88277e3cb2e7e145fa38d10cc40a6a963885dcc465ef3ae33613aa31946b971990a8255ee9b7cef615d245df811781ddc2e69e1e05e1a39f6a2b0afeb6dcf823100d908ced0eef6dec65fd5838e55a169e5b721d5ea338a9c774a8b00000000000000201fd7137d18bc3d68dd74bf8b883288f9f69134af0f9a7678e89650f6eb0d00bcf1ee85af6b3aa34dc3abdf394e46eba02a4123be9e0b9cffe1f4cc94a849a72e866fdbee4f54ed6e390b7878bc32c9162a53cc700cc76f511553beb3e8a5548c18a465ddf34b54fa622d570c68df841d26d321c55313342ea9aeadffb01bd170061b9f3ef1247dc95939065a21bb13292ada858065e5f0136b2587206a1ea1e70ae9518be6ce63feffc2dc73a9a3dcca2c20e458708396b77610e843afbf370658a9265717eec815ec959c7f56d0a1af4ddbf7ae443576ef97165fdf3261f2c056d27fee3a97d486d276656fe3f7f7318089ca569fba710ac82e33ffcaeae4486605d1f70218a3c5b8f7807332e0855d7464f0014826d0e99760074844ddf19a0d7710553e8017dd706e272317ba8cda3eb5c07ec47d7a83914d8e643d02f648556a961eef4d03001b58b5fde1caca410ed780a6b0949d4edaace4f2ec336ec42f54c599e544b15d90eee64edbbc4099e1007b8a3be073eaba00a90bf614d63a4ec5817d88f1f96c0e1b0b557b180652b48a369a8734d35a8e88ad95d3abd6766de60217b7be22fd92b72aaec06c2a25a254ff6ef5673e96964d5221667f55f42e87900980a43ec4d757dd78a4c7af24309798b4a7ffa5ab66292082c58abf144d6319ceb1cf15d7110945e660734f4c9c14714a1356226fcde8c8c418546bca29696b815c3ef6ec1a41f52ecfa5df9ae36cda15ebc44b59381b01ff88ebe4b63f22ce019c4b7d7dcabe79a334aa8b17acce32a10a91202176d90d69184ea2d802a28417765a91ac60a05b68c8f37f3eb73695f9cd0c9d3add3e224e607c7ea60eb15a0f3b7b4576a27b7e166723e0daaf07f798977827bec92180dbf2a4f9f502f614797d1d817b9749dbb5bd5088aba720a3ce3fe985bcaab0834c859b2b02505d9876f1179619ec39edc8f48f6dadc66886e872b655a955ffebc6341ca394077aa28a6872b57bf154afa910ded2f1c2593765229ea01a60588ab939bf8adc14aac406df62a31a49f0356485340733422c1027ee253c52287267b361d040445a82e827d3d1082edac263c7034ca25481b162031b6bf6b4a1acdb84ed2108fe00000000000002a0e1efaa9f098cf6af927d2a03b6b6735e23725f60a6412123f4b7c08c42e8d8067a2e00fd8c3b3af67d2929e1f7c739a300000000000000010000000000000000e1efaa9f098cf6af927d2a03b6b6735e23725f60a6412123f4b7c08c42e8d8067a2e00fd8c3b3af67d2929e1f7c739a3";
 
 /// Main error type for the crate.
 #[derive(Error, Debug, Clone)]
@@ -54,9 +53,16 @@ lazy_static! {
     /// Load the genesis DBC.
     /// The genesis DBC is the first DBC in the network. It is created without
     /// a source transaction, as there was nothing before it.
-    pub static ref GENESIS_DBC: Dbc = match sn_dbc::Dbc::from_hex(GENESIS_DBC_HEX) {
-        Ok(dbc) => dbc,
-        Err(err) => panic!("Failed to read genesis DBC: {err:?}"),
+    pub static ref GENESIS_DBC: Dbc = {
+        let main_key = match SecretKey::from_hex(GENESIS_DBC_SK) {
+            Ok(sk) => MainKey::new(sk),
+            Err(err) => panic!("Failed to parse hard-coded genesis DBC SK: {err:?}"),
+        };
+
+        match create_first_dbc_from_key(&main_key) {
+            Ok(dbc) => dbc,
+            Err(err) => panic!("Failed to create genesis DBC: {err:?}"),
+        }
     };
 }
 
@@ -105,7 +111,6 @@ async fn create_genesis_wallet() -> LocalWallet {
 /// Create a first DBC given any key (i.e. not specifically the hard coded genesis key).
 /// The derivation index and blinding factor are hard coded to ensure deterministic creation.
 /// This is useful in tests.
-#[cfg(test)]
 pub(crate) fn create_first_dbc_from_key(first_dbc_key: &MainKey) -> GenesisResult<Dbc> {
     let public_address = first_dbc_key.public_address();
     let derivation_index = [0u8; 32];

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -123,10 +123,7 @@ pub(crate) fn create_first_dbc_from_key(first_dbc_key: &MainKey) -> GenesisResul
     // The src tx is empty as this is the first DBC.
     let genesis_input = InputHistory {
         input: RevealedInput::new(derived_key, revealed_amount),
-        input_src_tx: DbcTransaction {
-            inputs: vec![],
-            outputs: vec![],
-        },
+        input_src_tx: DbcTransaction::empty(),
     };
 
     let reason = Hash::hash(b"GENESIS");

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -17,9 +17,9 @@ pub enum Error {
     /// Failed to create transfer.
     #[error("Transfer error {0}")]
     CreateTransfer(#[from] crate::client_transfers::Error),
-    /// Could not build storage payment reason for content
-    #[error("Could not build storage payment reason for content: {0}")]
-    StoragePaymentReason(#[from] crate::payment_proof::error::Error),
+    /// Could not build storage payment proof for content
+    #[error("Could not build storage payment proof for content: {0}")]
+    StoragePaymentProof(#[from] crate::payment_proof::error::Error),
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -14,7 +14,6 @@ use super::{
     KeyLessWallet, Result,
 };
 use crate::client_transfers::{create_storage_payment_transfer, create_transfer, TransferOutputs};
-
 use sn_dbc::{Dbc, DbcIdSource, DerivedKey, Hash, MainKey, PublicAddress, Token};
 
 use std::{
@@ -196,16 +195,18 @@ impl LocalWallet {
     pub async fn local_send_storage_payment(
         &mut self,
         storage_cost: Token,
-        reason_hash: Hash,
+        root_hash: Hash,
+        reason_hash: Option<Hash>,
     ) -> Result<TransferOutputs> {
         let available_dbcs = self.available_dbcs();
         trace!("Available DBCs: {:#?}", available_dbcs);
 
         let transfer = create_storage_payment_transfer(
             available_dbcs,
-            storage_cost,
             self.address(),
-            reason_hash,
+            storage_cost,
+            root_hash,
+            reason_hash.unwrap_or_default(),
         )?;
 
         self.update_local_wallet(&transfer);

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -464,11 +464,8 @@ mod tests {
         assert_eq!(GENESIS_DBC_AMOUNT - send_amount, sender.balance().as_nano());
 
         let recipient_dbc = &created_dbcs[0];
-        assert_eq!(Token::from_nano(send_amount), recipient_dbc.amount);
-        assert_eq!(
-            &recipient_public_address,
-            recipient_dbc.dbc.public_address()
-        );
+        assert_eq!(Token::from_nano(send_amount), recipient_dbc.token()?);
+        assert_eq!(&recipient_public_address, recipient_dbc.public_address());
 
         Ok(())
     }
@@ -525,8 +522,8 @@ mod tests {
 
         let a_created_for_others = &sender.wallet.dbcs_created_for_others[0];
         let b_created_for_others = &deserialized.wallet.dbcs_created_for_others[0];
-        assert_eq!(a_created_for_others.dbc, b_created_for_others.dbc);
-        assert_eq!(a_created_for_others.amount, b_created_for_others.amount);
+        assert_eq!(a_created_for_others, b_created_for_others);
+        assert_eq!(a_created_for_others.token()?, b_created_for_others.token()?);
 
         let a_spent = sender
             .wallet
@@ -566,7 +563,7 @@ mod tests {
         let to = vec![(Token::from_nano(send_amount), recipient_public_address)];
         let transfer = sender.local_send(to, None).await?;
         let created_dbcs = transfer.created_dbcs;
-        let dbc = created_dbcs[0].dbc.clone();
+        let dbc = created_dbcs[0].clone();
         let dbc_id = dbc.id();
         sender.store_created_dbc(dbc).await?;
 

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -63,8 +63,6 @@ pub use self::{
     local_store::LocalWallet,
 };
 
-use super::client_transfers::CreatedDbc;
-
 use sn_dbc::{Dbc, DbcId, PublicAddress, Token};
 
 use std::collections::BTreeMap;
@@ -83,7 +81,7 @@ pub(super) struct KeyLessWallet {
     /// They are not owned by us, but we
     /// keep them here so we can track our
     /// transfer history.
-    dbcs_created_for_others: Vec<CreatedDbc>,
+    dbcs_created_for_others: Vec<Dbc>,
 }
 
 /// Return the name of a PublicAddress.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 20:52 UTC
This pull request adds the ability to send storage cost payments to a special network-owned output. It introduces a new function called `local_send_storage_payment` to support this functionality, which creates a new network-owned DBC and associated outputs with a `Hash` derived from the `reason_hash` and the set of input dbcs to spend using SHA-3.
<!-- reviewpad:summarize:end --> 
