### PR TITLE
feat: provide option for log output in json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,6 +5445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5454,12 +5464,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -35,7 +35,8 @@ async fn main() -> Result<()> {
         ("sn_client".to_string(), Level::INFO),
         ("sn_networking".to_string(), Level::INFO),
     ];
-    let log_appender_guard = init_logging(logging_targets, &Some(tmp_dir.join("safe-client")))?;
+    let log_appender_guard =
+        init_logging(logging_targets, &Some(tmp_dir.join("safe-client")), false)?;
     #[cfg(feature = "metrics")]
     tokio::spawn(init_metrics(std::process::id()));
 

--- a/sn_logging/Cargo.toml
+++ b/sn_logging/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "~0.1.26" }
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
 tracing-opentelemetry = { version = "0.17", optional = true }
-tracing-subscriber = { version = "0.3.16" }
+tracing-subscriber = { version = "0.3.16", features=["json"] }
 
 [features]
 otlp = [

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard = init_logging(logging_targets, &None)?;
+    let _log_appender_guard = init_logging(logging_targets, &None, false)?;
 
     let opt = Opt::parse();
     let addr = opt.addr;

--- a/sn_node/src/bin/faucet.rs
+++ b/sn_node/src/bin/faucet.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard = init_logging(logging_targets, &None)?;
+    let _log_appender_guard = init_logging(logging_targets, &None, false)?;
 
     let opt = Opt::parse();
 

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -80,6 +80,12 @@ struct Opt {
     /// When this flag is set, we will not filter out local addresses that we observe.
     #[clap(long)]
     local: bool,
+
+    /// Use JSON for logging output.
+    ///
+    /// Only applies when --log-dir is also set to output logs to file.
+    #[clap(long)]
+    json_log_output: bool,
 }
 
 #[derive(Debug)]
@@ -103,12 +109,13 @@ fn main() -> Result<()> {
         ("sn_node".to_string(), Level::INFO),
     ];
     #[cfg(not(feature = "otlp"))]
-    let _log_appender_guard = init_logging(logging_targets, &opt.log_dir)?;
+    let _log_appender_guard = init_logging(logging_targets, &opt.log_dir, opt.json_log_output)?;
     #[cfg(feature = "otlp")]
     let (_rt, _log_appender_guard) = {
         // init logging in a separate runtime if we are sending traces to an opentelemetry server
         let rt = Runtime::new()?;
-        let guard = rt.block_on(async { init_logging(logging_targets, &opt.log_dir) })?;
+        let guard = rt
+            .block_on(async { init_logging(logging_targets, &opt.log_dir, opt.json_log_output) })?;
         (rt, guard)
     };
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -109,7 +109,8 @@ async fn data_availability_during_churn() -> Result<()> {
         ("sn_networking".to_string(), Level::TRACE),
         ("sn_node".to_string(), Level::TRACE),
     ];
-    let log_appender_guard = init_logging(logging_targets, &Some(tmp_dir.join("safe-client")))?;
+    let log_appender_guard =
+        init_logging(logging_targets, &Some(tmp_dir.join("safe-client")), false)?;
 
     println!("Creating a client...");
     let client = get_client().await;

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -43,7 +43,7 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None)?;
+    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None, false)?;
 
     let first_wallet_dir = TempDir::new()?;
     let first_wallet_balance = Token::from_nano(1_000_000_000);
@@ -96,7 +96,7 @@ async fn double_spend_transfers_fail() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None)?;
+    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None, false)?;
 
     // create 1 wallet add money from faucet
     let first_wallet_dir = TempDir::new()?;
@@ -173,7 +173,7 @@ async fn storage_payment_succeeds() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None)?;
+    let _log_appender_guard = sn_logging::init_logging(logging_targets, &None, false)?;
 
     let paying_wallet_dir = TempDir::new()?;
     let paying_wallet_balance = Token::from_nano(500_000);


### PR DESCRIPTION
Some users who had been interacting with the InstallNet testnet requested output in this form. It doesn't give us any more elaborate data, like say what comes from an Open Telemetry trace, but might function as a starting point.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 22:31 UTC
This pull request adds an option for log output in JSON. This new feature has been requested by some users interacting with the InstallNet testnet and it might function as a starting point but does not provide elaborate data like Open Telemetry trace.
<!-- reviewpad:summarize:end --> 
