### PR TITLE
feat(node): expose log markers in public api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "sn_protocol",
  "sn_registers",
  "sn_transfers",
+ "strum",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4927,6 +4928,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.16",
+]
 
 [[package]]
 name = "stun"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -67,6 +67,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 walkdir = "2.3.1"
 xor_name = "5.0.0"
 tracing-log = { version = "0.1.3", features = ["env_logger"] }
+strum = { version = "0.25.0", features = ["derive"] }
 
 [dev-dependencies]
 assert_fs = "1.0.0"

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -14,7 +14,7 @@ mod rpc;
 use sn_logging::init_logging;
 #[cfg(feature = "metrics")]
 use sn_logging::metrics::init_metrics;
-use sn_node::{Node, NodeEvent, NodeEventsReceiver};
+use sn_node::{Marker, Node, NodeEvent, NodeEventsReceiver};
 use sn_peers_acquisition::PeersArgs;
 
 use clap::Parser;
@@ -235,7 +235,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
     let _handle = tokio::spawn(async move {
         loop {
             match node_events_rx.recv().await {
-                Ok(NodeEvent::ConnectedToNetwork) => info!("Connected to the Network"),
+                Ok(NodeEvent::ConnectedToNetwork) => Marker::NodeConnectedToNetwork.log(),
                 Ok(NodeEvent::ChannelClosed) | Err(RecvError::Closed) => {
                     if let Err(err) = ctrl_tx
                         .send(NodeCtrl::Stop {

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -47,6 +47,7 @@ mod api;
 mod error;
 mod event;
 mod get_validation;
+mod log_markers;
 mod put_validation;
 mod replication;
 mod spends;
@@ -54,6 +55,7 @@ mod spends;
 pub use self::{
     api::RunningNode,
     event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
+    log_markers::Marker,
 };
 
 use libp2p::{Multiaddr, PeerId};

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::PeerId;
+use sn_protocol::messages::{Cmd, CmdResponse};
+use std::time::Duration;
+// this gets us to_string easily enough
+use strum::Display;
+
+/// Public Markers for generating log output,
+/// These generate apprioriate log level output and consistent strings.
+/// Changing these log markers is a breaking change.
+#[derive(Debug, Clone, Display)]
+pub enum Marker<'a> {
+    /// The node has started
+    NodeConnectedToNetwork,
+
+    /// No network activity in some time
+    NoNetworkActivity(Duration),
+
+    /// Network Cmd message received
+    NodeCmdReceived(&'a Cmd),
+
+    /// Network Cmd message response was generated
+    NodeCmdResponded(&'a CmdResponse),
+
+    /// Peer was added to the routing table
+    PeerAddedToRoutingTable(PeerId),
+}
+
+impl<'a> Marker<'a> {
+    /// Returns the string representation of the LogMarker.
+    pub fn log(&self) {
+        // Down the line, if some logs are noisier than others, we can
+        // match the type and log a different level.
+        info!("{self:?}");
+    }
+}


### PR DESCRIPTION
Start using them for some more crucial log messages, which we'll treat as an API and have to version accordingly.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 01:58 UTC
This pull request adds log markers to the public API, which are used for more crucial log messages. These log markers will be treated as an API and versioned accordingly.
<!-- reviewpad:summarize:end --> 
