### PR TITLE
chore(client): initial refactor around uploads

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -91,7 +91,7 @@ impl Files {
     /// Directly writes [`Bytes`] to the network in the
     /// form of immutable chunks, without any batching.
     #[instrument(skip(self, bytes), level = "debug")]
-    pub async fn upload(
+    pub async fn upload_with_proof(
         &self,
         bytes: Bytes,
         payment_proofs: &PaymentProofsMap,

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -268,7 +268,10 @@ fn store_chunks_task(client: Client, content: ContentList, churn_period: Duratio
             println!("Storing Chunk at {addr:?} in {delay:?}");
             sleep(delay).await;
 
-            match file_api.upload(bytes, &BTreeMap::default()).await {
+            match file_api
+                .upload_with_proof(bytes, &BTreeMap::default())
+                .await
+            {
                 Ok(_) => content
                     .write()
                     .await


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 02:50 UTC
This pull request refactors client for uploads - it moves the logic of uploading one file into a separate function, introduces a map for payment proofs, and replaces the upload method with a new method that also takes payment proofs.
<!-- reviewpad:summarize:end --> 
