### PR TITLE
chore(network): remove `NetworkEvent::PutRecord` dead code

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -185,8 +185,6 @@ impl Client {
             NetworkEvent::RequestReceived { .. } => {}
             // Clients do not handle responses
             NetworkEvent::ResponseReceived { .. } => {}
-            // Clients do not store Records
-            NetworkEvent::PutRequest { .. } => {}
             // We do not listen on sockets.
             NetworkEvent::NewListenAddr(_) => {}
             // We are not doing AutoNAT and don't care about our status.

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -147,12 +147,6 @@ impl Node {
                     }
                 });
             }
-            NetworkEvent::PutRequest { peer, record } => {
-                debug!("Got a Record PutRequest from {peer:?}");
-                if let Err(err) = self.validate_and_store_record(record).await {
-                    error!("Error while validating PutRequest {err:?}");
-                }
-            }
             NetworkEvent::PeerAdded(peer_id) => {
                 debug!("PeerAdded: {peer_id}");
                 // perform a get_closest query to self on node join. This should help populate the node's RT


### PR DESCRIPTION
- Since we do not use `kad.put_record` or `kad's replication flow`, we should not get any inbound `PutRecord` from the swarm.
