### PR TITLE
feat: use standarised directories for files/wallet commands

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     println!("Instantiating a SAFE client...");
 
     let secret_key = bls::SecretKey::random();
-    let root_dir = get_client_dir().await?;
+    let client_data_dir_path = get_client_data_dir_path().await?;
 
     if opt.peers.peers.is_empty() {
         if !cfg!(feature = "local-discovery") {
@@ -61,8 +61,8 @@ async fn main() -> Result<()> {
     let client = Client::new(secret_key, Some(opt.peers.peers), opt.timeout).await?;
 
     match opt.cmd {
-        SubCmd::Wallet(cmds) => wallet_cmds(cmds, &client, &root_dir).await?,
-        SubCmd::Files(cmds) => files_cmds(cmds, client.clone(), &root_dir).await?,
+        SubCmd::Wallet(cmds) => wallet_cmds(cmds, &client, &client_data_dir_path).await?,
+        SubCmd::Files(cmds) => files_cmds(cmds, client.clone(), &client_data_dir_path).await?,
         SubCmd::Register(cmds) => register_cmds(cmds, &client).await?,
     };
 
@@ -70,9 +70,9 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn get_client_dir() -> Result<PathBuf> {
-    let mut home_dirs = dirs_next::home_dir().expect("A homedir to exist.");
-    home_dirs.push(".safe");
+async fn get_client_data_dir_path() -> Result<PathBuf> {
+    let mut home_dirs = dirs_next::data_dir().expect("Data directory is obtainable");
+    home_dirs.push("safe");
     home_dirs.push("client");
     tokio::fs::create_dir_all(home_dirs.as_path()).await?;
     Ok(home_dirs)

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -24,29 +24,35 @@ use walkdir::WalkDir;
 // They are used for inserting line breaks when the help menu is rendered in the UI.
 #[derive(Parser, Debug)]
 pub enum WalletCmds {
-    /// Print the address of the wallet.
+    /// Print the wallet address.
     Address,
-    /// Print the balance of the wallet.
+    /// Print the wallet balance.
     Balance,
-    /// Deposit DBCs to the local wallet.
+    /// Deposit DBCs from the received directory to the local wallet.
     ///
-    /// Tries to load DBCs from the received DBCs path in the wallet directory and deposit them to
-    /// the wallet.
+    /// The default received directory is platform specific:
+    ///  - Linux: $HOME/.local/share/safe/wallet/received_dbcs
+    ///  - macOS: $HOME/Library/Application Support/safe/wallet/received_dbcs
+    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\wallet\received_dbcs
     ///
-    /// Received DBCs must be placed in this directory manually.
+    /// If you find the default path unwieldy, you can also set the RECEIVED_DBCS_PATH environment
+    /// variable to a path you would prefer to work with.
+    #[clap(verbatim_doc_comment)]
     Deposit,
+    /// Send a DBC.
     Send {
         /// The number of nanos to send.
-        ///
-        /// Necessary if the `to` argument is used.
         #[clap(name = "amount")]
         amount: String,
-        /// The hex-encoded public address for the recipient of the DBC.
+        /// Hex-encoded public address of the recipient.
         #[clap(name = "to")]
         to: String,
     },
+    /// Make a payment for chunk storage based on files to be stored.
+    ///
+    /// Right now this command is highly experimental and doesn't really do anything functional.
     Pay {
-        /// The location of the files to pay the storage for.
+        /// Location of the files to be stored.
         #[clap(name = "path", value_name = "DIRECTORY")]
         path: PathBuf,
     },

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -13,7 +13,7 @@ use super::{
 
 use sn_dbc::Dbc;
 use sn_protocol::storage::DbcAddress;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 // Filename for storing a wallet.
@@ -73,10 +73,12 @@ pub(super) async fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path
 
 /// Loads all the dbcs found in the received dbcs dir.
 pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
-    // The new dbcs dir within the wallet dir.
-    let received_dbcs_path = wallet_dir.join(RECEIVED_DBCS_DIR_NAME);
-    let mut deposits = vec![];
+    let received_dbcs_path = match std::env::var("RECEIVED_DBCS_PATH") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => wallet_dir.join(RECEIVED_DBCS_DIR_NAME),
+    };
 
+    let mut deposits = vec![];
     for entry in walkdir::WalkDir::new(received_dbcs_path)
         .into_iter()
         .flatten()


### PR DESCRIPTION
BREAKING CHANGE: use `~/.local/share/safe/wallet` as the root directory for wallet storage and `~/.local/share/safe/client` for files related to downloads/uploads.

The previous directories were `~/.safe/wallet` and `~/.safe/client`, which we can phase out in preference of using directories in the XDG standard.

Usage of a `RECEIVED_DBCS_PATH` environment variable was added for users who may feel the default directory a bit unwieldy for working with the `wallet deposit` command, especially on Windows, where the `AppData` directory is marked as hidden and so will only be shown by Windows Explorer if users have viewing hidden files enabled.

Also provided and/or clarified documentation for other commands.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 21:03 UTC
This pull request introduces standardized directories in Safe and changes the root directories for wallet storage and client files to comply with the XDG standard. The default directories for storing received DBCs have also been changed to be platform-specific and `RECEIVED_DBCS_PATH` environment variable has been added for users who find the default directory unwieldy. Additionally, some documentation for the wallet subcommand has been provided and clarified.
<!-- reviewpad:summarize:end --> 
