### PR TITLE
feat(node): only add to routing table after Identify success

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -135,6 +135,7 @@ impl SwarmDriver {
 
         let mut kad_cfg = KademliaConfig::default();
         let _ = kad_cfg
+            .set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::Manual)
             // how often a node will replicate records that it has stored, aka copying the key-value pair to other nodes
             // this is a heavier operation than publication, so it is done less frequently
             // Set to `None` to ensure periodic replication disabled.


### PR DESCRIPTION
KademliaBucketInserts::Manual

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Jun 23 08:42 UTC
This pull request adds a new feature to the node such that data is only added to the routing table after a successful Identify. It also modifies KademliaBucketInserts::Manual in the lib.rs file.
<!-- reviewpad:summarize:end --> 
