### PR TITLE
Dialing without peer ID

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -100,7 +100,6 @@ pub struct SwarmDriver {
     swarm: Swarm<NodeBehaviour>,
     cmd_receiver: mpsc::Receiver<SwarmCmd>,
     event_sender: mpsc::Sender<NetworkEvent>,
-    pending_dial: HashMap<PeerId, oneshot::Sender<Result<()>>>,
     pending_get_closest_peers: PendingGetClosest,
     pending_requests: HashMap<RequestId, Option<oneshot::Sender<Result<Response>>>>,
     pending_query: HashMap<QueryId, oneshot::Sender<Result<Record>>>,
@@ -356,7 +355,6 @@ impl SwarmDriver {
             swarm,
             cmd_receiver: swarm_cmd_receiver,
             event_sender: network_event_sender,
-            pending_dial: Default::default(),
             pending_get_closest_peers: Default::default(),
             pending_requests: Default::default(),
             pending_query: Default::default(),
@@ -467,14 +465,9 @@ impl Network {
     }
 
     /// Dial the given peer at the given address.
-    pub async fn dial(&self, peer_id: PeerId, peer_addr: Multiaddr) -> Result<()> {
+    pub async fn dial(&self, addr: Multiaddr) -> Result<()> {
         let (sender, receiver) = oneshot::channel();
-        self.send_swarm_cmd(SwarmCmd::Dial {
-            peer_id,
-            peer_addr,
-            sender,
-        })
-        .await?;
+        self.send_swarm_cmd(SwarmCmd::Dial { addr, sender }).await?;
         receiver.await?
     }
 
@@ -824,8 +817,22 @@ pub fn multiaddr_is_global(multiaddr: &Multiaddr) -> bool {
     })
 }
 
-// Strip out the p2p protocol from a multiaddr.
-pub fn multiaddr_strip_p2p(multiaddr: &Multiaddr) -> Multiaddr {
+/// Pop off the `/p2p/<peer_id>`. This mutates the `Multiaddr` and returns the `PeerId` if it exists.
+pub(crate) fn multiaddr_pop_p2p(multiaddr: &mut Multiaddr) -> Option<PeerId> {
+    let id = match multiaddr.iter().last() {
+        Some(Protocol::P2p(hash)) => PeerId::from_multihash(hash).ok(),
+        _ => None,
+    };
+
+    // Mutate the `Multiaddr` to remove the `/p2p/<peer_id>`.
+    if id.is_some() {
+        let _ = multiaddr.pop();
+    }
+
+    id
+}
+/// Build a `Multiaddr` with the p2p protocol filtered out.
+pub(crate) fn multiaddr_strip_p2p(multiaddr: &Multiaddr) -> Multiaddr {
     multiaddr
         .iter()
         .filter(|p| !matches!(p, Protocol::P2p(_)))

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
-clap = { version = "4.2.1", features = ["derive"]}
+clap = { version = "4.2.1", features = ["derive"] }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 chrono = "~0.4.19"
 custom_debug = "~0.5.0"

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -9,9 +9,7 @@
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
 use libp2p::{autonat::NatStatus, identity::Keypair, kad::RecordKey, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use sn_networking::{
-    multiaddr_strip_p2p, MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState,
-};
+use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::{
@@ -65,7 +63,7 @@ impl Node {
     pub async fn run(
         keypair: Option<Keypair>,
         addr: SocketAddr,
-        initial_peers: Vec<(PeerId, Multiaddr)>,
+        initial_peers: Vec<Multiaddr>,
         local: bool,
         root_dir: &Path,
     ) -> Result<RunningNode> {
@@ -190,11 +188,9 @@ impl Node {
                     let network = self.network.clone();
                     let peers = self.initial_peers.clone();
                     let _handle = spawn(async move {
-                        for (peer_id, addr) in &peers {
-                            // The addresses passed might contain the peer_id, which we already pass separately.
-                            let addr = multiaddr_strip_p2p(addr);
-                            if let Err(err) = network.dial(*peer_id, addr.clone()).await {
-                                tracing::error!("Failed to dial {peer_id}: {err:?}");
+                        for addr in &peers {
+                            if let Err(err) = network.dial(addr.clone()).await {
+                                tracing::error!("Failed to dial {addr}: {err:?}");
                             };
                         }
                     });

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -19,7 +19,7 @@ use sn_peers_acquisition::PeersArgs;
 
 use clap::Parser;
 use eyre::{eyre, Error, Result};
-use libp2p::{Multiaddr, PeerId};
+use libp2p::Multiaddr;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
@@ -167,7 +167,7 @@ fn main() -> Result<()> {
 
 async fn start_node(
     node_socket_addr: SocketAddr,
-    peers: Vec<(PeerId, Multiaddr)>,
+    peers: Vec<Multiaddr>,
     rpc: Option<SocketAddr>,
     local: bool,
     log_dir: &str,

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -58,7 +58,7 @@ pub use self::{
     log_markers::Marker,
 };
 
-use libp2p::{Multiaddr, PeerId};
+use libp2p::Multiaddr;
 use sn_networking::Network;
 use sn_registers::RegisterStorage;
 
@@ -71,5 +71,5 @@ pub struct Node {
     registers: RegisterStorage,
     events_channel: NodeEventsChannel,
     /// Peers that are dialed at startup of node.
-    initial_peers: Vec<(PeerId, Multiaddr)>,
+    initial_peers: Vec<Multiaddr>,
 }


### PR DESCRIPTION
This allows us to pass `--peer=1.2.3.4:1234` instead of a multiaddr containing the peer ID.

This changes the bootstrapping somewhat and the API surrounding how we dial to accomodate for passing a multiaddr without peer ID.
