### PR TITLE
feat(node): write secret key to disk and re-use

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -79,9 +79,6 @@ pub enum Error {
     #[error("Record was not found locally")]
     RecordNotFound,
 
-    #[error("Could not configure root directory: {0}")]
-    RootDirConfigError(String),
-
     #[error("No SwarmCmd channel capacity")]
     NoSwarmCmdChannelCapacity,
 }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -72,11 +72,11 @@ impl Node {
     ///
     /// Returns an error if there is a problem initializing the `SwarmDriver`.
     pub async fn run(
-        keypair: Option<Keypair>,
+        keypair: Keypair,
         addr: SocketAddr,
         initial_peers: Vec<Multiaddr>,
         local: bool,
-        root_dir: Option<PathBuf>,
+        root_dir: PathBuf,
     ) -> Result<RunningNode> {
         let (network, mut network_event_receiver, swarm_driver) =
             SwarmDriver::new(keypair, addr, local, root_dir)?;


### PR DESCRIPTION
If no `secret-key` file exists, a key is generated and written to that file. If it exists, we read the key from the file and use that. An option is added to the command-line to force a new key to be generated, even if the file exists.
