### PR TITLE
chore(networking): reduce some log levels to make 'info' more useful

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -225,7 +225,7 @@ impl SwarmDriver {
                     }
                 }
                 mdns::Event::Expired(peer) => {
-                    info!("mdns peer {peer:?} expired");
+                    debug!("mdns peer {peer:?} expired");
                 }
             },
             SwarmEvent::NewListenAddr { address, .. } => {
@@ -241,7 +241,7 @@ impl SwarmDriver {
                 peer_id, endpoint, ..
             } => {
                 if endpoint.is_dialer() {
-                    info!("Connected with {peer_id:?}");
+                    debug!("Connected with {peer_id:?}");
 
                     self.dialed_peers.push(peer_id);
 
@@ -256,7 +256,7 @@ impl SwarmDriver {
                 cause,
                 num_established,
             } => {
-                info!("Connection closed to Peer {peer_id}({num_established:?}) - {endpoint:?} - {cause:?}");
+                debug!("Connection closed to Peer {peer_id}({num_established:?}) - {endpoint:?} - {cause:?}");
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 trace!("OutgoingConnectionError to {peer_id:?} - {error:?}");
@@ -287,7 +287,7 @@ impl SwarmDriver {
                     if let Some(sender) = self.pending_dial.remove(&peer_id) {
                         let _ = sender.send(Err(error.into()));
                     } else {
-                        info!("OutgoingConnectionError is due to non pending_dial to {peer_id}");
+                        debug!("OutgoingConnectionError is due to non pending_dial to {peer_id}");
                     }
                 }
             }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -524,7 +524,7 @@ impl Network {
     /// forwarded to itself. Hence the flow remains the same and there is no branching at the upper
     /// layers.
     pub async fn node_send_to_closest(&self, request: &Request) -> Result<Vec<Result<Response>>> {
-        info!(
+        debug!(
             "Sending {request:?} with dst {:?} to the closest peers.",
             request.dst()
         );
@@ -541,7 +541,7 @@ impl Network {
     /// forwarded to itself. Hence the flow remains the same and there is no branching at the upper
     /// layers.
     pub async fn send_req_no_reply_to_closest(&self, request: &Request) -> Result<()> {
-        info!(
+        debug!(
             "Sending {request:?} with dst {:?} to the closest peers.",
             request.dst()
         );
@@ -554,7 +554,7 @@ impl Network {
 
     /// Send `Request` to the closest peers to self
     pub async fn send_req_no_reply_to_self_closest(&self, request: &Request) -> Result<()> {
-        info!("Sending {request:?} to self closest peers.");
+        debug!("Sending {request:?} to self closest peers.");
         // Using `client_get_closest_peers` to filter self out.
         let closest_peers = self.client_get_closest_peers(&request.dst()).await?;
         for peer in closest_peers {
@@ -569,7 +569,7 @@ impl Network {
         request: &Request,
         expect_all_responses: bool,
     ) -> Result<Vec<Result<Response>>> {
-        info!(
+        debug!(
             "Sending {request:?} with dst {:?} to the closest peers.",
             request.dst()
         );
@@ -898,7 +898,7 @@ mod tests {
                 let res = res
                     .remove(0)
                     .expect("There should be at least one response!");
-                info!("Got response {:?}", res);
+                debug!("Got response {:?}", res);
                 assert_matches!(
                     res,
                     Response::Cmd(CmdResponse::StoreChunk(Ok(CmdOk::StoredSuccessfully)))


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Jun 23 00:55 UTC
This pull request reduces some log levels in the networking module to make 'info' level logging more useful. The patch specifically modifies the log level of various messages to 'debug' level, including log messages related to mdns peer expiration and connection establishment, and also log messages related to outgoing connection errors.
<!-- reviewpad:summarize:end --> 
