### PR TITLE
feat: replicate to lost record peer; client upload chunk to chunk's closest; forwarding chunk

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -297,12 +297,9 @@ impl Client {
         Err(Error::UnexpectedResponses)
     }
 
-    /// Return the closest_peers to self, fetched from local.
-    pub(super) async fn get_closest_local_peers(&self) -> Result<Vec<PeerId>> {
-        Ok(self
-            .network
-            .get_closest_local_peers(&NetworkAddress::from_peer(self.network.peer_id))
-            .await?)
+    /// Return all the peers from the local network knowledge.
+    pub(super) async fn get_all_local_peers(&self) -> Result<Vec<PeerId>> {
+        Ok(self.network.get_all_local_peers().await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -302,6 +302,14 @@ impl Client {
         Ok(self.network.get_all_local_peers().await?)
     }
 
+    /// Returns the closest peers to the given `NetworkAddress`
+    /// that is fetched from the local Routing Table.
+    /// It is ordered by increasing distance of the peers.
+    /// Note self peer_id is not included in the result.
+    pub async fn get_closest_local_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
+        Ok(self.network.get_closest_local_peers(key).await?)
+    }
+
     /// Retrieve a `Chunk` from the kad network.
     pub(super) async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
         info!("Getting chunk: {address:?}");

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -218,7 +218,7 @@ impl Client {
                 }
                 self.peers_added += 1;
             }
-            NetworkEvent::PeerRemoved(_) => {}
+            NetworkEvent::PeerRemoved(_) | NetworkEvent::LostRecordDetected(_) => {}
         }
 
         Ok(())

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -169,9 +169,9 @@ impl Files {
         let payment = payment_proofs.get(&address.name().0).cloned();
         // TODO: re-enable requirement to always provide payment proof
         //.ok_or(super::Error::MissingPaymentProof(address))?;
-        let all_peers = self.client.get_all_local_peers().await?;
+
         let dst = NetworkAddress::from_chunk_address(address);
-        let closest_peers = sort_peers_by_address(all_peers, &dst, CLOSE_GROUP_SIZE)?;
+        let closest_peers = self.client.get_closest_local_peers(&dst).await?;
         self.client
             .store_chunk(chunk, payment, closest_peers)
             .await?;

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -335,6 +335,10 @@ impl Node {
                 match self.validate_and_store_chunk(chunk_with_payment).await {
                     Ok(cmd_ok) => {
                         self.events_channel.broadcast(NodeEvent::ChunkStored(addr));
+                        let mut stateless_node_copy = self.clone();
+                        let _handle = spawn(async move {
+                            stateless_node_copy.try_replicate_an_entry(addr).await;
+                        });
                         CmdResponse::StoreChunk(Ok(cmd_ok))
                     }
                     Err(err) => {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -8,10 +8,14 @@
 
 use crate::error::Result;
 use crate::Node;
-use libp2p::{kad::KBucketKey, PeerId};
+use libp2p::{
+    kad::{KBucketKey, RecordKey},
+    PeerId,
+};
 use sn_networking::{sort_peers_by_address, sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, Request},
+    storage::ChunkAddress,
     NetworkAddress,
 };
 use std::collections::{BTreeMap, HashSet};
@@ -25,6 +29,39 @@ const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 const REPLICATION_RANGE: usize = 8;
 
 impl Node {
+    /// In case self is not among the closest to the chunk,
+    /// replicate the chunk to its closest peers
+    pub(crate) async fn try_replicate_an_entry(&mut self, addr: ChunkAddress) {
+        let our_address = NetworkAddress::from_peer(self.network.peer_id);
+        // The address may need to be put into the `ReplicationList`,
+        // hence have to use the form deduced from `RecordKey`.
+        let chunk_address = NetworkAddress::from_record_key(RecordKey::new(addr.name()));
+        let close_peers =
+            if let Ok(peers) = self.network.get_closest_local_peers(&chunk_address).await {
+                peers
+            } else {
+                return;
+            };
+
+        // Only carry out replication when self is out of the closest range
+        match close_peers.get(CLOSE_GROUP_SIZE - 1) {
+            Some(peer) => {
+                if our_address.distance(&chunk_address)
+                    <= NetworkAddress::from_peer(*peer).distance(&chunk_address)
+                {
+                    return;
+                }
+            }
+            None => return,
+        };
+        trace!("Being out of closest range, replicating {addr:?} to {close_peers:?}");
+        for peer in close_peers.iter() {
+            let _ = self
+                .send_replicate_cmd_without_wait(&our_address, peer, vec![chunk_address.clone()])
+                .await;
+        }
+    }
+
     /// Replication is triggered when the newly added peer or the dead peer was among our closest.
     pub(crate) async fn try_trigger_replication(
         &mut self,
@@ -136,9 +173,7 @@ impl Node {
         }
 
         for (peer_id, keys) in replications {
-            let (left, mut remaining_keys) = keys.split_at(0);
-            trace!("Left len {:?}", left.len());
-            trace!("Remaining keys len {:?}", remaining_keys.len());
+            let (_left, mut remaining_keys) = keys.split_at(0);
             while remaining_keys.len() > MAX_REPLICATION_KEYS_PER_REQUEST {
                 let (left, right) = remaining_keys.split_at(MAX_REPLICATION_KEYS_PER_REQUEST);
                 remaining_keys = right;

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -32,10 +32,7 @@ impl Node {
         is_dead_peer: bool,
     ) -> Result<()> {
         let our_address = NetworkAddress::from_peer(self.network.peer_id);
-        trace!(
-            "Self peer id {:?} converted to {our_address:?}",
-            self.network.peer_id
-        );
+
         // Fetch from local shall be enough.
         let closest_peers = self.network.get_closest_local_peers(&our_address).await?;
         if !closest_peers.iter().any(|key| key == peer) {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Jun 23 08:23 UTC
This pull request contains two patches. The first one introduces a feature that allows tracking of lost records from peers. The second patch fixes the issue where client upload to peers was not always being sent to the closest peers to the chunk and instead defaulted to sending it to the closest peers to the node.
<!-- reviewpad:summarize:end --> 
