### PR TITLE
refactor: minor improvements to payment proof merkletree utils and adding proptests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,6 +4861,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "merkletree",
+ "proptest",
  "rand 0.8.5",
  "serde",
  "sn_dbc",

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -166,7 +166,7 @@ impl Files {
     ) -> Result<ChunkAddress> {
         let chunk = package_small(small)?;
         let address = *chunk.address();
-        let payment = payment_proofs.get(&address.name().0).cloned();
+        let payment = payment_proofs.get(address.name()).cloned();
         // TODO: re-enable requirement to always provide payment proof
         //.ok_or(super::Error::MissingPaymentProof(address))?;
 
@@ -204,7 +204,7 @@ impl Files {
                 let client = self.client.clone();
                 let all_peers_clone = all_peers.clone();
                 let chunk_addr = *chunk.address();
-                let payment = payment_proofs.get(&chunk_addr.name().0).cloned();
+                let payment = payment_proofs.get(chunk_addr.name()).cloned();
                 // TODO: re-enable requirement to always provide payment proof
                 //.ok_or(super::Error::MissingPaymentProof(chunk_addr))?;
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -9,7 +9,7 @@
 use super::Client;
 
 use sn_dbc::{Dbc, PublicAddress, Token};
-use sn_protocol::messages::{MerkleTreeNodesType, PaymentProof};
+use sn_protocol::messages::PaymentProof;
 use sn_transfers::{
     client_transfers::TransferOutputs,
     payment_proof::build_payment_proofs,
@@ -22,7 +22,7 @@ use std::{collections::BTreeMap, iter::Iterator};
 use xor_name::XorName;
 
 /// Map from content address name to its corresponding PaymentProof.
-pub type PaymentProofsMap = BTreeMap<MerkleTreeNodesType, PaymentProof>;
+pub type PaymentProofsMap = BTreeMap<XorName, PaymentProof>;
 
 /// A wallet client can be used to send and
 /// receive tokens to/from other wallets.

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -242,12 +242,11 @@ impl Node {
                     }
 
                     // check the reason hash verifies the merkle-tree audit trail and path against the content address name
-                    validate_payment_proof(addr_name, reason_hash, audit_trail, path).map_err(
-                        |err| ProtocolError::InvalidPaymentProof {
+                    let _ = validate_payment_proof(addr_name, reason_hash, audit_trail, path)
+                        .map_err(|err| ProtocolError::InvalidPaymentProof {
                             addr_name,
                             reason: err.to_string(),
-                        },
-                    )?
+                        })?;
                 }
             }
         }

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -32,5 +32,6 @@ walkdir = "2.3.1"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-eyre = "0.6.8"
 assert_fs = "1.0.0"
+eyre = "0.6.8"
+proptest = { version = "1.0.0" }

--- a/sn_transfers/src/payment_proof/error.rs
+++ b/sn_transfers/src/payment_proof/error.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use sn_dbc::Hash;
 use thiserror::Error;
 use xor_name::XorName;
 
@@ -31,6 +32,9 @@ pub enum Error {
     #[error("The leaf data for which proof was generated doesn't match the given item: {0:?}")]
     AuditTrailItemMismatch(XorName),
     /// The root data of the proof doesn't match the given hash
-    #[error("The root data of the proof doesn't match the given hash: {0}")]
-    RootHashMismatch(String),
+    #[error(
+        "The root data of the proof doesn't match the given hash: {}",
+        .0.to_hex()
+    )]
+    RootHashMismatch(Hash),
 }

--- a/sn_transfers/src/payment_proof/error.rs
+++ b/sn_transfers/src/payment_proof/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// The leaf data for which proof was generated doesn't match the given item
     #[error("The leaf data for which proof was generated doesn't match the given item: {0:?}")]
     AuditTrailItemMismatch(XorName),
-    /// The root data of the proof doesn't match the given reason hash
-    #[error("The root data of the proof doesn't match the given reason hash: {0}")]
-    ReasonHashMismatch(String),
+    /// The root data of the proof doesn't match the given hash
+    #[error("The root data of the proof doesn't match the given hash: {0}")]
+    RootHashMismatch(String),
 }

--- a/sn_transfers/src/payment_proof/mod.rs
+++ b/sn_transfers/src/payment_proof/mod.rs
@@ -74,8 +74,7 @@ use typenum::{UInt, UTerm, B0, B1};
 use xor_name::XorName;
 
 /// Map from content address name to its corresponding audit trail and trail path.
-pub type PaymentProofsTrailInfoMap =
-    BTreeMap<MerkleTreeNodesType, (Vec<MerkleTreeNodesType>, Vec<usize>)>;
+pub type PaymentProofsTrailInfoMap = BTreeMap<XorName, (Vec<MerkleTreeNodesType>, Vec<usize>)>;
 
 // We use a binary Merkle-tree to build payment proofs
 type BinaryMerkletreeProofType = Proof<MerkleTreeNodesType, UInt<UInt<UTerm, B1>, B0>>;
@@ -125,7 +124,10 @@ pub fn build_payment_proofs<'a>(
                 reason: err.to_string(),
             })?;
 
-        payment_proofs.insert(addr, (proof.lemma().to_vec(), proof.path().to_vec()));
+        payment_proofs.insert(
+            XorName(addr),
+            (proof.lemma().to_vec(), proof.path().to_vec()),
+        );
     }
 
     Ok((root_hash, payment_proofs))
@@ -253,17 +255,17 @@ mod tests {
         assert_eq!(payment_proofs.len(), addrs.len());
 
         assert!(
-            matches!(payment_proofs.get(&name0.0), Some((audit_trail, path)) if validate_payment_proof(name0, &root_hash, audit_trail, path).is_ok())
+            matches!(payment_proofs.get(&name0), Some((audit_trail, path)) if validate_payment_proof(name0, &root_hash, audit_trail, path).is_ok())
         );
         assert!(
-            matches!(payment_proofs.get(&name1.0), Some((audit_trail, path)) if validate_payment_proof(name1, &root_hash, audit_trail, path).is_ok())
+            matches!(payment_proofs.get(&name1), Some((audit_trail, path)) if validate_payment_proof(name1, &root_hash, audit_trail, path).is_ok())
         );
         assert!(
-            matches!(payment_proofs.get(&name2.0), Some(( audit_trail, path)) if validate_payment_proof(name2, &root_hash, audit_trail, path).is_ok())
+            matches!(payment_proofs.get(&name2), Some(( audit_trail, path)) if validate_payment_proof(name2, &root_hash, audit_trail, path).is_ok())
         );
 
         let (audit_trail, path) = payment_proofs
-            .get(&name2.0)
+            .get(&name2)
             .cloned()
             .ok_or_else(|| eyre!("Failed to obtain valid payment proof"))?;
         let invalid_name = XorName([99; 32]);

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -79,7 +79,7 @@ pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
     };
 
     let mut deposits = vec![];
-    for entry in walkdir::WalkDir::new(received_dbcs_path)
+    for entry in walkdir::WalkDir::new(&received_dbcs_path)
         .into_iter()
         .flatten()
     {
@@ -104,7 +104,7 @@ pub(super) async fn load_received_dbcs(wallet_dir: &Path) -> Result<Vec<Dbc>> {
     }
 
     if deposits.is_empty() {
-        println!("No deposits found.");
+        println!("No deposits found at {}.", received_dbcs_path.display());
     }
 
     Ok(deposits)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Jun 23 15:36 UTC
This pull request includes changes to multiple files. In summary, it adds the `proptest` crate as a dev dependency, changes dependencies order, modifies error messages in some functions, and updates the implementation of payment proofs in Rust. Specifically, it replaces a Merkle tree node type, changes an import statement, modifies a `println!` statement, changes a case in the `Error` enum, and updates two functions involved in payment proofs (`build_payment_proofs` and `validate_payment_proof`).
<!-- reviewpad:summarize:end --> 
