### PR TITLE
feat(node): add handle for Cmd::Response(Ok)

### DIFF
--- a/sn_logging/src/metrics.rs
+++ b/sn_logging/src/metrics.rs
@@ -130,7 +130,7 @@ pub async fn init_metrics(pid: u32) {
             process,
         };
         match serde_json::to_string(&metrics) {
-            Ok(metrics) => debug!("PID: {} {metrics}, ", std::process::id()),
+            Ok(metrics) => debug!("{metrics}"),
             Err(err) => error!("Metrics error, could not serialize to JSON {err}"),
         }
 

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -274,6 +274,11 @@ impl Node {
                     warn!("Cannot parse PeerId from {holder:?}");
                 }
             }
+            Response::Cmd(CmdResponse::Replicate(Ok(()))) => {
+                // Nothing to do, response was fine
+                // This only exists to ensure we dont drop the handle and
+                // exit early, potentially logging false connection woes
+            }
             other => {
                 error!("handle_response not implemented for {other:?}");
                 return Ok(());


### PR DESCRIPTION
This should stop a lot of pointless logging around the response there

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jun 23 03:14 UTC
This pull request adds a handle for Cmd::Response(Ok), which should stop pointless logging around the response.
<!-- reviewpad:summarize:end --> 
