### PR TITLE
fix: replicate data only to nodes in the close group

### DIFF
--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -55,7 +55,14 @@ impl Node {
             None => return,
         };
         trace!("Being out of closest range, replicating {addr:?} to {close_peers:?}");
+        let mut peers_updated = 0;
         for peer in close_peers.iter() {
+            peers_updated += 1;
+
+            if peers_updated > CLOSE_GROUP_SIZE {
+                // Sent to enough peers
+                break;
+            }
             let _ = self
                 .send_replicate_cmd_without_wait(&our_address, peer, vec![chunk_address.clone()])
                 .await;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jun 23 06:26 UTC
This pull request fixes the issue where data was being unnecessarily replicated to all nodes instead of just those in the close group. The replication now only happens to the nodes in the close group.
<!-- reviewpad:summarize:end --> 
