### PR TITLE
Revert "feat: append peer id to node's default root dir"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4697,7 +4697,6 @@ dependencies = [
  "async-trait",
  "blsttc",
  "bytes",
- "dirs-next",
  "eyre",
  "futures",
  "itertools",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -17,7 +17,6 @@ local-discovery=["libp2p/mdns"]
 [dependencies]
 async-trait = "0.1"
 bytes = { version = "1.0.1", features = ["serde"] }
-dirs-next = "~2.0.0"
 eyre = "0.6.8"
 futures = "~0.3.13"
 itertools = "~0.10.1"

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -78,7 +78,4 @@ pub enum Error {
 
     #[error("Record was not found locally")]
     RecordNotFound,
-
-    #[error("Could not configure root directory: {0}")]
-    RootDirConfigError(String),
 }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -58,7 +58,7 @@ use std::{
     iter,
     net::SocketAddr,
     num::NonZeroUsize,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::Duration,
 };
 use tokio::sync::{mpsc, oneshot};
@@ -127,7 +127,7 @@ impl SwarmDriver {
         keypair: Option<Keypair>,
         addr: SocketAddr,
         local: bool,
-        root_dir: Option<PathBuf>,
+        root_dir: &Path,
     ) -> Result<(Network, mpsc::Receiver<NetworkEvent>, Self)> {
         // get a random integer between REPLICATION_INTERVAL_LOWER_BOUND and REPLICATION_INTERVAL_UPPER_BOUND
         let replication_interval = rand::thread_rng()
@@ -160,13 +160,13 @@ impl SwarmDriver {
             .set_provider_publication_interval(None);
 
         let (network, events_receiver, mut swarm_driver) = Self::with(
-            root_dir,
             keypair,
             kad_cfg,
             local,
             false,
             replication_interval,
             None,
+            Some(root_dir.join("record_store")),
             ProtocolSupport::Full,
             IDENTIFY_AGENT_VERSION_STR.to_string(),
         )?;
@@ -201,14 +201,15 @@ impl SwarmDriver {
             );
 
         Self::with(
-            Some(std::env::temp_dir()),
-            None, // clients use signer for transactions; network keypair is not used
+            // clients use signer for transactions, but the network keypair is not used
+            None,
             kad_cfg,
             local,
             true,
             // Nonsense interval for the client which never replicates
             Duration::from_secs(1000),
             request_timeout,
+            None,
             ProtocolSupport::Outbound,
             IDENTIFY_CLIENT_VERSION_STR.to_string(),
         )
@@ -217,13 +218,13 @@ impl SwarmDriver {
     #[allow(clippy::too_many_arguments)]
     /// Private helper to create the network components with the provided config and req/res behaviour
     fn with(
-        initial_root_dir_path: Option<PathBuf>,
         keypair: Option<Keypair>,
         kad_cfg: KademliaConfig,
         local: bool,
         is_client: bool,
         replication_interval: Duration,
         request_response_timeout: Option<Duration>,
+        disk_store_path: Option<PathBuf>,
         req_res_protocol: ProtocolSupport,
         identify_version: String,
     ) -> Result<(Network, mpsc::Receiver<NetworkEvent>, Self)> {
@@ -243,9 +244,9 @@ impl SwarmDriver {
         };
 
         let peer_id = PeerId::from(keypair.public());
+
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
         info!("PeerId: {peer_id} has replication interval of {replication_interval:?}");
-        let root_dir_path = Self::get_root_dir_path(initial_root_dir_path, peer_id)?;
 
         // RequestResponse Behaviour
         let request_response = {
@@ -264,17 +265,17 @@ impl SwarmDriver {
         // Kademlia Behaviour
         let kademlia = {
             // Configures the disk_store to store records under the provided path and increase the max record size
-            let storage_dir_path = root_dir_path.join("record_store");
-            if let Err(error) = std::fs::create_dir_all(&storage_dir_path) {
+            let storage_dir = disk_store_path.unwrap_or(std::env::temp_dir());
+            if let Err(error) = std::fs::create_dir_all(&storage_dir) {
                 return Err(Error::FailedToCreateRecordStoreDir {
-                    path: storage_dir_path,
+                    path: storage_dir,
                     source: error,
                 });
             }
 
             let store_cfg = DiskBackedRecordStoreConfig {
                 max_value_bytes: 1024 * 1024,
-                storage_dir: storage_dir_path,
+                storage_dir,
                 replication_interval,
                 ..Default::default()
             };
@@ -368,7 +369,6 @@ impl SwarmDriver {
             Network {
                 swarm_cmd_sender,
                 peer_id,
-                root_dir_path,
             },
             network_event_receiver,
             swarm_driver,
@@ -400,22 +400,6 @@ impl SwarmDriver {
                 },
             }
         }
-    }
-
-    fn get_root_dir_path(root_dir_path: Option<PathBuf>, peer_id: PeerId) -> Result<PathBuf> {
-        let path = if let Some(path) = root_dir_path {
-            path
-        } else {
-            dirs_next::data_dir()
-                .ok_or_else(|| {
-                    Error::RootDirConfigError("could not obtain root directory path".to_string())
-                })?
-                .join("safe")
-                .join("node")
-                .join(peer_id.to_string())
-        };
-        std::fs::create_dir_all(path.clone())?;
-        Ok(path)
     }
 }
 
@@ -459,7 +443,6 @@ pub fn sort_peers_by_key<T>(
 pub struct Network {
     pub swarm_cmd_sender: mpsc::Sender<SwarmCmd>,
     pub peer_id: PeerId,
-    pub root_dir_path: PathBuf,
 }
 
 impl Network {
@@ -862,7 +845,7 @@ mod tests {
         messages::{CmdOk, CmdResponse, Query, Request, Response},
         storage::Chunk,
     };
-    use std::{net::SocketAddr, path::PathBuf, time::Duration};
+    use std::{net::SocketAddr, path::Path, time::Duration};
 
     #[tokio::test]
     async fn msg_to_self_should_not_error_out() -> Result<()> {
@@ -873,7 +856,7 @@ mod tests {
                 .parse::<SocketAddr>()
                 .expect("0.0.0.0:0 should parse into a valid `SocketAddr`"),
             true,
-            Some(PathBuf::from("")),
+            Path::new(""),
         )?;
         let _driver_handle = tokio::spawn(driver.run());
 

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -21,7 +21,7 @@ use sn_protocol::{
     NetworkAddress,
 };
 use sn_registers::RegisterStorage;
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::Path, time::Duration};
 use tokio::task::spawn;
 
 /// Once a node is started and running, the user obtains
@@ -35,17 +35,6 @@ impl RunningNode {
     /// Returns this node's `PeerId`
     pub fn peer_id(&self) -> PeerId {
         self.network.peer_id
-    }
-
-    /// Returns the root directory path for the node.
-    ///
-    /// This will either be a value defined by the user, or a default location, plus the peer ID
-    /// appended. The default location is platform specific:
-    ///  - Linux: $HOME/.local/share/safe/node/peer-id
-    ///  - macOS: $HOME/Library/Application Support/safe/node/peer-id
-    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\node\peer-id
-    pub fn root_dir_path(&self) -> PathBuf {
-        self.network.root_dir_path.clone()
     }
 
     /// Returns a `SwarmLocalState` with some information obtained from swarm's local state.
@@ -78,7 +67,7 @@ impl Node {
         addr: SocketAddr,
         initial_peers: Vec<(PeerId, Multiaddr)>,
         local: bool,
-        root_dir: Option<PathBuf>,
+        root_dir: &Path,
     ) -> Result<RunningNode> {
         let (network, mut network_event_receiver, swarm_driver) =
             SwarmDriver::new(keypair, addr, local, root_dir)?;
@@ -86,7 +75,7 @@ impl Node {
 
         let node = Self {
             network: network.clone(),
-            registers: RegisterStorage::new(&network.root_dir_path),
+            registers: RegisterStorage::new(root_dir),
             events_channel: node_events_channel.clone(),
             initial_peers,
         };


### PR DESCRIPTION
This reverts commit 86b83b68d039330f666fc60db5bdcc6a605c8aa9.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jun 23 08:34 UTC
This pull request removes the `dirs-next` dependency, updates Cargo.lock and Cargo.toml, and makes some changes to the SwarmDriver and Node structs including modifying the root directory to be of type Path. It also updates the tests and adds a new method to the Node struct, `get_root_dir_path`.
<!-- reviewpad:summarize:end --> 
