### PR TITLE
fix: get_closest_local shall only return CLOSE_GROUP_SIZE peers

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
-use crate::error::Result;
+use crate::{error::Result, CLOSE_GROUP_SIZE};
 use libp2p::{
     kad::{kbucket::Distance, store::RecordStore, Record, RecordKey},
     multiaddr::Protocol,
@@ -267,12 +267,14 @@ impl SwarmDriver {
                 let key = key.as_kbucket_key();
                 // calls `kbuckets.closest_keys(key)` internally, which orders the peers by
                 // increasing distance
+                // Note it will return all peers, heance a chop down is required.
                 let closest_peers = self
                     .swarm
                     .behaviour_mut()
                     .kademlia
                     .get_closest_local_peers(&key)
                     .map(|peer| peer.into_preimage())
+                    .take(CLOSE_GROUP_SIZE)
                     .collect();
 
                 let _ = sender.send(closest_peers);


### PR DESCRIPTION
Closes https://github.com/maidsafe/safe_network/pull/448

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jun 23 10:01 UTC
This pull request fixes a bug where `get_closest_local` was incorrectly returning all peers rather than only `CLOSE_GROUP_SIZE` peers. The code was adjusted to correctly limit the number of peers returned.
<!-- reviewpad:summarize:end --> 
