### PR TITLE
feat: append peer id to node's default root dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4697,6 +4697,7 @@ dependencies = [
  "async-trait",
  "blsttc",
  "bytes",
+ "dirs-next",
  "eyre",
  "futures",
  "itertools",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -17,6 +17,7 @@ local-discovery=["libp2p/mdns"]
 [dependencies]
 async-trait = "0.1"
 bytes = { version = "1.0.1", features = ["serde"] }
+dirs-next = "~2.0.0"
 eyre = "0.6.8"
 futures = "~0.3.13"
 itertools = "~0.10.1"

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -78,4 +78,7 @@ pub enum Error {
 
     #[error("Record was not found locally")]
     RecordNotFound,
+
+    #[error("Could not configure root directory: {0}")]
+    RootDirConfigError(String),
 }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -22,7 +22,7 @@ use eyre::{eyre, Error, Result};
 use libp2p::{Multiaddr, PeerId};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::Duration,
 };
 use tokio::{
@@ -48,9 +48,10 @@ struct Opt {
     /// Specify the node's data directory.
     ///
     /// If not provided, the default location is platform specific:
-    ///  - Linux: $HOME/.local/share/safe/node
-    ///  - macOS: $HOME/Library/Application Support/safe/node
-    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\node
+    ///  - Linux: $HOME/.local/share/safe/node/<peer-id>
+    ///  - macOS: $HOME/Library/Application Support/safe/node/<peer-id>
+    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\node\<peer-id>
+    #[allow(rustdoc::invalid_html_tags)]
     #[clap(long, verbatim_doc_comment)]
     root_dir: Option<PathBuf>,
 
@@ -129,7 +130,6 @@ fn main() -> Result<()> {
         }
     }
 
-    let root_dir = get_root_dir_path(opt.root_dir)?;
     let log_dir = if let Some(path) = opt.log_dir {
         format!("{}", path.display())
     } else {
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
             opt.rpc,
             opt.local,
             &log_dir,
-            &root_dir,
+            opt.root_dir.clone(),
         ))?;
 
         // actively shut down the runtime
@@ -171,7 +171,7 @@ async fn start_node(
     rpc: Option<SocketAddr>,
     local: bool,
     log_dir: &str,
-    root_dir: &Path,
+    root_dir: Option<PathBuf>,
 ) -> Result<()> {
     let started_instant = std::time::Instant::now();
 
@@ -185,7 +185,7 @@ async fn start_node(
 
     // write the PID to the root dir
     let pid = std::process::id();
-    let pid_file = root_dir.join("safenode.pid");
+    let pid_file = running_node.root_dir_path().join("safenode.pid");
     let mut file = File::create(&pid_file).await?;
     file.write_all(pid.to_string().as_bytes()).await?;
 
@@ -275,17 +275,4 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
             }
         }
     });
-}
-
-fn get_root_dir_path(root_dir_path: Option<PathBuf>) -> Result<PathBuf> {
-    let path = if let Some(path) = root_dir_path {
-        path
-    } else {
-        dirs_next::data_dir()
-            .ok_or_else(|| eyre!("Could not obtain data directory"))?
-            .join("safe")
-            .join("node")
-    };
-    std::fs::create_dir_all(path.clone())?;
-    Ok(path)
 }


### PR DESCRIPTION
BREAKING CHANGE: The default root directory for the node will now have the node's peer ID appended to its path.

Using the peer ID facilitates running multiple node processes on a single machine, without the need to explicitly use the `--root-dir` argument for each node to specify its own root directory. Previously, if they didn't do that, all the nodes would share the same record store.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jun 23 13:28 UTC
This pull request introduces a new dependency `dirs-next` and changes the `root_dir` parameter to be an optional `PathBuf` in multiple places. It also modifies the implementation of `SwarmDriver::get_root_dir_path()` and `Node` and `RunningNode` struct to accommodate this change. Additionally, it adds an `error` variant to the `Error` enum in `error.rs` related to root directory configuration.
<!-- reviewpad:summarize:end --> 
