### PR TITLE
ci: ensure we use rust-cache v2 everywhere

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -28,9 +28,8 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
+      - uses: Swatinem/rust-cache@v2
+          continue-on-error: true
 
       - run: cargo install cargo-criterion
 

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -38,9 +38,8 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
+      - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
 
       - run: cargo install cargo-criterion
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -29,11 +29,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         continue-on-error: true
-        with:
-          cache-on-failure: true
-          sharedKey: ${{github.run_id}}
 
       - name: install ripgrep ubuntu
         run: sudo apt-get install ripgrep


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Jun 23 00:06 UTC
This pull request updates the CI pipelines to use rust-cache v2 everywhere. The previous version of rust-cache is replaced with the latest version. The latest version allows the CI to continue even when caching fails.
<!-- reviewpad:summarize:end --> 
