### PR TITLE
fix(networking): local-discovery should not be default

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -71,6 +71,11 @@ jobs:
         # Deny certain `rustdoc` lints that are unwanted.
         # See https://doc.rust-lang.org/rustdoc/lints.html for lints that are 'warning' by default.
         run: RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps
+      
+      - name: Check local-discovery is not a default feature
+        shell: bash
+        run: if [[ ! $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].features.default[]? | select(. == "local-discovery")') ]]; then echo "local-discovery is not a default feature in any package."; else echo "local-discovery is a default feature in at least one package." && exit 1; fi
+
 
       - name: Check the whole workspace can build
         run: cargo build --all-targets --all-features

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.3.1"
 
 [features]
-default=["local-discovery"]
+default=[]
 local-discovery=["libp2p/mdns"]
 
 [dependencies]

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -31,18 +31,18 @@ use self::{
     replication_fetcher::ReplicationFetcher,
 };
 use futures::{future::select_all, StreamExt};
+#[cfg(feature = "local-discovery")]
+use libp2p::mdns;
 use libp2p::{
     identity::Keypair,
-    kad::{kbucket::Distance, KademliaStoreInserts},
+    kad::{
+        kbucket::Distance, kbucket::Key as KBucketKey, Kademlia, KademliaConfig,
+        KademliaStoreInserts, QueryId, Record, RecordKey,
+    },
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{behaviour::toggle::Toggle, Swarm, SwarmBuilder},
     Multiaddr, PeerId, Transport,
-};
-#[cfg(feature = "local-discovery")]
-use libp2p::{
-    kad::{kbucket::Key as KBucketKey, Kademlia, KademliaConfig, QueryId, Record, RecordKey},
-    mdns,
 };
 use rand::Rng;
 use sn_protocol::{


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Jun 23 03:44 UTC
This pull request includes two patches. 

The first patch fixes an issue in the networking module. The `local-discovery` feature should not be set as the default, so the patch modifies the `Cargo.toml` file to remove `local-discovery` from the default features.

The second patch is related to the CI workflow. It adds a step to check that `local-discovery` is not set as a default feature in any crate. If `local-discovery` is found as a default feature, the CI job will fail.

Overall, these patches aim to improve the networking functionality and ensure that `local-discovery` is not automatically enabled.
<!-- reviewpad:summarize:end --> 
