### PR TITLE
feat(node): increase node event channel size

### DIFF
--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,6 +10,8 @@ use sn_dbc::DbcId;
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
 use tokio::sync::broadcast;
 
+const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
+
 /// Channel where users of the public API can listen to events broadcasted by the node.
 #[derive(Clone, Debug)]
 pub struct NodeEventsChannel(broadcast::Sender<NodeEvent>);
@@ -19,7 +21,7 @@ pub type NodeEventsReceiver = broadcast::Receiver<NodeEvent>;
 
 impl Default for NodeEventsChannel {
     fn default() -> Self {
-        Self(broadcast::channel(100).0)
+        Self(broadcast::channel(NODE_EVENT_CHANNEL_SIZE).0)
     }
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Jun 23 05:19 UTC
This pull request increases the node event channel size in the sn_node/src/event.rs file. The size is increased from 100 to 10,000 to accommodate more events.
<!-- reviewpad:summarize:end --> 
