### PR TITLE
networking: no blocking send events +  increase node event channel size

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt-get install ripgrep
 
       - name: Build sn bins
-        run: cargo build --release --bins 
+        run: cargo build --release --features=local-discovery --bins 
         timeout-minutes: 30
 
       - name: Build churn tests 
@@ -76,10 +76,10 @@ jobs:
       - name: Start a client to upload files
         run: |
           ls -l ./target/release
-          cargo run --bin safe --release -- files upload -- "./target/release/faucet"
-          cargo run --bin safe --release -- files upload -- "./target/release/safe"
-          cargo run --bin safe --release -- files upload -- "./target/release/safenode"
-          cargo run --bin safe --release -- files upload -- "./target/release/testnet"
+          cargo run --bin safe --features=local-discovery --release -- files upload -- "./target/release/faucet"
+          cargo run --bin safe --features=local-discovery --release -- files upload -- "./target/release/safe"
+          cargo run --bin safe --features=local-discovery --release -- files upload -- "./target/release/safenode"
+          cargo run --bin safe --features=local-discovery --release -- files upload -- "./target/release/testnet"
         id: client-file-upload
         env:
           SN_LOG: "all"

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -273,12 +273,11 @@ impl SwarmDriver {
                 // `self` then handles the request and sends a response back again to itself.
                 if peer == *self.swarm.local_peer_id() {
                     trace!("Sending request to self");
-                    self.event_sender
-                        .send(NetworkEvent::RequestReceived {
-                            req,
-                            channel: MsgResponder::FromSelf(sender),
-                        })
-                        .await?;
+
+                    self.send_event(NetworkEvent::RequestReceived {
+                        req,
+                        channel: MsgResponder::FromSelf(sender),
+                    });
                 } else {
                     let request_id = self
                         .swarm

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -301,9 +301,7 @@ impl SwarmDriver {
                         None => {
                             // responses that are not awaited at the call site must be handled
                             // separately
-                            self.event_sender
-                                .send(NetworkEvent::ResponseReceived { res: resp })
-                                .await?;
+                            self.send_event(NetworkEvent::ResponseReceived { res: resp });
                         }
                     }
                 }

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -81,4 +81,7 @@ pub enum Error {
 
     #[error("Could not configure root directory: {0}")]
     RootDirConfigError(String),
+
+    #[error("No SwarmCmd channel capacity")]
+    NoSwarmCmdChannelCapacity,
 }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -259,10 +259,7 @@ impl SwarmDriver {
                     };
                     if is_wrong_id || is_all_connection_failed {
                         info!("Detected dead peer {peer_id:?}");
-                        let _ = self
-                            .event_sender
-                            .send(NetworkEvent::PeerRemoved(peer_id))
-                            .await;
+                        self.send_event(NetworkEvent::PeerRemoved(peer_id));
                         let _ = self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
                         self.log_kbuckets(&peer_id);
                     }
@@ -360,9 +357,7 @@ impl SwarmDriver {
                 // In that case, we can try to trigger a replication to it.
                 let peer_ids: Vec<PeerId> = cache_candidates.values().copied().collect();
                 trace!("Candidates {peer_ids:?} failed to respond a record query request.");
-                self.event_sender
-                    .send(NetworkEvent::LostRecordDetected(peer_ids))
-                    .await?;
+                self.send_event(NetworkEvent::LostRecordDetected(peer_ids));
             }
             KademliaEvent::OutboundQueryProgressed {
                 id,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -216,9 +216,7 @@ impl SwarmDriver {
             SwarmEvent::NewListenAddr { address, .. } => {
                 let local_peer_id = *self.swarm.local_peer_id();
                 let address = address.with(Protocol::P2p(local_peer_id.into()));
-                self.event_sender
-                    .send(NetworkEvent::NewListenAddr(address.clone()))
-                    .await?;
+                self.send_event(NetworkEvent::NewListenAddr(address.clone()));
                 info!("Local node is listening on {address:?}");
             }
             SwarmEvent::IncomingConnection { .. } => {}
@@ -278,9 +276,7 @@ impl SwarmDriver {
                 autonat::Event::OutboundProbe(e) => trace!("AutoNAT outbound probe: {e:?}"),
                 autonat::Event::StatusChanged { old, new } => {
                     info!("AutoNAT status changed: {old:?} -> {new:?}");
-                    self.event_sender
-                        .send(NetworkEvent::NatStatusChanged(new.clone()))
-                        .await?;
+                    self.send_event(NetworkEvent::NatStatusChanged(new.clone()));
 
                     match new {
                         NatStatus::Public(_addr) => {
@@ -390,9 +386,7 @@ impl SwarmDriver {
             } => {
                 if is_new_peer {
                     self.log_kbuckets(&peer);
-                    self.event_sender
-                        .send(NetworkEvent::PeerAdded(peer))
-                        .await?;
+                    self.send_event(NetworkEvent::PeerAdded(peer));
                 }
             }
             KademliaEvent::InboundRequest {

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -53,9 +53,7 @@ impl SwarmDriver {
                             None => {
                                 // responses that are not awaited at the call site must be handled
                                 // separately
-                                self.event_sender
-                                    .send(NetworkEvent::ResponseReceived { res: response })
-                                    .await?;
+                                self.send_event(NetworkEvent::ResponseReceived { res: response });
                             }
                         }
                     } else {

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -31,16 +31,10 @@ impl SwarmDriver {
                     ..
                 } => {
                     trace!("Received request with id: {request_id:?}, req: {request:?}");
-                    if let Err(error) = self
-                        .event_sender
-                        .send(NetworkEvent::RequestReceived {
-                            req: request,
-                            channel: MsgResponder::FromPeer(channel),
-                        })
-                        .await
-                    {
-                        error!("Failed in notify {request_id:?} NetworkEvent: {error:?}");
-                    }
+                    self.send_event(NetworkEvent::RequestReceived {
+                        req: request,
+                        channel: MsgResponder::FromPeer(channel),
+                    })
                 }
                 Message::Response {
                     request_id,

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,6 +10,8 @@ use sn_dbc::DbcId;
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
 use tokio::sync::broadcast;
 
+const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
+
 /// Channel where users of the public API can listen to events broadcasted by the node.
 #[derive(Clone, Debug)]
 pub struct NodeEventsChannel(broadcast::Sender<NodeEvent>);
@@ -19,7 +21,7 @@ pub type NodeEventsReceiver = broadcast::Receiver<NodeEvent>;
 
 impl Default for NodeEventsChannel {
     fn default() -> Self {
-        Self(broadcast::channel(100).0)
+        Self(broadcast::channel(NODE_EVENT_CHANNEL_SIZE).0)
     }
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Jun 23 05:19 UTC
This pull request modifies several files in the codebase.

In `sn_networking/src/msg/mod.rs`, changes were made to handle received requests. The code now uses the `send_event` method to send a `RequestReceived` event to the `event_sender`. Additionally, the error handling for failed notifications seems to have been removed.

In `sn_networking/src/event.rs`, the diff includes changes to the `send_event` method. The use of `event_sender.send` has been replaced with `self.send_event` for the `NewListenAddr`, `NatStatusChanged`, and `PeerAdded` events. The `await` keyword after sending these events has also been removed. Additionally, a call to the `log_kbuckets` function has been added before sending the `PeerAdded` event.

The `impl SwarmDriver` block in the `sn_networking/src/cmd.rs` file has been modified. Specifically, lines 273-280 were changed to replace the `self.event_sender.send(...)` call with a call to `self.send_event(...)`.

In the `event.rs` file, a constant named `NODE_EVENT_CHANNEL_SIZE` with a value of `10_000` has been added. This constant is used to define the size of the event channel in the `NodeEventsChannel` struct. The default implementation of `NodeEventsChannel` has been modified to use the new constant value. This change increases the channel size to accommodate more events.

In the diff, the following changes were made:

- Added a new field `event_sender` in the `SwarmDriver` struct.
- Added a new method `send_event` to send events asynchronously.
- Replaced the usage of `await` with non-blocking calls for certain commands in the `Network` struct.
- Updated the `send_swarm_cmd` method to handle full capacity of the `SwarmCmd` channel and provide error handling.

In the `sn_networking/src/error.rs` file, a new variant `NoSwarmCmdChannelCapacity` has been added to the `Error` enum. This variant is used when there is no SwarmCmd channel capacity available.

This pull request includes various changes to improve event handling, error handling, and code organization in the codebase.
<!-- reviewpad:summarize:end --> 
