### PR TITLE
feat: client do not wait for response when upload

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -39,7 +39,7 @@ jobs:
 
      
       - name: Build sn bins
-        run: cargo build --release --bins
+        run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
 
       - name: Start a local network
@@ -47,15 +47,6 @@ jobs:
         env:
           SN_LOG: "all"
         timeout-minutes: 10
-
-      - name: Set contact env var node.
-        shell: bash
-        # get all nodes listen ports
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
-
-      - name: Check contact peer
-        shell: bash
-        run: echo "Peer is $SAFE_PEERS"
 
       # Start a heaptracked node instance to compare memory usage
       - name: Start safenode with heaptrack
@@ -75,7 +66,7 @@ jobs:
         # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
         # passes to tee which displays it in the terminal and writes to output.txt
         run: |
-          cargo criterion --message-format=json 2>&1 | tee -a output.txt
+          cargo criterion --features=local-discovery --message-format=json 2>&1 | tee -a output.txt
           cat output.txt | rg benchmark-complete | jq -s 'map({
           name: (.id | split("/"))[-1],
           unit: "MiB/s",

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -49,7 +49,7 @@ jobs:
 
      
       - name: Build sn bins
-        run: cargo build --release --bins
+        run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
 
       - name: Start a local network
@@ -57,15 +57,6 @@ jobs:
         env:
           SN_LOG: "all"
         timeout-minutes: 10
-
-      - name: Set contact env var node.
-        shell: bash
-        # get all nodes listen ports
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
-
-      - name: Check contact peer
-        shell: bash
-        run: echo "Peer is $SAFE_PEERS"
 
       # Start a heaptracked node instance to compare memory usage
       - name: Start safenode with heaptrack
@@ -85,7 +76,7 @@ jobs:
         # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
         # passes to tee which displays it in the terminal and writes to output.txt
         run: |
-          cargo criterion --message-format=json 2>&1 | tee -a output.txt
+          cargo criterion --features=local-discovery --message-format=json 2>&1 | tee -a output.txt
           cat output.txt | rg benchmark-complete | jq -s 'map({
             name: (.id | split("/"))[-1],
             unit: "MiB/s",


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Jun 23 10:11 UTC
This pull request introduces a new feature where the client no longer waits for a response when uploading. The `send_and_complete` function is added to the `sn_networking` module to send a request to a set of peers and collect all the responses. This eliminates the need to wait for a single response and handles multiple error responses at once. Overall, this patch improves the efficiency of the upload process in the client.
<!-- reviewpad:summarize:end --> 
