### PR TITLE
fix(node): ensure keys are wiped on restart

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -100,7 +100,7 @@ jobs:
         # then check we have an expected level of restarts
         # TODO: make this use an env var, or relate to testnet size
         run : |
-          restart_count=$(rg "Node is restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+          restart_count=$(rg "Node is wiping data and restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
           detected_dead_peer=$(rg "Detected dead peer" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Detected dead peer $detected_dead_peer times"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -392,7 +392,7 @@ jobs:
         # then check we have an expected level of restarts
         # TODO: make this use an env var, or relate to testnet size
         run : |
-          restart_count=$(rg "Node is restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+          restart_count=$(rg "Node is wiping data and restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
           detected_dead_peer=$(rg "Detected dead peer" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Detected dead peer $detected_dead_peer times"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -360,7 +360,7 @@ jobs:
         # then check we have an expected level of restarts
         # TODO: make this use an env var, or relate to testnet size
         run : |
-          restart_count=$(rg "Node is restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+          restart_count=$(rg "Node is wiping data and restarting in" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
           detected_dead_peer=$(rg "Detected dead peer" ~/.safe/node/local-test-network -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "Detected dead peer $detected_dead_peer times"

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -23,6 +23,7 @@ use tokio::task::spawn;
 
 /// Once a node is started and running, the user obtains
 /// a `NodeRunning` object which can be used to interact with it.
+#[derive(Clone)]
 pub struct RunningNode {
     network: Network,
     node_events_channel: NodeEventsChannel,

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -239,7 +239,8 @@ async fn start_node(
                 sleep(delay).await;
 
                 // remove the whole node dir
-                let _ = tokio::fs::remove_dir_all(running_node.root_dir_path()).await;
+                let _ =
+                    tokio::fs::remove_file(running_node.root_dir_path().join("secret-key")).await;
                 break Ok(());
             }
             Some(NodeCtrl::Stop { delay, cause }) => {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jul 23 14:34 UTC
This pull request fixes an issue in the node code where keys were not being properly wiped on restart. The patch includes changes to the `api.rs` and `main.rs` files. In `api.rs`, a `RunningNode` struct is modified to include the `Clone` trait. In `main.rs`, the `start_node` function is updated to ensure keys are correctly wiped on restart. The node log path is displayed on restart, and the node root directory is wiped using `tokio::fs::remove_dir_all()`.
<!-- reviewpad:summarize:end --> 
