### PR TITLE
Various Enhancements for the `testnet` Binary

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -56,7 +56,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -61,7 +61,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -316,7 +316,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -420,7 +420,7 @@ jobs:
           CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
+  NODE_DATA_PATH: /home/runner/.local/share/safe/node
 
 jobs:
   cargo-udeps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -104,6 +104,10 @@ jobs:
         run: cargo test --no-run --release
         timeout-minutes: 30
 
+      - name: Run testnet tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_testnet
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release --package sn_networking

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -227,7 +227,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup
         env:
           SN_LOG: "all"
@@ -322,7 +322,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup
         env:
           SN_LOG: "all"

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -145,6 +145,7 @@ impl TracingLayers {
                 }
             }
         };
+
         let targets = match std::env::var("SN_LOG") {
             Ok(sn_log_val) => {
                 println!("Using SN_LOG={sn_log_val}");

--- a/sn_node/build.rs
+++ b/sn_node/build.rs
@@ -5,8 +5,6 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-// use sn_build_info::pre_build_set_git_commit_env;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("./src/protocol/safenode_proto/safenode.proto")?;
     Ok(())

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -239,6 +239,8 @@ async fn start_node(
     let started_instant = std::time::Instant::now();
 
     info!("Starting node ...");
+    debug!("Built with git version: {}", sn_build_info::git_info());
+
     let running_node = Node::run(keypair, node_socket_addr, peers, local, root_dir).await?;
 
     // write the PID to the root dir

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -241,6 +241,7 @@ async fn start_node(
     info!("Starting node ...");
     debug!("Built with git version: {}", sn_build_info::git_info());
 
+    info!("Starting node ...");
     let running_node = Node::run(keypair, node_socket_addr, peers, local, root_dir).await?;
 
     // write the PID to the root dir

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -341,18 +341,73 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
     });
 }
 
-async fn create_secret_key_file(path: impl AsRef<Path>) -> Result<tokio::fs::File, std::io::Error> {
-    let mut opt = tokio::fs::OpenOptions::new();
+fn init_logging(
+    log_output_dest: Option<LogOutputDestArg>,
+    peer_id: PeerId,
+    format: Option<LogFormat>,
+) -> Result<(String, Option<WorkerGuard>)> {
+    let logging_targets = vec![
+        ("safenode".to_string(), Level::INFO),
+        ("sn_transfers".to_string(), Level::INFO),
+        ("sn_networking".to_string(), Level::INFO),
+        ("sn_node".to_string(), Level::INFO),
+    ];
+
+    let output_dest = if let Some(log_output_dest) = log_output_dest {
+        match log_output_dest {
+            LogOutputDestArg::Stdout => LogOutputDest::Stdout,
+            LogOutputDestArg::Default => {
+                let path = dirs_next::data_dir()
+                    .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
+                    .join("safe")
+                    .join("node")
+                    .join(peer_id.to_string())
+                    .join("logs");
+                LogOutputDest::Path(path)
+            }
+            LogOutputDestArg::Path(path) => LogOutputDest::Path(path),
+        }
+    } else {
+        LogOutputDest::Stdout
+    };
+
+    #[cfg(not(feature = "otlp"))]
+    let log_appender_guard = sn_logging::init_logging(
+        logging_targets,
+        output_dest.clone(),
+        format.unwrap_or(LogFormat::Default),
+    )?;
+    #[cfg(feature = "otlp")]
+    let (_rt, log_appender_guard) = {
+        // init logging in a separate runtime if we are sending traces to an opentelemetry server
+        let rt = Runtime::new()?;
+        let guard = rt.block_on(async {
+            sn_logging::init_logging(
+                logging_targets,
+                output_dest.clone(),
+                format.unwrap_or(LogFormat::Default),
+            )
+        })?;
+        (rt, guard)
+    };
+    Ok((output_dest.to_string(), log_appender_guard))
+}
+
+fn create_secret_key_file(path: impl AsRef<Path>) -> Result<std::fs::File, std::io::Error> {
+    let mut opt = std::fs::OpenOptions::new();
     opt.write(true).create_new(true);
 
     // On Unix systems, make sure only the current user can read/write.
     #[cfg(unix)]
-    let opt = opt.mode(0o600);
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opt.mode(0o600);
+    }
 
-    opt.open(path).await
+    opt.open(path)
 }
 
-async fn keypair_from_path(path: impl AsRef<Path>) -> Result<Keypair> {
+fn keypair_from_path(path: impl AsRef<Path>) -> Result<Keypair> {
     let keypair = match std::fs::read(&path) {
         // If the file is opened successfully, read the key from it
         Ok(key) => {
@@ -367,9 +422,8 @@ async fn keypair_from_path(path: impl AsRef<Path>) -> Result<Keypair> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             let secret_key = libp2p::identity::ed25519::SecretKey::generate();
             let mut file = create_secret_key_file(&path)
-                .await
                 .map_err(|err| eyre!("could not create secret key file: {err}"))?;
-            file.write_all(secret_key.as_ref()).await?;
+            file.write_all(secret_key.as_ref())?;
 
             info!("generated new key and stored to file: {:?}", path.as_ref());
 
@@ -396,13 +450,13 @@ fn get_root_dir(peer_id: PeerId) -> Result<PathBuf> {
 
 /// The keypair is located inside the root directory. At the same time, when no dir is specified,
 /// the dir name is derived from the keypair used in the application: the peer ID is used as the directory name.
-async fn get_root_dir_and_keypair(root_dir: Option<PathBuf>) -> Result<(PathBuf, Keypair)> {
+fn get_root_dir_and_keypair(root_dir: Option<PathBuf>) -> Result<(PathBuf, Keypair)> {
     match root_dir {
         Some(dir) => {
-            tokio::fs::create_dir_all(&dir).await?;
+            std::fs::create_dir_all(&dir)?;
 
             let secret_key_path = dir.join("secret-key");
-            Ok((dir, keypair_from_path(secret_key_path).await?))
+            Ok((dir, keypair_from_path(secret_key_path)?))
         }
         None => {
             let secret_key = libp2p::identity::ed25519::SecretKey::generate();
@@ -411,14 +465,13 @@ async fn get_root_dir_and_keypair(root_dir: Option<PathBuf>) -> Result<(PathBuf,
             let peer_id = keypair.public().to_peer_id();
 
             let dir = get_root_dir(peer_id)?;
-            tokio::fs::create_dir_all(&dir).await?;
+            std::fs::create_dir_all(&dir)?;
 
             let secret_key_path = dir.join("secret-key");
 
-            let mut file = create_secret_key_file(&secret_key_path)
-                .await
+            let mut file = create_secret_key_file(secret_key_path)
                 .map_err(|err| eyre!("could not create secret key file: {err}"))?;
-            file.write_all(secret_key.as_ref()).await?;
+            file.write_all(secret_key.as_ref())?;
 
             Ok((dir, keypair))
         }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -22,7 +22,7 @@ const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 // Defines how close that a node will trigger replication.
 // That is, the node has to be among the REPLICATION_RANGE closest to data,
 // to carry out the replication.
-const REPLICATION_RANGE: usize = 8;
+const REPLICATION_RANGE: usize = 12;
 
 impl Node {
     /// Replication is triggered when the newly added peer or the dead peer was among our closest.
@@ -50,7 +50,7 @@ impl Node {
             return Ok(());
         };
 
-        let distance_bar = match sorted_peers.get(CLOSE_GROUP_SIZE) {
+        let distance_bar = match sorted_peers.get(REPLICATION_RANGE) {
             Some(peer) => NetworkAddress::from_peer(*peer).distance(&our_address),
             None => {
                 debug!("could not obtain distance_bar as sorted_peers.len() <= CLOSE_GROUP_SIZE ");

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -16,8 +16,6 @@ chaos = []
 statemap = []
 otlp = []
 local-discovery = []
-# verify-nodes: performs a last step querying and verifying net knowledge to lanched nodes
-verify-nodes = ["prost", "tonic", "tonic-build", "libp2p"]
 
 [[bin]]
 path="src/main.rs"
@@ -28,10 +26,10 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-libp2p = { version="0.51", optional = true }
-prost = { version = "0.9", optional = true }
+libp2p = { version="0.51" }
+prost = { version = "0.9" }
 regex = "1.7.1"
-tonic = { version = "0.6.2", optional = true }
+tonic = { version = "0.6.2" }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = "~0.3.1"
@@ -42,7 +40,7 @@ version = "1.17.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [build-dependencies]
-tonic-build = { version = "0.6.2", optional = true }
+tonic-build = { version = "0.6.2" }
 
 [dev-dependencies]
 assert_fs = "~1.0"

--- a/sn_testnet/build.rs
+++ b/sn_testnet/build.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "verify-nodes")]
     tonic_build::compile_protos("../sn_protocol/src/safenode_proto/safenode.proto")?;
 
     Ok(())

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -173,6 +173,18 @@ pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     Ok(())
 }
 
+pub async fn obtain_peer_id(address: SocketAddr) -> Result<PeerId> {
+    let endpoint = format!("https://{address}");
+    println!("Connecting to node's RPC service at {endpoint} ...");
+    let mut client = SafeNodeClient::connect(endpoint).await?;
+
+    let request = Request::new(NodeInfoRequest {});
+    let response = client.node_info(request).await?;
+    let node_info = response.get_ref();
+    let peer_id = PeerId::from_bytes(&node_info.peer_id)?;
+    Ok(peer_id)
+}
+
 // Parse node logs files and extract info for each of them
 fn nodes_info_from_logs(path: &Path) -> Result<BTreeMap<u32, NodeInfo>> {
     let mut nodes = BTreeMap::<PathBuf, NodeInfo>::new();

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -58,16 +58,16 @@ impl Display for NodeInfo {
 pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     let mut delay_secs = 10;
     while delay_secs > 0 {
-        println!("We'll be verifying testnet nodes info in {delay_secs}secs ...");
+        println!("Verifying nodes in {delay_secs} seconds...");
         sleep(Duration::from_secs(1)).await;
         delay_secs -= 1;
     }
     println!();
-    println!("======== Verifying testnet nodes ========");
+    println!("======== Verifying Nodes ========");
 
     let expected_node_count = node_count as usize;
     println!(
-        "Checking nodes log files to verify all ({expected_node_count}) nodes \
+        "Checking log files to verify all ({expected_node_count}) nodes \
         have joined. Logs path: {}",
         logs_path.display()
     );
@@ -168,7 +168,7 @@ pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     }
 
     println!();
-    println!("PeerIds and network knowledge of nodes are the expected!");
+    println!("Peer IDs and node network knowledge are as expected!");
 
     Ok(())
 }

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -124,10 +124,7 @@ impl TestnetBuilder {
             self.flamegraph_mode,
             Box::new(node_launcher),
         )?;
-        let network_contacts_path = nodes_dir_path
-            .join(GENESIS_NODE_DIR_NAME)
-            .join("section_tree");
-        Ok((testnet, network_contacts_path))
+        Ok(testnet)
     }
 }
 
@@ -217,7 +214,7 @@ impl Testnet {
 
         let rpc_address = "127.0.0.1:12001".parse()?;
         let mut launch_args =
-            self.get_launch_args("safenode-1".to_string(), Some(rpc_address), None, node_args)?;
+            self.get_launch_args("safenode-1".to_string(), Some(rpc_address), node_args)?;
 
         let genesis_port: u16 = 11101;
         // Let's start gen on a different port
@@ -273,7 +270,6 @@ impl Testnet {
     /// # Arguments
     ///
     /// * `number_of_nodes` - The number of nodes to launch.
-    /// * `network_contacts_path` - The path to the network contacts file.
     /// * `node_args` - Additional arguments to pass to the node process, e.g., --json-logs.
     ///
     /// # Errors
@@ -281,12 +277,7 @@ impl Testnet {
     /// Returns an error if:
     /// * The node data directories cannot be created
     /// * The node process fails
-    pub fn launch_nodes(
-        &mut self,
-        number_of_nodes: usize,
-        network_contacts_path: &Path,
-        node_args: Vec<String>,
-    ) -> Result<()> {
+    pub fn launch_nodes(&mut self, number_of_nodes: usize, node_args: Vec<String>) -> Result<()> {
         let start = self.node_count + 2;
         let end = self.node_count + number_of_nodes;
         for i in start..=end {
@@ -304,7 +295,6 @@ impl Testnet {
             let launch_args = self.get_launch_args(
                 format!("safenode-{i}"),
                 Some(rpc_address),
-                Some(network_contacts_path),
                 node_args.clone(),
             )?;
             let launch_bin = self.get_launch_bin();
@@ -326,7 +316,6 @@ impl Testnet {
         &self,
         node_name: String,
         rpc_address: Option<SocketAddr>,
-        _network_contacts_path: Option<&Path>,
         node_args: Vec<String>,
     ) -> Result<Vec<String>> {
         let node_data_dir_path = self.nodes_dir_path.join(node_name.clone());
@@ -725,8 +714,6 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let network_contacts_file = tmp_data_dir.child("network-contacts");
-        network_contacts_file.write_str("section tree content")?;
 
         let mut node_launcher = MockNodeLauncher::new();
         for i in 1..=20 {
@@ -741,8 +728,6 @@ mod test {
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
-                        "--network-contacts-file".to_string(),
-                        network_contacts_file.path().to_str().unwrap().to_string(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
                         "--log-dir".to_string(),
@@ -760,11 +745,7 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_nodes(
-            20,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
 
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
@@ -778,8 +759,6 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let network_contacts_file = tmp_data_dir.child("network-contacts");
-        network_contacts_file.write_str("section tree content")?;
 
         let mut node_launcher = MockNodeLauncher::new();
         node_launcher.expect_launch().returning(|_, _| Ok(()));
@@ -790,11 +769,7 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_nodes(
-            20,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
 
         assert!(result.is_ok());
         for i in 1..=20 {
@@ -811,8 +786,6 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        let network_contacts_file = tmp_data_dir.child("network-contacts");
-        network_contacts_file.write_str("section tree content")?;
 
         let mut node_launcher = MockNodeLauncher::new();
         node_launcher.expect_launch().returning(|_, _| Ok(()));
@@ -823,11 +796,7 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_nodes(
-            20,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
 
         assert!(result.is_ok());
         for i in 2..=20 {
@@ -845,8 +814,6 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let network_contacts_file = tmp_data_dir.child("network-contacts");
-        network_contacts_file.write_str("section tree content")?;
 
         let mut node_launcher = MockNodeLauncher::new();
         for i in 1..=20 {
@@ -873,8 +840,6 @@ mod test {
                         "--bin".to_string(),
                         SAFENODE_BIN_NAME.to_string(),
                         "--".to_string(),
-                        "--network-contacts-file".to_string(),
-                        network_contacts_file.path().to_str().unwrap().to_string(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
                         "--log-dir".to_string(),
@@ -892,11 +857,7 @@ mod test {
             true,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_nodes(
-            20,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
 
         assert!(result.is_ok());
         Ok(())
@@ -909,8 +870,6 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let network_contacts_file = tmp_data_dir.child("network-contacts");
-        network_contacts_file.write_str("section tree content")?;
 
         let mut node_launcher = MockNodeLauncher::new();
         for i in 1..=30 {
@@ -925,8 +884,6 @@ mod test {
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
-                        "--network-contacts-file".to_string(),
-                        network_contacts_file.path().to_str().unwrap().to_string(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
                         "--log-dir".to_string(),
@@ -944,19 +901,11 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_nodes(
-            20,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
 
-        let result = testnet.launch_nodes(
-            10,
-            network_contacts_file.path(),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet.launch_nodes(10, vec!["--json-logs".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 30);
         for i in 1..=30 {

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -566,7 +566,7 @@ mod test {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    "A genesis node cannot be launched for an existing network"
+                    "A new testnet cannot be launched until the data directory is cleared"
                 );
                 Ok(())
             }

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -9,10 +9,13 @@
 pub mod check_testnet;
 
 use color_eyre::{eyre::eyre, Result};
+use libp2p::identity::PeerId;
 #[cfg(test)]
 use mockall::automock;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::process::{Command, Stdio};
 use tracing::{debug, info};
 
@@ -32,6 +35,17 @@ pub trait NodeLauncher {
     fn launch(&self, node_bin_path: &Path, args: Vec<String>) -> Result<()>;
 }
 
+/// This trait exists for unit testing.
+///
+/// It allows us to return a dummy PeerId during a test without making a real RPC call.
+#[cfg_attr(test, automock)]
+pub trait RpcClient {
+    fn obtain_peer_id(
+        &self,
+        rpc_address: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = Result<PeerId>> + 'static>>;
+}
+
 #[derive(Default)]
 pub struct SafeNodeLauncher {}
 impl NodeLauncher for SafeNodeLauncher {
@@ -43,6 +57,21 @@ impl NodeLauncher for SafeNodeLauncher {
             .stderr(Stdio::inherit())
             .spawn()?;
         Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct SafeRpcClient {}
+impl RpcClient for SafeRpcClient {
+    fn obtain_peer_id(
+        &self,
+        rpc_address: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = Result<PeerId>> + 'static>> {
+        Box::pin(async move {
+            let peer_id = crate::check_testnet::obtain_peer_id(rpc_address).await?;
+            info!("Obtained peer ID {}", peer_id.to_string());
+            Ok(peer_id)
+        })
     }
 }
 
@@ -115,7 +144,6 @@ impl TestnetBuilder {
             std::fs::remove_dir_all(nodes_dir_path.clone())?;
         }
 
-        let node_launcher = SafeNodeLauncher::default();
         let testnet = Testnet::new(
             self.node_bin_path
                 .as_ref()
@@ -125,7 +153,8 @@ impl TestnetBuilder {
                 .unwrap_or(DEFAULT_NODE_LAUNCH_INTERVAL),
             nodes_dir_path.clone(),
             self.flamegraph_mode,
-            Box::new(node_launcher),
+            Box::default() as Box<SafeNodeLauncher>,
+            Box::default() as Box<SafeRpcClient>,
         )?;
         Ok(testnet)
     }
@@ -138,6 +167,7 @@ pub struct Testnet {
     pub flamegraph_mode: bool,
     pub node_count: usize,
     pub launcher: Box<dyn NodeLauncher>,
+    pub rpc_client: Box<dyn RpcClient>,
 }
 
 impl Testnet {
@@ -151,6 +181,7 @@ impl Testnet {
         nodes_dir_path: PathBuf,
         flamegraph_mode: bool,
         launcher: Box<dyn NodeLauncher>,
+        rpc_client: Box<dyn RpcClient>,
     ) -> Result<Self> {
         let mut node_count = 0;
         if nodes_dir_path.exists() {
@@ -178,6 +209,7 @@ impl Testnet {
             flamegraph_mode,
             node_count,
             launcher,
+            rpc_client,
         })
     }
 
@@ -186,15 +218,15 @@ impl Testnet {
         TestnetBuilder::default()
     }
 
-    /// Launches a genesis node at the specified address.
+    /// Launches a genesis node at 127.0.0.1:11101.
     ///
-    /// Returns the multiaddress of the genesis node.
+    /// The RPC service is launched along with the node, on port 12001.
+    ///
+    /// Returns the MultiAdrr of the genesis node, including the peer ID.
     ///
     /// # Arguments
     ///
-    /// * `address` - Optional address for where the genesis node will listen for connections. If
-    /// not specified, the 127.0.0.1:12000 local address will be used.
-    /// * `node_args` - Additional arguments to pass to the node process, e.g., --json-logs.
+    /// * `node_args` - Additional arguments to pass to the node process, e.g., --json-log-output.
     ///
     /// # Errors
     ///
@@ -202,11 +234,7 @@ impl Testnet {
     /// * The node data directory cannot be created
     /// * The node process fails
     /// * The network has already been launched previously
-    pub async fn launch_genesis(
-        &self,
-        _address: Option<SocketAddr>,
-        node_args: Vec<String>,
-    ) -> Result<String> {
+    pub async fn launch_genesis(&self, node_args: Vec<String>) -> Result<String> {
         if self.node_count != 0 {
             return Err(eyre!(
                 "A genesis node cannot be launched for an existing network"
@@ -225,7 +253,6 @@ impl Testnet {
         std::fs::create_dir_all(node_data_dir_path)?;
 
         let launch_bin = self.get_launch_bin();
-
         self.launcher.launch(&launch_bin, launch_args)?;
         info!(
             "Delaying for {} seconds before launching other nodes",
@@ -233,12 +260,8 @@ impl Testnet {
         );
         std::thread::sleep(std::time::Duration::from_millis(self.node_launch_interval));
 
-        let peer_id = check_testnet::obtain_peer_id(rpc_address).await?;
-        let genesis_multi_addr = format!(
-            "/ip4/127.0.0.1/tcp/{:?}/p2p/{}",
-            genesis_port,
-            peer_id.to_string()
-        );
+        let peer_id = self.rpc_client.obtain_peer_id(rpc_address).await?;
+        let genesis_multi_addr = format!("/ip4/127.0.0.1/tcp/{:?}/p2p/{}", genesis_port, peer_id);
         Ok(genesis_multi_addr)
     }
 
@@ -255,7 +278,11 @@ impl Testnet {
     /// * The node data directories cannot be created
     /// * The node process fails
     pub fn launch_nodes(&mut self, number_of_nodes: usize, node_args: Vec<String>) -> Result<()> {
-        let start = self.node_count + 2;
+        let start = if self.node_count == 0 {
+            self.node_count + 2
+        } else {
+            self.node_count + 1
+        };
         let end = self.node_count + number_of_nodes;
         for i in start..=end {
             info!("Launching node {i} of {end}...");
@@ -268,7 +295,6 @@ impl Testnet {
             std::fs::create_dir_all(&node_data_dir_path)?;
 
             let rpc_address = format!("127.0.0.1:{}", 12000 + i).parse()?;
-
             let launch_args = self.get_launch_args(
                 format!("safenode-{i}"),
                 Some(rpc_address),
@@ -338,22 +364,38 @@ mod test {
     use super::*;
     use assert_fs::prelude::*;
     use color_eyre::Result;
+    use libp2p::identity::Keypair;
     use mockall::predicate::*;
 
     const NODE_LAUNCH_INTERVAL: u64 = 0;
     const TESTNET_DIR_NAME: &str = "local-test-network";
 
-    #[test]
-    fn new_should_create_a_testnet_with_zero_nodes_when_no_previous_network_exists() -> Result<()> {
+    fn setup_default_mocks() -> (MockNodeLauncher, MockRpcClient) {
         let mut node_launcher = MockNodeLauncher::new();
         node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let rpc_client = setup_default_rpc_client_mock();
+        (node_launcher, rpc_client)
+    }
 
+    fn setup_default_rpc_client_mock() -> MockRpcClient {
+        let mut rpc_client = MockRpcClient::new();
+        rpc_client.expect_obtain_peer_id().returning(move |_| {
+            let peer_id = PeerId::from_public_key(&Keypair::generate_ed25519().public());
+            Box::pin(async move { Ok(peer_id) })
+        });
+        rpc_client
+    }
+
+    #[test]
+    fn new_should_create_a_testnet_with_zero_nodes_when_no_previous_network_exists() -> Result<()> {
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             PathBuf::from(SAFENODE_BIN_NAME),
             30000,
             PathBuf::from(TESTNET_DIR_NAME),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
 
         assert_eq!(testnet.node_bin_path, PathBuf::from(SAFENODE_BIN_NAME));
@@ -377,21 +419,21 @@ mod test {
             node_dir.create_dir_all()?;
         }
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             PathBuf::from(SAFENODE_BIN_NAME),
             30000,
             nodes_dir.to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
 
         assert_eq!(testnet.node_bin_path, PathBuf::from(SAFENODE_BIN_NAME));
         assert_eq!(testnet.node_launch_interval, 30000);
         assert_eq!(testnet.nodes_dir_path, nodes_dir.to_path_buf());
         assert!(!testnet.flamegraph_mode);
-        assert_eq!(testnet.node_count, 20);
+        assert_eq!(testnet.node_count, 19);
 
         Ok(())
     }
@@ -410,22 +452,21 @@ mod test {
         let random_dir = nodes_dir.child("user-created-random-dir");
         random_dir.create_dir_all()?;
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
-
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             PathBuf::from(SAFENODE_BIN_NAME),
             30000,
             nodes_dir.to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
 
         assert_eq!(testnet.node_bin_path, PathBuf::from(SAFENODE_BIN_NAME));
         assert_eq!(testnet.node_launch_interval, 30000);
         assert_eq!(testnet.nodes_dir_path, nodes_dir.to_path_buf());
         assert!(!testnet.flamegraph_mode);
-        assert_eq!(testnet.node_count, 20);
+        assert_eq!(testnet.node_count, 19);
 
         Ok(())
     }
@@ -443,6 +484,7 @@ mod test {
             .ok_or_else(|| eyre!("Unable to obtain path"))?
             .to_string();
 
+        let rpc_address: SocketAddr = "127.0.0.1:12001".parse()?;
         let mut node_launcher = MockNodeLauncher::new();
         node_launcher
             .expect_launch()
@@ -450,82 +492,43 @@ mod test {
             .with(
                 eq(node_bin_path.path().to_path_buf()),
                 eq(vec![
-                    "--first".to_string(),
-                    "10.0.0.1:12000".to_string(),
-                    "--local-addr".to_string(),
-                    "0.0.0.0:12000".to_string(),
+                    "--log-dir".to_string(),
+                    genesis_data_dir.clone(),
                     "--root-dir".to_string(),
                     genesis_data_dir.clone(),
-                    "--log-dir".to_string(),
-                    genesis_data_dir,
-                    "--json-logs".to_string(),
+                    "--local".to_string(),
+                    "--rpc".to_string(),
+                    rpc_address.to_string(),
+                    "--json-log-output".to_string(),
+                    "--port".to_string(),
+                    "11101".to_string(),
                 ]),
             )
             .returning(|_, _| Ok(()));
-
-        let testnet = Testnet::new(
-            node_bin_path.path().to_path_buf(),
-            NODE_LAUNCH_INTERVAL,
-            nodes_dir.path().to_path_buf(),
-            false,
-            Box::new(node_launcher),
-        )?;
-        let result = testnet
-            .launch_genesis(
-                Some("10.0.0.1:12000".parse()?),
-                vec!["--json-logs".to_string()],
-            )
-            .await;
-
-        assert!(result.is_ok());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn launch_genesis_should_launch_the_genesis_node_as_a_local_network() -> Result<()> {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
-        node_bin_path.write_binary(b"fake safenode code")?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
-        let genesis_data_dir = nodes_dir
-            .child(GENESIS_NODE_DIR_NAME)
-            .to_str()
-            .ok_or_else(|| eyre!("Unable to obtain path"))?
-            .to_string();
-
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher
-            .expect_launch()
+        let peer_id = PeerId::from_public_key(&Keypair::generate_ed25519().public());
+        let mut rpc_client = MockRpcClient::new();
+        rpc_client
+            .expect_obtain_peer_id()
             .times(1)
-            .with(
-                eq(node_bin_path.path().to_path_buf()),
-                eq(vec![
-                    "--first".to_string(),
-                    "127.0.0.1:12000".to_string(),
-                    "--local-addr".to_string(),
-                    "0.0.0.0:12000".to_string(),
-                    "--root-dir".to_string(),
-                    genesis_data_dir.clone(),
-                    "--log-dir".to_string(),
-                    genesis_data_dir,
-                    "--json-logs".to_string(),
-                ]),
-            )
-            .returning(|_, _| Ok(()));
-
+            .with(eq(rpc_address))
+            .returning(move |_| Box::pin(async move { Ok(peer_id) }));
         let testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet
-            .launch_genesis(None, vec!["--json-logs".to_string()])
-            .await;
 
-        assert!(result.is_ok());
+        let multiaddr = testnet
+            .launch_genesis(vec!["--json-log-output".to_string()])
+            .await?;
+
+        assert_eq!(
+            format!("/ip4/127.0.0.1/tcp/11101/p2p/{}", peer_id),
+            multiaddr
+        );
         Ok(())
     }
 
@@ -537,20 +540,17 @@ mod test {
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
         let result = testnet
-            .launch_genesis(
-                Some("10.0.0.1:12000".parse()?),
-                vec!["--json-logs".to_string()],
-            )
+            .launch_genesis(vec!["--json-log-output".to_string()])
             .await;
 
         assert!(result.is_ok());
@@ -567,20 +567,17 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
         let result = testnet
-            .launch_genesis(
-                Some("10.0.0.1:12000".parse()?),
-                vec!["--json-logs".to_string()],
-            )
+            .launch_genesis(vec!["--json-log-output".to_string()])
             .await;
 
         assert!(result.is_ok());
@@ -605,6 +602,7 @@ mod test {
             .ok_or_else(|| eyre!("Unable to obtain path"))?
             .to_string();
 
+        let rpc_address: SocketAddr = "127.0.0.1:12001".parse()?;
         let mut node_launcher = MockNodeLauncher::new();
         node_launcher
             .expect_launch()
@@ -623,18 +621,26 @@ mod test {
                     "--bin".to_string(),
                     SAFENODE_BIN_NAME.to_string(),
                     "--".to_string(),
-                    "--first".to_string(),
-                    "10.0.0.1:12000".to_string(),
-                    "--local-addr".to_string(),
-                    "0.0.0.0:12000".to_string(),
+                    "--log-dir".to_string(),
+                    genesis_data_dir_str.clone(),
                     "--root-dir".to_string(),
                     genesis_data_dir_str.clone(),
-                    "--log-dir".to_string(),
-                    genesis_data_dir_str,
-                    "--json-logs".to_string(),
+                    "--local".to_string(),
+                    "--rpc".to_string(),
+                    rpc_address.to_string(),
+                    "--json-log-output".to_string(),
+                    "--port".to_string(),
+                    "11101".to_string(),
                 ]),
             )
             .returning(|_, _| Ok(()));
+        let peer_id = PeerId::from_public_key(&Keypair::generate_ed25519().public());
+        let mut rpc_client = MockRpcClient::new();
+        rpc_client
+            .expect_obtain_peer_id()
+            .times(1)
+            .with(eq(rpc_address))
+            .returning(move |_| Box::pin(async move { Ok(peer_id) }));
 
         let testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
@@ -642,15 +648,16 @@ mod test {
             nodes_dir.path().to_path_buf(),
             true,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet
-            .launch_genesis(
-                Some("10.0.0.1:12000".parse()?),
-                vec!["--json-logs".to_string()],
-            )
-            .await;
+        let multiaddr = testnet
+            .launch_genesis(vec!["--json-log-output".to_string()])
+            .await?;
 
-        assert!(result.is_ok());
+        assert_eq!(
+            format!("/ip4/127.0.0.1/tcp/11101/p2p/{}", peer_id),
+            multiaddr
+        );
         Ok(())
     }
 
@@ -668,21 +675,17 @@ mod test {
             node_dir.create_dir_all()?;
         }
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
-
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
         let result = testnet
-            .launch_genesis(
-                Some("10.0.0.1:12000".parse()?),
-                vec!["--json-logs".to_string()],
-            )
+            .launch_genesis(vec!["--json-log-output".to_string()])
             .await;
 
         match result {
@@ -703,10 +706,12 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
+        let genesis_node_dir = tmp_data_dir.child("safenode-1");
+        genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 1..=20 {
+        for i in 2..=20 {
+            let rpc_port = 12000 + i;
             let node_data_dir = nodes_dir
                 .join(&format!("safenode-{i}"))
                 .to_str()
@@ -718,15 +723,19 @@ mod test {
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
+                        "--log-dir".to_string(),
+                        node_data_dir.clone(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
-                        "--log-dir".to_string(),
-                        node_data_dir,
-                        "--json-logs".to_string(),
+                        "--local".to_string(),
+                        "--rpc".to_string(),
+                        format!("127.0.0.1:{}", rpc_port),
+                        "--json-log-output".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
         }
+        let rpc_client = setup_default_rpc_client_mock();
 
         let mut testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
@@ -734,8 +743,9 @@ mod test {
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
 
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
@@ -749,20 +759,22 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
+        let genesis_node_dir = tmp_data_dir.child("safenode-1");
+        genesis_node_dir.create_dir_all()?;
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let mut testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
 
         assert!(result.is_ok());
-        for i in 1..=20 {
+        for i in 2..=20 {
             let node_dir = nodes_dir.child(format!("safenode-{i}"));
             node_dir.assert(predicates::path::is_dir());
         }
@@ -776,15 +788,17 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
+        let genesis_node_dir = tmp_data_dir.child("safenode-1");
+        genesis_node_dir.create_dir_all()?;
 
-        let mut node_launcher = MockNodeLauncher::new();
-        node_launcher.expect_launch().returning(|_, _| Ok(()));
+        let (node_launcher, rpc_client) = setup_default_mocks();
         let mut testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
             NODE_LAUNCH_INTERVAL,
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
         let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
 
@@ -803,10 +817,12 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
+        let genesis_node_dir = tmp_data_dir.child("safenode-1");
+        genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 1..=20 {
+        for i in 2..=20 {
+            let rpc_port = 12000 + i;
             let node_data_dir = nodes_dir.join(&format!("safenode-{i}"));
             let graph_output_file_path = node_data_dir
                 .join(format!("safenode-{i}-flame.svg"))
@@ -830,15 +846,19 @@ mod test {
                         "--bin".to_string(),
                         SAFENODE_BIN_NAME.to_string(),
                         "--".to_string(),
+                        "--log-dir".to_string(),
+                        node_data_dir.clone(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
-                        "--log-dir".to_string(),
-                        node_data_dir,
-                        "--json-logs".to_string(),
+                        "--local".to_string(),
+                        "--rpc".to_string(),
+                        format!("127.0.0.1:{}", rpc_port),
+                        "--json-log-output".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
         }
+        let rpc_client = setup_default_rpc_client_mock();
 
         let mut testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
@@ -846,8 +866,9 @@ mod test {
             nodes_dir.path().to_path_buf(),
             true,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
 
         assert!(result.is_ok());
         Ok(())
@@ -859,10 +880,12 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
+        let genesis_node_dir = tmp_data_dir.child("safenode-1");
+        genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 1..=30 {
+        for i in 2..=30 {
+            let rpc_port = 12000 + i;
             let node_data_dir = nodes_dir
                 .join(&format!("safenode-{i}"))
                 .to_str()
@@ -874,15 +897,19 @@ mod test {
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
+                        "--log-dir".to_string(),
+                        node_data_dir.clone(),
                         "--root-dir".to_string(),
                         node_data_dir.clone(),
-                        "--log-dir".to_string(),
-                        node_data_dir,
-                        "--json-logs".to_string(),
+                        "--local".to_string(),
+                        "--rpc".to_string(),
+                        format!("127.0.0.1:{}", rpc_port),
+                        "--json-log-output".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
         }
+        let rpc_client = setup_default_rpc_client_mock();
 
         let mut testnet = Testnet::new(
             node_bin_path.path().to_path_buf(),
@@ -890,15 +917,16 @@ mod test {
             nodes_dir.path().to_path_buf(),
             false,
             Box::new(node_launcher),
+            Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
 
-        let result = testnet.launch_nodes(10, vec!["--json-logs".to_string()]);
+        let result = testnet.launch_nodes(10, vec!["--json-log-output".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 30);
-        for i in 1..=30 {
+        for i in 2..=30 {
             let node_dir = nodes_dir.child(format!("safenode-{i}"));
             node_dir.assert(predicates::path::is_dir());
         }

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod check_testnet;
 
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{eyre::eyre, Help, Result};
 use libp2p::identity::PeerId;
 #[cfg(test)]
 use mockall::automock;
@@ -108,12 +108,6 @@ impl TestnetBuilder {
     /// will be a directory for each node.
     pub fn nodes_dir_path(&mut self, nodes_dir_path: PathBuf) -> &mut Self {
         self.nodes_dir_path = Some(nodes_dir_path);
-        self
-    }
-
-    /// Set this to clear out the existing node data directory for a new network.
-    pub fn clear_nodes_dir(&mut self) -> &mut Self {
-        self.clear_nodes_dir = true;
         self
     }
 
@@ -222,14 +216,14 @@ impl Testnet {
     /// # Errors
     ///
     /// Returns an error if:
-    /// * The node data directory cannot be created
+    /// * The node data directory is already populated with previous node root directories
     /// * The node process fails
-    /// * The network has already been launched previously
     pub async fn launch_genesis(&self, node_args: Vec<String>) -> Result<String> {
         if self.node_count != 0 {
             return Err(eyre!(
-                "A genesis node cannot be launched for an existing network"
-            ));
+                "A new testnet cannot be launched until the data directory is cleared"
+            )
+            .suggestion("Try again using the `--clean` argument"));
         }
 
         let rpc_address = "127.0.0.1:12001".parse()?;

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -5,6 +5,9 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+
+pub mod check_testnet;
+
 use color_eyre::{eyre::eyre, Result};
 #[cfg(test)]
 use mockall::automock;
@@ -199,7 +202,7 @@ impl Testnet {
     /// * The node data directory cannot be created
     /// * The node process fails
     /// * The network has already been launched previously
-    pub fn launch_genesis(
+    pub async fn launch_genesis(
         &self,
         _address: Option<SocketAddr>,
         node_args: Vec<String>,
@@ -210,14 +213,11 @@ impl Testnet {
             ));
         }
 
-        // info!("Launching genesis node using address {address}...");
-
         let rpc_address = "127.0.0.1:12001".parse()?;
         let mut launch_args =
             self.get_launch_args("safenode-1".to_string(), Some(rpc_address), node_args)?;
 
         let genesis_port: u16 = 11101;
-        // Let's start gen on a different port
         launch_args.push("--port".to_string());
         launch_args.push(genesis_port.to_string());
 
@@ -233,36 +233,13 @@ impl Testnet {
         );
         std::thread::sleep(std::time::Duration::from_millis(self.node_launch_interval));
 
-        // Now lets grab the genesis peer id.
-        let gen_id_query_args = vec![
-            "run",
-            "--release",
-            "--example",
-            "safenode_rpc_client",
-            "--",
-            "127.0.0.1:12001",
-            "info",
-        ];
-
-        let result = Command::new("cargo").args(gen_id_query_args).output()?;
-
-        use regex::Regex;
-        let re = Regex::new(r"Peer Id: ([^\n]+)").unwrap();
-        let stdout = String::from_utf8(result.stdout).unwrap();
-        if let Some(captures) = re.captures(&stdout) {
-            let peer_id = captures.get(1).unwrap().as_str();
-            info!("Peer Id: {}", peer_id);
-
-            let genesis_multi_addr =
-                format!("/ip4/127.0.0.1/tcp/{:?}/p2p/{}", genesis_port, peer_id);
-
-            Ok(genesis_multi_addr)
-        } else {
-            let err = String::from_utf8(result.stderr)?;
-            Err(eyre!(
-                "Genesis node PeerId could not be determined: {err:?}"
-            ))
-        }
+        let peer_id = check_testnet::obtain_peer_id(rpc_address).await?;
+        let genesis_multi_addr = format!(
+            "/ip4/127.0.0.1/tcp/{:?}/p2p/{}",
+            genesis_port,
+            peer_id.to_string()
+        );
+        Ok(genesis_multi_addr)
     }
 
     /// Launches a number of new nodes, either for a new network or an existing network.
@@ -453,8 +430,8 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_should_launch_the_genesis_node() -> Result<()> {
+    #[tokio::test]
+    async fn launch_genesis_should_launch_the_genesis_node() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
@@ -493,17 +470,19 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(
-            Some("10.0.0.1:12000".parse()?),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet
+            .launch_genesis(
+                Some("10.0.0.1:12000".parse()?),
+                vec!["--json-logs".to_string()],
+            )
+            .await;
 
         assert!(result.is_ok());
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_should_launch_the_genesis_node_as_a_local_network() -> Result<()> {
+    #[tokio::test]
+    async fn launch_genesis_should_launch_the_genesis_node_as_a_local_network() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
@@ -542,14 +521,16 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(None, vec!["--json-logs".to_string()]);
+        let result = testnet
+            .launch_genesis(None, vec!["--json-logs".to_string()])
+            .await;
 
         assert!(result.is_ok());
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_should_create_the_genesis_data_directory() -> Result<()> {
+    #[tokio::test]
+    async fn launch_genesis_should_create_the_genesis_data_directory() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
@@ -565,10 +546,12 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(
-            Some("10.0.0.1:12000".parse()?),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet
+            .launch_genesis(
+                Some("10.0.0.1:12000".parse()?),
+                vec!["--json-logs".to_string()],
+            )
+            .await;
 
         assert!(result.is_ok());
         let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
@@ -576,8 +559,8 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_should_create_the_genesis_data_directory_when_parents_are_missing(
+    #[tokio::test]
+    async fn launch_genesis_should_create_the_genesis_data_directory_when_parents_are_missing(
     ) -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
@@ -593,10 +576,12 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(
-            Some("10.0.0.1:12000".parse()?),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet
+            .launch_genesis(
+                Some("10.0.0.1:12000".parse()?),
+                vec!["--json-logs".to_string()],
+            )
+            .await;
 
         assert!(result.is_ok());
         let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
@@ -604,8 +589,8 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_with_flamegraph_mode_should_launch_the_genesis_node() -> Result<()> {
+    #[tokio::test]
+    async fn launch_genesis_with_flamegraph_mode_should_launch_the_genesis_node() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
@@ -658,17 +643,20 @@ mod test {
             true,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(
-            Some("10.0.0.1:12000".parse()?),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet
+            .launch_genesis(
+                Some("10.0.0.1:12000".parse()?),
+                vec!["--json-logs".to_string()],
+            )
+            .await;
 
         assert!(result.is_ok());
         Ok(())
     }
 
-    #[test]
-    fn launch_genesis_should_return_error_if_we_are_using_an_existing_network() -> Result<()> {
+    #[tokio::test]
+    async fn launch_genesis_should_return_error_if_we_are_using_an_existing_network() -> Result<()>
+    {
         let tmp_data_dir = assert_fs::TempDir::new()?;
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
@@ -690,10 +678,12 @@ mod test {
             false,
             Box::new(node_launcher),
         )?;
-        let result = testnet.launch_genesis(
-            Some("10.0.0.1:12000".parse()?),
-            vec!["--json-logs".to_string()],
-        );
+        let result = testnet
+            .launch_genesis(
+                Some("10.0.0.1:12000".parse()?),
+                vec!["--json-logs".to_string()],
+            )
+            .await;
 
         match result {
             Ok(_) => Err(eyre!("This test should return an error")),

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -221,7 +221,7 @@ async fn run_network(
         .flamegraph_mode(flamegraph_mode)
         .build()?;
 
-    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone()).await?;
+    let gen_multi_addr = testnet.launch_genesis(node_args.clone()).await?;
 
     node_args.push("--peer".to_string());
     node_args.push(gen_multi_addr);

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -27,9 +27,6 @@
     unused_results
 )]
 
-#[cfg(feature = "verify-nodes")]
-mod check_testnet;
-
 use sn_testnet::{Testnet, DEFAULT_NODE_LAUNCH_INTERVAL, SAFENODE_BIN_NAME};
 
 use clap::Parser;
@@ -224,14 +221,13 @@ async fn run_network(
         .flamegraph_mode(flamegraph_mode)
         .build()?;
 
-    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone())?;
+    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone()).await?;
 
     node_args.push("--peer".to_string());
     node_args.push(gen_multi_addr);
     testnet.launch_nodes(node_count as usize, node_args)?;
 
-    #[cfg(feature = "verify-nodes")]
-    check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
+    sn_testnet::check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
 
     Ok(())
 }


### PR DESCRIPTION
- 1f49a23 **feat: remove network contacts from `testnet` bin**

  While we do still have the concept of contacting other peers--via the `--peer` argument or
  `SAFE_PEERS` environment variable--we are not using a 'network contacts' file any more, so we don't
  need this argument for the `testnet` binary.

- c5f20ba **refactor: obtain genesis peer id directly**

  BREAKING CHANGE: Remove the `verify-nodes` feature in favour of just including this code in the
  binary. It only increases the size by a few megabytes and the binary is much more useful with this
  code.

  Refactor the genesis launching process to use the gRPC generated code to obtain the genesis peer ID,
  rather than using the `safe_rpc_client` example. The latter was actually built during the process,
  which involved having the source code checked out. This is probably an assumption we shouldn't make
  of a released binary. It's intended to be able to work stand alone, without the source.

- f779592 **tests: restore sn_testnet unit tests**

  The `sn_testnet` crate was more or less just copy/pasted from the previous safe_network repo and
  its behaviour was quickly changed for dealing with the new `safenode` binary. For quickness, the
  unit tests were subverted.

  These unit tests are now brought into line with the way the new `safenode` process operates and we
  can now keep them running for preventing regressions when things change.

- 5cd6409 **feat: remove node directory management**

  The testnet binary is updated to remove any node directory management, which is now performed by the
  `safenode` process.

  This simplifies both the code and test cases, and also removes a few cases that are no longer
  necessary.

- a1eb03e **feat: provide a `--clean` flag**

  Provides a `--clean` flag to remove all previous node root directories under the data directory,
  which is platform specific.

- 24dd50a **ci: remove use of `verify-nodes` feature**

  This feature has now been removed from the `testnet` binary. The functionality is now in the binary
  by default.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jul 23 22:14 UTC
This pull request includes the following changes:

1. The file diff removes the initialization of logging targets and the `init_logging` function call. It also removes the import of the `Level` enum from `tracing_core`.

2. The file diff for `main.rs` includes changes such as adding environment variables, modifying commands for starting a local network, updating benchmarks section, modifying benchmark names and parameters, and updating commands for checking memory usage.

3. The file `replication.rs` has changes related to adjusting the replication behavior of the `Node` implementation.

4. The file `sequential_transfers.rs` has changes related to logging configuration and do not affect the core functionality.

5. The `Cargo.toml` file has changes related to dependencies, versions, and package updates.

6. The changes in `mod.rs` include importing additional modules, initializing logging configuration, and removing logging related code.

7. The changes in `check_testnet.rs` include updating log output and console messages, new function addition, and modifying log file checking.

8. The file `build.rs` has changes related to removing unused import and modifying the compilation process of `safenode.proto`.

9. The file `data_with_churn.rs` has changes related to logging and removing records from specific directories.

10. The file `cli.rs` has changes related to importing additional modules and adding new options and subcommands.

11. The file `.github/workflows/nightly.yml` has changes related to modifying commands, removing trailing newline, and updating run flags.

12. The file `sn_logging.rs` has changes related to adding enums, implementing methods, and adding a new function for initializing logging configuration.

13. The file `safenode_rpc_client.rs` has changes related to logging initialization and imports.

14. The diff of the file `data_with_churn.rs` includes changes related to importing additional modules, changing arguments for `init_logging` function, replacing path with variable, and removing a `println!` statement.

15. The changes in `cli.rs` include importing additional modules, adding a function for parsing log output, and adding a struct with new fields.

16. The file `memcheck.yml` has changes related to setting environment variables, adding steps for package installation, modifying commands for building and starting nodes, modifying commands for checking network and replication, modifying commands for checking client files, modifying commands for monitoring memory usage, and modifying commands for creating log files archive.

17. The diff in `build.rs` removes the conditional compilation feature and changes the location of the `tonic_build::compile_protos` line.

Please review these changes and let me know if you need any further clarification.
<!-- reviewpad:summarize:end --> 
