### PR TITLE
ci: print peak client mem consumption in CI

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -248,6 +248,10 @@ jobs:
           path: heaptrack.safe.*
         continue-on-error: true
 
+      - name: Print heaptrack
+        run: rg "peak heap memory consumption" ./heaptrack.safe.txt
+        shell: bash
+
       - name: Check client memory usage
         id: client-memory-usage-check
         shell: bash


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 04:54 UTC
This pull request adds a feature to print the peak client memory consumption in the CI workflow. It includes changes to the benchmark-prs.yml file to add a step for printing heaptrack and checking client memory usage.
<!-- reviewpad:summarize:end --> 
