### PR TITLE
chore: use master branch of cargo-udeps

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,10 +30,7 @@ jobs:
           components: rustfmt
 
       - name: Install cargo-udeps
-        # TODO: (2023-07-03) This is a non-released version from udeps, which includes a bug fix:
-        # https://github.com/est31/cargo-udeps/issues/180
-        # Change this when this is released.
-        run: cargo install --git=https://github.com/est31/cargo-udeps.git --rev=f7a4705 --locked
+        run: cargo install --git https://github.com/est31/cargo-udeps --locked
       - name: Run cargo-udeps
         run: cargo +nightly udeps --all-targets
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 05:33 UTC
This pull request updates the .github/workflows/merge.yml file by modifying the installation command for cargo-udeps. The previous version involved using a non-released version from udeps that included a bug fix. Now, the patch changes the command to install cargo-udeps from the master branch of the repository using the --git flag. This ensures that the latest version of cargo-udeps is installed before running the cargo-udeps command.
<!-- reviewpad:summarize:end --> 
