### PR TITLE
feat: Using put record for upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,12 +349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,11 +4623,9 @@ dependencies = [
 name = "sn_networking"
 version = "0.3.11"
 dependencies = [
- "assert_matches",
  "async-trait",
  "blsttc",
  "bytes",
- "eyre",
  "futures",
  "itertools",
  "libp2p",
@@ -4641,7 +4633,6 @@ dependencies = [
  "rand 0.8.5",
  "rmp-serde",
  "serde",
- "sn_logging",
  "sn_protocol",
  "thiserror",
  "tokio",

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -18,8 +18,8 @@ use futures::future::select_all;
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use libp2p::{
-    kad::{RecordKey, K_VALUE},
-    Multiaddr, PeerId,
+    kad::{Record, RecordKey, K_VALUE},
+    Multiaddr,
 };
 use sn_dbc::{DbcId, SignedSpend};
 use sn_networking::{close_group_majority, multiaddr_is_global, NetworkEvent, SwarmDriver};
@@ -27,8 +27,8 @@ use sn_protocol::{
     error::Error as ProtocolError,
     messages::{Cmd, CmdResponse, PaymentProof, Query, QueryResponse, Request, Response},
     storage::{
-        try_deserialize_record, Chunk, ChunkAddress, ChunkWithPayment, DbcAddress, RecordHeader,
-        RecordKind,
+        try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, ChunkWithPayment,
+        DbcAddress, RecordHeader, RecordKind,
     },
     NetworkAddress,
 };
@@ -260,55 +260,22 @@ impl Client {
         ClientRegister::create(self.clone(), xorname, tag)
     }
 
-    /// Store `Chunk` to spcified target.
+    /// Store `Chunk` as a record.
     pub(super) async fn store_chunk(
         &self,
         chunk: Chunk,
         payment: Option<PaymentProof>,
-        closest_peers: Vec<PeerId>,
     ) -> Result<()> {
-        let address = *chunk.name();
-        info!("Store chunk: {:?}", address);
-        let request = Request::Cmd(Cmd::StoreChunk { chunk, payment });
-
-        // Result will be: just one with `StoreChunk(Ok(_))` response;
-        // or a vector of error responses, which only take the first into account.
-        let mut responses = self
-            .network
-            .send_and_get_responses(closest_peers, &request, false)
-            .await
-            .into_iter()
-            .map(|res| res.map_err(Error::Network))
-            .collect_vec();
-        let response = if let Some(response) = responses.pop() {
-            response?
-        } else {
-            return Err(Error::UnexpectedResponses);
+        info!("Store chunk: {:?}", chunk.address());
+        let chunk_with_payment = ChunkWithPayment { chunk, payment };
+        let record = Record {
+            key: RecordKey::new(chunk_with_payment.chunk.name()),
+            value: try_serialize_record(&chunk_with_payment, RecordKind::Chunk)?,
+            publisher: None,
+            expires: None,
         };
 
-        if matches!(response, Response::Cmd(CmdResponse::StoreChunk(Ok(_)))) {
-            return Ok(());
-        }
-
-        if let Response::Cmd(CmdResponse::StoreChunk(result)) = response {
-            result?;
-        };
-
-        // If there were no store chunk errors, then we had unexpected responses.
-        Err(Error::UnexpectedResponses)
-    }
-
-    /// Return all the peers from the local network knowledge.
-    pub(super) async fn get_all_local_peers(&self) -> Result<Vec<PeerId>> {
-        Ok(self.network.get_all_local_peers().await?)
-    }
-
-    /// Returns the closest peers to the given `NetworkAddress`
-    /// that is fetched from the local Routing Table.
-    /// It is ordered by increasing distance of the peers.
-    /// Note self peer_id is not included in the result.
-    pub async fn get_closest_local_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
-        Ok(self.network.get_closest_local_peers(key).await?)
+        Ok(self.network.put_record(record).await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -117,7 +117,6 @@ impl Client {
                                 continue;
                             }
                         };
-                        trace!("Client received a network event {the_event:?}");
                         if let Err(err) = client_clone.handle_network_event(the_event) {
                             warn!("Error handling network event: {err}");
                         }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -17,11 +17,7 @@ use bytes::Bytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use self_encryption::{self, ChunkInfo, DataMap, EncryptedChunk, MIN_ENCRYPTABLE_BYTES};
-use sn_networking::{sort_peers_by_address, CLOSE_GROUP_SIZE};
-use sn_protocol::{
-    storage::{Chunk, ChunkAddress},
-    NetworkAddress,
-};
+use sn_protocol::storage::{Chunk, ChunkAddress};
 use tokio::task;
 use tracing::trace;
 use xor_name::XorName;
@@ -170,11 +166,7 @@ impl Files {
         // TODO: re-enable requirement to always provide payment proof
         //.ok_or(super::Error::MissingPaymentProof(address))?;
 
-        let dst = NetworkAddress::from_chunk_address(address);
-        let closest_peers = self.client.get_closest_local_peers(&dst).await?;
-        self.client
-            .store_chunk(chunk, payment, closest_peers)
-            .await?;
+        self.client.store_chunk(chunk, payment).await?;
 
         if verify {
             self.verify_chunk_is_stored(address).await?;
@@ -192,7 +184,6 @@ impl Files {
         payment_proofs: &PaymentProofsMap,
         verify: bool,
     ) -> Result<ChunkAddress> {
-        let all_peers = self.client.get_all_local_peers().await?;
         let (head_address, mut all_chunks) = encrypt_large(large)?;
         trace!("Client upload started");
         while !all_chunks.is_empty() {
@@ -202,17 +193,13 @@ impl Files {
             let mut tasks = vec![];
             for chunk in next_batch {
                 let client = self.client.clone();
-                let all_peers_clone = all_peers.clone();
                 let chunk_addr = *chunk.address();
                 let payment = payment_proofs.get(chunk_addr.name()).cloned();
                 // TODO: re-enable requirement to always provide payment proof
                 //.ok_or(super::Error::MissingPaymentProof(chunk_addr))?;
 
                 tasks.push(task::spawn(async move {
-                    let dst = NetworkAddress::from_chunk_address(chunk_addr);
-                    let closest_peers =
-                        sort_peers_by_address(all_peers_clone, &dst, CLOSE_GROUP_SIZE)?;
-                    client.store_chunk(chunk, payment, closest_peers).await?;
+                    client.store_chunk(chunk, payment).await?;
                     if verify {
                         let _ = client.get_chunk(chunk_addr).await?;
                     }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -17,14 +17,12 @@ local-discovery=["libp2p/mdns"]
 [dependencies]
 async-trait = "0.1"
 bytes = { version = "1.0.1", features = ["serde"] }
-eyre = "0.6.8"
 futures = "~0.3.13"
 itertools = "~0.10.1"
 libp2p = { version="0.51", features = ["tokio", "dns", "kad", "macros", "request-response", "identify", "autonat", "mplex", "noise", "tcp", "yamux"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_logging = { path = "../sn_logging", features = ["test-utils"], version = "0.2.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.2.1" }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
@@ -32,6 +30,5 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 bls = { package = "blsttc", version = "8.0.1" }
 quickcheck = "1.0.3"

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -195,7 +195,6 @@ impl SwarmDriver {
                 let _ = sender.send(record);
             }
             SwarmCmd::PutRecord { record, sender } => {
-                // TODO: shall we wait for the response?
                 let request_id = self
                     .swarm
                     .behaviour_mut()

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -79,6 +79,9 @@ pub enum Error {
     #[error("Record was not found locally")]
     RecordNotFound,
 
+    #[error("Record not put to network properly")]
+    RecordNotPut,
+
     #[error("No SwarmCmd channel capacity")]
     NoSwarmCmdChannelCapacity,
 }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -421,21 +421,10 @@ impl SwarmDriver {
                 }
             }
             KademliaEvent::InboundRequest {
-                request: InboundRequest::PutRecord { source, record, .. },
+                request: InboundRequest::PutRecord { .. },
             } => {
-                if record.is_some() {
-                    // Currently we do not perform `kad.put_record()` or use `kad's replication` in our codebase,
-                    // hence we should not receive any inbound PutRecord.
-                    warn!("Kad's PutRecord handling is not implemented yet. {source:?} has triggerd kad.put_record or has enabled kad's replication flow");
-                } else {
-                    // If the Record filtering is not enabled at the kad cfg, a malicious node
-                    // can just call `kad.put_record()` which would store that record at the
-                    // closest nodes without any validations
-                    //
-                    // Enable it to instead get the above `PutRequest` event which is then
-                    // handled separately
-                    warn!("The PutRecord KademliaEvent should include a Record. Enable record filtering via the kad config")
-                }
+                // Ignored to reduce logging. When `Record filtering` is enabled,
+                // the `record` variable will contain the content for further validation before put.
             }
             KademliaEvent::InboundRequest {
                 request:

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -7,10 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::RegisterCmd;
-use crate::{
-    storage::{Chunk, ChunkAddress, DbcAddress},
-    NetworkAddress,
-};
+use crate::{storage::DbcAddress, NetworkAddress};
 use serde::{Deserialize, Serialize};
 // TODO: remove this dependency and define these types herein.
 pub use sn_dbc::{DbcId, DbcTransaction, Hash, SignedSpend};
@@ -24,15 +21,6 @@ pub use sn_dbc::{DbcId, DbcTransaction, Hash, SignedSpend};
 #[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, custom_debug::Debug)]
 pub enum Cmd {
-    /// [`Chunk`] write operation.
-    ///
-    /// [`Chunk`]: crate::storage::Chunk
-    StoreChunk {
-        chunk: Chunk,
-        // Storage payment proof
-        // TODO: temporarily payment proof is optional
-        payment: Option<PaymentProof>,
-    },
     /// [`Register`] write operation.
     ///
     /// [`Register`]: sn_registers::Register
@@ -62,9 +50,6 @@ impl Cmd {
     /// Used to send a cmd to the close group of the address.
     pub fn dst(&self) -> NetworkAddress {
         match self {
-            Cmd::StoreChunk { chunk, .. } => {
-                NetworkAddress::from_chunk_address(ChunkAddress::new(*chunk.name()))
-            }
             Cmd::Register(cmd) => NetworkAddress::from_register_address(cmd.dst()),
             Cmd::SpendDbc(signed_spend) => {
                 NetworkAddress::from_dbc_address(DbcAddress::from_dbc_id(signed_spend.dbc_id()))
@@ -78,9 +63,6 @@ impl Cmd {
 impl std::fmt::Display for Cmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Cmd::StoreChunk { chunk, .. } => {
-                write!(f, "Cmd::StoreChunk({:?})", chunk.name())
-            }
             Cmd::Register(cmd) => {
                 write!(f, "Cmd::Register({:?})", cmd.name()) // more qualification needed
             }

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -67,18 +67,16 @@ pub enum CmdResponse {
     /// Response to DbcCmd::Spend.
     Spend(Result<CmdOk>),
     //
-    // ===== Chunk =====
-    //
-    /// Response to Cmd::StoreChunk
-    StoreChunk(Result<CmdOk>),
-    //
     // ===== Register Data =====
     //
     /// Response to RegisterCmd::Create.
     CreateRegister(Result<()>),
     /// Response to RegisterCmd::Edit.
     EditRegister(Result<()>),
-    /// Response to ReplicateCmd
+    //
+    // ===== Replication =====
+    //
+    /// Response to replication cmd
     Replicate(Result<()>),
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 13:26 UTC
This pull request includes multiple file diffs with various changes. Here is a summary of the changes:

1. In `replication.rs`:
   - Rearranged import statements for `libp2p` and `sn_protocol` crates.
   - Removed the import of `storage::ChunkAddress`.
   - Removed the `try_replicate_an_entry` method.
   - Modified the `try_trigger_replication` method.

2. In `api.rs`:
   - Removed the import of `ChunkWithPayment` and `DbcAddress` from `sn_protocol`.
   - Updated the import of `NetworkAddress`.
   - Removed the `handle_node_cmd` implementation for the `Cmd::StoreChunk` case, which involved storing a chunk and its payment and then replicating an entry. The code for chunk storage and replication is no longer present.
   - Updated the implementation for the `Cmd::Replicate` case, which receives a list of keys to replicate.

3. In `SwarmCmd`:
   - Imported the `Quorum` type from the `libp2p::kad` module.
   - Added a new variant `PutRecord`, which represents putting a record to the network and includes the record to be put and a sender for the result.
   - Modified the `SwarmDriver` implementation to handle the new `PutRecord` variant.
   - Added new comments for the `PutRecord` variant in the `SwarmCmd` enum and its handling in the `SwarmDriver` implementation.

4. In `sn_client/src/api.rs`:
   - Added an import statement for `Record` in the `libp2p` module.
   - Modified the `store_chunk` function to store a `Chunk` as a record.
   - Removed the `get_all_local_peers` function.
   - Modified the `get_closest_local_peers` function to use the `get_closest_local_peers` method of the `network` field.

5. In `response.rs`:
   - Removed the `StoreChunk` variant of the `CmdResponse` enum.
   - Reorganized comments to group related sections together.
   - Updated the comment for the `Replicate` variant.

6. In `event.rs`:
   - Added a new variant `OutboundQueryProgressed` to the `KademliaEvent` enum, which includes a `PutRecord` result and additional fields.
   - Implemented handling for the new `OutboundQueryProgressed` variant in the `SwarmDriver` implementation.
   - Added logging statements and error handling for the `PutRecord` operation.

7. In `error.rs`:
   - Added a new error variant `RecordNotPut` to the `Error` enum, used when a record is not put to the network properly.

These changes include modifications to import statements, method removals, method modifications, variant additions, and comment updates. Let me know if you need further assistance with this diff.
<!-- reviewpad:summarize:end --> 
