### PR TITLE
test out reduced range

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -155,12 +155,20 @@ jobs:
           RUST_LOG: "safenode,safe=trace"
         timeout-minutes: 10
 
+      - name: Check nodes running
+        shell: bash
+        timeout-minutes: 1
+        continue-on-error: true
+        run: pgrep safenode | wc -l
+        if: always()
+
+
       - name: Kill all nodes
         shell: bash
         timeout-minutes: 1
         continue-on-error: true
         run: |
-          pkill safenode
+          killall safenode
           echo "$(pgrep safenode | wc -l) nodes still running"
         if: always()
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -89,9 +89,9 @@ jobs:
         run: cargo test --release -p sn_node --test data_with_churn -- --nocapture 
         env:
           CHUNKS_ONLY: true
-          TEST_DURATION_MINS: 10
+          TEST_DURATION_MINS: 15
           SN_LOG: "all"
-        timeout-minutes: 15
+        timeout-minutes: 20
 
       - name: Verify restart of nodes using rg
         shell: bash

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -26,7 +26,7 @@ const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 // Defines how close that a node will trigger replication.
 // That is, the node has to be among the REPLICATION_RANGE closest to data,
 // to carry out the replication.
-const REPLICATION_RANGE: usize = 8;
+const REPLICATION_RANGE: usize = 4;
 
 impl Node {
     /// In case self is not among the closest to the chunk,


### PR DESCRIPTION
This should provide a bit more time per node cycle for replication## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 14:17 UTC
This pull request includes three patches. 

Patch 1/3 updates the CI configuration to give slightly more time to memcheck, increasing the test duration from 10 minutes to 15 minutes.

Patch 2/3 adds a step to check the number of nodes running and includes the output in the log.

Patch 3/3 reduces the replication range from 8 to 4 in the `replication.rs` file.

Overall, these patches aim to improve the testing process, monitor the number of running nodes, and optimize the replication range.
<!-- reviewpad:summarize:end --> 
