### PR TITLE
test: adding tests for uploading paid chunks and run them in CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -309,7 +309,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release --features local-discovery multiple_sequential_transfers_succeed --no-run
+        run: cargo test --release --features local-discovery dbc_transfer_,storage_payment_ --no-run
         timeout-minutes: 30
         env:
           CARGO_TARGET_DIR: "./transfer-target"
@@ -321,14 +321,14 @@ jobs:
         timeout-minutes: 10
 
       - name: execute the dbc spend test
-        run: cargo test --release --features="local-discovery" multiple_sequential_transfers_succeed  -- --nocapture
+        run: cargo test --release --features="local-discovery" dbc_transfer_ -- --nocapture
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 10
 
-      - name: execute the storage payment test
-        run: cargo test --release --features="local-discovery" storage_payment_succeeds -- --nocapture
+      - name: execute the storage payment tests
+        run: cargo test --release --features="local-discovery" storage_payment_ -- --nocapture
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -8,29 +8,19 @@
 
 mod common;
 
-use common::{get_client_and_wallet, get_wallet};
+use common::{get_client_and_wallet, get_wallet, init_logging};
 
 use sn_client::send;
 
 use sn_dbc::{random_derivation_index, rng, Token};
-use sn_logging::{init_logging, LogFormat, LogOutputDest};
 use sn_transfers::client_transfers::create_transfer;
-use tracing_core::Level;
 
 use assert_fs::TempDir;
 use eyre::Result;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn multiple_sequential_transfers_succeed() -> Result<()> {
-    let logging_targets = vec![
-        ("safenode".to_string(), Level::INFO),
-        ("sn_client".to_string(), Level::TRACE),
-        ("sn_transfers".to_string(), Level::INFO),
-        ("sn_networking".to_string(), Level::INFO),
-        ("sn_node".to_string(), Level::INFO),
-    ];
-    let _log_appender_guard =
-        init_logging(logging_targets, LogOutputDest::Stdout, LogFormat::Default)?;
+async fn dbc_transfer_multiple_sequential_succeed() -> Result<()> {
+    init_logging();
 
     let first_wallet_balance = 1_000_000_000;
     let first_wallet_dir = TempDir::new()?;
@@ -66,16 +56,8 @@ async fn multiple_sequential_transfers_succeed() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn double_spend_transfers_fail() -> Result<()> {
-    let logging_targets = vec![
-        ("safenode".to_string(), Level::INFO),
-        ("sn_client".to_string(), Level::TRACE),
-        ("sn_transfers".to_string(), Level::INFO),
-        ("sn_networking".to_string(), Level::INFO),
-        ("sn_node".to_string(), Level::INFO),
-    ];
-    let _log_appender_guard =
-        init_logging(logging_targets, LogOutputDest::Stdout, LogFormat::Default)?;
+async fn dbc_transfer_double_spend_fail() -> Result<()> {
+    init_logging();
 
     // create 1 wallet add money from faucet
     let first_wallet_balance = 1_000_000_000;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 16:27 UTC
This pull request includes the following changes:

1. The `Cargo.toml` file:
- Added the `async_once` dependency with version "0.2.6".

2. The file `sequential_transfers.rs`:
- Removed the import `tracing_core::Level`.
- Renamed the function `multiple_sequential_transfers_succeed` to `dbc_transfer_multiple_sequential_succeed`.
- Renamed the function `double_spend_transfers_fail` to `dbc_transfer_double_spend_fail`.
- Modified the logging targets in the `init_logging` function calls.

3. The file `sn_node/tests/common/mod.rs`:
- Added import statements for various dependencies.
- Added a static variable and a function for initializing logging targets.
- Added a lazy static variable for restricting access to the faucet wallet.
- Modified the `get_client_and_wallet` function.
- Added print statements for logging purposes.

4. The file `.github/workflows/merge.yml`:
- Modified the build and test commands for different steps.

5. The file `storage_payments.rs`:
- Added import statements for various dependencies.
- Added a function for generating random content and creating chunks.
- Modified and added functions for handling storage payments and chunk uploading scenarios.
- Modified the `Cargo.toml` file to include new dependencies.

Please review these changes and make any necessary adjustments or further modifications.
<!-- reviewpad:summarize:end --> 
