### PR TITLE
feat: faucet server and cli DBC read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "asn1-rs"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +782,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "ciborium"
@@ -4679,6 +4691,7 @@ dependencies = [
  "sn_transfers",
  "strum",
  "thiserror",
+ "tiny_http",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5106,6 +5119,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log",
+ "time 0.3.22",
+ "url",
 ]
 
 [[package]]

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -119,6 +119,7 @@ async fn read(root_dir: &Path) -> Result<()> {
     let old_balance = wallet.balance();
     wallet.deposit(vec![dbc]);
     let new_balance = wallet.balance();
+    wallet.store().await?;
 
     println!("Successfully stored dbc to wallet dir. \nOld balance: {old_balance}\nNew balance: {new_balance}");
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/safenode/main.rs"
 
 [[bin]]
 name = "faucet"
-path = "src/bin/faucet.rs"
+path = "src/bin/faucet/main.rs"
 
 [features]
 default=["metrics"]
@@ -68,6 +68,7 @@ walkdir = "2.3.1"
 xor_name = "5.0.0"
 tracing-log = { version = "0.1.3", features = ["env_logger"] }
 strum = { version = "0.25.0", features = ["derive"] }
+tiny_http = "0.11"
 
 [dev-dependencies]
 assert_fs = "1.0.0"

--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -28,7 +28,7 @@ use tiny_http::{Response, Server};
 /// curl "localhost:8000/`cargo run  --features="local-discovery"  --bin safe --release  wallet address | tail -n 1`" > dbc_hex
 ///
 /// # feed DBC to local wallet
-/// cat dbc_hex | cargo run  --features="local-discovery"  --bin safe --release  wallet read
+/// cat dbc_hex | cargo run  --features="local-discovery"  --bin safe --release  wallet deposit --stdin
 ///
 /// # balance should be updated
 /// ```

--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::path;
+
+use crate::{claim_genesis, send_tokens};
+use eyre::{eyre, Result};
+use sn_client::Client;
+
+use tiny_http::{Response, Server};
+
+/// Run the faucet server.
+///
+/// This will listen on port 8000 and send tokens to any request.
+///
+/// # Example
+///
+/// ```bash
+/// # run faucet server
+/// cargo run  --features="local-discovery" --bin faucet --release -- server
+///
+/// # query faucet server for DBC at `get local wallet address`
+/// curl "localhost:8000/`cargo run  --features="local-discovery"  --bin safe --release  wallet address | tail -n 1`" > dbc_hex
+///
+/// # feed DBC to local wallet
+/// cat dbc_hex | cargo run  --features="local-discovery"  --bin safe --release  wallet read
+///
+/// # balance should be updated
+/// ```
+
+pub async fn run_faucet_server(client: &Client) -> Result<()> {
+    let server =
+        Server::http("0.0.0.0:8000").map_err(|e| eyre!("Failed to start server: {}", e))?;
+    claim_genesis(client).await;
+
+    println!("Starting http server listening on port 8000...");
+    for request in server.incoming_requests() {
+        println!(
+            "received request! method: {:?}, url: {:?}, headers: {:?}",
+            request.method(),
+            request.url(),
+            request.headers()
+        );
+        let key = request.url().trim_matches(path::is_separator);
+
+        match send_tokens(client, "10", key).await {
+            Ok(dbc) => {
+                println!("Sent tokens to {}", key);
+                let response = Response::from_string(dbc);
+                let _ = request
+                    .respond(response)
+                    .map_err(|e| eprintln!("Failed to send response: {}", e));
+            }
+            Err(e) => {
+                eprintln!("Failed to send tokens to {}: {}", key, e);
+                let response = Response::from_string(format!("Failed to send tokens: {}", e));
+                let _ = request
+                    .respond(response.with_status_code(500))
+                    .map_err(|e| eprintln!("Failed to send response: {}", e));
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jul 23 02:59 UTC
This pull request adds a new feature to the codebase. It includes changes to the `Cargo.lock`, `sn_cli/src/subcommands/wallet.rs`, `sn_node/Cargo.toml`, `sn_node/src/bin/faucet/faucet_server.rs`, and `sn_node/src/bin/faucet/main.rs` files.

The changes in the `Cargo.lock` file include the addition of the `ascii` and `chunked_transfer` packages.

The `sn_cli/src/subcommands/wallet.rs` file now includes a new command, `Read`, which reads a DBC from stdin and deposits it to the local wallet.

In the `sn_node/Cargo.toml` file, the `path` for the `faucet` binary has been changed from `src/bin/faucet.rs` to `src/bin/faucet/main.rs`.

A new file, `sn_node/src/bin/faucet/faucet_server.rs`, has been added. This file contains the implementation of the faucet server, which listens on port 8000 and sends tokens to any request.

The `sn_node/src/bin/faucet.rs` file has been renamed to `sn_node/src/bin/faucet/main.rs`.


<!-- reviewpad:summarize:end --> 
