### PR TITLE
docs: add docs to `dialed_peers` for explanation

### DIFF
--- a/sn_networking/src/circular_vec.rs
+++ b/sn_networking/src/circular_vec.rs
@@ -5,6 +5,9 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+
+/// Based on https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/7
+
 #[derive(Debug)]
 pub struct CircularVec<T> {
     inner: std::collections::VecDeque<T>,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -108,6 +108,7 @@ pub struct SwarmDriver {
     pending_query: HashMap<QueryId, oneshot::Sender<Result<Record>>>,
     replication_fetcher: ReplicationFetcher,
     local: bool,
+    /// A list of the most recent peers we have dialed ourselves.
     dialed_peers: CircularVec<PeerId>,
     dead_peers: BTreeSet<PeerId>,
 }
@@ -365,6 +366,10 @@ impl SwarmDriver {
             pending_query: Default::default(),
             replication_fetcher: Default::default(),
             local,
+            // We use 63 here, as in practice the capactiy will be rounded to the nearest 2^(n-1).
+            // Source: https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/8
+            // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
+            // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
             dead_peers: Default::default(),
         };


### PR DESCRIPTION
Add some docs to explain what the `dialed_peers` is about with the circular buffer.
