### PR TITLE
Various Enhancements for `testnet` Binary

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -2,7 +2,6 @@ name: PR Benchmarks
 
 on: pull_request
 
-
 env:
   CARGO_INCREMENTAL: '0'
   RUST_BACKTRACE: 1
@@ -56,7 +55,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -17,6 +17,7 @@ env:
   RUST_BACKTRACE: 1
   CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
   NODE_DATA_PATH: /home/runner/.local/share/safe/node
+  HEAPNODE_DATA_PATH: /home/runner/.local/share/safe/heapnode
 
 jobs:
   benchmark:
@@ -49,12 +50,9 @@ jobs:
       - name: ubuntu install ripgrep
         run: sudo apt-get -y install ripgrep
 
-      # A consistent file with a size of 95MB.
-      - name: download the testing file
+      - name: Download 95mb file to be uploaded with the safe client
         shell: bash
-        run: |
-          wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
-          ls -la
+        run: wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
      
       - name: Build sn bins
         run: cargo build --release --bins --features local-discovery
@@ -66,12 +64,11 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 10
 
-      # Start a heaptracked node instance to compare memory usage
-      - name: Start safenode with heaptrack
+      - name: Start a heaptracked node instance to compare memory usage
         run: |
-          mkdir -p ~/.safe/heapnode
+          mkdir -p $HEAPNODE_DATA_PATH
           heaptrack ./target/release/safenode \
-            --root-dir ~/.safe/heapnode --log-output-dest ~/.safe/heapnode --local &
+            --root-dir $HEAPNODE_DATA_PATH --log-output-dest $HEAPNODE_DATA_PATH --local &
           sleep 10
         env:
           SN_LOG: "all"
@@ -79,7 +76,6 @@ jobs:
       ########################
       ### Benchmark        ###
       ########################
-
       - name: Bench `safe`
         shell: bash
         # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
@@ -111,12 +107,9 @@ jobs:
           auto-push: true
           max-items-in-chart: 300
 
-      # Start a heaptracked client instance to compare memory usage
-      # The generated large single file (around 450MB) may vary little bit along the releases
-      - name: Start client with heaptrack
+      - name: Start a heaptracked client instance to compare memory usage
         shell: bash
-        run: |
-          heaptrack ./target/release/safe files upload ./the-test-data.zip
+        run: heaptrack ./target/release/safe --log-output-dest data-dir files upload the-test-data.zip
         env:
           SN_LOG: "all"
 
@@ -136,7 +129,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          find ~/.safe/heapnode -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
+          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
           find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
           find $CLIENT_DATA_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
           find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
@@ -160,8 +153,8 @@ jobs:
       - name: Analyze node memory usage
         shell: bash
         run: |
-          HEAPTRACK_FILE=$(ls -t heaptrack.safenode.*.zst | head -1)
-          heaptrack --analyze $HEAPTRACK_FILE > heaptrack.safenode.txt
+          heaptrack_file=$(ls -t heaptrack.safenode.*.zst | head -1)
+          heaptrack --analyze $heaptrack_file > heaptrack.safenode.txt
 
       - name: Upload Node Heaptrack
         uses: actions/upload-artifact@main
@@ -171,35 +164,32 @@ jobs:
         continue-on-error: true
 
       - name: Check node memory usage
-        id: node-memory-usage-check
         shell: bash
-        env:
-          NODE_MEM_LIMIT_MB: "100" # mb
         run: |
-          MEMORY_USAGE=$(rg "peak heap memory consumption" ./heaptrack.safenode.txt | awk '{
+          node_mem_limit_mb="100" # mb
+          memory_usage=$(rg "peak heap memory consumption" ./heaptrack.safenode.txt | awk '{
             if ($5 ~ /K/) {
-                  sub(/K/, "", $5);
-                  $5 = $5 / 1024;
-              } else if ($5 ~ /G/) {
-                  sub(/G/, "", $5);
-                  $5 = $5 * 1024;
-              }
-                else if ($5 ~ /M/) {
-                  sub(/M/, "", $5);
-                  $5 = $5;
-              }
+              sub(/K/, "", $5);
+              $5 = $5 / 1024;
+            } else if ($5 ~ /G/) {
+              sub(/G/, "", $5);
+              $5 = $5 * 1024;
+            } else if ($5 ~ /M/) {
+              sub(/M/, "", $5);
+              $5 = $5;
+            }
             print $5;
-          }'  )
-          echo "Memory usage: $MEMORY_USAGE MB"
-          if (( $(echo "$MEMORY_USAGE > $NODE_MEM_LIMIT_MB" | bc -l) )); then
-            echo "Node memory usage exceeded threshold: $MEMORY_USAGE MB"
+          }' )
+          echo "Memory usage: $memory_usage MB"
+          if (( $(echo "$memory_usage > $node_mem_limit_mb" | bc -l) )); then
+            echo "Node memory usage exceeded threshold: $memory_usage MB"
             exit 1
           fi
-          # Write the node memory usage to a JSON file
+          # Write the node memory usage to a file
           echo '[
               {
-                  "name": "Peak memory w/ `safe` benchmarks",
-                  "value": '$MEMORY_USAGE',
+                  "name": "node-memory-usage-through-safe-benchmark",
+                  "value": '$memory_usage',
                   "unit": "MB"
               }
           ]' > node_memory_usage.json
@@ -228,8 +218,8 @@ jobs:
       - name: Analyze client memory usage
         shell: bash
         run: |
-          HEAPTRACK_FILE=$(ls -t heaptrack.safe.*.zst | head -1)
-          heaptrack --analyze $HEAPTRACK_FILE > heaptrack.safe.txt
+          heaptrack_file=$(ls -t heaptrack.safe.*.zst | head -1)
+          heaptrack --analyze $heaptrack_file > heaptrack.safe.txt
 
       - name: Upload Client Heaptrack
         uses: actions/upload-artifact@main
@@ -245,52 +235,56 @@ jobs:
         shell: bash
 
       - name: Check client memory usage
-        id: client-memory-usage-check
         shell: bash
-        # remove once this is not bugging out
-        continue-on-error: true
-        env:
-          CLIENT_AVG_MEM_LIMIT_MB: "600" # mb
         run: |
           peak_mem_usage=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{
-              if ($5 ~ /K/) {
-                  sub(/K/, "", $5);
-                  $5 = $5 / 1024;
-              } else if ($5 ~ /G/) {
-                  sub(/G/, "", $5);
-                  $5 = $5 * 1024;
-              }
-                else if ($5 ~ /M/) {
-                  sub(/M/, "", $5);
-                  $5 = $5;
-              }
-              print $5;
-          }'  )
+            if ($5 ~ /K/) {
+              sub(/K/, "", $5);
+              $5 = $5 / 1024;
+            } else if ($5 ~ /G/) {
+              sub(/G/, "", $5);
+              $5 = $5 * 1024;
+            } else if ($5 ~ /M/) {
+              sub(/M/, "", $5);
+              $5 = $5;
+            }
+            print $5;
+          }')
+          client_peak_mem_limit_mb="2000" # mb
           echo "Peak memory usage: $peak_mem_usage MB"
-          mem_reads=($(rg "\"memory_used_mb\":\d+" $CLIENT_DATA_PATH/safenode.* -o --no-line-number --no-filename | rg "\d+" -o))
+          if (( $(echo "$peak_mem_usage > $client_peak_mem_limit_mb" | bc -l) )); then
+            echo "Client peak memory usage exceeded threshold: $client_peak_mem_limit_mb MB"
+            exit 1
+          fi
+
+          mem_reads=($(rg "\"memory_used_mb\":\d+" $CLIENT_DATA_PATH/logs/safenode.* \
+            -o --no-line-number --no-filename | rg "\d+" -o))
           total_mem=$(ls heaptrack.safe.txt | wc -l)
           echo "Total memory initial value is: $total_mem"
           for mem in "${mem_reads[@]}"; do
             total_mem=$((total_mem+$(($mem))))
           done
-          num_of_times=$(rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/safenode.* -c --stats | rg "(\d+) matches" | rg "\d+" -o)
+
+          client_avg_mem_limit_mb="700" # mb
+          num_of_times=$(rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safenode.* \
+            -c --stats | rg "(\d+) matches" | rg "\d+" -o)
           echo "num_of_times: $num_of_times"
           echo "Total memory is: $total_mem"
           average_mem=$(($total_mem/$(($num_of_times))))
           echo "Average memory is: $average_mem"
-          if (( $(echo "$average_mem > $CLIENT_AVG_MEM_LIMIT_MB" | bc -l) )); then
-            echo "Client average memory usage exceeded threshold: $CLIENT_AVG_MEM_LIMIT_MB MB"
+          if (( $(echo "$average_mem > $client_avg_mem_limit_mb" | bc -l) )); then
+            echo "Client average memory usage exceeded threshold: $client_avg_mem_limit_mb MB"
             exit 1
           fi
           # Write the client memory usage to a file
           echo '[
               {
-                  "name": "Peak memory usage w/ ~450mb upload",
+                  "name": "client-peak-memory-usage-during-upload",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               },
               {
-                  "name": "Average memory usage w/ ~450mb upload",
+                  "name": "client-average-memory-usage-during-upload",
                   "value": '$average_mem',
                   "unit": "MB"
               }

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -103,6 +103,10 @@ jobs:
         run: cargo test --no-run --release
         timeout-minutes: 30
 
+      - name: Run testnet tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_testnet
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release --package sn_networking

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -163,7 +163,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -311,7 +311,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -415,7 +415,7 @@ jobs:
           CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -227,7 +227,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup
         env:
           SN_LOG: "all"
@@ -322,7 +322,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet --features verify-nodes -- --interval 2000 --node-path ./target/release/safenode
+        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         id: section-startup
         env:
           SN_LOG: "all"

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -16,8 +16,6 @@ chaos = []
 statemap = []
 otlp = []
 local-discovery = []
-# verify-nodes: performs a last step querying and verifying net knowledge to lanched nodes
-verify-nodes = ["prost", "tonic", "tonic-build", "libp2p"]
 
 [[bin]]
 path="src/main.rs"
@@ -28,10 +26,10 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-libp2p = { version="0.51", optional = true }
-prost = { version = "0.9", optional = true }
+libp2p = { version="0.51" }
+prost = { version = "0.9" }
 regex = "1.7.1"
-tonic = { version = "0.6.2", optional = true }
+tonic = { version = "0.6.2" }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = "~0.3.1"
@@ -42,7 +40,7 @@ version = "1.17.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [build-dependencies]
-tonic-build = { version = "0.6.2", optional = true }
+tonic-build = { version = "0.6.2" }
 
 [dev-dependencies]
 assert_fs = "~1.0"

--- a/sn_testnet/build.rs
+++ b/sn_testnet/build.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "verify-nodes")]
     tonic_build::compile_protos("../sn_protocol/src/safenode_proto/safenode.proto")?;
 
     Ok(())

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -173,6 +173,18 @@ pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     Ok(())
 }
 
+pub async fn obtain_peer_id(address: SocketAddr) -> Result<PeerId> {
+    let endpoint = format!("https://{address}");
+    println!("Connecting to node's RPC service at {endpoint} ...");
+    let mut client = SafeNodeClient::connect(endpoint).await?;
+
+    let request = Request::new(NodeInfoRequest {});
+    let response = client.node_info(request).await?;
+    let node_info = response.get_ref();
+    let peer_id = PeerId::from_bytes(&node_info.peer_id)?;
+    Ok(peer_id)
+}
+
 // Parse node logs files and extract info for each of them
 fn nodes_info_from_logs(path: &Path) -> Result<BTreeMap<u32, NodeInfo>> {
     let mut nodes = BTreeMap::<PathBuf, NodeInfo>::new();

--- a/sn_testnet/src/check_testnet.rs
+++ b/sn_testnet/src/check_testnet.rs
@@ -58,16 +58,16 @@ impl Display for NodeInfo {
 pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     let mut delay_secs = 10;
     while delay_secs > 0 {
-        println!("We'll be verifying testnet nodes info in {delay_secs}secs ...");
+        println!("Verifying nodes in {delay_secs} seconds...");
         sleep(Duration::from_secs(1)).await;
         delay_secs -= 1;
     }
     println!();
-    println!("======== Verifying testnet nodes ========");
+    println!("======== Verifying Nodes ========");
 
     let expected_node_count = node_count as usize;
     println!(
-        "Checking nodes log files to verify all ({expected_node_count}) nodes \
+        "Checking log files to verify all ({expected_node_count}) nodes \
         have joined. Logs path: {}",
         logs_path.display()
     );
@@ -168,7 +168,7 @@ pub async fn run(logs_path: &Path, node_count: u32) -> Result<()> {
     }
 
     println!();
-    println!("PeerIds and network knowledge of nodes are the expected!");
+    println!("Peer IDs and node network knowledge are as expected!");
 
     Ok(())
 }

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -24,7 +24,6 @@ pub const DEFAULT_NODE_LAUNCH_INTERVAL: u64 = 1000;
 pub const SAFENODE_BIN_NAME: &str = "safenode";
 #[cfg(target_os = "windows")]
 pub const SAFENODE_BIN_NAME: &str = "safenode.exe";
-const GENESIS_NODE_DIR_NAME: &str = "safenode-1";
 
 /// This trait exists for unit testing.
 ///
@@ -189,15 +188,7 @@ impl Testnet {
             for entry in entries {
                 let entry = entry?;
                 if entry.file_type()?.is_dir() {
-                    let dir_name = entry.file_name().clone();
-                    let dir_name = dir_name
-                        .to_str()
-                        .ok_or_else(|| eyre!("Failed to obtain dir name"))?;
-                    // This excludes any directories the user may have created under the network
-                    // data directory path, either intentionally or unintentionally.
-                    if dir_name.starts_with("safenode-") && dir_name != GENESIS_NODE_DIR_NAME {
-                        node_count += 1;
-                    }
+                    node_count += 1;
                 }
             }
         }
@@ -249,9 +240,6 @@ impl Testnet {
         launch_args.push("--port".to_string());
         launch_args.push(genesis_port.to_string());
 
-        let node_data_dir_path = self.nodes_dir_path.join("safenode-1");
-        std::fs::create_dir_all(node_data_dir_path)?;
-
         let launch_bin = self.get_launch_bin();
         self.launcher.launch(&launch_bin, launch_args)?;
         info!(
@@ -286,14 +274,6 @@ impl Testnet {
         let end = self.node_count + number_of_nodes;
         for i in start..=end {
             info!("Launching node {i} of {end}...");
-            let node_data_dir_path = self
-                .nodes_dir_path
-                .join(format!("safenode-{i}"))
-                .to_str()
-                .ok_or_else(|| eyre!("Unable to obtain node data directory path"))?
-                .to_string();
-            std::fs::create_dir_all(&node_data_dir_path)?;
-
             let rpc_address = format!("127.0.0.1:{}", 12000 + i).parse()?;
             let launch_args = self.get_launch_args(
                 format!("safenode-{i}"),
@@ -321,13 +301,12 @@ impl Testnet {
         rpc_address: Option<SocketAddr>,
         node_args: Vec<String>,
     ) -> Result<Vec<String>> {
-        let node_data_dir_path = self.nodes_dir_path.join(node_name.clone());
         let mut launch_args = Vec::new();
         if self.flamegraph_mode {
             launch_args.push("flamegraph".to_string());
             launch_args.push("--output".to_string());
             launch_args.push(
-                node_data_dir_path
+                self.nodes_dir_path
                     .join(format!("{node_name}-flame.svg"))
                     .to_str()
                     .ok_or_else(|| eyre!("Unable to obtain path"))?
@@ -367,6 +346,7 @@ mod test {
     use libp2p::identity::Keypair;
     use mockall::predicate::*;
 
+    const GENESIS_NODE_NAME: &str = "safenode-1";
     const NODE_LAUNCH_INTERVAL: u64 = 0;
     const TESTNET_DIR_NAME: &str = "local-test-network";
 
@@ -433,40 +413,7 @@ mod test {
         assert_eq!(testnet.node_launch_interval, 30000);
         assert_eq!(testnet.nodes_dir_path, nodes_dir.to_path_buf());
         assert!(!testnet.flamegraph_mode);
-        assert_eq!(testnet.node_count, 19);
-
-        Ok(())
-    }
-
-    #[test]
-    fn new_should_create_a_testnet_ignoring_random_directories_in_the_node_data_dir() -> Result<()>
-    {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        let genesis_data_dir = nodes_dir.child("safenode-1");
-        genesis_data_dir.create_dir_all()?;
-        for i in 1..=20 {
-            let node_dir = nodes_dir.child(format!("safenode-{i}"));
-            node_dir.create_dir_all()?;
-        }
-        let random_dir = nodes_dir.child("user-created-random-dir");
-        random_dir.create_dir_all()?;
-
-        let (node_launcher, rpc_client) = setup_default_mocks();
-        let testnet = Testnet::new(
-            PathBuf::from(SAFENODE_BIN_NAME),
-            30000,
-            nodes_dir.to_path_buf(),
-            false,
-            Box::new(node_launcher),
-            Box::new(rpc_client),
-        )?;
-
-        assert_eq!(testnet.node_bin_path, PathBuf::from(SAFENODE_BIN_NAME));
-        assert_eq!(testnet.node_launch_interval, 30000);
-        assert_eq!(testnet.nodes_dir_path, nodes_dir.to_path_buf());
-        assert!(!testnet.flamegraph_mode);
-        assert_eq!(testnet.node_count, 19);
+        assert_eq!(testnet.node_count, 20);
 
         Ok(())
     }
@@ -478,11 +425,6 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let genesis_data_dir = nodes_dir
-            .child(GENESIS_NODE_DIR_NAME)
-            .to_str()
-            .ok_or_else(|| eyre!("Unable to obtain path"))?
-            .to_string();
 
         let rpc_address: SocketAddr = "127.0.0.1:12001".parse()?;
         let mut node_launcher = MockNodeLauncher::new();
@@ -492,14 +434,13 @@ mod test {
             .with(
                 eq(node_bin_path.path().to_path_buf()),
                 eq(vec![
-                    "--log-dir".to_string(),
-                    genesis_data_dir.clone(),
-                    "--root-dir".to_string(),
-                    genesis_data_dir.clone(),
+                    "--log-output-dest".to_string(),
+                    "data-dir".to_string(),
                     "--local".to_string(),
                     "--rpc".to_string(),
                     rpc_address.to_string(),
-                    "--json-log-output".to_string(),
+                    "--log-format".to_string(),
+                    "json".to_string(),
                     "--port".to_string(),
                     "11101".to_string(),
                 ]),
@@ -521,9 +462,8 @@ mod test {
             Box::new(rpc_client),
         )?;
 
-
         let multiaddr = testnet
-            .launch_genesis(vec!["--json-log-output".to_string()])
+            .launch_genesis(vec!["--log-format".to_string(), "json".to_string()])
             .await?;
 
         assert_eq!(
@@ -533,60 +473,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn launch_genesis_should_create_the_genesis_data_directory() -> Result<()> {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
-        node_bin_path.write_binary(b"fake safenode code")?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
-
-        let (node_launcher, rpc_client) = setup_default_mocks();
-        let testnet = Testnet::new(
-            node_bin_path.path().to_path_buf(),
-            NODE_LAUNCH_INTERVAL,
-            nodes_dir.path().to_path_buf(),
-            false,
-            Box::new(node_launcher),
-            Box::new(rpc_client),
-        )?;
-        let result = testnet
-            .launch_genesis(vec!["--json-log-output".to_string()])
-            .await;
-
-        assert!(result.is_ok());
-        let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
-        genesis_data_dir.assert(predicates::path::is_dir());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn launch_genesis_should_create_the_genesis_data_directory_when_parents_are_missing(
-    ) -> Result<()> {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
-        node_bin_path.write_binary(b"fake safenode code")?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-
-        let (node_launcher, rpc_client) = setup_default_mocks();
-        let testnet = Testnet::new(
-            node_bin_path.path().to_path_buf(),
-            NODE_LAUNCH_INTERVAL,
-            nodes_dir.path().to_path_buf(),
-            false,
-            Box::new(node_launcher),
-            Box::new(rpc_client),
-        )?;
-        let result = testnet
-            .launch_genesis(vec!["--json-log-output".to_string()])
-            .await;
-
-        assert!(result.is_ok());
-        let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
-        genesis_data_dir.assert(predicates::path::is_dir());
-        Ok(())
-    }
-
+    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn launch_genesis_with_flamegraph_mode_should_launch_the_genesis_node() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
@@ -594,14 +481,7 @@ mod test {
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
         nodes_dir.create_dir_all()?;
-        let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
-        let graph_output_file =
-            genesis_data_dir.child(format!("{GENESIS_NODE_DIR_NAME}-flame.svg"));
-        let genesis_data_dir_str = nodes_dir
-            .child(GENESIS_NODE_DIR_NAME)
-            .to_str()
-            .ok_or_else(|| eyre!("Unable to obtain path"))?
-            .to_string();
+        let graph_output_file = nodes_dir.child(format!("{GENESIS_NODE_NAME}-flame.svg"));
 
         let rpc_address: SocketAddr = "127.0.0.1:12001".parse()?;
         let mut node_launcher = MockNodeLauncher::new();
@@ -622,14 +502,13 @@ mod test {
                     "--bin".to_string(),
                     SAFENODE_BIN_NAME.to_string(),
                     "--".to_string(),
-                    "--log-dir".to_string(),
-                    genesis_data_dir_str.clone(),
-                    "--root-dir".to_string(),
-                    genesis_data_dir_str.clone(),
+                    "--log-output-dest".to_string(),
+                    "data-dir".to_string(),
                     "--local".to_string(),
                     "--rpc".to_string(),
                     rpc_address.to_string(),
-                    "--json-log-output".to_string(),
+                    "--log-format".to_string(),
+                    "json".to_string(),
                     "--port".to_string(),
                     "11101".to_string(),
                 ]),
@@ -652,7 +531,7 @@ mod test {
             Box::new(rpc_client),
         )?;
         let multiaddr = testnet
-            .launch_genesis(vec!["--json-log-output".to_string()])
+            .launch_genesis(vec!["--log-format".to_string(), "json".to_string()])
             .await?;
 
         assert_eq!(
@@ -669,7 +548,7 @@ mod test {
         let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
         node_bin_path.write_binary(b"fake safenode code")?;
         let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        let genesis_data_dir = nodes_dir.child(GENESIS_NODE_DIR_NAME);
+        let genesis_data_dir = nodes_dir.child(GENESIS_NODE_NAME);
         genesis_data_dir.create_dir_all()?;
         for i in 1..=20 {
             let node_dir = nodes_dir.child(format!("safenode-{i}"));
@@ -686,7 +565,7 @@ mod test {
             Box::new(rpc_client),
         )?;
         let result = testnet
-            .launch_genesis(vec!["--json-log-output".to_string()])
+            .launch_genesis(vec!["--log-format".to_string(), "json".to_string()])
             .await;
 
         match result {
@@ -713,25 +592,19 @@ mod test {
         let mut node_launcher = MockNodeLauncher::new();
         for i in 2..=20 {
             let rpc_port = 12000 + i;
-            let node_data_dir = nodes_dir
-                .join(&format!("safenode-{i}"))
-                .to_str()
-                .ok_or_else(|| eyre!("Unable to obtain path"))?
-                .to_string();
             node_launcher
                 .expect_launch()
                 .times(1)
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
-                        "--log-dir".to_string(),
-                        node_data_dir.clone(),
-                        "--root-dir".to_string(),
-                        node_data_dir.clone(),
+                        "--log-output-dest".to_string(),
+                        "data-dir".to_string(),
                         "--local".to_string(),
                         "--rpc".to_string(),
                         format!("127.0.0.1:{}", rpc_port),
-                        "--json-log-output".to_string(),
+                        "--log-format".to_string(),
+                        "json".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
@@ -746,72 +619,14 @@ mod test {
             Box::new(node_launcher),
             Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--log-format".to_string(), "json".to_string()]);
 
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
         Ok(())
     }
 
-    #[test]
-    fn launch_nodes_should_create_directories_for_each_node() -> Result<()> {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
-        node_bin_path.write_binary(b"fake safenode code")?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        nodes_dir.create_dir_all()?;
-        let genesis_node_dir = tmp_data_dir.child("safenode-1");
-        genesis_node_dir.create_dir_all()?;
-
-        let (node_launcher, rpc_client) = setup_default_mocks();
-        let mut testnet = Testnet::new(
-            node_bin_path.path().to_path_buf(),
-            NODE_LAUNCH_INTERVAL,
-            nodes_dir.path().to_path_buf(),
-            false,
-            Box::new(node_launcher),
-            Box::new(rpc_client),
-        )?;
-        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
-
-        assert!(result.is_ok());
-        for i in 2..=20 {
-            let node_dir = nodes_dir.child(format!("safenode-{i}"));
-            node_dir.assert(predicates::path::is_dir());
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn launch_nodes_should_create_directories_when_parents_are_missing() -> Result<()> {
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let node_bin_path = tmp_data_dir.child(SAFENODE_BIN_NAME);
-        node_bin_path.write_binary(b"fake safenode code")?;
-        let nodes_dir = tmp_data_dir.child(TESTNET_DIR_NAME);
-        let genesis_node_dir = tmp_data_dir.child("safenode-1");
-        genesis_node_dir.create_dir_all()?;
-
-        let (node_launcher, rpc_client) = setup_default_mocks();
-        let mut testnet = Testnet::new(
-            node_bin_path.path().to_path_buf(),
-            NODE_LAUNCH_INTERVAL,
-            nodes_dir.path().to_path_buf(),
-            false,
-            Box::new(node_launcher),
-            Box::new(rpc_client),
-        )?;
-        let result = testnet.launch_nodes(20, vec!["--json-logs".to_string()]);
-
-        assert!(result.is_ok());
-        for i in 2..=20 {
-            let node_dir = nodes_dir.child(format!("safenode-{i}"));
-            node_dir.assert(predicates::path::is_dir());
-        }
-
-        Ok(())
-    }
-
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn launch_nodes_with_flamegraph_should_launch_the_specified_number_of_nodes() -> Result<()> {
         let tmp_data_dir = assert_fs::TempDir::new()?;
@@ -824,13 +639,8 @@ mod test {
         let mut node_launcher = MockNodeLauncher::new();
         for i in 2..=20 {
             let rpc_port = 12000 + i;
-            let node_data_dir = nodes_dir.join(&format!("safenode-{i}"));
-            let graph_output_file_path = node_data_dir
+            let graph_output_file_path = nodes_dir
                 .join(format!("safenode-{i}-flame.svg"))
-                .to_str()
-                .ok_or_else(|| eyre!("Unable to obtain path"))?
-                .to_string();
-            let node_data_dir = node_data_dir
                 .to_str()
                 .ok_or_else(|| eyre!("Unable to obtain path"))?
                 .to_string();
@@ -847,14 +657,13 @@ mod test {
                         "--bin".to_string(),
                         SAFENODE_BIN_NAME.to_string(),
                         "--".to_string(),
-                        "--log-dir".to_string(),
-                        node_data_dir.clone(),
-                        "--root-dir".to_string(),
-                        node_data_dir.clone(),
+                        "--log-output-dest".to_string(),
+                        "data-dir".to_string(),
                         "--local".to_string(),
                         "--rpc".to_string(),
                         format!("127.0.0.1:{}", rpc_port),
-                        "--json-log-output".to_string(),
+                        "--log-format".to_string(),
+                        "json".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
@@ -869,7 +678,7 @@ mod test {
             Box::new(node_launcher),
             Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--log-format".to_string(), "json".to_string()]);
 
         assert!(result.is_ok());
         Ok(())
@@ -887,25 +696,19 @@ mod test {
         let mut node_launcher = MockNodeLauncher::new();
         for i in 2..=30 {
             let rpc_port = 12000 + i;
-            let node_data_dir = nodes_dir
-                .join(&format!("safenode-{i}"))
-                .to_str()
-                .ok_or_else(|| eyre!("Unable to obtain path"))?
-                .to_string();
             node_launcher
                 .expect_launch()
                 .times(1)
                 .with(
                     eq(node_bin_path.path().to_path_buf()),
                     eq(vec![
-                        "--log-dir".to_string(),
-                        node_data_dir.clone(),
-                        "--root-dir".to_string(),
-                        node_data_dir.clone(),
+                        "--log-output-dest".to_string(),
+                        "data-dir".to_string(),
                         "--local".to_string(),
                         "--rpc".to_string(),
                         format!("127.0.0.1:{}", rpc_port),
-                        "--json-log-output".to_string(),
+                        "--log-format".to_string(),
+                        "json".to_string(),
                     ]),
                 )
                 .returning(|_, _| Ok(()));
@@ -920,17 +723,13 @@ mod test {
             Box::new(node_launcher),
             Box::new(rpc_client),
         )?;
-        let result = testnet.launch_nodes(20, vec!["--json-log-output".to_string()]);
+        let result = testnet.launch_nodes(20, vec!["--log-format".to_string(), "json".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 20);
 
-        let result = testnet.launch_nodes(10, vec!["--json-log-output".to_string()]);
+        let result = testnet.launch_nodes(10, vec!["--log-format".to_string(), "json".to_string()]);
         assert!(result.is_ok());
         assert_eq!(testnet.node_count, 30);
-        for i in 2..=30 {
-            let node_dir = nodes_dir.child(format!("safenode-{i}"));
-            node_dir.assert(predicates::path::is_dir());
-        }
         Ok(())
     }
 }

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod check_testnet;
 
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{eyre::eyre, Help, Result};
 use libp2p::identity::PeerId;
 #[cfg(test)]
 use mockall::automock;
@@ -108,12 +108,6 @@ impl TestnetBuilder {
     /// will be a directory for each node.
     pub fn nodes_dir_path(&mut self, nodes_dir_path: PathBuf) -> &mut Self {
         self.nodes_dir_path = Some(nodes_dir_path);
-        self
-    }
-
-    /// Set this to clear out the existing node data directory for a new network.
-    pub fn clear_nodes_dir(&mut self) -> &mut Self {
-        self.clear_nodes_dir = true;
         self
     }
 
@@ -222,14 +216,14 @@ impl Testnet {
     /// # Errors
     ///
     /// Returns an error if:
-    /// * The node data directory cannot be created
+    /// * The node data directory is already populated with previous node root directories
     /// * The node process fails
-    /// * The network has already been launched previously
     pub async fn launch_genesis(&self, node_args: Vec<String>) -> Result<String> {
         if self.node_count != 0 {
             return Err(eyre!(
-                "A genesis node cannot be launched for an existing network"
-            ));
+                "A new testnet cannot be launched until the data directory is cleared"
+            )
+            .suggestion("Try again using the `--clean` argument"));
         }
 
         let rpc_address = "127.0.0.1:12001".parse()?;
@@ -573,7 +567,7 @@ mod test {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    "A genesis node cannot be launched for an existing network"
+                    "A new testnet cannot be launched until the data directory is cleared"
                 );
                 Ok(())
             }

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -221,7 +221,7 @@ async fn run_network(
         .flamegraph_mode(flamegraph_mode)
         .build()?;
 
-    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone()).await?;
+    let gen_multi_addr = testnet.launch_genesis(node_args.clone()).await?;
 
     node_args.push("--peer".to_string());
     node_args.push(gen_multi_addr);

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -27,9 +27,6 @@
     unused_results
 )]
 
-#[cfg(feature = "verify-nodes")]
-mod check_testnet;
-
 use sn_testnet::{Testnet, DEFAULT_NODE_LAUNCH_INTERVAL, SAFENODE_BIN_NAME};
 
 use clap::Parser;
@@ -224,14 +221,13 @@ async fn run_network(
         .flamegraph_mode(flamegraph_mode)
         .build()?;
 
-    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone())?;
+    let gen_multi_addr = testnet.launch_genesis(None, node_args.clone()).await?;
 
     node_args.push("--peer".to_string());
     node_args.push(gen_multi_addr);
     testnet.launch_nodes(node_count as usize, node_args)?;
 
-    #[cfg(feature = "verify-nodes")]
-    check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
+    sn_testnet::check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
 
     Ok(())
 }


### PR DESCRIPTION
- 48db17d **ci: bring benchmark chart workflow in line**

  The workflow for generating benchmark charts is very similar to the benchmark workflow that runs for
  PRs, but it was missed in the previous PR when the benchmark workflow was updated.

  This change brings the two in line with each other.

- 3d8732a **feat: remove network contacts from `testnet` bin**

  While we do still have the concept of contacting other peers--via the `--peer` argument or
  `SAFE_PEERS` environment variable--we are not using a 'network contacts' file any more, so we don't
  need this argument for the `testnet` binary.
  
- 9039d1a **refactor: obtain genesis peer id directly**

  Refactor the genesis launching process to use the gRPC generated code to obtain the genesis peer ID,
  rather than using the `safe_rpc_client` example. The latter was actually built during the process,
  which involved having the source code checked out. This is probably an assumption we shouldn't make
  of a released binary. It's intended to be able to work stand alone, without the source.

  BREAKING CHANGE: Also remove the `verify-nodes` feature in favour of just including this code in the
  binary. It only increases the size by a few megabytes and the binary is much more useful with this
  code.
  
- 71f8056 **tests: restore sn_testnet unit tests**

  The `sn_testnet` crate was more or less just copy/pasted from the previous safe_network repo and
  its behaviour was quickly changed for dealing with the new `safenode` binary. For quickness, the
  unit tests were subverted.

  These unit tests are now brought into line with the way the new `safenode` process operates and we
  can now keep them running for preventing regressions when things change.

- a4f4896 **feat: remove node directory management**

  The testnet binary is updated to remove any node directory management, which is now performed by the
  `safenode` process.

  This simplifies both the code and test cases, and also removes a few cases that are no longer
  necessary.
  
- 634c287 **feat: provide a `--clean` flag**

  Provides a `--clean` flag to remove all previous node root directories under the data directory,
  which is platform specific.
  
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Jul 23 20:14 UTC
This pull request includes the following changes:

1. In the `Cmd` struct, the `network_contacts_path` field has been removed. It was previously used with the 'join' command to specify the location of the network contacts file. The default location is now used if the value is not supplied.

2. In the `main` and `join_network` functions, the `network_contacts_path` parameter has been removed.

3. The `testnet.launch_nodes` function calls in both the `run_network` and `join_network` functions no longer include the `network_contacts_path` parameter.

4. The `check_testnet::run` function call within the `run_network` function has been removed.

5. The `init_tracing` function no longer returns a `Result` type.

This pull request also includes several changes in the `.github/workflows/generate-benchmark-charts.yml` file:

- Added `HEAPNODE_DATA_PATH` environment variable to set the data path for `heapnode`.
- Updated the names of job steps to accurately reflect their purposes.
- Updated the `run` command to download a 95MB file to be uploaded with the safe client.
- Updated the `run` command to start a heaptracked node instance with the appropriate data path.
- Updated the `run` command to start a heaptracked client instance with the appropriate data path.
- Updated the `run` command to upload the test data file.
- Updated the `run` command to find log files and create compressed archives.
- Updated the `run` command to analyze the heaptrack file for node memory usage.
- Updated the `name` and `value` of a JSON object to reflect node memory usage.
- Updated the `run` command to analyze the heaptrack file for client memory usage.
- Updated the `name` and `value` of JSON objects to reflect client memory usage.

In the `lib.rs` file, the following changes are present:

1. In the `TestnetBuilder` struct, the `build` method now returns a `Result<Testnet>` instead of `(Testnet, PathBuf)`. The network contacts path is no longer returned.

2. In the `TestnetBuilder` struct, the `build` method implementation has been updated to reflect the change in the method signature. The `network_contacts_path` variable has been removed from the implementation.

3. In the `Testnet` struct, the `launch_nodes` method no longer includes the `network_contacts_path` parameter in its signature or implementation.

4. In the `Testnet` struct, the `get_launch_args` method no longer includes the `_network_contacts_path` parameter in its implementation.

5. The tests for the `TestnetBuilder` and `Testnet` structs have been updated to match the changes in method signatures and implementations.

These changes simplify the code by removing unnecessary parameters and returning values.
<!-- reviewpad:summarize:end --> 
