### PR TITLE
ci: fix chart naming

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -188,7 +188,7 @@ jobs:
           # Write the node memory usage to a file
           echo '[
               {
-                  "name": "node-memory-usage-through-safe-benchmark",
+                  "name": "Peak memory w/ `safe` benchmarks",
                   "value": '$memory_usage',
                   "unit": "MB"
               }
@@ -279,12 +279,12 @@ jobs:
           # Write the client memory usage to a file
           echo '[
               {
-                  "name": "client-peak-memory-usage-during-upload",
+                  "name": "Peak memory usage w/ upload",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               },
               {
-                  "name": "client-average-memory-usage-during-upload",
+                  "name": "Average memory usage w/ upload",
                   "value": '$average_mem',
                   "unit": "MB"
               }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jul 23 09:05 UTC
This pull request fixes the naming of charts in the CI workflow for generating benchmark charts. The names of the charts related to memory usage have been updated to provide more clarity. Specifically, the name "node-memory-usage-through-safe-benchmark" has been changed to "Peak memory w/ `safe` benchmarks", and the name "client-peak-memory-usage-during-upload" has been changed to "Peak memory usage w/ upload". Additionally, the name "client-average-memory-usage-during-upload" has been changed to "Average memory usage w/ upload". These changes aim to improve the readability and understanding of the generated benchmark charts.
<!-- reviewpad:summarize:end --> 
