### PR TITLE
fix: update testnet protoc build call

### DIFF
--- a/sn_testnet/build.rs
+++ b/sn_testnet/build.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../sn_protocol/src/safenode_proto/safenode.proto")?;
+    tonic_build::compile_protos("./src/protocol/safenode_proto/safenode.proto")?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jul 23 11:20 UTC
This pull request updates the testnet protoc build call in the `build.rs` file. The path for compiling protos has been adjusted from `"../sn_protocol/src/safenode_proto/safenode.proto"` to `"./src/protocol/safenode_proto/safenode.proto"`.
<!-- reviewpad:summarize:end --> 
