### PR TITLE
ci: duplicate proto files for sn_testnet

### DIFF
--- a/sn_testnet/build.rs
+++ b/sn_testnet/build.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../sn_protocol/src/safenode_proto/safenode.proto")?;
+    tonic_build::compile_protos("./src/protocol/safenode_proto/safenode.proto")?;
 
     Ok(())
 }

--- a/sn_testnet/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_testnet/src/protocol/safenode_proto/req_resp_types.proto
@@ -1,0 +1,60 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+// Version of protocol buffer used
+syntax = "proto3";
+
+// Package name
+package safenode_proto;
+
+// Basic info about the node and safenode app
+message NodeInfoRequest {}
+
+message NodeInfoResponse {
+  bytes peer_id = 1;
+  uint32 pid = 2;
+  string log_dir = 3;
+  string bin_version = 4;
+  uint64 uptime_secs = 5;
+}
+
+// Stream of node events
+message NodeEventsRequest {}
+
+message NodeEvent {
+  string event = 1;
+}
+
+// Stop the safenode app
+message StopRequest {
+  uint64 delay_millis = 1;
+}
+
+message StopResponse {}
+
+// Restart the safenode app
+message RestartRequest {
+  uint64 delay_millis = 1;
+}
+
+message RestartResponse {}
+
+// Update the safenode app
+message UpdateRequest {
+  uint64 delay_millis = 1;
+}
+
+message UpdateResponse {}
+
+// Information about how this node's connections to the network and peers
+message NetworkInfoRequest {}
+
+message NetworkInfoResponse {
+  repeated bytes connected_peers = 1;
+  repeated string listeners = 2;
+}

--- a/sn_testnet/src/protocol/safenode_proto/safenode.proto
+++ b/sn_testnet/src/protocol/safenode_proto/safenode.proto
@@ -1,0 +1,42 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+// Protocol buffer for the gRPC interface exposed by a SAFE node to be used
+// for administration, infrastructure, and support purposes. This interface
+// is completely isolated and different from the node-to-node and client-to-node
+// messaging protocol defined by SAFE for network management and data storage/transfers.
+// For more information refer to https://grpc.io.
+
+// Version of protocol buffer used
+syntax = "proto3";
+
+// Package name
+package safenode_proto;
+
+import "req_resp_types.proto";
+
+// Service exposed by a SAFE node for administration, infrastructure, and support purposes
+service SafeNode {
+  // Returns information about this node
+  rpc NodeInfo (NodeInfoRequest) returns (NodeInfoResponse);
+
+  // Returns information related to this node's connections to the network and peers
+  rpc NetworkInfo (NetworkInfoRequest) returns (NetworkInfoResponse);
+
+  // Returns a stream of events as triggered by this node
+  rpc NodeEvents (NodeEventsRequest) returns (stream NodeEvent);
+
+  // Stop the execution of this node
+  rpc Stop (StopRequest) returns (StopResponse);
+
+  // Restart the node
+  rpc Restart (RestartRequest) returns (RestartResponse);
+
+  // Update the node
+  rpc Update (UpdateRequest) returns (UpdateResponse);
+}


### PR DESCRIPTION
This is a quick fix to the publishing problem regarding missing proto files, which duplicates the files.

It is not completely straight forward to reference the files from another crate due to the way the Cargo publishing process works.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jul 23 12:45 UTC
This pull request fixes the publishing problem by duplicating the missing proto files for the `sn_testnet` crate. The fix involves duplicating the `req_resp_types.proto` and `safenode.proto` files in the `safenode_proto` directory. The changes also update the build script to reference the duplicated proto files instead of the original ones. This ensures that the proto files are correctly included during the publishing process.
<!-- reviewpad:summarize:end --> 
