### PR TITLE
chore: add more logging around replication

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -158,7 +158,26 @@ impl SwarmDriver {
                 let _ = sender.send(peers);
             }
             SwarmCmd::AddKeysToReplicationFetcher { peer, keys, sender } => {
-                let keys_to_fetch = self.replication_fetcher.add_keys(peer, keys);
+                // check if we have any of the data before adding it.
+                let existing_keys: HashSet<NetworkAddress> = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .record_addresses();
+
+                // remove any keys that we already have from replication fetcher
+                self.replication_fetcher.remove_held_data(&existing_keys);
+
+                let non_existing_keys: Vec<NetworkAddress> = keys
+                    .iter()
+                    .filter(|key| !existing_keys.contains(key))
+                    .cloned()
+                    .collect();
+
+                let keys_to_fetch = self
+                    .replication_fetcher
+                    .add_keys_to_replicate_per_peer(peer, non_existing_keys);
                 let _ = sender.send(keys_to_fetch);
             }
             SwarmCmd::NotifyFetchResult {

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -96,10 +96,6 @@ pub enum SwarmCmd {
     PutLocalRecord {
         record: Record,
     },
-    /// Get all the Addresses of all Records stored locally
-    GetAllRecordAddress {
-        sender: oneshot::Sender<HashSet<NetworkAddress>>,
-    },
     /// Get the list of keys that within the provided distance to the target Key
     GetRecordKeysClosestToTarget {
         key: NetworkAddress,
@@ -135,15 +131,6 @@ pub struct SwarmLocalState {
 impl SwarmDriver {
     pub(crate) async fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
         match cmd {
-            SwarmCmd::GetAllRecordAddress { sender } => {
-                let addresses = self
-                    .swarm
-                    .behaviour_mut()
-                    .kademlia
-                    .store_mut()
-                    .record_addresses();
-                let _ = sender.send(addresses);
-            }
             SwarmCmd::GetRecordKeysClosestToTarget {
                 key,
                 distance,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -648,16 +648,6 @@ impl Network {
         self.send_swarm_cmd(SwarmCmd::PutLocalRecord { record })
     }
 
-    /// Get the RecordAddress of all the Records stored locally
-    pub async fn get_all_local_record_addresses(&self) -> Result<HashSet<NetworkAddress>> {
-        let (sender, receiver) = oneshot::channel();
-        self.send_swarm_cmd(SwarmCmd::GetAllRecordAddress { sender })?;
-
-        receiver
-            .await
-            .map_err(|_e| Error::InternalMsgChannelDropped)
-    }
-
     /// Returns true if a RecordKey is present locally in the RecordStore
     pub async fn is_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
         let (sender, receiver) = oneshot::channel();

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -9,7 +9,7 @@
 use libp2p::PeerId;
 use sn_protocol::NetworkAddress;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     time::{Duration, Instant},
 };
 
@@ -35,9 +35,9 @@ pub(crate) struct ReplicationFetcher {
 }
 
 impl ReplicationFetcher {
-    // Add a list of keys of a holder.
-    // Return with a list of keys to fetch, if presents.
-    pub(crate) fn add_keys(
+    /// Add a list of keys of a holder.
+    /// Return with a list of keys to fetch from holder
+    pub(crate) fn add_keys_to_replicate_per_peer(
         &mut self,
         peer_id: PeerId,
         keys: Vec<NetworkAddress>,
@@ -46,6 +46,10 @@ impl ReplicationFetcher {
             self.add_holder(key, peer_id);
         }
         self.next_to_fetch()
+    }
+    /// Remove keys that we hold already and no longer need to be replicated.
+    pub(crate) fn remove_held_data(&mut self, keys: &HashSet<NetworkAddress>) {
+        self.to_be_fetched.retain(|key, _| !keys.contains(key));
     }
 
     // Notify the fetch result of a key from a holder.

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -183,11 +183,14 @@ impl Node {
                 }
             }
             NetworkEvent::PeerRemoved(peer_id) => {
+                Marker::PeerRemovedFromRoutingTable(peer_id).log();
+
                 if let Err(err) = self.try_trigger_replication(&peer_id, true).await {
                     error!("Error while triggering replication {err:?}");
                 }
             }
             NetworkEvent::LostRecordDetected(peer_ids) => {
+                Marker::LostRecordDetected(&peer_ids).log();
                 for peer_id in peer_ids.iter() {
                     if let Err(err) = self.try_trigger_replication(peer_id, false).await {
                         error!("Error while triggering replication to {peer_id:?} {err:?}");

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -31,6 +31,22 @@ pub enum Marker<'a> {
 
     /// Peer was added to the routing table
     PeerAddedToRoutingTable(PeerId),
+
+    /// Peer was removed from the routing table
+    PeerRemovedFromRoutingTable(PeerId),
+
+    /// Lost Record Detected
+    LostRecordDetected(&'a Vec<PeerId>),
+
+    /// Keys of Records we are fetching to replicate locally
+    FetchingKeysForReplication {
+        /// fetching_keys_len: number of keys we are fetching
+        fetching_keys_len: usize,
+        /// provided_keys_len: number of keys we were provided (the difference would be the number of keys we already have)
+        provided_keys_len: usize,
+        /// peer_id: the peer we are fetching from
+        peer_id: PeerId,
+    },
 }
 
 impl<'a> Marker<'a> {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::error::Result;
 use crate::Node;
+use crate::{error::Result, log_markers::Marker};
 use libp2p::{kad::KBucketKey, PeerId};
 use sn_networking::{sort_peers_by_address, sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{
@@ -160,6 +160,14 @@ impl Node {
             .network
             .add_keys_to_replication_fetcher(peer_id, non_existing_keys)
             .await?;
+
+        Marker::FetchingKeysForReplication {
+            fetching_keys_len: keys_to_fetch.len(),
+            provided_keys_len: keys.len(),
+            peer_id,
+        }
+        .log();
+
         self.fetch_replication_keys_without_wait(keys_to_fetch)
             .await?;
         Ok(())

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -155,6 +155,10 @@ impl Node {
             .add_keys_to_replication_fetcher(peer_id, keys)
             .await?;
 
+        if keys_to_fetch.is_empty() {
+            return Ok(());
+        }
+
         Marker::FetchingKeysForReplication {
             fetching_keys_len: keys_to_fetch.len(),
             provided_keys_len,

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -32,6 +32,8 @@ use sn_testnet::{Testnet, DEFAULT_NODE_LAUNCH_INTERVAL, SAFENODE_BIN_NAME};
 use clap::Parser;
 use color_eyre::{eyre::eyre, Help, Result};
 use std::{
+    fs::remove_dir_all,
+    io::ErrorKind,
     path::PathBuf,
     process::{Command, Stdio},
 };
@@ -116,7 +118,16 @@ async fn main() -> Result<()> {
             .join("safe")
             .join("node");
         println!("Cleaning previous node directories under {node_data_dir:?}");
-        std::fs::remove_dir_all(node_data_dir)?;
+        if let Err(e) = remove_dir_all(node_data_dir) {
+            match e.kind() {
+                ErrorKind::NotFound => {
+                    println!("No previous node directories found under");
+                }
+                _ => {
+                    return Err(e.into());
+                }
+            }
+        }
     }
 
     if args.flame {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jul 23 13:24 UTC
This pull request includes two patches. 

Patch 1/2 is a chore that adds more logging around replication. It includes changes to the `api.rs`, `log_markers.rs`, and `replication.rs` files. The changes in `api.rs` add logging statements for when a peer is removed from the routing table and when a lost record is detected. The changes in `log_markers.rs` add new log markers for these events. The changes in `replication.rs` add logging statements for when keys are being fetched for replication.

Patch 2/2 is a feature that makes replication flows per peer. It includes changes to the `cmd.rs`, `lib.rs`, `replication_fetcher.rs`, and `api.rs` files. The changes in `cmd.rs` modify the `AddKeysToReplicationFetcher` command to use the new `add_keys_to_replicate_per_peer` method in the replication fetcher. The changes in `lib.rs` rename the `notify_fetch_result` method to `notify_replication_fetch_result` and update its usage in the `api.rs` file. The changes in `replication_fetcher.rs` modify the `add_keys_to_replicate_per_peer` method to add keys to replicate per peer and limit the number of parallel fetches per peer. The changes in `api.rs` update the usage of the `notify_replication_fetch_result` method.

Overall, these patches improve the logging and replication flow in the codebase.
<!-- reviewpad:summarize:end --> 
