### PR TITLE
test(CI): churning test with register ops as well

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Chunks data integrity during nodes churn
         run: cargo test --release -p sn_node --test data_with_churn -- --nocapture 
         env:
-          CHUNKS_ONLY: true
           TEST_DURATION_MINS: 15
           SN_LOG: "all"
         timeout-minutes: 20

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -424,15 +424,32 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 10
 
+      - name: Start a client to create a register
+        run: cargo run --bin safe --release --features local-discovery -- register create baobao
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
       - name: Chunks data integrity during nodes churn (during 10min)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"
-          CHUNKS_ONLY: true
           TEST_DURATION_MINS: 10
           SN_LOG: "all"
         timeout-minutes: 30
+
+      - name: Start a client to get the created register
+        run: cargo run --bin safe --release --features="local-discovery" -- register get baobao
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit the created register
+        run: cargo run --bin safe --release --features="local-discovery" -- register edit baobao wood
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
 
       - name: Verify restart of nodes using rg
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -356,7 +356,6 @@ jobs:
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"
-          CHUNKS_ONLY: true
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6
           SN_LOG: "all"

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -83,7 +83,8 @@ async fn edit_register(name: String, entry: String, client: &Client) -> Result<(
         Err(error) => {
             println!(
                 "Did not retrieve Register '{name}' from all nodes in the close group! {error}"
-            )
+            );
+            return Err(error.into());
         }
     }
 
@@ -107,7 +108,8 @@ async fn get_registers(names: Vec<String>, client: &Client) -> Result<()> {
             Err(error) => {
                 println!(
                     "Did not retrieve Register '{name}' from all nodes in the close group! {error}"
-                )
+                );
+                return Err(error.into());
             }
         }
     }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -279,7 +279,9 @@ impl Client {
     /// Create a new Register.
     pub async fn create_register(&self, xorname: XorName, tag: u64) -> Result<ClientRegister> {
         info!("Instantiating a new Register replica with name {xorname} and tag {tag}");
-        ClientRegister::create(self.clone(), xorname, tag)
+        let mut client_register = ClientRegister::create(self.clone(), xorname, tag)?;
+        client_register.sync().await?;
+        Ok(client_register)
     }
 
     /// Store `Chunk` as a record.

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -96,6 +96,7 @@ async fn data_availability_during_churn() -> Result<()> {
     let churn_count = Arc::new(RwLock::new(0_usize));
 
     // Allow to disable Registers data creation/checks, storing and querying only Chunks during churn.
+    // Default to be not carry out chunks only during churn.
     let chunks_only = std::env::var("CHUNKS_ONLY").is_ok();
 
     println!(

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -100,6 +100,21 @@ impl NetworkAddress {
         }
     }
 
+    // For track and logging purpose, return the convertable `RecordKey`.
+    fn to_record_key(&self) -> Option<RecordKey> {
+        match self {
+            NetworkAddress::RecordKey(bytes) => Some(RecordKey::new(bytes)),
+            NetworkAddress::ChunkAddress(chunk_address) => {
+                Some(RecordKey::new(chunk_address.name()))
+            }
+            NetworkAddress::RegisterAddress(register_address) => {
+                Some(RecordKey::new(register_address.name()))
+            }
+            NetworkAddress::DbcAddress(dbc_address) => Some(RecordKey::new(dbc_address.name())),
+            _ => None,
+        }
+    }
+
     /// Return the `KBucketKey` representation of this `NetworkAddress`.
     ///
     /// The `KBucketKey` is used for calculating proximity/distance to other items (whether nodes or data).
@@ -142,6 +157,11 @@ impl std::fmt::Debug for NetworkAddress {
             ),
             NetworkAddress::RecordKey(_) => "NetworkAddress::RecordKey(".to_string(),
         };
-        write!(f, "{name_str}{:?})", self.as_bytes())
+        write!(
+            f,
+            "{name_str} - {:?} - {:?})",
+            self.to_record_key(),
+            self.as_kbucket_key()
+        )
     }
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jul 23 14:35 UTC
This pull request updates the CI tests by adding register operations to the existing churning test. It also includes new steps to start a client, create a register, get the created register, and edit the created register. These changes aim to improve the overall testing coverage and ensure the integrity of data during node churn.
<!-- reviewpad:summarize:end --> 
