### PR TITLE
refactor: chunk files only once when making payment for their storage

### DIFF
--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -17,10 +17,10 @@ use xor_name::XorName;
 pub struct Chunk {
     /// Network address. Omitted when serialising and
     /// calculated from the `value` when deserialising.
-    address: ChunkAddress,
+    pub address: ChunkAddress,
     /// Contained data.
     #[debug(skip)]
-    value: Bytes,
+    pub value: Bytes,
 }
 
 impl Chunk {


### PR DESCRIPTION
Resolves #340 .

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jul 23 17:45 UTC
This pull request refactors the code related to making payments for storage when chunking files. It includes changes to the `files.rs` and `wallet.rs` files.

In the `files.rs` file, the `upload_files` function has been modified to chunk and store files in a more efficient way. Instead of chunking files and making payments for each chunk individually, now the files are chunked only once and stored using the `chunk_and_pay_for_storage` function from the `wallet.rs` file. The `upload_file` function has been renamed to `upload_chunks` to reflect this change.

The `upload_files` function now takes care of storing the chunks and generating the proofs for payment. It also creates a directory to store the uploaded files and saves information about the uploaded files in a file for future reference.

The `chunk_and_pay_for_storage` function in the `wallet.rs` file has been modified to accommodate the changes in the `files.rs` file. It now takes an additional parameter `pay` to indicate whether payment should be made for storage. It chunks the files, stores the chunks, and generates the payment proofs if `pay` is true.

Overall, these changes improve the efficiency of chunking and storing files by reducing the number of times chunks are created and payments are made.
<!-- reviewpad:summarize:end --> 
