### PR TITLE
feat(node): shuffle data waiting for fetch

### DIFF
--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -87,7 +87,7 @@ impl ReplicationFetcher {
         // Randomize the order of keys to fetch
         let mut rng = thread_rng();
         let mut data_to_fetch = self.to_be_fetched.iter_mut().collect::<Vec<_>>();
-        data_to_fetch.shuffle(&mut rng); // devskim: ignore DS148264 - this is crypto secure using os rng 
+        data_to_fetch.shuffle(&mut rng); // devskim: ignore DS148264 - this is crypto secure using os rng
 
         for (key, holders) in data_to_fetch {
             let mut failed_counter = 0;

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -188,10 +188,12 @@ impl Node {
                 }
             }
             NetworkEvent::LostRecordDetected(peer_ids) => {
-                Marker::LostRecordDetected(&peer_ids).log();
-                for peer_id in peer_ids.iter() {
-                    if let Err(err) = self.try_trigger_replication(peer_id, false).await {
-                        error!("Error while triggering replication to {peer_id:?} {err:?}");
+                if !peer_ids.is_empty() {
+                    Marker::LostRecordDetected(&peer_ids).log();
+                    for peer_id in peer_ids.iter() {
+                        if let Err(err) = self.try_trigger_replication(peer_id, false).await {
+                            error!("Error while triggering replication to {peer_id:?} {err:?}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This should more evenly spread out replications across the network as oppsosed to forcing all ndoes to query the same space at the same time

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jul 23 19:50 UTC
This pull request introduces a new feature to the node's replication fetch process. It implements shuffling of data waiting to be fetched in order to evenly spread out replications across the network. The patch modifies the `replication_fetcher.rs` file and increases the value of `MAX_PARALLEL_FETCH` to 8. Additionally, it adds code to randomize the order of keys to fetch, resulting in a more balanced distribution of replication requests. The pull request also includes some debug logs for tracking the number of records awaiting fetch.
<!-- reviewpad:summarize:end --> 
