### PR TITLE
ci: increase reg test time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -246,6 +246,13 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
+      
+      - name: Check safenode process count (non win)
+        shell: bash
+        timeout-minutes: 1
+        if: always() && matrix.os != 'windows-latest'
+        continue-on-error: true
+        run: echo "$(pgrep safenode | wc -l) nodes running"
 
       - name: Kill all nodes on Windows
         shell: bash
@@ -263,6 +270,7 @@ jobs:
         continue-on-error: true
         run: |
           pkill safenode
+          sleep 5
           echo "$(pgrep safenode | wc -l) nodes still running"
 
       - name: Tar log files

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Run register tests
         shell: bash
-        timeout-minutes: 25
+        timeout-minutes: 50
         env:
           PROPTEST_CASES: 512
         run: cargo test --release -p sn_registers


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jul 23 07:32 UTC
This pull request consists of two patches. 

The first patch increases the timeout for running register tests in the nightly workflow from 25 minutes to 50 minutes. 

The second patch adds a step to count the number of running safenode processes in the nightly workflow, excluding Windows. This step echoes the count of nodes running using the command "$(pgrep safenode | wc -l)".
<!-- reviewpad:summarize:end --> 
