### PR TITLE
fix: connection overloading

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -52,9 +52,6 @@ pub enum Error {
     #[error("Dial Error")]
     DialError(#[from] DialError),
 
-    #[error("This peer is already being dialed: {0}")]
-    AlreadyDialingPeer(libp2p::PeerId),
-
     #[error("Outbound Error")]
     OutboundError(#[from] OutboundFailure),
 

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -166,6 +166,12 @@ impl SwarmDriver {
                                 .unique()
                                 .collect();
 
+                            info!("Addrs provided: {addrs:?}");
+
+                            for addr in &addrs {
+                                self.dial(addr.clone())?;
+                            }
+
                             // If the peer supports AutoNAT, add it as server
                             if info
                                 .protocols
@@ -407,6 +413,7 @@ impl SwarmDriver {
                 old_peer,
                 ..
             } => {
+                info!("RoutingUpdate {:?}" ,peer);
                 if is_new_peer {
                     if self.dead_peers.remove(&peer) {
                         info!("A dead peer {peer:?} joined back with the same ID");

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -140,7 +140,7 @@ impl SwarmDriver {
 
         let mut kad_cfg = KademliaConfig::default();
         let _ = kad_cfg
-            // .set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::OnConnected)
+            .set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::OnConnected)
             // how often a node will replicate records that it has stored, aka copying the key-value pair to other nodes
             // this is a heavier operation than publication, so it is done less frequently
             // Set to `None` to ensure periodic replication disabled.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -140,7 +140,7 @@ impl SwarmDriver {
 
         let mut kad_cfg = KademliaConfig::default();
         let _ = kad_cfg
-            .set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::Manual)
+            // .set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::OnConnected)
             // how often a node will replicate records that it has stored, aka copying the key-value pair to other nodes
             // this is a heavier operation than publication, so it is done less frequently
             // Set to `None` to ensure periodic replication disabled.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jul 23 08:13 UTC
This pull request includes three patches. Here's a summary of each patch:

Patch 1/3: The patch increases the timeout for running register tests in the continuous integration workflow from 25 minutes to 50 minutes.

Patch 2/3: This patch adds a step to count the number of running safenode processes in the nightly run of the CI workflow. This step only executes on non-Windows operating systems and continues even if there is an error.

Patch 3/3: The patch fixes a bug where the routing table was manually updated after the Identify event, causing issues. The code that updates the routing table has been commented out temporarily to prevent these issues.
<!-- reviewpad:summarize:end --> 
