### PR TITLE
ci: enable workflow dispatch for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,8 @@ name: Nightly. Full Network Tests
 on:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
+    
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jul 23 10:53 UTC
This pull request enables workflow dispatch for nightly builds. It adds the `workflow_dispatch` event to the scheduled cron job trigger.
<!-- reviewpad:summarize:end --> 
