### PR TITLE
fix: prevent multiple concurrent get_closest calls when joining

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -411,7 +411,10 @@ impl SwarmDriver {
                 // TODO: send an error response back?
             }
             KademliaEvent::RoutingUpdated {
-                peer, is_new_peer, ..
+                peer,
+                is_new_peer,
+                old_peer,
+                ..
             } => {
                 if is_new_peer {
                     if self.dead_peers.remove(&peer) {
@@ -419,6 +422,12 @@ impl SwarmDriver {
                     }
                     self.log_kbuckets(&peer);
                     self.send_event(NetworkEvent::PeerAdded(peer));
+                }
+
+                if old_peer.is_some() {
+                    info!("Evicted old peer on new peer join: {old_peer:?}");
+                    self.send_event(NetworkEvent::PeerRemoved(peer));
+                    self.log_kbuckets(&peer);
                 }
             }
             KademliaEvent::InboundRequest {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jul 23 11:22 UTC
This pull request fixes an issue where multiple concurrent `get_closest` calls were being made when joining. The patch modifies the `event.rs` and `api.rs` files. In `event.rs`, the `RoutingUpdated` event now checks if an old peer exists and removes it when a new peer joins. In `api.rs`, the `handle_network_event` function now uses the `initial_join_underway_or_done` flag instead of `initial_join_flows_done` to perform a `get_closest` query to self on node join. Additionally, error handling is improved.
<!-- reviewpad:summarize:end --> 
