### PR TITLE
 chore(metrics): remove network stats 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,23 +1298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "default-net"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06254cc7a9b82a9e3e78849eab1af3dbef006bf629b2928b882534d84ded6b9"
-dependencies = [
- "dlopen2",
- "libc",
- "memalloc",
- "netlink-packet-core 0.5.0",
- "netlink-packet-route 0.15.0",
- "netlink-sys",
- "once_cell",
- "system-configuration",
- "windows 0.48.0",
-]
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,29 +1423,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.23",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b121caccfc363e4d9a4589528f3bef7c71b83c6ed01c8dc68cbeeb7fd29ec698"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a09ac8bb8c16a282264c379dffba707b9c998afc7506009137f3c6136888078"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2894,12 +2854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memalloc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,18 +3046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5cf0b54effda4b91615c40ff0fd12d0d4c9a6e0f5116874f03941792ff535a"
-dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "netlink-packet-utils",
-]
-
-[[package]]
 name = "netlink-packet-route"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,21 +3055,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "libc",
- "netlink-packet-core 0.4.2",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "netlink-packet-core 0.5.0",
+ "netlink-packet-core",
  "netlink-packet-utils",
 ]
 
@@ -3152,7 +3080,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core 0.4.2",
+ "netlink-packet-core",
  "netlink-sys",
  "thiserror",
  "tokio",
@@ -4171,7 +4099,7 @@ checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
  "futures",
  "log",
- "netlink-packet-route 0.12.0",
+ "netlink-packet-route",
  "netlink-proto",
  "nix",
  "thiserror",
@@ -4613,7 +4541,6 @@ dependencies = [
 name = "sn_logging"
 version = "0.2.0"
 dependencies = [
- "default-net",
  "file-rotate",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/sn_logging/Cargo.toml
+++ b/sn_logging/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.2.0"
 
 [dependencies]
-default-net = { version = "0.15.0", optional = true }
 file-rotate = "0.7.3"
 opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.10", optional = true }
@@ -38,7 +37,6 @@ otlp = [
 ]
 test-utils = []
 process-metrics = [
-    "default-net",
     "serde",
     "serde_json",
     "sysinfo",

--- a/sn_logging/src/metrics.rs
+++ b/sn_logging/src/metrics.rs
@@ -8,7 +8,7 @@
 
 use serde::Serialize;
 use std::time::Duration;
-use sysinfo::{self, CpuExt, NetworkExt, Pid, PidExt, ProcessExt, System, SystemExt};
+use sysinfo::{self, CpuExt, Pid, PidExt, ProcessExt, System, SystemExt};
 use tracing::{debug, error};
 
 const UPDATE_INTERVAL: Duration = Duration::from_secs(5);
@@ -28,25 +28,8 @@ struct Metrics {
     system_memory_used_mb: f32,
     // Percentage of RAM used
     system_memory_usage_percent: f32,
-    // Network metrics is None if the default network interface cannot be found
-    network: Option<NetworkMetrics>,
     // Process metrics is None if the Pid for the process is invalid
     process: Option<ProcessMetrics>,
-}
-
-#[derive(Debug, Serialize)]
-#[allow(dead_code)]
-struct NetworkMetrics {
-    // The default network interface
-    interface_name: String,
-    // Bytes received during UPDATE_INTERVAL
-    bytes_received: u64,
-    // Bytes transmitted during UPDATE_INTERVAL
-    bytes_transmitted: u64,
-    // The total MBytes received through the interface
-    total_mb_received: f32,
-    // The total MBytes transmitted through the interface
-    total_mb_transmitted: f32,
 }
 
 #[derive(Debug, Serialize)]
@@ -71,7 +54,6 @@ struct ProcessMetrics {
 pub async fn init_metrics(pid: u32) {
     let mut sys = System::new_all();
     let pid = Pid::from_u32(pid);
-    let default_interface = default_net::get_default_interface();
 
     loop {
         refresh_metrics(&mut sys, pid);
@@ -95,29 +77,6 @@ pub async fn init_metrics(pid: u32) {
             }
         };
 
-        let network = if let Ok(default_interface) = &default_interface {
-            if let Some((interface_name, network_stat)) = sys
-                .networks()
-                .into_iter()
-                .find(|&(interface, _)| interface == &default_interface.name)
-            {
-                let network = NetworkMetrics {
-                    interface_name: interface_name.clone(),
-                    bytes_received: network_stat.received(),
-                    bytes_transmitted: network_stat.transmitted(),
-                    total_mb_received: network_stat.total_received() as f32 / TO_MB,
-                    total_mb_transmitted: network_stat.total_transmitted() as f32 / TO_MB,
-                };
-                Some(network)
-            } else {
-                // Could not get stats for the default interface
-                None
-            }
-        } else {
-            // Could not obtain the default network interface");
-            None
-        };
-
         let cpu_stat = sys.global_cpu_info();
         let metrics = Metrics {
             physical_cpu_threads: sys.cpus().len(),
@@ -126,7 +85,6 @@ pub async fn init_metrics(pid: u32) {
             system_memory_used_mb: sys.used_memory() as f32 / TO_MB,
             system_memory_usage_percent: (sys.used_memory() as f32 / sys.total_memory() as f32)
                 * 100.0,
-            network,
             process,
         };
         match serde_json::to_string(&metrics) {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Jul 23 08:54 UTC
This pull request fixes the network metrics by collecting metrics from all the network interfaces instead of just the default one. It modifies the `metrics.rs` file to update the `NetworkMetrics` struct to include statistics for all interfaces. The `init_metrics` function has been updated to loop through all the network interfaces and sum up the received and transmitted bytes and calculate the total MBytes received and transmitted.
<!-- reviewpad:summarize:end --> 
