### PR TITLE
chore(clippy): fix clippy warnings

### DIFF
--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -81,7 +81,7 @@ where
         // Write level and target
         let level = *event.metadata().level();
         let module = event.metadata().module_path().unwrap_or("<unknown module>");
-        let time = SystemTime::default();
+        let time = SystemTime;
 
         write!(writer, "[")?;
         time.format_time(&mut writer)?;
@@ -116,7 +116,7 @@ impl TracingLayers {
                 tracing_fmt::layer()
                     .with_ansi(false)
                     .with_target(false)
-                    .event_format(LogFormatter::default())
+                    .event_format(LogFormatter)
                     .boxed()
             }
             LogOutputDest::Path(ref path) => {
@@ -140,7 +140,7 @@ impl TracingLayers {
                     LogFormat::Default => tracing_fmt::layer()
                         .with_ansi(false)
                         .with_writer(file_rotation)
-                        .event_format(LogFormatter::default())
+                        .event_format(LogFormatter)
                         .boxed(),
                 }
             }
@@ -251,7 +251,7 @@ pub fn init_test_logger() {
             //.pretty()
             .with_ansi(false)
             .with_target(false)
-            .event_format(LogFormatter::default())
+            .event_format(LogFormatter)
             .try_init()
             .unwrap_or_else(|_| println!("Error initializing logger"));
     });


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jul 23 18:14 UTC
This pull request fixes clippy warnings in the sn_logging crate. It changes the usage of the SystemTime struct and modifies the event_format method calls to use the LogFormatter struct. The changes aim to improve code quality and maintainability.
<!-- reviewpad:summarize:end --> 
