### PR TITLE
feat(client): keep storage payment proofs in local wallet

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -11,8 +11,9 @@ use super::wallet::{chunk_and_pay_for_storage, ChunkedFile};
 use bytes::Bytes;
 use clap::Parser;
 use color_eyre::Result;
-use sn_client::{Client, Files, PaymentProofsMap};
+use sn_client::{Client, Files};
 use sn_protocol::storage::{Chunk, ChunkAddress};
+use sn_transfers::wallet::PaymentProofsMap;
 
 use std::{
     fs,
@@ -89,13 +90,6 @@ async fn upload_files(
 
     let (chunks_to_upload, payment_proofs) =
         chunk_and_pay_for_storage(&client, root_dir, &files_path, pay).await?;
-
-    if chunks_to_upload.is_empty() {
-        println!(
-            "The provided path does not contain any file. Please check your path!\nExiting..."
-        );
-        return Ok(());
-    }
 
     let mut chunks_to_fetch = Vec::new();
     for (

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -9,15 +9,17 @@
 use super::{
     chunks::{to_chunk, DataMapLevel, Error, SmallFile},
     error::Result,
-    wallet::PaymentProofsMap,
     Client,
 };
+
+use sn_protocol::storage::{Chunk, ChunkAddress};
+use sn_transfers::wallet::PaymentProofsMap;
+
 use bincode::deserialize;
 use bytes::Bytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use self_encryption::{self, ChunkInfo, DataMap, EncryptedChunk, MIN_ENCRYPTABLE_BYTES};
-use sn_protocol::storage::{Chunk, ChunkAddress};
 use tokio::task::{self, JoinHandle};
 use tracing::trace;
 use xor_name::XorName;

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::{
     faucet::{get_tokens_from_faucet, load_faucet_wallet},
     file_apis::Files,
     register::ClientRegister,
-    wallet::{send, PaymentProofsMap, WalletClient},
+    wallet::{send, WalletClient},
 };
 
 use self::event::ClientEventsChannel;

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -64,8 +64,13 @@ pub use self::{
 };
 
 use sn_dbc::{Dbc, DbcId, PublicAddress, Token};
+use sn_protocol::messages::PaymentProof;
 
 use std::collections::BTreeMap;
+use xor_name::XorName;
+
+/// Map from content address name to its corresponding PaymentProof.
+pub type PaymentProofsMap = BTreeMap<XorName, PaymentProof>;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(super) struct KeyLessWallet {
@@ -82,6 +87,8 @@ pub(super) struct KeyLessWallet {
     /// keep them here so we can track our
     /// transfer history.
     dbcs_created_for_others: Vec<Dbc>,
+    /// Cached proofs of storage payments made to be used for uploading the paid content.
+    paymet_proofs: PaymentProofsMap,
 }
 
 /// Return the name of a PublicAddress.


### PR DESCRIPTION
Resolves #344.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jul 23 20:13 UTC
This pull request introduces a new feature in the client code. It adds the capability to store payment proofs for storage in the local wallet. Several files have been modified to implement this feature, including `sn_cli/src/subcommands/files.rs`, `sn_cli/src/subcommands/wallet.rs`, `sn_client/src/file_apis.rs`, `sn_client/src/lib.rs`, `sn_client/src/wallet.rs`, `sn_transfers/src/wallet/local_store.rs`, and `sn_transfers/src/wallet/mod.rs`. The changes include adding import statements, modifying function parameters and return types, adding new methods, and updating data structures. Overall, this patch enhances the functionality of the client code by allowing storage payment proofs to be kept in the local wallet.
<!-- reviewpad:summarize:end --> 
