### PR TITLE
feat(networking): remove LostRecordEvent

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -81,11 +81,6 @@ jobs:
       - name: Check the whole workspace can build
         run: cargo build --all-targets --all-features
 
-      - name: Check we could publish sn_node
-        run: cargo publish --dry-run -p sn_node
-      
-      - name: Check we could publish sn_cli
-        run: cargo publish --dry-run -p sn_cli
 
   unit:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -224,9 +224,7 @@ impl Client {
                 }
                 self.peers_added += 1;
             }
-            NetworkEvent::PeerRemoved(_)
-            | NetworkEvent::LostRecordDetected(_)
-            | NetworkEvent::UnverifiedRecord(_) => {}
+            NetworkEvent::PeerRemoved(_) | NetworkEvent::UnverifiedRecord(_) => {}
         }
 
         Ok(())

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -201,16 +201,6 @@ impl Node {
                     error!("Error while triggering replication {err:?}");
                 }
             }
-            NetworkEvent::LostRecordDetected(peer_ids) => {
-                if !peer_ids.is_empty() {
-                    Marker::LostRecordDetected(&peer_ids).log();
-                    for peer_id in peer_ids.iter() {
-                        if let Err(err) = self.try_trigger_replication(peer_id, false).await {
-                            error!("Error while triggering replication to {peer_id:?} {err:?}");
-                        }
-                    }
-                }
-            }
             NetworkEvent::NewListenAddr(_) => {
                 if !cfg!(feature = "local-discovery") {
                     let network = self.network.clone();


### PR DESCRIPTION
Kad docs on the event we use here:
``` 
FinishedWithNoAdditionalRecord {
/// If caching is enabled, these are the peers closest
        /// _to the record key_ (not the local node) that were queried but
        /// did not return the record, sorted by distance to the record key
        /// from closest to farthest. How many of these are tracked is configured
        /// by [`KademliaConfig::set_caching`]. If the lookup used a quorum of
        /// 1, these peers will be sent the record as a means of caching.
        /// If the lookup used a quorum > 1, you may wish to use these
        /// candidates with [`Kademlia::put_record_to`] after selecting
        /// one of the returned records.
        ```
        
This reads to me like it'll return for any/all peers on the route to the data (as they wont necessarily have that data), and so this might well not be how we want to trigger replication.

I'm leaning towards removing this for now, and see how we go and coming back with a more comprehensive approach for "healing" lost data (that wont trigger as frequently as this seems to).

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 09:39 UTC
This pull request removes the `LostRecordEvent` from the networking feature. The event is currently causing high memory usage and the removal is done temporarily to see if it has any impact. The patch removes the event from multiple locations in the codebase.
<!-- reviewpad:summarize:end --> 
