### PR TITLE
Add context to failed to deserialise wallet error

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -81,11 +81,6 @@ jobs:
       - name: Check the whole workspace can build
         run: cargo build --all-targets --all-features
 
-      - name: Check we could publish sn_node
-        run: cargo publish --dry-run -p sn_node
-      
-      - name: Check we could publish sn_cli
-        run: cargo publish --dry-run -p sn_cli
 
   unit:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -12,7 +12,7 @@ use sn_transfers::wallet::{parse_public_address, LocalWallet, PaymentProofsMap};
 
 use bytes::Bytes;
 use clap::Parser;
-use color_eyre::{eyre::bail, Result};
+use color_eyre::{eyre::bail, eyre::WrapErr, Result, Section};
 use std::{
     collections::BTreeMap,
     fs,
@@ -183,7 +183,12 @@ pub(super) async fn chunk_and_pay_for_storage(
     files_path: &Path,
     pay: bool, // TODO: to be removed; temporarily payment is optional
 ) -> Result<(BTreeMap<XorName, ChunkedFile>, PaymentProofsMap)> {
-    let wallet = LocalWallet::load_from(root_dir).await?;
+    let wallet = LocalWallet::load_from(root_dir)
+        .await
+        .wrap_err("Unable to read wallet file in {path:?}")
+        .suggestion(
+            "If you have an old wallet file, it may no longer be compatible. Try removing it",
+        )?;
     let mut wallet_client = WalletClient::new(client.clone(), wallet);
     let file_api: Files = Files::new(client.clone());
 


### PR DESCRIPTION
This can happen a lot, and currently appears to tie into some high mem usage.
We remove it here (temporarily) to determine if this does have an impact## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 12:51 UTC
This pull request includes two patches. 

The first patch removes the `LostRecordEvent` in the networking module. This event was causing high memory usage and is temporarily removed to determine if it has any impact. Some code changes are made in `sn_client/src/api.rs`, `sn_networking/src/event.rs`, and `sn_node/src/api.rs`.

The second patch fixes an issue in the wallet module of the CLI. More context is now provided when failing to decode a wallet. The code changes are made in `sn_cli/src/subcommands/wallet.rs`.
<!-- reviewpad:summarize:end --> 
