### PR TITLE
chore(networking): improve connected peers count log

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -439,7 +439,7 @@ impl SwarmDriver {
                     }
                     self.log_kbuckets(&peer);
                     self.send_event(NetworkEvent::PeerAdded(peer));
-                    let connected_peers = self.swarm.connected_peers().collect_vec().len();
+                    let connected_peers = self.swarm.connected_peers().count();
 
                     info!("Connected peers: {connected_peers}");
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 13:45 UTC
This pull request improves the connected peers count log in the networking module. The patch modifies the event.rs file by changing the way the connected peers count is calculated. Instead of using the `collect_vec().len()` method, it now uses the `count()` method to directly get the count of connected peers.
<!-- reviewpad:summarize:end --> 
