### PR TITLE
WIP Compress log files on windows

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -256,7 +256,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 
@@ -362,7 +362,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 
@@ -521,7 +521,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -257,7 +257,7 @@ jobs:
         continue-on-error: true
         run: |
           Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+            Compress-Archive -DestinationPath log_files.tar.gz
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs
@@ -308,18 +308,21 @@ jobs:
       - name: Build sn bins
         run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
+        if: matrix.os == 'windows-latest'
 
       - name: Build testing executable
         run: cargo test --release --features local-discovery dbc_transfer_,storage_payment_ --no-run
         timeout-minutes: 30
         env:
           CARGO_TARGET_DIR: "./transfer-target"
+        if: matrix.os == 'windows-latest'
 
       - name: Start a local network
         run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
           SN_LOG: "all"
         timeout-minutes: 10
+        if: matrix.os == 'windows-latest'
 
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" dbc_transfer_ -- --nocapture
@@ -327,6 +330,7 @@ jobs:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 10
+        if: matrix.os == 'windows-latest'
 
       - name: execute the storage payment tests
         run: cargo test --release --features="local-discovery" storage_payment_ -- --nocapture
@@ -334,15 +338,7 @@ jobs:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 10
-
-      - name: Kill all nodes (unix)
-        shell: bash
-        timeout-minutes: 1
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-        if: failure() && matrix.os != 'windows-latest'
+        if: matrix.os == 'windows-latest'
 
       - name: Kill all nodes (windows)
         shell: pwsh
@@ -351,19 +347,12 @@ jobs:
         run: Get-Process safenode | Stop-Process -Force
         if: failure() && matrix.os == 'windows-latest'
 
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
       - name: Tar log files (windows)
         shell: pwsh
         continue-on-error: true
         run: |
           Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+            Compress-Archive -DestinationPath log_files.tar.gz
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs
@@ -521,8 +510,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,7 +132,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 
@@ -298,7 +298,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 
@@ -460,7 +460,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
         run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
+          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
             ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
         if: failure() && matrix.os == 'windows-latest'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,7 +133,7 @@ jobs:
         continue-on-error: true
         run: |
           Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+            Compress-Archive -DestinationPath log_files.tar.gz
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs
@@ -299,7 +299,7 @@ jobs:
         continue-on-error: true
         run: |
           Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+            Compress-Archive log_files.tar.gz
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs
@@ -461,7 +461,7 @@ jobs:
         continue-on-error: true
         run: |
           Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File |
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
+            Compress-Archive log_files.tar.gz
         if: failure() && matrix.os == 'windows-latest'
 
       - name: Upload Node Logs

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -154,7 +154,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
     let proofs = wallet_client
         .pay_for_storage(random_content_addrs.iter())
         .await?;
-    assert_eq!(proofs.len(), random_content_addrs.len());
+    assert_eq!(proofs.len(), 3366);
 
     // check we've paid only for addresses we haven't previously paid for, 1 nano per addr
     let new_balance = Token::from_nano(wallet_original_balance - random_content_addrs.len() as u64);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 14:35 UTC
This pull request includes two patches. 

The first patch fixes an issue with log file compression on Windows. The changes are made to the `.github/workflows/merge.yml` and `.github/workflows/nightly.yml` files. The patch modifies the PowerShell script to correctly compress log files when running on Windows.

The second patch is a work in progress (WIP) and only affects the `sn_node/tests/storage_payments.rs` file. The changes adjust the assertion for the length of `proofs` to 3366.

Please review these changes and provide feedback.
<!-- reviewpad:summarize:end --> 
