### PR TITLE
chore(networking): remove some uneeded async

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -130,7 +130,7 @@ pub struct SwarmLocalState {
 }
 
 impl SwarmDriver {
-    pub(crate) async fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
+    pub(crate) fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
         match cmd {
             SwarmCmd::GetRecordKeysClosestToTarget {
                 key,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -124,7 +124,7 @@ pub enum NetworkEvent {
 
 impl SwarmDriver {
     // Handle `SwarmEvents`
-    pub(super) async fn handle_swarm_events<EventError: std::error::Error>(
+    pub(super) fn handle_swarm_events<EventError: std::error::Error>(
         &mut self,
         event: SwarmEvent<NodeEvent, EventError>,
     ) -> Result<()> {
@@ -132,12 +132,12 @@ impl SwarmDriver {
         let _ = span.enter();
         match event {
             SwarmEvent::Behaviour(NodeEvent::MsgReceived(event)) => {
-                if let Err(e) = self.handle_msg(event).await {
+                if let Err(e) = self.handle_msg(event) {
                     warn!("MsgReceivedError: {e:?}");
                 }
             }
             SwarmEvent::Behaviour(NodeEvent::Kademlia(kad_event)) => {
-                self.handle_kad_event(kad_event).await?;
+                self.handle_kad_event(kad_event)?;
             }
             SwarmEvent::Behaviour(NodeEvent::Identify(iden)) => {
                 match *iden {
@@ -318,7 +318,7 @@ impl SwarmDriver {
         Ok(())
     }
 
-    async fn handle_kad_event(&mut self, kad_event: KademliaEvent) -> Result<()> {
+    fn handle_kad_event(&mut self, kad_event: KademliaEvent) -> Result<()> {
         match kad_event {
             ref event @ KademliaEvent::OutboundQueryProgressed {
                 id,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -386,12 +386,12 @@ impl SwarmDriver {
                 stats,
                 step,
             } => {
-                trace!(
-                    "Query task {id:?} returned with record {:?} from peer {:?}, {stats:?} - {step:?}",
-                    peer_record.record.key,
-                    peer_record.peer
-                );
                 if let Some(sender) = self.pending_query.remove(&id) {
+                    trace!(
+                        "Query task {id:?} returned with record {:?} from peer {:?}, {stats:?} - {step:?}",
+                        peer_record.record.key,
+                        peer_record.peer
+                    );
                     sender
                         .send(Ok(peer_record.record))
                         .map_err(|_| Error::InternalMsgChannelDropped)?;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -419,13 +419,13 @@ impl SwarmDriver {
         loop {
             tokio::select! {
                 swarm_event = self.swarm.select_next_some() => {
-                    if let Err(err) = self.handle_swarm_events(swarm_event).await {
+                    if let Err(err) = self.handle_swarm_events(swarm_event) {
                         warn!("Error while handling swarm event: {err}");
                     }
                 },
                 some_cmd = self.cmd_receiver.recv() => match some_cmd {
                     Some(cmd) => {
-                        if let Err(err) = self.handle_cmd(cmd).await {
+                        if let Err(err) = self.handle_cmd(cmd) {
                             warn!("Error while handling cmd: {err}");
                         }
                     },
@@ -572,7 +572,7 @@ impl Network {
         );
         let closest_peers = self.node_get_closest_peers(&request.dst()).await?;
         for peer in closest_peers {
-            self.send_req_ignore_reply(request.clone(), peer).await?;
+            self.send_req_ignore_reply(request.clone(), peer)?;
         }
         Ok(())
     }
@@ -583,7 +583,7 @@ impl Network {
         // Using `client_get_closest_peers` to filter self out.
         let closest_peers = self.client_get_closest_peers(&request.dst()).await?;
         for peer in closest_peers {
-            self.send_req_ignore_reply(request.clone(), peer).await?;
+            self.send_req_ignore_reply(request.clone(), peer)?;
         }
         Ok(())
     }
@@ -660,7 +660,7 @@ impl Network {
 
     /// Put `Record` to the local RecordStore
     /// Must be called after the validations are performed on the Record
-    pub async fn put_local_record(&self, record: Record) -> Result<()> {
+    pub fn put_local_record(&self, record: Record) -> Result<()> {
         debug!(
             "Writing Record locally, for {:?} - length {:?}",
             record.key,
@@ -718,7 +718,7 @@ impl Network {
 
     /// Set the acceptable range of record entry. A record is removed from the storage if the
     /// distance between the record and the node is greater than the provided `distance`.
-    pub async fn set_record_distance_range(&self, distance: Distance) -> Result<()> {
+    pub fn set_record_distance_range(&self, distance: Distance) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::SetRecordDistanceRange { distance })
     }
 
@@ -738,7 +738,7 @@ impl Network {
 
     /// Send `Request` to the the given `PeerId` and do _not_ await a response here.
     /// Instead the Response will be handled by the common `response_handler`
-    pub async fn send_req_ignore_reply(&self, req: Request, peer: PeerId) -> Result<()> {
+    pub fn send_req_ignore_reply(&self, req: Request, peer: PeerId) -> Result<()> {
         let swarm_cmd = SwarmCmd::SendRequest {
             req,
             peer,
@@ -748,7 +748,7 @@ impl Network {
     }
 
     /// Send a `Response` through the channel opened by the requester.
-    pub async fn send_response(&self, resp: Response, channel: MsgResponder) -> Result<()> {
+    pub fn send_response(&self, resp: Response, channel: MsgResponder) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::SendResponse { resp, channel })
     }
 

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -14,7 +14,7 @@ use tracing::{trace, warn};
 
 impl SwarmDriver {
     /// Forwards `Request` to the upper layers using `Sender<NetworkEvent>`. Sends `Response` to the peers
-    pub async fn handle_msg(
+    pub fn handle_msg(
         &mut self,
         event: request_response::Event<Request, Response>,
     ) -> Result<(), Error> {

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -293,8 +293,7 @@ impl Node {
                         .network
                         .notify_fetch_result(peer_id, address, true)
                         .await?;
-                    self.fetch_replication_keys_without_wait(keys_to_fetch)
-                        .await?;
+                    self.fetch_replication_keys_without_wait(keys_to_fetch)?;
                 } else {
                     warn!("Cannot parse PeerId from {holder:?}");
                 }
@@ -308,8 +307,7 @@ impl Node {
                         .network
                         .notify_fetch_result(peer_id, address, false)
                         .await?;
-                    self.fetch_replication_keys_without_wait(keys_to_fetch)
-                        .await?;
+                    self.fetch_replication_keys_without_wait(keys_to_fetch)?;
                 } else {
                     warn!("Cannot parse PeerId from {holder:?}");
                 }
@@ -334,7 +332,7 @@ impl Node {
             Request::Cmd(cmd) => self.handle_node_cmd(cmd).await,
             Request::Query(query) => self.handle_query(query).await,
         };
-        self.send_response(response, response_channel).await;
+        self.send_response(response, response_channel);
     }
 
     async fn handle_query(&self, query: Query) -> Response {
@@ -418,8 +416,8 @@ impl Node {
         Response::Cmd(resp)
     }
 
-    async fn send_response(&self, resp: Response, response_channel: MsgResponder) {
-        if let Err(err) = self.network.send_response(resp, response_channel).await {
+    fn send_response(&self, resp: Response, response_channel: MsgResponder) {
+        if let Err(err) = self.network.send_response(resp, response_channel) {
             warn!("Error while sending response: {err:?}");
         }
     }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -119,7 +119,7 @@ impl Node {
 
         // finally store the Record directly into the local storage
         debug!("Storing chunk {chunk_name:?} as Record locally");
-        self.network.put_local_record(record).await.map_err(|err| {
+        self.network.put_local_record(record).map_err(|err| {
             warn!("Error while locally storing Chunk as a Record{err}");
             ProtocolError::ChunkNotStored(chunk_name)
         })?;
@@ -162,7 +162,7 @@ impl Node {
             expires: None,
         };
         debug!("Storing register {reg_addr:?} as Record locally");
-        self.network.put_local_record(record).await.map_err(|err| {
+        self.network.put_local_record(record).map_err(|err| {
             warn!("Error while locally storing register as a Record {err}");
             ProtocolError::RegisterNotStored(*reg_addr.name())
         })?;
@@ -239,7 +239,7 @@ impl Node {
             publisher: None,
             expires: None,
         };
-        self.network.put_local_record(record).await.map_err(|_| {
+        self.network.put_local_record(record).map_err(|_| {
             let err = ProtocolError::SpendNotStored(format!("Cannot PUT Spend with {dbc_addr:?}"));
             error!("Cannot put spend {err:?}");
             err


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jul 23 07:55 UTC
This pull request includes two patches. 

The first patch removes some unnecessary `async` keywords from the code in the `sn_networking/src/event.rs` file. It replaces `self.handle_kad_event(kad_event).await?` with `self.handle_kad_event(kad_event)?`, and `self.handle_msg(event).await?` with `self.handle_msg(event)?`. These changes were made to remove unnecessary asynchronous behavior and simplify the code.

The second patch cleans up unused `async` keywords from several functions in multiple files (`sn_networking/src/lib.rs`, `sn_node/src/api.rs`, `sn_node/src/put_validation.rs`, and `sn_node/src/replication.rs`). It replaces `async fn` with `pub fn` for functions that do not require asynchronous behavior. This change improves code readability and removes unnecessary complexity.
<!-- reviewpad:summarize:end --> 
