### PR TITLE
feat: make Chunks storage payment required

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -83,6 +83,20 @@ jobs:
         shell: bash
         run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
+      - name: Start a faucet client to claim genesis
+        run: cargo run --bin faucet --release -- claim-genesis
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Create and fund a wallet to pay for files storage
+        run: |
+          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!
       - name: Start a client to upload files

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -341,12 +341,24 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
-      - name: Chunks data integrity during nodes churn (during 10min)
+      - name: Chunks data integrity during nodes churn (during 10min) - Linux/MacOS
+        if: matrix.os != 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 10
+          SN_LOG: "all"
+        timeout-minutes: 30
+
+      - name: Chunks data integrity during nodes churn (during 10min) - Windows
+        if: matrix.os == 'windows-latest'
+        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
+          TEST_DURATION_MINS: 10
+          TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
         timeout-minutes: 30
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -164,6 +164,26 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
+      - name: Start a faucet client to claim genesis
+        run: cargo run --bin faucet --release -- claim-genesis
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Create and fund a wallet to pay for files storage
+        run: |
+          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to pay for files storage
+        run: cargo run --bin safe --release -- wallet pay "./resources"
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
       - name: Start a client to upload files
         run: cargo run --bin safe --release -- files upload -- "./resources"
         env:
@@ -190,12 +210,6 @@ jobs:
 
       - name: Start a client to edit a register
         run: cargo run --bin safe --release -- register edit baobao wood
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
         env:
           SN_LOG: "all"
         timeout-minutes: 2
@@ -327,12 +341,6 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
-      - name: Start a client to create a register
-        run: cargo run --bin safe --release --features local-discovery -- register create baobao
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
       - name: Chunks data integrity during nodes churn (during 10min)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
@@ -341,18 +349,6 @@ jobs:
           TEST_DURATION_MINS: 10
           SN_LOG: "all"
         timeout-minutes: 30
-
-      - name: Start a client to get the created register
-        run: cargo run --bin safe --release --features="local-discovery" -- register get baobao
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
-      - name: Start a client to edit the created register
-        run: cargo run --bin safe --release --features="local-discovery" -- register edit baobao wood
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
 
       - name: Verify restart of nodes using rg
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,9 +45,29 @@ jobs:
       - name: Check contact peer
         shell: bash
         run: echo "Peer is $SAFE_PEERS"
-      
+    
+      - name: Start a faucet client to claim genesis
+        run: cargo run --bin faucet --release -- claim-genesis
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Create and fund a wallet to pay for files storage
+        run: |
+          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to pay for files storage
+        run: cargo run --bin safe --release -- wallet pay "./resources"
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+    
       - name: Start a client to carry out chunk actions
-        run: cargo run --bin safe --release -- files upload -- "./resources"
+        run: cargo run --bin safe --release -- files upload "./resources"
         env:
           SN_LOG: "all"
         timeout-minutes: 2
@@ -66,12 +86,6 @@ jobs:
 
       - name: Start a client to edit a register
         run: cargo run --bin safe --release -- register edit baobao wood
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
         env:
           SN_LOG: "all"
         timeout-minutes: 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "bytes",
  "crdts",
  "custom_debug",
+ "hex",
  "libp2p",
  "rmp-serde",
  "serde",

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -28,9 +28,6 @@ pub enum FilesCmds {
         /// The location of the files to upload.
         #[clap(name = "path", value_name = "DIRECTORY")]
         path: PathBuf,
-        /// Whether to make the payment and generate proofs for the files to upload.
-        #[clap(long)]
-        pay: bool,
     },
     Download {
         /// Name of the file to download.
@@ -44,7 +41,7 @@ pub enum FilesCmds {
 
 pub(crate) async fn files_cmds(cmds: FilesCmds, client: Client, root_dir: &Path) -> Result<()> {
     match cmds {
-        FilesCmds::Upload { path, pay } => upload_files(path, client, root_dir, pay).await?,
+        FilesCmds::Upload { path } => upload_files(path, client, root_dir).await?,
         FilesCmds::Download {
             file_name,
             file_addr,
@@ -77,19 +74,14 @@ pub(crate) async fn files_cmds(cmds: FilesCmds, client: Client, root_dir: &Path)
 }
 
 /// Givena directory, upload all files contained
-async fn upload_files(
-    files_path: PathBuf,
-    client: Client,
-    root_dir: &Path,
-    pay: bool,
-) -> Result<()> {
+async fn upload_files(files_path: PathBuf, client: Client, root_dir: &Path) -> Result<()> {
     let file_api: Files = Files::new(client.clone());
 
     // The input files_path has to be a dir
     let file_names_path = root_dir.join("uploaded_files");
 
     let (chunks_to_upload, payment_proofs) =
-        chunk_and_pay_for_storage(&client, root_dir, &files_path, pay).await?;
+        chunk_and_pay_for_storage(&client, root_dir, &files_path).await?;
 
     let mut chunks_to_fetch = Vec::new();
     for (

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -72,7 +72,7 @@ pub(crate) async fn wallet_cmds(cmds: WalletCmds, client: &Client, root_dir: &Pa
         WalletCmds::Deposit { stdin } => deposit(root_dir, stdin).await?,
         WalletCmds::Send { amount, to } => send(amount, to, client, root_dir).await?,
         WalletCmds::Pay { path } => {
-            chunk_and_pay_for_storage(client, root_dir, &path, true).await?;
+            chunk_and_pay_for_storage(client, root_dir, &path).await?;
         }
     }
     Ok(())
@@ -181,7 +181,6 @@ pub(super) async fn chunk_and_pay_for_storage(
     client: &Client,
     root_dir: &Path,
     files_path: &Path,
-    pay: bool, // TODO: to be removed; temporarily payment is optional
 ) -> Result<(BTreeMap<XorName, ChunkedFile>, PaymentProofsMap)> {
     let wallet = LocalWallet::load_from(root_dir)
         .await
@@ -241,11 +240,6 @@ pub(super) async fn chunk_and_pay_for_storage(
 
     if chunked_files.is_empty() {
         bail!("The provided path does not contain any file. Please check your path!\nExiting...");
-    }
-
-    // For now, we make the payment for Chunks storage only if requested by the user
-    if !pay {
-        return Ok((chunked_files, PaymentProofsMap::default()));
     }
 
     println!(

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -280,11 +280,7 @@ impl Client {
     }
 
     /// Store `Chunk` as a record.
-    pub(super) async fn store_chunk(
-        &self,
-        chunk: Chunk,
-        payment: Option<PaymentProof>,
-    ) -> Result<()> {
+    pub(super) async fn store_chunk(&self, chunk: Chunk, payment: PaymentProof) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());
         let chunk_with_payment = ChunkWithPayment { chunk, payment };
         let record = Record {

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -9,7 +9,10 @@
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 use super::ClientEvent;
+
+use sn_protocol::storage::ChunkAddress;
 use sn_registers::{Entry, EntryHash};
+
 use std::collections::BTreeSet;
 use thiserror::Error;
 
@@ -50,4 +53,7 @@ pub enum Error {
         Entries hashes of branches are: {0:?}"
     )]
     ContentBranchDetected(BTreeSet<(EntryHash, Entry)>),
+
+    #[error("Missing a payment proof for address {0:?}")]
+    MissingPaymentProof(ChunkAddress),
 }

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -16,17 +16,6 @@ pub async fn get_tokens_from_faucet(amount: Token, to: PublicAddress, client: &C
     .await
 }
 
-/// Returns a dbc with the requested number of tokens to be transferred from genesis to another wallet.
-/// For use by the network churning test.
-pub async fn get_tokens_from_genesis_to_another_wallet(
-    genesis_wallet: LocalWallet,
-    amount: Token,
-    to: PublicAddress,
-    client: &Client,
-) -> Dbc {
-    send(genesis_wallet, amount, to, client).await
-}
-
 /// Use the client to load the faucet wallet from the genesis Wallet.
 /// With all balance transferred from the genesis_wallet to the faucet_wallet.
 pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWallet {

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -150,9 +150,10 @@ impl Files {
             next_batch_size += 1;
             let client = self.client.clone();
             let chunk_addr = *chunk.address();
-            let payment = payment_proofs.get(chunk_addr.name()).cloned();
-            // TODO: re-enable requirement to always provide payment proof
-            //.ok_or(super::Error::MissingPaymentProof(chunk_addr))?;
+            let payment = payment_proofs
+                .get(chunk_addr.name())
+                .cloned()
+                .ok_or(super::Error::MissingPaymentProof(chunk_addr))?;
 
             tasks.push(task::spawn(async move {
                 client.store_chunk(chunk, payment).await?;
@@ -211,9 +212,10 @@ impl Files {
     ) -> Result<ChunkAddress> {
         let chunk = package_small(small)?;
         let address = *chunk.address();
-        let payment = payment_proofs.get(address.name()).cloned();
-        // TODO: re-enable requirement to always provide payment proof
-        //.ok_or(super::Error::MissingPaymentProof(address))?;
+        let payment = payment_proofs
+            .get(address.name())
+            .cloned()
+            .ok_or(super::Error::MissingPaymentProof(address))?;
 
         self.client.store_chunk(chunk, payment).await?;
 

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -23,10 +23,7 @@ pub(crate) use error::Result;
 pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
-    faucet::{
-        get_tokens_from_faucet, get_tokens_from_genesis_to_another_wallet,
-        load_faucet_wallet_from_genesis_wallet,
-    },
+    faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
     file_apis::Files,
     register::ClientRegister,
     wallet::{send, WalletClient},

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -14,6 +14,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
+hex = "~0.4.3" 
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -19,6 +19,7 @@ use libp2p::{
     PeerId,
 };
 use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
 
 /// This is the address in the network by which proximity/distance
 /// to other items (whether nodes or data chunks) are calculated.
@@ -141,8 +142,8 @@ impl NetworkAddress {
     // }
 }
 
-impl std::fmt::Debug for NetworkAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for NetworkAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name_str = match self {
             NetworkAddress::PeerId(_) => "NetworkAddress::PeerId(".to_string(),
             NetworkAddress::ChunkAddress(chunk_address) => {
@@ -163,5 +164,27 @@ impl std::fmt::Debug for NetworkAddress {
             self.to_record_key(),
             self.as_kbucket_key()
         )
+    }
+}
+
+impl Display for NetworkAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            NetworkAddress::PeerId(id) => {
+                write!(f, "NetworkAddress::PeerId({})", hex::encode(id))
+            }
+            NetworkAddress::ChunkAddress(addr) => {
+                write!(f, "NetworkAddress::ChunkAddress({addr:?})")
+            }
+            NetworkAddress::DbcAddress(addr) => {
+                write!(f, "NetworkAddress::DbcAddress({addr:?})")
+            }
+            NetworkAddress::RegisterAddress(addr) => {
+                write!(f, "NetworkAddress::RegisterAddress({addr:?})")
+            }
+            NetworkAddress::RecordKey(key) => {
+                write!(f, "NetworkAddress::RecordKey({})", hex::encode(key))
+            }
+        }
     }
 }

--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -76,5 +76,5 @@ impl<'de> Deserialize<'de> for Chunk {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ChunkWithPayment {
     pub chunk: Chunk,
-    pub payment: Option<PaymentProof>,
+    pub payment: PaymentProof,
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jul 23 14:11 UTC
This pull request includes the following changes:

- Removed the `pay` flag from the `FilesCmds::Upload` variant in the `FilesCmds` enum.
- Removed the `pay` flag from the `files_cmds` function signature.
- Modified the `upload_files` function to remove the `pay` parameter and updated the function calls that use this function accordingly.
- Removed the `pay` flag from the `WalletCmds::Pay` variant in the `WalletCmds` enum.
- Removed the `pay` flag from the `chunk_and_pay_for_storage` function signature.
- Modified the `chunk_and_pay_for_storage` function to remove the `pay` parameter and updated the function calls that use this function accordingly.
- Updated the `store_chunk` function in the `Client` struct to remove the `payment` option and make it required.
- Updated the `store_chunk` function in the `Files` struct to remove the check for a payment proof and made it required.
- Removed the `MissingPaymentProof` variant from the `Error` enum in the `error.rs` file.
- Removed the check for a payment proof in the `Files` struct's `upload_small` function and made it required.
- Updated the `validate_chunk_payment` function in the `Node` struct to remove the check for a payment proof and made it required.
- Updated the `ChunkWithPayment` struct to remove the `Option` wrapper from the `payment` field and made it required.

These changes remove the ability to specify whether to make a payment and generate proofs for uploaded files and instead enforce that a payment and payment proof must be provided.
<!-- reviewpad:summarize:end --> 
