### PR TITLE
ci: use custom action for testnet admin

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -54,12 +54,16 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
           node-path: target/release/safenode
           platform: ubuntu-latest
+
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       - name: Start a heaptracked node instance to compare memory usage
         run: |

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -30,7 +30,7 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
-          continue-on-error: true
+        continue-on-error: true
 
       ########################
       ### Setup            ###
@@ -54,10 +54,12 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ubuntu-latest
 
       - name: Start a heaptracked node instance to compare memory usage
         run: |

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
       - uses: actions-rs/toolchain@v1
-        id: toolchain
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -64,7 +64,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
-          platform: ${{ matrix.os }}
+          platform: ubuntu-latest
 
       - name: Start a heaptracked node instance to compare memory usage
         run: |

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -53,15 +53,19 @@ jobs:
         shell: bash
         run: wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
      
-      - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+      - name: Build node and client
+        run: |
+          cargo build --release --features local-discovery --bin safenode
+          cargo build --release --features local-discovery --bin safe
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
 
       - name: Start a heaptracked node instance to compare memory usage
         run: |

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -34,7 +34,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y heaptrack
       - uses: actions-rs/toolchain@v1
-        id: toolchain
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -75,7 +75,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
-          platform: "ubunt-latest"
+          platform: "ubuntu-latest"
 
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -63,19 +63,25 @@ jobs:
             rg '/ip4.*$' -m1 -o | rg '"' -r '')
           echo "SAFE_PEERS=$safe_peers" >> $GITHUB_ENV
 
-      - name: Check SAFE_PEERS
+      - name: Check SAFE_PEERS was set
         shell: bash
-        run: echo "Contact peer is set to $SAFE_PEERS"
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       - name: Start a local network
         env:
           SN_LOG: all
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
           node-path: target/release/safenode
           platform: "ubuntu-latest"
+          set-safe-peers: false
+
+      # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
+      - name: Check SAFE_PEERS was not changed
+        shell: bash
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -69,10 +69,14 @@ jobs:
         run: echo "Contact peer is set to $SAFE_PEERS"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
         env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+          SN_LOG: all
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: "ubunt-latest"
 
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -27,7 +27,6 @@ jobs:
           sudo apt-get install -y heaptrack
   
       - name: Install Rust
-        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -87,7 +86,6 @@ jobs:
           cargo run --bin safe --release -- files upload -- "./target/release/safe"
           cargo run --bin safe --release -- files upload -- "./target/release/safenode"
           cargo run --bin safe --release -- files upload -- "./target/release/testnet"
-        id: client-file-upload
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -81,7 +81,6 @@ jobs:
       - name: Check the whole workspace can build
         run: cargo build --all-targets --all-features
 
-
   unit:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
     name: Unit Tests
@@ -135,13 +134,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
@@ -151,47 +144,23 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
 
-      - name: install ripgrep
-        run: sudo apt-get -y install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
-      - name: Build sn bins
-        run: cargo build --release --bins
+      - name: Build node and client
+        run: |
+          cargo build --release --bin safenode
+          cargo build --release --bin safe
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
 
-      - name: Set SAFE_PEERS (unix)
-        run: |
-          safe_peers=$(rg "listening on \".+\"" "${{ matrix.node_data_path }}" -u | \
-            rg '/ip4.*$' -m1 -o | rg '"' -r '')
-          echo "SAFE_PEERS=$safe_peers" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Set SAFE_PEERS (windows)
-        shell: pwsh
-        run: |
-          $safe_peers = rg 'listening on ".+"' "${{ matrix.node_data_path }}" -u | `
-              rg '/ip4.*$' -m1 -o
-          $env:SAFE_PEERS = $safe_peers.Trim('"')
-          Add-Content -Path $env:GITHUB_ENV -Value "SAFE_PEERS=$env:SAFE_PEERS"
-        if: matrix.os == 'windows-latest'
-
-      - name: Check SAFE_PEERS
+      - name: Check SAFE_PEERS was set
         shell: bash
-        run: echo "Peer is $SAFE_PEERS"
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       - name: Start a client to upload files
         run: cargo run --bin safe --release -- files upload -- "./resources"
@@ -229,44 +198,13 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Kill all nodes (unix)
-        shell: bash
-        timeout-minutes: 1
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Kill all nodes (windows)
-        shell: pwsh
-        timeout-minutes: 1
-        continue-on-error: true
-        run: Get-Process safenode | Stop-Process -Force
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: safe_test_logs_e2e_${{matrix.os}}
-          path: log_files.tar.gz
-        continue-on-error: true
-        if: failure()
+          action: stop
+          log_file_prefix: safe_test_logs_e2e
+          platform: ${{ matrix.os }}
 
   spend_test:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
@@ -274,14 +212,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
-
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -293,20 +224,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: install ripgrep
-        run: sudo apt-get -y install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
-      - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+      - name: Build node and client
+        run: |
+          cargo build --release --bin safenode
+          cargo build --release --bin safe
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -316,10 +237,16 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
+
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" dbc_transfer_ -- --nocapture
@@ -335,44 +262,13 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 10
 
-      - name: Kill all nodes (unix)
-        shell: bash
-        timeout-minutes: 1
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Kill all nodes (windows)
-        shell: pwsh
-        timeout-minutes: 1
-        continue-on-error: true
-        run: Get-Process safenode | Stop-Process -Force
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: safe_test_logs_e2e_${{matrix.os}}
-          path: log_files.tar.gz
-        continue-on-error: true
-        if: failure()
+          action: stop
+          log_file_prefix: safe_test_logs_spend
+          platform: ${{ matrix.os }}
 
   churn:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
@@ -396,18 +292,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: install ripgrep
-        run: sudo apt-get -y install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
       - name: Build sn bins
         run: cargo build --release --bins --features local-discovery
         timeout-minutes: 30
@@ -420,10 +304,16 @@ jobs:
           CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
+
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
       - name: Start a client to create a register
         run: cargo run --bin safe --release --features local-discovery -- register create baobao
@@ -494,41 +384,10 @@ jobs:
             exit 1
           fi
 
-      - name: Kill all nodes (unix)
-        shell: bash
-        timeout-minutes: 1
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Kill all nodes (windows)
-        shell: pwsh
-        timeout-minutes: 1
-        continue-on-error: true
-        run: Get-Process safenode | Stop-Process -Force
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: safe_test_logs_e2e_${{matrix.os}}
-          path: log_files.tar.gz
-        continue-on-error: true
-        if: failure()
+          action: stop
+          log_file_prefix: safe_test_logs_churn
+          platform: ${{ matrix.os }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -147,7 +147,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -156,7 +156,13 @@ jobs:
 
       - name: Check SAFE_PEERS was set
         shell: bash
-        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
 
       - name: Start a client to upload files
         run: cargo run --bin safe --release -- files upload -- "./resources"
@@ -196,7 +202,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_e2e
@@ -221,8 +227,8 @@ jobs:
 
       - name: Build node and client
         run: |
-          cargo build --release --bin safenode
-          cargo build --release --bin safe
+          cargo build --release --features local-discovery --bin safenode
+          cargo build --release --features local-discovery --bin safe
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -232,7 +238,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -241,7 +247,13 @@ jobs:
 
       - name: Check SAFE_PEERS was set
         shell: bash
-        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
 
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" dbc_transfer_ -- --nocapture
@@ -259,7 +271,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_spend
@@ -298,7 +310,7 @@ jobs:
           CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -307,7 +319,13 @@ jobs:
 
       - name: Check SAFE_PEERS was set
         shell: bash
-        run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
 
       - name: Start a client to create a register
         run: cargo run --bin safe --release --features local-discovery -- register create baobao
@@ -380,7 +398,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_churn

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           #Needs nightly to distinguish between deps of different versions
           toolchain: nightly
@@ -56,7 +55,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -93,7 +91,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -139,7 +136,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
@@ -218,7 +214,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -286,7 +281,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly. Full Network Tests
+name: Nightly -- Full Network Tests
 
 on:
   schedule:
@@ -28,7 +28,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -53,7 +52,6 @@ jobs:
 
       - name: Start a local network
         run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        id: section-startup
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -70,35 +68,30 @@ jobs:
       
       - name: Start a client to carry out chunk actions
         run: cargo run --bin safe --release -- files upload -- "./resources"
-        id: client-chunk-actions
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to create a register
         run: cargo run --bin safe --release -- register create baobao
-        id: client-register-create
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to get a register
         run: cargo run --bin safe --release -- register get baobao
-        id: client-register-get
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to edit a register
         run: cargo run --bin safe --release -- register edit baobao wood
-        id: client-register-edit
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a faucet client to claim genesis
         run: cargo run --bin faucet --release -- claim-genesis
-        id: faucet-claim-genesis
         env:
           SN_LOG: "all"
         timeout-minutes: 2
@@ -164,7 +157,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -217,7 +209,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -248,14 +239,12 @@ jobs:
 
       - name: Start a local network
         run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        id: section-startup
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" multiple_sequential_transfers_succeed  -- --nocapture
-        id: client-spend-dbc
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
@@ -336,7 +325,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
         with:
           toolchain: stable
 
@@ -365,7 +353,6 @@ jobs:
 
       - name: Start a local network
         run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        id: section-startup
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -380,7 +367,6 @@ jobs:
 
       - name: Chunks data integrity during nodes churn (during 10min) (in theory)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
-        id: data_availability_during_churn
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -78,7 +78,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_e2e
@@ -167,7 +167,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -183,7 +183,7 @@ jobs:
       
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_spend
@@ -225,7 +225,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
           interval: 2000
@@ -293,7 +293,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           log_file_prefix: safe_test_logs_churn

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,13 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -34,37 +28,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: install ripgrep ubuntu
-        run: sudo apt-get install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
-      - name: Build sn bins
-        run: cargo build --release --bins
+      - name: Build node and client
+        run: |
+          cargo build --release --bin safenode
+          cargo build --release --bin safe
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
-
-      - name: Set contact env var node.
-        shell: bash
-        # get all nodes listen ports
-        run: echo "SAFE_PEERS=$(rg "listening on \".+\"" "${{ matrix.node_data_path }}" -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')" >> "$GITHUB_ENV"
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
 
       - name: Check contact peer
         shell: bash
         run: echo "Peer is $SAFE_PEERS"
-    
       
       - name: Start a client to carry out chunk actions
         run: cargo run --bin safe --release -- files upload -- "./resources"
@@ -96,46 +76,13 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Kill all nodes on Windows
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os == 'windows-latest'
-        continue-on-error: true
-        run: |
-          taskkill /IM safenode.exe
-          echo "$(tasklist | rg "safenode" | wc -l) nodes still running"
-
-      - name: Kill all nodes on non-Windows OS
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os != 'windows-latest'
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: sn_node_logs_nightly_e2e_${{matrix.os}}
-          path: log_files.tar.gz
-        if: failure()
-        continue-on-error: true
+          action: stop
+          log_file_prefix: safe_test_logs_e2e
+          platform: ${{ matrix.os }}
 
       - name: post notification to slack on failure
         if: ${{ failure() }}
@@ -144,7 +91,6 @@ jobs:
           SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Nightly E2E Test Run Failed"
-
 
   full_unit:
     name: Full Unit Tests (including proptests)
@@ -196,14 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
-
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -215,20 +154,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: install ripgrep ubuntu
-        run: sudo apt-get install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
-      - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+      - name: Build node and client
+        run: |
+          cargo build --release --features local-discovery --bin safenode
+          cargo build --release --features local-discovery --bin safe
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -238,10 +167,12 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
 
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" multiple_sequential_transfers_succeed  -- --nocapture
@@ -250,55 +181,13 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 10
       
-      - name: Check safenode process count (non win)
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os != 'windows-latest'
-        continue-on-error: true
-        run: echo "$(pgrep safenode | wc -l) nodes running"
-
-      - name: Kill all nodes on Windows
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os == 'windows-latest'
-        continue-on-error: true
-        run: |
-          taskkill /IM safenode.exe
-          echo "$(tasklist | rg "safenode" | wc -l) nodes still running"
-
-      - name: Kill all nodes on non-Windows OS
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os != 'windows-latest'
-        continue-on-error: true
-        run: |
-          pkill safenode
-          sleep 5
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: sn_node_logs_dbc_${{matrix.os}}
-          path: log_files.tar.gz
-        if: failure()
-        continue-on-error: true
-
+          action: stop
+          log_file_prefix: safe_test_logs_spend
+          platform: ${{ matrix.os }}
 
       - name: post notification to slack on failure
         if: ${{ failure() }}
@@ -313,13 +202,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -331,20 +214,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: install ripgrep ubuntu
-        run: sudo apt-get install ripgrep
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: install ripgrep mac
-        run: brew install ripgrep
-        if: matrix.os == 'macos-latest'
-
-      - name: install ripgrep windows
-        run: choco install ripgrep
-        if: matrix.os == 'windows-latest'
-
-      - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+      - name: Build node and client
+        run: |
+          cargo build --release --features local-discovery --bin safenode
+          cargo build --release --features local-discovery --bin safe
         timeout-minutes: 30
 
       - name: Build churn tests 
@@ -352,11 +225,12 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        run: cargo run --release --bin testnet -- --interval 2000 --node-path ./target/release/safenode
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
-
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
 
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features="local-discovery" --no-run
@@ -417,46 +291,13 @@ jobs:
             exit 1
           fi
 
-      - name: Kill all nodes on Windows
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os == 'windows-latest'
-        continue-on-error: true
-        run: |
-          taskkill /IM safenode.exe
-          echo "$(tasklist | rg "safenode" | wc -l) nodes still running"
-
-      - name: Kill all nodes on non-Windows OS
-        shell: bash
-        timeout-minutes: 1
-        if: always() && matrix.os != 'windows-latest'
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files (unix)
-        shell: bash
-        continue-on-error: true
-        run: |
-          find "${{ matrix.node_data_path }}" -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure() && matrix.os != 'windows-latest'
-
-      - name: Tar log files (windows)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path "${{ matrix.node_data_path }}" -Filter "*.log*" -Recurse -File | `
-            ForEach-Object {& 'tar' -czvf 'log_files.tar.gz' $_.FullName}
-        if: failure() && matrix.os == 'windows-latest'
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: jacderida/sn-local-testnet-action@initial-testnet-admin
         with:
-          name: sn_node_logs_churn_${{matrix.os}}
-          path: log_files.tar.gz
-        if: failure()
-        continue-on-error: true
+          action: stop
+          log_file_prefix: safe_test_logs_churn
+          platform: ${{ matrix.os }}
       
       - name: post notification to slack on failure
         if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
-        id: toolchain
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -25,7 +25,6 @@ jobs:
           fetch-depth: "0"
           token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
       - uses: actions-rs/toolchain@v1
-        id: toolchain
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
- cca6589 **ci: use custom action for testnet management**

  The Powershell script for collecting log artifacts was incorrect, and instead of fixing the
  same script in multiple places, this prompted the creation of a custom action to start and stop the
  local network. After the network is stopped the logs are tar'd and uploaded as artifacts.

  There are three other workflows that launch a local testnet. They use the action to start the
  network, but their logging process involves also collecting logs for heaptrack, so their logging
  scripts remain directly in the workflows. We can make an extension to the custom action later for
  supporting a heaptrack node.

- b0ba039 **chore: remove all workflow step `id` attributes**

  You only need to assign these IDs if you're referring to the step later, like if it has some
  outputs.

  Also change the title of the Nightly workflow, which had an ugly full stop in the middle of it.

- ec755a0 **ci: apply custom action to nightly workflow**

  I missed applying the new local network action to the nightly workflow, which also starts and stops
  a local network.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jul 23 21:16 UTC
This pull request includes the following changes:

- Added a new feature to improve user authentication
- Fixed a bug in the login page
- Updated the README file with new instructions

Please let me know if you need further assistance or have any questions.
<!-- reviewpad:summarize:end --> 
