### PR TITLE
feat: faucet integration in testnet bin

### DIFF
--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -25,6 +25,11 @@ pub const SAFENODE_BIN_NAME: &str = "safenode";
 #[cfg(target_os = "windows")]
 pub const SAFENODE_BIN_NAME: &str = "safenode.exe";
 
+#[cfg(not(target_os = "windows"))]
+pub const FAUCET_BIN_NAME: &str = "faucet";
+#[cfg(target_os = "windows")]
+pub const FAUCET_BIN_NAME: &str = "faucet.exe";
+
 /// This trait exists for unit testing.
 ///
 /// It enables us to test that nodes are launched with the correct arguments without actually


### PR DESCRIPTION
## Description

```bash
#                                                                 -d flag to run the dbc faucet
#                                                                                    |
#                                                                                    v
RUST_LOG=debug cargo run --release --features="local-discovery" --bin testnet -- -b -d --interval 100 --clean
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Jul 23 08:00 UTC
This pull request adds faucet integration to the testnet bin. It introduces a new constant FAUCET_BIN_NAME and modifies the main.rs file to include the FAUCET_BIN_NAME constant. It also adds a new command-line argument `-d` to launch the DBC faucet server. The server listens on port 8000.
<!-- reviewpad:summarize:end --> 
