### PR TITLE
chore: remove un-used Query::GetRegister

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -327,11 +327,6 @@ impl Node {
 
     async fn handle_query(&self, query: Query) -> Response {
         let resp = match query {
-            Query::GetRegister(address) => {
-                trace!("Got GetRegister query for {address:?}");
-                let result = self.get_signed_register_from_network(address).await;
-                QueryResponse::GetRegister(result)
-            }
             Query::GetChunk(address) => {
                 trace!("Got GetChunk query for {address:?}");
                 let result = self.get_chunk_from_network(address).await;

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -14,7 +14,7 @@ use sn_protocol::{
     messages::ReplicatedData,
     storage::{
         try_deserialize_record, Chunk, ChunkAddress, ChunkWithPayment, DbcAddress, RecordHeader,
-        RecordKind, RegisterAddress,
+        RecordKind,
     },
     NetworkAddress,
 };
@@ -38,29 +38,6 @@ impl Node {
         } else {
             error!("RecordKind mismatch while trying to retrieve a chunk");
             Err(Error::RecordKindMismatch(RecordKind::Chunk))
-        }
-    }
-
-    pub(crate) async fn get_signed_register_from_network(
-        &self,
-        address: RegisterAddress,
-    ) -> Result<SignedRegister> {
-        let record = self
-            .network
-            .get_record_from_network(RecordKey::new(address.name()))
-            .await
-            .map_err(|_| Error::RegisterNotFound(address))?;
-        debug!("Got record from the network, {:?}", record.key);
-        let header =
-            RecordHeader::from_record(&record).map_err(|_| Error::RegisterNotFound(address))?;
-
-        if let RecordKind::Register = header.kind {
-            let register = try_deserialize_record::<SignedRegister>(&record)
-                .map_err(|_| Error::RegisterNotFound(address))?;
-            Ok(register)
-        } else {
-            error!("RecordKind mismatch while trying to retrieve a chunk");
-            Err(Error::RecordKindMismatch(RecordKind::Register))
         }
     }
 

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    storage::{ChunkAddress, DbcAddress, RegisterAddress},
+    storage::{ChunkAddress, DbcAddress},
     NetworkAddress,
 };
 
@@ -29,13 +29,6 @@ pub enum Query {
     /// [`Chunk`]:  crate::storage::Chunk
     /// [`GetChunk`]: super::QueryResponse::GetChunk
     GetChunk(ChunkAddress),
-    /// Retrieve a [`SignedRegister`] at the given address.
-    ///
-    /// This should eventually lead to a [`GetRegister`] response.
-    ///
-    /// [`SignedRegister`]: sn_registers::SignedRegister
-    /// [`GetRegister`]: super::QueryResponse::GetRegister
-    GetRegister(RegisterAddress),
     /// Retrieve a [`SignedSpend`] at the given address.
     ///
     /// This should eventually lead to a [`GetDbcSpend`] response.
@@ -62,7 +55,6 @@ impl Query {
     pub fn dst(&self) -> NetworkAddress {
         match self {
             Query::GetChunk(address) => NetworkAddress::from_chunk_address(*address),
-            Query::GetRegister(address) => NetworkAddress::from_register_address(*address),
             Query::GetSpend(address) => NetworkAddress::from_dbc_address(*address),
             Query::GetReplicatedData { address, .. } => address.clone(),
         }
@@ -74,9 +66,6 @@ impl std::fmt::Display for Query {
         match self {
             Query::GetChunk(address) => {
                 write!(f, "Query::GetChunk({address:?})")
-            }
-            Query::GetRegister(address) => {
-                write!(f, "Query::GetRegister({address:?})")
             }
             Query::GetSpend(address) => {
                 write!(f, "Query::GetSpend({address:?})")

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 use sn_dbc::SignedSpend;
 use std::fmt::Debug;
 
-use sn_registers::SignedRegister;
-
 /// The response to a query, containing the query result.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
@@ -41,13 +39,6 @@ pub enum QueryResponse {
     ///
     /// [`GetReplicatedData`]: crate::messages::Query::GetReplicatedData
     GetReplicatedData(Result<(NetworkAddress, ReplicatedData)>),
-    //
-    // ===== Register =====
-    //
-    /// Response to [`GetRegister`]
-    ///
-    /// [`GetRegister`]: crate::messages::Query::GetRegister
-    GetRegister(Result<SignedRegister>),
 }
 
 /// The response to a Cmd, containing the query result.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Jul 23 09:39 UTC
This pull request removes the unused function `Node::get_signed_register_from_network` and its associated code in `sn_protocol/src/messages/query.rs` and `sn_protocol/src/messages/response.rs`. The function was not being used and can be safely removed.
<!-- reviewpad:summarize:end --> 
