### PR TITLE
chore(networking): simplify OutgoingConnErr handling

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -21,13 +21,14 @@ use libp2p::{
     multiaddr::Protocol,
     request_response::{self, ResponseChannel as PeerResponseChannel},
     swarm::{behaviour::toggle::Toggle, DialError, NetworkBehaviour, SwarmEvent},
-    Multiaddr, PeerId,
+    Multiaddr, PeerId, TransportError,
 };
 use sn_protocol::{
     messages::{Request, Response},
     NetworkAddress,
 };
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
@@ -255,34 +256,30 @@ impl SwarmDriver {
             } => {
                 debug!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
             }
-            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                error!("OutgoingConnectionError to {peer_id:?} - {error:?}");
-                if let Some(peer_id) = peer_id {
-                    // Related errors are: WrongPeerId, ConnectionRefused(TCP), HandshakeTimedOut(QUIC)
-                    let err_string = format!("{error:?}");
-                    let is_wrong_id = err_string.contains("WrongPeerId");
-                    let is_all_connection_failed = if let DialError::Transport(ref errors) = error {
-                        errors.iter().all(|(_, error)| {
-                            let err_string = format!("{error:?}");
-                            err_string.contains("ConnectionRefused")
-                        }) || errors.iter().all(|(_, error)| {
-                            let err_string = format!("{error:?}");
-                            err_string.contains("HandshakeTimedOut")
-                        })
-                    } else {
-                        false
-                    };
-                    if is_wrong_id || is_all_connection_failed {
-                        info!("Detected dead peer {peer_id:?}");
-                        if let Some(dead_peer) =
-                            self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id)
-                        {
-                            self.send_event(NetworkEvent::PeerRemoved(
-                                *dead_peer.node.key.preimage(),
-                            ));
-                        }
-                        self.log_kbuckets(&peer_id);
+            SwarmEvent::OutgoingConnectionError {
+                peer_id: Some(failed_peer_id),
+                error,
+                connection_id,
+            } => {
+                error!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
+
+                let peer_died = match error {
+                    DialError::WrongPeerId { .. } => true,
+                    DialError::Transport(errors) => errors.iter().any(|(_, error)| matches!(error, TransportError::Other(err) if err.kind() == ErrorKind::ConnectionRefused) ),
+                    _ => false,
+                };
+
+                if peer_died {
+                    info!("Detected dead peer {failed_peer_id:?}");
+                    if let Some(dead_peer) = self
+                        .swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .remove_peer(&failed_peer_id)
+                    {
+                        self.send_event(NetworkEvent::PeerRemoved(*dead_peer.node.key.preimage()));
                     }
+                    self.log_kbuckets(&failed_peer_id);
                 }
             }
             SwarmEvent::IncomingConnectionError { .. } => {}

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -82,6 +82,21 @@ pub async fn get_funded_wallet(
     std::thread::sleep(std::time::Duration::from_secs(5));
 
     println!("Verifying the transfer from faucet...");
+
+    // loop over verification for 10s in case the write has not gone through instantaneously
+    let mut verified = false;
+    for _ in 0..10 {
+        if client.verify(&tokens).await.is_ok() {
+            verified = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    if !verified {
+        panic!("Failed to verify the transfer from faucet");
+    }
+
     client.verify(&tokens).await?;
     local_wallet.deposit(vec![tokens]);
     assert_eq!(local_wallet.balance(), wallet_balance);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jul 23 12:30 UTC
This pull request simplifies the handling of OutgoingConnErr in the networking module. It includes changes to the event.rs file where several lines of code have been modified. The modifications involve the handling of OutgoingConnectionError events, specifically related to dead peers. Previously, the code checked for specific error conditions such as WrongPeerId, ConnectionRefused, and HandshakeTimedOut. Now, the code uses pattern matching to handle these errors in a more concise manner. Additionally, the code removes dead peers from the peer list and logs the changes to the KBuckets. Overall, these changes aim to improve the clarity and efficiency of the OutgoingConnErr handling process.
<!-- reviewpad:summarize:end --> 
