### PR TITLE
chore(networking): remove PutRecord kad query tracking.

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -139,7 +139,7 @@ async fn upload_chunks(
         });
 
     file_api
-        .upload_chunks_in_batches(chunks_reader, payment_proofs, false)
+        .upload_chunks_in_batches(chunks_reader, payment_proofs, true)
         .await?;
     Ok(())
 }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -51,6 +51,11 @@ impl ClientRegister {
         Ok(reg)
     }
 
+    /// Get the underlying register
+    pub fn register(&self) -> &Register {
+        &self.register
+    }
+
     /// Create a new Register Locally.
     pub fn create(client: Client, name: XorName, tag: u64) -> Result<Self> {
         Self::create_register(client, name, tag, Permissions::new_owner_only())

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -207,7 +207,10 @@ impl SwarmDriver {
                     .kademlia
                     .put_record(record, Quorum::All)?;
                 trace!("Sending record {request_id:?} to network");
-                let _ = self.pending_record_put.insert(request_id, sender);
+
+                if let Err(err) = sender.send(Ok(())) {
+                    error!("Could not send response to PutRecord cmd: {:?}", err);
+                }
             }
             SwarmCmd::PutLocalRecord { record } => {
                 self.swarm

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -340,33 +340,6 @@ impl SwarmDriver {
             }
             KademliaEvent::OutboundQueryProgressed {
                 id,
-                result: QueryResult::PutRecord(put_record_res),
-                stats,
-                step,
-            } => {
-                trace!("PutRecord task {id:?} returned, {stats:?} - {step:?}",);
-                if let Some(sender) = self.pending_record_put.remove(&id) {
-                    match put_record_res {
-                        Ok(put_record_ok) => {
-                            trace!(
-                                "PutRecord task {id:?} of {:?} completed successfully.",
-                                put_record_ok.key
-                            );
-                            sender
-                                .send(Ok(()))
-                                .map_err(|_| Error::InternalMsgChannelDropped)?;
-                        }
-                        Err(err) => {
-                            warn!("PutRecord task {id:?} completed with error {:?}.", err);
-                            sender
-                                .send(Err(err.into()))
-                                .map_err(|_| Error::InternalMsgChannelDropped)?;
-                        }
-                    }
-                }
-            }
-            KademliaEvent::OutboundQueryProgressed {
-                id,
                 result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(peer_record))),
                 stats,
                 step,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -107,7 +107,6 @@ pub struct SwarmDriver {
     pending_get_closest_peers: PendingGetClosest,
     pending_requests: HashMap<RequestId, Option<oneshot::Sender<Result<Response>>>>,
     pending_query: HashMap<QueryId, oneshot::Sender<Result<Record>>>,
-    pending_record_put: HashMap<QueryId, oneshot::Sender<Result<()>>>,
     replication_fetcher: ReplicationFetcher,
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
@@ -384,7 +383,6 @@ impl SwarmDriver {
             pending_get_closest_peers: Default::default(),
             pending_requests: Default::default(),
             pending_query: Default::default(),
-            pending_record_put: Default::default(),
             replication_fetcher: Default::default(),
             local,
             // We use 63 here, as in practice the capactiy will be rounded to the nearest 2^(n-1).

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -89,14 +89,19 @@ pub async fn get_funded_wallet(
     // loop over verification for 10s in case the write has not gone through instantaneously
     let mut verified = false;
     for _ in 0..100 {
-        if client.verify(&tokens).await.is_ok() {
-            verified = true;
+        match client.verify(&tokens).await {
+            Ok(_) => {
+                verified = true;
 
-            println!(
-                "Verified after {} seconds.",
-                verification_start.elapsed().as_secs()
-            );
-            break;
+                println!(
+                    "Verified after {} seconds.",
+                    verification_start.elapsed().as_secs()
+                );
+                break;
+            }
+            Err(error) => {
+                println!("Failed to verify the transfer from faucet: {error:?}");
+            }
         }
         sleep(std::time::Duration::from_secs(10)).await;
     }


### PR DESCRIPTION
This doesn't tell us anything useful and is more state to keep track of in the swarm driver

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jul 23 12:35 UTC
This pull request removes the PutRecord kad query tracking in the networking module. This change eliminates unnecessary state and reduces complexity in the swarm driver.
<!-- reviewpad:summarize:end --> 
