### PR TITLE
feat: not to carry out existence check explicitly

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -244,8 +244,10 @@ impl RecordStore for DiskBackedRecordStore {
     fn put(&mut self, record: Record) -> Result<()> {
         if self.records.contains(&record.key) {
             trace!("Unverified Record {:?} already exists.", record.key);
-            // Blindly sent to validation to allow double spend can be detected.
-            // TODO: consider avoid throw duplicated chunk to validation.
+            // To avoid sending duplicated data for validation,
+            // do nothing for already existing entry.
+            // The double spend case shall be handled separately.
+            return Ok(());
         }
         trace!(
             "Unverified Record {:?} try to validate and store",

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -473,16 +473,14 @@ impl Node {
                 // Check parents
                 check_parent_spends(&parent_spends, &signed_spend)?;
 
+                // The record_store won't store duplicated record.
+                // To avoid `get_record` targeting a non-existing record,
+                // which result in it only complete after a fixed timeout (currently 10s),
+                // no explicit check of existence to be carried out here.
+                // A double spend complain shall be addressed via separate approach.
                 // check the network if any spend has happened for the same dbc_id
                 // Does not return an error, instead the Vec<SignedSpend> is returned.
-                let mut spends = if let Ok(spend) = self.get_spend_from_network(dbc_addr).await {
-                    vec![spend]
-                } else {
-                    vec![]
-                };
-                // aggregate the spends from the network with our own
-                spends.push(signed_spend);
-                aggregate_spends(spends, dbc_id)
+                vec![signed_spend]
             }
             _ => {
                 debug!("Received >1 spends with parent. Aggregating the spends to check for double spend. Not performing parent check or querying the network for double spend");


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jul 23 14:20 UTC
This pull request includes a feature addition that avoids explicit existence checks for already existing entries in the record store. Instead of sending duplicated data for validation, the patch does nothing for already existing entries and handles the double spend case separately.
<!-- reviewpad:summarize:end --> 
