### PR TITLE
chore(networking): remove dead_peers state

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -21,13 +21,14 @@ use libp2p::{
     multiaddr::Protocol,
     request_response::{self, ResponseChannel as PeerResponseChannel},
     swarm::{behaviour::toggle::Toggle, DialError, NetworkBehaviour, SwarmEvent},
-    Multiaddr, PeerId,
+    Multiaddr, PeerId, TransportError,
 };
 use sn_protocol::{
     messages::{Request, Response},
     NetworkAddress,
 };
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
@@ -255,32 +256,30 @@ impl SwarmDriver {
             } => {
                 debug!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
             }
-            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                error!("OutgoingConnectionError to {peer_id:?} - {error:?}");
-                if let Some(peer_id) = peer_id {
-                    // Related errors are: WrongPeerId, ConnectionRefused(TCP), HandshakeTimedOut(QUIC)
-                    let err_string = format!("{error:?}");
-                    let is_wrong_id = err_string.contains("WrongPeerId");
-                    let is_all_connection_failed = if let DialError::Transport(ref errors) = error {
-                        errors.iter().all(|(_, error)| {
-                            let err_string = format!("{error:?}");
-                            err_string.contains("ConnectionRefused")
-                        }) || errors.iter().all(|(_, error)| {
-                            let err_string = format!("{error:?}");
-                            err_string.contains("HandshakeTimedOut")
-                        })
-                    } else {
-                        false
-                    };
-                    if is_wrong_id || is_all_connection_failed {
-                        info!("Detected dead peer {peer_id:?}");
-                        if !self.dead_peers.contains(&peer_id) {
-                            let _ = self.dead_peers.insert(peer_id);
-                            self.send_event(NetworkEvent::PeerRemoved(peer_id));
-                        }
-                        let _ = self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
-                        self.log_kbuckets(&peer_id);
+            SwarmEvent::OutgoingConnectionError {
+                peer_id: Some(failed_peer_id),
+                error,
+                connection_id,
+            } => {
+                error!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
+
+                let peer_died = match error {
+                    DialError::WrongPeerId { .. } => true,
+                    DialError::Transport(errors) => errors.iter().any(|(_, error)| matches!(error, TransportError::Other(err) if err.kind() == ErrorKind::ConnectionRefused) ),
+                    _ => false,
+                };
+
+                if peer_died {
+                    info!("Detected dead peer {failed_peer_id:?}");
+                    if self.dead_peers.insert(failed_peer_id) {
+                        self.send_event(NetworkEvent::PeerRemoved(failed_peer_id));
+                        let _ = self
+                            .swarm
+                            .behaviour_mut()
+                            .kademlia
+                            .remove_peer(&failed_peer_id);
                     }
+                    self.log_kbuckets(&failed_peer_id);
                 }
             }
             SwarmEvent::IncomingConnectionError { .. } => {}

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -54,7 +54,7 @@ use sn_protocol::{
     NetworkAddress,
 };
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -112,7 +112,6 @@ pub struct SwarmDriver {
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
     dialed_peers: CircularVec<PeerId>,
-    dead_peers: BTreeSet<PeerId>,
     is_client: bool,
 }
 
@@ -393,7 +392,6 @@ impl SwarmDriver {
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
-            dead_peers: Default::default(),
             is_client,
         };
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -486,17 +486,6 @@ impl Network {
     }
 
     /// Dial the given peer at the given address.
-    pub async fn add_to_routing_table(&self, peer_id: PeerId, peer_addr: Multiaddr) -> Result<()> {
-        let (sender, receiver) = oneshot::channel();
-        self.send_swarm_cmd(SwarmCmd::AddToRoutingTable {
-            peer_id,
-            peer_addr,
-            sender,
-        })?;
-        receiver.await?
-    }
-
-    /// Dial the given peer at the given address.
     pub async fn dial(&self, addr: Multiaddr) -> Result<()> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::Dial { addr, sender })?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jul 23 08:12 UTC
This pull request includes two patches. 

The first patch, labeled [PATCH 1/2], is a chore in the networking module. It removes the dead_peers state from the event and lib files in the sn_networking crate. Several lines of code related to handling dead peers are removed, and the logic for removing dead peers from the kademlia behavior is updated. This patch also includes other minor code changes.

The second patch, labeled [PATCH 2/2], is another chore in the networking module. It cleans up an unused function, `add_to_routing_table()`, from the lib file in the sn_networking crate. This function is deleted, along with its associated code.

These patches make improvements to the networking functionality by removing dead_peer state and unused code.
<!-- reviewpad:summarize:end --> 
