### PR TITLE
fix(testnet): clean the whole safe dir

### DIFF
--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -119,15 +119,15 @@ async fn main() -> Result<()> {
     let args = Cmd::from_args();
 
     if args.clean {
-        let node_data_dir = dirs_next::data_dir()
+        let safe_data_dir = dirs_next::data_dir()
             .ok_or_else(|| eyre!("could not obtain root directory path".to_string()))?
-            .join("safe")
-            .join("node");
-        println!("Cleaning previous node directories under {node_data_dir:?}");
-        if let Err(e) = remove_dir_all(node_data_dir) {
+            .join("safe");
+
+        println!("Cleaning previous safe directories under {safe_data_dir:?}");
+        if let Err(e) = remove_dir_all(safe_data_dir) {
             match e.kind() {
                 ErrorKind::NotFound => {
-                    println!("No previous node directories found under");
+                    println!("No previous safe directories found.");
                 }
                 _ => {
                     return Err(e.into());

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -105,7 +105,7 @@ pub async fn create_genesis_wallet() -> LocalWallet {
 
     LocalWallet::load_from(&root_dir)
         .await
-        .expect("Faucet wallet shall be created successfully.")
+        .expect("Faucet wallet (after genesis) shall be created successfully.")
 }
 
 /// Create a first DBC given any key (i.e. not specifically the hard coded genesis key).
@@ -210,6 +210,8 @@ pub(super) fn split(
 
 pub async fn create_faucet_wallet() -> LocalWallet {
     let root_dir = get_faucet_dir().await;
+
+    println!("Creating faucet wallet... {:#?}", root_dir);
     LocalWallet::load_from(&root_dir)
         .await
         .expect("Faucet wallet shall be created successfully.")
@@ -218,23 +220,23 @@ pub async fn create_faucet_wallet() -> LocalWallet {
 // We need deterministic and fix path for the genesis wallet.
 // Otherwise the test instances will not be able to find the same genesis instance.
 async fn get_genesis_dir() -> PathBuf {
-    let mut home_dirs = dirs_next::home_dir().expect("A homedir to exist.");
-    home_dirs.push(".safe");
-    home_dirs.push("test_genesis");
-    tokio::fs::create_dir_all(home_dirs.as_path())
+    let mut data_dirs = dirs_next::data_dir().expect("A homedir to exist.");
+    data_dirs.push("safe");
+    data_dirs.push("test_genesis");
+    tokio::fs::create_dir_all(data_dirs.as_path())
         .await
         .expect("Genesis test path to be successfully created.");
-    home_dirs
+    data_dirs
 }
 
 // We need deterministic and fix path for the faucet wallet.
 // Otherwise the test instances will not be able to find the same faucet instance.
 async fn get_faucet_dir() -> PathBuf {
-    let mut home_dirs = dirs_next::home_dir().expect("A homedir to exist.");
-    home_dirs.push(".safe");
-    home_dirs.push("test_faucet");
-    tokio::fs::create_dir_all(home_dirs.as_path())
+    let mut data_dirs = dirs_next::data_dir().expect("A homedir to exist.");
+    data_dirs.push("safe");
+    data_dirs.push("test_faucet");
+    tokio::fs::create_dir_all(data_dirs.as_path())
         .await
         .expect("Faucet test path to be successfully created.");
-    home_dirs
+    data_dirs
 }


### PR DESCRIPTION
Also more test wallet creation in to that same safedir

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jul 23 11:32 UTC
This pull request fixes an issue in the testnet code where the entire "safe" directory is now cleaned instead of just the "node" directory. Additionally, more test wallet creation has been added to the same safedir. In the sn_transfers module, there are changes related to creating the genesis wallet and the faucet wallet, including the use of deterministic and fixed paths for these wallets.
<!-- reviewpad:summarize:end --> 
