### PR TITLE
feat(rpc): add new `GetAllLocalRecordAddresses` api

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -78,6 +78,10 @@ pub enum SwarmCmd {
         key: RecordKey,
         sender: oneshot::Sender<bool>,
     },
+    /// Get the Addresses of all the Records held locally
+    GetAllLocalRecordAddresses {
+        sender: oneshot::Sender<HashSet<NetworkAddress>>,
+    },
     /// Get Record from the Kad network
     GetNetworkRecord {
         key: RecordKey,
@@ -225,6 +229,15 @@ impl SwarmDriver {
                     .store_mut()
                     .contains(&key);
                 let _ = sender.send(has_key);
+            }
+            SwarmCmd::GetAllLocalRecordAddresses { sender } => {
+                let addresses = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .record_addresses();
+                let _ = sender.send(addresses);
             }
 
             SwarmCmd::StartListening { addr, sender } => {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -669,6 +669,16 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)
     }
 
+    /// Returns the Addresses of all the locally stored Records
+    pub async fn get_all_local_record_addresses(&self) -> Result<HashSet<NetworkAddress>> {
+        let (sender, receiver) = oneshot::channel();
+        self.send_swarm_cmd(SwarmCmd::GetAllLocalRecordAddresses { sender })?;
+
+        receiver
+            .await
+            .map_err(|_e| Error::InternalMsgChannelDropped)
+    }
+
     // Add a list of keys of a holder to RecordFetcher.  Return with a list of keys to fetch, if present.
     pub async fn add_keys_to_replication_fetcher(
         &self,

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -11,8 +11,8 @@ use eyre::Result;
 use libp2p::{Multiaddr, PeerId};
 use safenode_proto::safe_node_client::SafeNodeClient;
 use safenode_proto::{
-    NetworkInfoRequest, NodeEventsRequest, NodeInfoRequest, RestartRequest, StopRequest,
-    UpdateRequest,
+    NetworkInfoRequest, NodeEventsRequest, NodeInfoRequest, RecordAddressesRequest, RestartRequest,
+    StopRequest, UpdateRequest,
 };
 use sn_logging::{init_logging, LogFormat, LogOutputDest};
 use sn_node::NodeEvent;
@@ -163,6 +163,22 @@ pub async fn node_events(addr: SocketAddr) -> Result<()> {
             }
         };
         println!("New event received: {event:?}");
+    }
+
+    Ok(())
+}
+
+pub async fn record_addresses(addr: SocketAddr) -> Result<()> {
+    let endpoint = format!("https://{addr}");
+    let mut client = SafeNodeClient::connect(endpoint).await?;
+    let response = client
+        .record_addresses(Request::new(RecordAddressesRequest {}))
+        .await?;
+
+    println!("Records held by the node:");
+    for bytes in response.get_ref().addresses.iter() {
+        let key = libp2p::kad::RecordKey::from(bytes.clone());
+        println!("Key: {key:?}");
     }
 
     Ok(())

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -17,6 +17,7 @@ use sn_protocol::{
     NetworkAddress,
 };
 use std::{
+    collections::HashSet,
     net::SocketAddr,
     path::PathBuf,
     sync::{
@@ -62,6 +63,12 @@ impl RunningNode {
     /// Returns the node events channel where to subscribe to receive `NodeEvent`s
     pub fn node_events_channel(&self) -> &NodeEventsChannel {
         &self.node_events_channel
+    }
+
+    /// Returns the list of all the RecordKeys held by the node
+    pub async fn get_all_record_addresses(&self) -> Result<HashSet<NetworkAddress>> {
+        let addresses = self.network.get_all_local_record_addresses().await?;
+        Ok(addresses)
     }
 }
 

--- a/sn_node/src/bin/safenode/rpc.rs
+++ b/sn_node/src/bin/safenode/rpc.rs
@@ -25,8 +25,8 @@ use tracing::{debug, info, trace};
 use safenode_proto::safe_node_server::{SafeNode, SafeNodeServer};
 use safenode_proto::{
     NetworkInfoRequest, NetworkInfoResponse, NodeEvent, NodeEventsRequest, NodeInfoRequest,
-    NodeInfoResponse, RestartRequest, RestartResponse, StopRequest, StopResponse, UpdateRequest,
-    UpdateResponse,
+    NodeInfoResponse, RecordAddressesRequest, RecordAddressesResponse, RestartRequest,
+    RestartResponse, StopRequest, StopResponse, UpdateRequest, UpdateResponse,
 };
 
 // this includes code generated from .proto files
@@ -129,6 +129,28 @@ impl SafeNode for SafeNodeRpcService {
         });
 
         Ok(Response::new(ReceiverStream::new(client_rx)))
+    }
+
+    async fn record_addresses(
+        &self,
+        request: Request<RecordAddressesRequest>,
+    ) -> Result<Response<RecordAddressesResponse>, Status> {
+        trace!(
+            "RPC request received at {}: {:?}",
+            self.addr,
+            request.get_ref()
+        );
+
+        let addresses = self
+            .running_node
+            .get_all_record_addresses()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|addr| addr.as_bytes())
+            .collect();
+
+        Ok(Response::new(RecordAddressesResponse { addresses }))
     }
 
     async fn stop(&self, request: Request<StopRequest>) -> Result<Response<StopResponse>, Status> {

--- a/sn_node/src/error.rs
+++ b/sn_node/src/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
     #[error("Protocol error {0}")]
     Protocol(#[from] ProtocolError),
 
+    #[error("Node wallet load issue: {0}.")]
+    CouldNotLoadWallet(String),
+
     #[error("Genesis error {0}")]
     Genesis(#[from] GenesisError),
+
+    #[error("Failed to parse NodeEvent")]
+    NodeEventParsingFailed,
 }

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
 use sn_dbc::DbcId;
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
 use tokio::sync::broadcast;
@@ -41,7 +43,7 @@ impl NodeEventsChannel {
 }
 
 /// Type of events broadcasted by the node to the public API.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum NodeEvent {
     /// The node has been connected to the network
     ConnectedToNetwork,
@@ -57,4 +59,16 @@ pub enum NodeEvent {
     ChannelClosed,
     /// AutoNAT discovered we are behind a NAT, thus private.
     BehindNat,
+}
+
+impl NodeEvent {
+    /// Convert NodeEvent to bytes
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        rmp_serde::to_vec(&self).map_err(|_| Error::NodeEventParsingFailed)
+    }
+
+    /// Get NodeEvent from bytes
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        rmp_serde::from_slice(bytes).map_err(|_| Error::NodeEventParsingFailed)
+    }
 }

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -23,11 +23,26 @@ message NodeInfoResponse {
   uint64 uptime_secs = 5;
 }
 
+// Information about how this node's connections to the network and peers
+message NetworkInfoRequest {}
+
+message NetworkInfoResponse {
+  repeated bytes connected_peers = 1;
+  repeated string listeners = 2;
+}
+
 // Stream of node events
 message NodeEventsRequest {}
 
 message NodeEvent {
   bytes event = 1;
+}
+
+// Addresses of all the Records stored by the node
+message RecordAddressesRequest {}
+
+message RecordAddressesResponse {
+    repeated bytes addresses = 1;
 }
 
 // Stop the safenode app
@@ -51,10 +66,3 @@ message UpdateRequest {
 
 message UpdateResponse {}
 
-// Information about how this node's connections to the network and peers
-message NetworkInfoRequest {}
-
-message NetworkInfoResponse {
-  repeated bytes connected_peers = 1;
-  repeated string listeners = 2;
-}

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -27,7 +27,7 @@ message NodeInfoResponse {
 message NodeEventsRequest {}
 
 message NodeEvent {
-  string event = 1;
+  bytes event = 1;
 }
 
 // Stop the safenode app

--- a/sn_node/src/protocol/safenode_proto/safenode.proto
+++ b/sn_node/src/protocol/safenode_proto/safenode.proto
@@ -31,6 +31,9 @@ service SafeNode {
   // Returns a stream of events as triggered by this node
   rpc NodeEvents (NodeEventsRequest) returns (stream NodeEvent);
 
+  // Returns the Addresses of all the Records stored by this node
+  rpc RecordAddresses (RecordAddressesRequest) returns (RecordAddressesResponse);
+
   // Stop the execution of this node
   rpc Stop (StopRequest) returns (StopResponse);
 


### PR DESCRIPTION
- Returning the `NodeEvent` as a byte allows us to match the contents inside more effectively.
- The `GetAllLocalRecordAddresses` is used inside the `verify_data_location` test

This PR is part of the "Close group based replication PRs". 1/3

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Jul 23 06:19 UTC
This pull request adds new functionality to the codebase, specifically related to retrieving the addresses of locally stored records. It introduces a new enum variant `GetAllLocalRecordAddresses` to the `SwarmCmd` enum in `cmd.rs`, which is used to send a request to retrieve the addresses of all locally stored records. The `SwarmDriver` impl in the same file handles this request by accessing the `kademlia` store and sending the addresses back to the requester. Similar changes have been made in other files such as `lib.rs`, `api.rs`, `safenode_rpc_client.rs`, `rpc.rs`, and `event.rs` to support this new functionality.
<!-- reviewpad:summarize:end --> 
