### PR TITLE
feat: replicate when our close group changes

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -71,7 +71,7 @@ impl Client {
         };
 
         // subscribe to our events channel first, so we don't have intermittent
-        // errors if it does not exist and we cannot send to it
+        // errors if it does not exist and we cannot send to it.
         // (eg, if PeerAdded happens faster than our events channel is created)
         let mut client_events_rx = client.events_channel();
 
@@ -130,8 +130,8 @@ impl Client {
             }
         });
 
+        // loop to connect to the network
         let mut is_connected = false;
-
         loop {
             let mut rng = rand::thread_rng();
             // Carry out 5 rounds of random get to fill up the RT at the beginning.
@@ -163,6 +163,14 @@ impl Client {
                 }
             }
         }
+        // The above loop breaks if `ConnectedToNetwork` is received, but we might need the
+        // receiver to still be active for us to not get any error if any other event is sent
+        let mut client_events_rx = client.events_channel();
+        spawn(async move {
+            loop {
+                let _ = client_events_rx.recv().await;
+            }
+        });
 
         Ok(client)
     }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -128,7 +128,9 @@ impl SwarmDriver {
                     .store_mut()
                     .record_addresses_ref();
                 let keys_to_fetch = self.replication_fetcher.add_keys(peer, keys, all_keys);
-                self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
+                if !keys_to_fetch.is_empty() {
+                    self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
+                }
             }
             SwarmCmd::GetNetworkRecord { key, sender } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
@@ -167,7 +169,9 @@ impl SwarmDriver {
                 {
                     Ok(_) => {
                         let new_keys_to_fetch = self.replication_fetcher.notify_about_new_put(key);
-                        self.send_event(NetworkEvent::KeysForReplication(new_keys_to_fetch));
+                        if !new_keys_to_fetch.is_empty() {
+                            self.send_event(NetworkEvent::KeysForReplication(new_keys_to_fetch));
+                        }
                     }
                     Err(err) => return Err(err.into()),
                 };

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -389,7 +389,7 @@ impl SwarmDriver {
             pending_query: Default::default(),
             replication_fetcher: Default::default(),
             local,
-            // We use 63 here, as in practice the capacity will be rounded to the nearest 2^(n-1).
+            // We use 63 here, as in practice the capacity will be rounded to the nearest 2^n-1.
             // Source: https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/8
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -19,14 +19,14 @@ impl SwarmDriver {
         event: request_response::Event<Request, Response>,
     ) -> Result<(), Error> {
         match event {
-            request_response::Event::Message { message, .. } => match message {
+            request_response::Event::Message { message, peer } => match message {
                 Message::Request {
                     request,
                     channel,
                     request_id,
                     ..
                 } => {
-                    trace!("Received request with id: {request_id:?}, req: {request:?}");
+                    trace!("Received request {request_id:?} from peer {peer:?}, req: {request:?}");
                     self.send_event(NetworkEvent::RequestReceived {
                         req: request,
                         channel: MsgResponder::FromPeer(channel),
@@ -36,7 +36,7 @@ impl SwarmDriver {
                     request_id,
                     response,
                 } => {
-                    trace!("Got response for id: {request_id:?}, res: {response}.");
+                    trace!("Got response {request_id:?} from peer {peer:?}, res: {response}.");
                     if let Some(sender) = self.pending_requests.remove(&request_id) {
                         // The sender will be provided if the caller (Requester) is awaiting for a response
                         // at the call site.

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -114,27 +114,6 @@ impl DiskBackedRecordStore {
         to_be_removed.iter().for_each(|key| self.remove(key));
     }
 
-    /// Returns the list of keys that are within the provided distance to the target
-    pub fn get_record_keys_closest_to_target(
-        &mut self,
-        target: KBucketKey<Vec<u8>>,
-        distance_bar: Distance,
-    ) -> Vec<Key> {
-        self.records
-            .iter()
-            .filter(|key| {
-                let record_key = KBucketKey::from(key.to_vec());
-                target.distance(&record_key) < distance_bar
-            })
-            .cloned()
-            .collect()
-    }
-
-    /// Setup the distance range.
-    pub fn set_distance_range(&mut self, distance_bar: Distance) {
-        self.distance_range = Some(distance_bar);
-    }
-
     // Converts a Key into a Hex string.
     fn key_to_hex(key: &Key) -> String {
         let key_bytes = key.as_ref();
@@ -150,6 +129,11 @@ impl DiskBackedRecordStore {
             .iter()
             .map(|record_key| NetworkAddress::from_record_key(record_key.clone()))
             .collect()
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    pub fn record_addresses_ref(&self) -> &HashSet<Key> {
+        &self.records
     }
 
     pub fn read_from_disk<'a>(key: &Key, storage_dir: &Path) -> Option<Cow<'a, Record>> {

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -5,142 +5,195 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+#![allow(clippy::mutable_key_type)]
 
-use libp2p::PeerId;
+use libp2p::{kad::RecordKey, PeerId};
 use rand::{seq::SliceRandom, thread_rng};
 use sn_protocol::NetworkAddress;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     time::{Duration, Instant},
 };
 
-// Max parallel fetches can be undertaken at the same time.
+// Max parallel fetches that can be undertaken at the same time.
 const MAX_PARALLEL_FETCH: usize = 8;
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.
-const FETCH_FAILED_DURATION: Duration = Duration::from_secs(10);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+
+// The maximum number of retries that is performed per peer.
+// Else the key is fetched from the Network
+const MAX_RETRIES_PER_PEER: u8 = 1;
+
+// If we have failed to fetch the key from <= PEERS_TRIED_BEFORE_NETWORK_FETCH number of peers, then it is sent out
+// to be fetched from the network
+const PEERS_TRIED_BEFORE_NETWORK_FETCH: u8 = 3;
+
+// The number of failed attempts while fetching the key from a peer.
+type FailedAttempts = u8;
+// The time at which the key was sent to be fetched from the peer.
+type ReplicationRequestSentTime = Instant;
 
 // Status of the data fetching progress from the holder.
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub(crate) enum HolderStatus {
     Pending,
     OnGoing,
-    Failed,
 }
 
 #[derive(Default)]
 pub(crate) struct ReplicationFetcher {
-    to_be_fetched: BTreeMap<NetworkAddress, BTreeMap<PeerId, (Instant, HolderStatus)>>,
+    to_be_fetched: HashMap<
+        RecordKey,
+        BTreeMap<PeerId, (ReplicationRequestSentTime, HolderStatus, FailedAttempts)>,
+    >,
     on_going_fetches: usize,
 }
 
 impl ReplicationFetcher {
-    /// Add a list of keys of a holder.
-    /// Return with a list of keys to fetch from holder
-    pub(crate) fn add_keys_to_replicate_per_peer(
+    // Adds the non existing incoming keys from the peer to the fetcher. Returns the next set of keys that has to be
+    // fetched from the peer/network.
+    pub(crate) fn add_keys(
         &mut self,
         peer_id: PeerId,
-        keys: Vec<NetworkAddress>,
-    ) -> Vec<(PeerId, NetworkAddress)> {
-        for key in keys {
-            self.add_holder(key, peer_id);
-        }
-        self.next_to_fetch()
-    }
-    /// Remove keys that we hold already and no longer need to be replicated.
-    pub(crate) fn remove_held_data(&mut self, keys: &HashSet<NetworkAddress>) {
-        self.to_be_fetched.retain(|key, _| !keys.contains(key));
+        incoming_keys: Vec<NetworkAddress>,
+        locally_stored_keys: &HashSet<RecordKey>,
+    ) -> Vec<(RecordKey, Option<PeerId>)> {
+        self.retain_keys(locally_stored_keys);
+
+        // add non existing keys to the fetcher
+        incoming_keys
+            .into_iter()
+            .filter_map(|incoming| incoming.as_record_key())
+            .filter(|incoming| !locally_stored_keys.contains(incoming))
+            .for_each(|incoming| self.add_holder_pey_key(incoming, peer_id));
+
+        self.next_keys_to_fetch()
     }
 
-    // Notify the fetch result of a key from a holder.
-    // Return with a list of keys to fetch, if presents.
-    pub(crate) fn notify_fetch_result(
+    // Notify the replication fetcher about a newly added Record to the node. The corresponding key can now be removed
+    // from the replication fetcher.
+    // Also returns the next set of keys that has to be fetched from the peer/network.
+    pub(crate) fn notify_about_new_put(
         &mut self,
-        peer_id: PeerId,
-        key: NetworkAddress,
-        result: bool,
-    ) -> Vec<(PeerId, NetworkAddress)> {
-        self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
-
-        if result {
-            let _ = self.to_be_fetched.remove(&key);
-        } else if let Some(holders) = self.to_be_fetched.get_mut(&key) {
-            if let Some(status) = holders.get_mut(&peer_id) {
-                status.1 = HolderStatus::Failed;
+        new_put: RecordKey,
+    ) -> Vec<(RecordKey, Option<PeerId>)> {
+        // if we're actively fetching for the key, reduce the on_going_fetches before removing the key
+        if let Some(holders) = self.to_be_fetched.get(&new_put) {
+            if holders
+                .values()
+                .any(|(_, status, _)| *status == HolderStatus::OnGoing)
+            {
+                self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
             }
         }
-        self.next_to_fetch()
+        self.to_be_fetched.remove(&new_put);
+        self.next_keys_to_fetch()
     }
 
-    // Returns a list of keys to fetch
-    fn next_to_fetch(&mut self) -> Vec<(PeerId, NetworkAddress)> {
-        let mut keys_to_fetch = vec![];
+    // Returns the set of keys that has to be fetched from the peer/network.
+    // If a key has not been sent out to be fetched, it is returned (to be fetched).
+    // If a key has not been fetched for `FETCH_TIMEOUT` from a peer, then the failed attempt is increased for that
+    // peer and its status is set to be `Pending`. i.e., it can be requeued again.
+    // For a key, if we have failed `MAX_RETRIES_PER_PEER` number of times from all holders or
+    // `PEERS_TRIED_BEFORE_NETWORK_FETCH` number of holders, then we queue the key to be fetched from the Network.
+    // If the key is returned None as the peer, then it has to be fetched from the network.
+    fn next_keys_to_fetch(&mut self) -> Vec<(RecordKey, Option<PeerId>)> {
+        // do not fetch any if max parallel fetches
         if self.on_going_fetches >= MAX_PARALLEL_FETCH {
-            return keys_to_fetch;
+            return vec![];
         }
-
         let len = MAX_PARALLEL_FETCH - self.on_going_fetches;
-        let mut all_failed_entries = vec![];
 
-        debug!("Records awaiting fetch: {:?}", self.to_be_fetched.len());
+        debug!(
+            "Number of records awaiting fetch: {:?}",
+            self.to_be_fetched.len()
+        );
         // Randomize the order of keys to fetch
         let mut rng = thread_rng();
         let mut data_to_fetch = self.to_be_fetched.iter_mut().collect::<Vec<_>>();
         data_to_fetch.shuffle(&mut rng); // devskim: ignore DS148264 - this is crypto secure using os rng
 
+        let mut keys_to_fetch = HashMap::new();
+        let mut to_be_removed = vec![];
         for (key, holders) in data_to_fetch {
-            let mut failed_counter = 0;
-            if holders.values().any(|status| {
-                HolderStatus::OnGoing == status.1
-                    && status.0 + FETCH_FAILED_DURATION > Instant::now()
-            }) {
-                continue;
-            }
-            for (peer_id, status) in holders.iter_mut() {
-                match status.1 {
+            let mut key_added_to_list = false;
+
+            //todo: shuffle holder so that we don't re attempt the same peer continuously until MAX_FAILED_ATTEMPTS_PER_PEER
+            for (peer_id, (replication_req_time, holder_status, failed_attempts)) in
+                holders.iter_mut()
+            {
+                match holder_status {
                     HolderStatus::Pending => {
-                        status.0 = Instant::now();
-                        status.1 = HolderStatus::OnGoing;
+                        // if we have added this key/if we have all max keys that we can
+                        // replicate, continue to the next holder;
+                        // todo: or if max failed attempts
+                        if key_added_to_list
+                            || keys_to_fetch.len() >= len
+                            || *failed_attempts >= MAX_RETRIES_PER_PEER
+                        {
+                            continue;
+                        }
+                        // set status of the holder
+                        *replication_req_time = Instant::now();
+                        *holder_status = HolderStatus::OnGoing;
+
+                        // add key for replication
+                        keys_to_fetch.insert(key.clone(), Some(*peer_id));
                         self.on_going_fetches += 1;
-                        keys_to_fetch.push((*peer_id, key.clone()));
-                        break;
+                        key_added_to_list = true;
                     }
                     HolderStatus::OnGoing => {
-                        trace!("Marking failed {key:?} on {peer_id:?}",);
-                        status.1 = HolderStatus::Failed;
-                        failed_counter += 1;
-                        self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
+                        if *replication_req_time + FETCH_TIMEOUT > Instant::now() {
+                            *failed_attempts += 1;
+                            // allows it to be re-queued
+                            *holder_status = HolderStatus::Pending;
+                            self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
+                        }
                     }
-                    HolderStatus::Failed => failed_counter += 1,
                 }
             }
 
-            if keys_to_fetch.len() >= len {
-                break;
-            }
-
-            if failed_counter == holders.len() {
-                warn!(
-                    "Failed to fetch copies of {key:?} from all {:?} holders",
-                    holders.len()
-                );
-                // TODO: fire `get_record` instead?
-                all_failed_entries.push(key.clone());
+            // If all holders or PEERS_TRIED_BEFORE_NETWORK_FETCH holders have exhausted MAX_FAILED_ATTEMPTS_PER_PEER,
+            // then the key has to be fetched from the network.
+            let failed_holders_count = holders
+                .values()
+                .filter(|(_, _, failed_attempts)| *failed_attempts >= MAX_RETRIES_PER_PEER)
+                .count();
+            if failed_holders_count == holders.len()
+                || failed_holders_count >= PEERS_TRIED_BEFORE_NETWORK_FETCH as usize
+            {
+                to_be_removed.push(key.clone());
+                keys_to_fetch.insert(key.clone(), None);
+                // Keys queued for Network fetch are not counted in MAX_PARALLEL_FETCH
+                self.on_going_fetches = self.on_going_fetches.saturating_sub(1);
             }
         }
 
-        for failed_key in all_failed_entries {
+        for failed_key in to_be_removed {
             let _ = self.to_be_fetched.remove(&failed_key);
         }
 
+        trace!("Sending out keys to fetch {keys_to_fetch:?}");
+
         keys_to_fetch
+            .into_iter()
+            .map(|(key, peer)| (key, peer))
+            .collect::<Vec<_>>()
     }
 
-    fn add_holder(&mut self, key: NetworkAddress, peer_id: PeerId) {
+    /// Remove keys that we hold already and no longer need to be replicated.
+    fn retain_keys(&mut self, existing_keys: &HashSet<RecordKey>) {
+        self.to_be_fetched
+            .retain(|key, _| !existing_keys.contains(key));
+    }
+
+    /// Add the holder for the following key
+    fn add_holder_pey_key(&mut self, key: RecordKey, peer_id: PeerId) {
         let holders = self.to_be_fetched.entry(key).or_insert(Default::default());
         let _ = holders
             .entry(peer_id)
-            .or_insert((Instant::now(), HolderStatus::Pending));
+            .or_insert((Instant::now(), HolderStatus::Pending, 0));
     }
 }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -196,11 +196,14 @@ impl Node {
                 Marker::PeerRemovedFromRoutingTable(peer_id).log();
             }
             NetworkEvent::CloseGroupUpdated(new_members) => {
-                if let Err(err) = self.try_trigger_replication(new_members).await {
+                Marker::CloseGroupUpdated(&new_members).log();
+                if let Err(err) = self.try_trigger_replication().await {
                     error!("Error while triggering replication {err:?}");
                 }
             }
             NetworkEvent::KeysForReplication(keys) => {
+                Marker::fetching_keys_for_replication(&keys).log();
+
                 if let Err(err) = self.fetch_replication_keys_without_wait(keys) {
                     error!("Error while trying to fetch replicated data {err:?}");
                 }

--- a/sn_node/src/error.rs
+++ b/sn_node/src/error.rs
@@ -23,9 +23,6 @@ pub enum Error {
     #[error("Protocol error {0}")]
     Protocol(#[from] ProtocolError),
 
-    #[error("Node wallet load issue: {0}.")]
-    CouldNotLoadWallet(String),
-
     #[error("Genesis error {0}")]
     Genesis(#[from] GenesisError),
 

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -39,7 +39,7 @@ pub enum Marker<'a> {
     LostRecordDetected(&'a Vec<PeerId>),
 
     /// Replication trigger was fired
-    ReplicationTriggered((&'a PeerId, bool)),
+    ReplicationTriggered(&'a Vec<PeerId>),
 
     /// Keys of Records we are fetching to replicate locally
     FetchingKeysForReplication {

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use libp2p::PeerId;
+use libp2p::{kad::RecordKey, PeerId};
 use sn_protocol::messages::{Cmd, CmdResponse};
 use std::time::Duration;
 // this gets us to_string easily enough
@@ -39,16 +39,19 @@ pub enum Marker<'a> {
     LostRecordDetected(&'a Vec<PeerId>),
 
     /// Replication trigger was fired
-    ReplicationTriggered(&'a Vec<PeerId>),
+    ReplicationTriggered,
+
+    /// The new members added to our close group
+    CloseGroupUpdated(&'a Vec<PeerId>),
 
     /// Keys of Records we are fetching to replicate locally
     FetchingKeysForReplication {
         /// fetching_keys_len: number of keys we are fetching
         fetching_keys_len: usize,
-        /// provided_keys_len: number of keys we were provided (the difference would be the number of keys we already have)
-        provided_keys_len: usize,
-        /// peer_id: the peer we are fetching from
-        peer_id: PeerId,
+        /// direct_fetch_count: number of keys we are directly fetching from a provided peer
+        direct_fetch_count: usize,
+        /// network_fetch_count: number of keys we are fetching from the network
+        network_fetch_count: usize,
     },
 }
 
@@ -58,5 +61,22 @@ impl<'a> Marker<'a> {
         // Down the line, if some logs are noisier than others, we can
         // match the type and log a different level.
         info!("{self:?}");
+    }
+
+    /// Helper to log the FetchingKeysForReplication variant
+    pub fn fetching_keys_for_replication(keys: &Vec<(RecordKey, Option<PeerId>)>) -> Self {
+        let direct_fetch_count = keys
+            .iter()
+            .filter(|(_, maybe_direct)| maybe_direct.is_some())
+            .count();
+        let network_fetch_count = keys
+            .iter()
+            .filter(|(_, maybe_direct)| maybe_direct.is_none())
+            .count();
+        Marker::FetchingKeysForReplication {
+            fetching_keys_len: keys.len(),
+            direct_fetch_count,
+            network_fetch_count,
+        }
     }
 }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -22,8 +22,8 @@ const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 
 impl Node {
     /// Replication is triggered when is there is a change in our close group
-    pub(crate) async fn try_trigger_replication(&mut self, new_members: Vec<PeerId>) -> Result<()> {
-        Marker::ReplicationTriggered(&new_members).log();
+    pub(crate) async fn try_trigger_replication(&mut self) -> Result<()> {
+        Marker::ReplicationTriggered.log();
         let our_close_group = self.network.get_our_close_group().await?;
         let our_peer_id = self.network.peer_id;
         let our_address = NetworkAddress::from_peer(our_peer_id);

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -8,8 +8,9 @@
 
 use crate::Node;
 use crate::{error::Result, log_markers::Marker};
-use libp2p::{kad::KBucketKey, PeerId};
-use sn_networking::{sort_peers_by_address, sort_peers_by_key, CLOSE_GROUP_SIZE};
+use libp2p::kad::RecordKey;
+use libp2p::PeerId;
+use sn_networking::{sort_peers_by_address, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, Request},
     NetworkAddress,
@@ -19,109 +20,32 @@ use std::collections::BTreeMap;
 // To reduce the number of messages exchanged, patch max 500 replication keys into one request.
 const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 
-// Defines how close that a node will trigger replication.
-// That is, the node has to be among the REPLICATION_RANGE closest to data,
-// to carry out the replication.
-const REPLICATION_RANGE: usize = 8;
-
 impl Node {
-    /// Replication is triggered when the newly added peer or the dead peer was among our closest.
-    pub(crate) async fn try_trigger_replication(
-        &mut self,
-        churned_peer: &PeerId,
-        is_dead_peer: bool,
-    ) -> Result<()> {
-        Marker::ReplicationTriggered((churned_peer, is_dead_peer)).log();
+    /// Replication is triggered when is there is a change in our close group
+    pub(crate) async fn try_trigger_replication(&mut self, new_members: Vec<PeerId>) -> Result<()> {
+        Marker::ReplicationTriggered(&new_members).log();
+        let our_close_group = self.network.get_our_close_group().await?;
         let our_peer_id = self.network.peer_id;
         let our_address = NetworkAddress::from_peer(our_peer_id);
-        let churned_peer_address = NetworkAddress::from_peer(*churned_peer);
 
         let all_peers = self.network.get_all_local_peers().await?;
-        if all_peers.len() < 2 * CLOSE_GROUP_SIZE {
-            return Ok(());
-        }
+        let all_records = self.network.get_all_local_record_addresses().await?;
 
-        // Only nearby peers (two times of the CLOSE_GROUP_SIZE) may affect the later on
-        // calculation of `closest peers to each entry`.
-        // Hence to reduce the computation work, no need to take all peers.
-        let sorted_peers: Vec<PeerId> = if let Ok(sorted_peers) =
-            sort_peers_by_address(all_peers, &churned_peer_address, 2 * CLOSE_GROUP_SIZE)
-        {
-            sorted_peers
-        } else {
-            return Ok(());
-        };
+        // a key is sent to a peer if the peer is considered to be close to that key
+        let mut replicate_to: BTreeMap<PeerId, Vec<NetworkAddress>> = Default::default();
+        for key in all_records {
+            let sorted_based_on_key =
+                sort_peers_by_address(all_peers.clone(), &key, CLOSE_GROUP_SIZE)?;
 
-        let distance_bar = match sorted_peers.get(CLOSE_GROUP_SIZE) {
-            Some(peer) => NetworkAddress::from_peer(*peer).distance(&our_address),
-            None => {
-                debug!("could not obtain distance_bar as sorted_peers.len() <= CLOSE_GROUP_SIZE ");
-                return Ok(());
-            }
-        };
-
-        // Do nothing if self is not among the closest range.
-        if our_address.distance(&churned_peer_address) > distance_bar {
-            return Ok(());
-        }
-
-        // Setup the record storage distance range.
-        self.network.set_record_distance_range(distance_bar)?;
-
-        // The fetched entries are records that supposed to be held by the churned_peer.
-        let entries_to_be_replicated = self
-            .network
-            .get_record_keys_closest_to_target(&churned_peer_address, distance_bar)
-            .await?;
-
-        let mut replications: BTreeMap<PeerId, Vec<NetworkAddress>> = Default::default();
-        for key in entries_to_be_replicated.iter() {
-            let record_key = KBucketKey::from(key.to_vec());
-            let closest_peers: Vec<_> = if let Ok(sorted_peers) =
-                sort_peers_by_key(sorted_peers.clone(), &record_key, CLOSE_GROUP_SIZE + 1)
-            {
-                sorted_peers
-            } else {
-                continue;
-            };
-
-            // Only carry out replication when self within REPLICATION_RANGE
-            let replicate_range = match closest_peers.get(REPLICATION_RANGE) {
-                Some(peer) => NetworkAddress::from_peer(*peer),
-                None => {
-                    debug!("could not obtain replicate_range as closest_peers.len() <= REPLICATION_RANGE");
-                    continue;
+            for peer in our_close_group.iter().filter(|&p| p != &our_peer_id) {
+                if sorted_based_on_key.contains(peer) {
+                    let keys_to_replicate = replicate_to.entry(*peer).or_insert(Default::default());
+                    keys_to_replicate.push(key.clone());
                 }
-            };
-
-            if our_address.as_kbucket_key().distance(&record_key)
-                >= replicate_range.as_kbucket_key().distance(&record_key)
-            {
-                continue;
-            }
-
-            let dsts = if is_dead_peer {
-                // To ensure more copies to be retained across the network,
-                // make all closest_peers as target in case of peer drop out.
-                // This can be reduced depends on the performance.
-                closest_peers
-            } else {
-                vec![*churned_peer]
-            };
-
-            for peer in dsts {
-                let keys_to_replicate = replications.entry(peer).or_insert(Default::default());
-                keys_to_replicate.push(NetworkAddress::from_record_key(key.clone()));
             }
         }
 
-        // Avoid replicate to self or to a dead peer
-        let _ = replications.remove(&our_peer_id);
-        if is_dead_peer {
-            let _ = replications.remove(churned_peer);
-        }
-
-        for (peer_id, keys) in replications {
+        for (peer_id, keys) in replicate_to {
             let (_left, mut remaining_keys) = keys.split_at(0);
             while remaining_keys.len() > MAX_REPLICATION_KEYS_PER_REQUEST {
                 let (left, right) = remaining_keys.split_at(MAX_REPLICATION_KEYS_PER_REQUEST);
@@ -133,40 +57,22 @@ impl Node {
         Ok(())
     }
 
-    /// Notify a list of keys within a holder to be replicated to self.
-    /// The `chunk_storage` is currently held by `swarm_driver` within `network` instance.
-    /// Hence has to carry out this notification.
-    pub(crate) async fn replication_keys_to_fetch(
+    /// Add a list of keys to the Replication fetcher. These keys are later fetched from the peer through the
+    /// replication process.
+    pub(crate) fn add_keys_to_replication_fetcher(
         &mut self,
-        holder: NetworkAddress,
+        peer: NetworkAddress,
         keys: Vec<NetworkAddress>,
     ) -> Result<()> {
-        let peer_id = if let Some(peer_id) = holder.as_peer_id() {
+        let peer_id = if let Some(peer_id) = peer.as_peer_id() {
             peer_id
         } else {
-            warn!("Can't parse PeerId from NetworkAddress {holder:?}");
+            warn!("Can't parse PeerId from NetworkAddress {peer:?}");
             return Ok(());
         };
-        trace!("Convert {holder:?} to {peer_id:?}");
 
-        let provided_keys_len = keys.len();
-        let keys_to_fetch = self
-            .network
-            .add_keys_to_replication_fetcher(peer_id, keys)
-            .await?;
-
-        if keys_to_fetch.is_empty() {
-            return Ok(());
-        }
-
-        Marker::FetchingKeysForReplication {
-            fetching_keys_len: keys_to_fetch.len(),
-            provided_keys_len,
-            peer_id,
-        }
-        .log();
-
-        self.fetch_replication_keys_without_wait(keys_to_fetch)?;
+        self.network
+            .add_keys_to_replication_fetcher(peer_id, keys)?;
         Ok(())
     }
 
@@ -174,15 +80,22 @@ impl Node {
     /// site
     pub(crate) fn fetch_replication_keys_without_wait(
         &self,
-        keys_to_fetch: Vec<(PeerId, NetworkAddress)>,
+        keys_to_fetch: Vec<(RecordKey, Option<PeerId>)>,
     ) -> Result<()> {
-        for (peer, key) in keys_to_fetch {
-            trace!("Fetching replication {key:?} from {peer:?}");
-            let request = Request::Query(Query::GetReplicatedData {
-                requester: NetworkAddress::from_peer(self.network.peer_id),
-                address: key,
-            });
-            self.network.send_req_ignore_reply(request, peer)?
+        for (key, maybe_peer) in keys_to_fetch {
+            match maybe_peer {
+                Some(peer) => {
+                    trace!("Fetching replication {key:?} from {peer:?}");
+                    let request = Request::Query(Query::GetReplicatedData {
+                        requester: NetworkAddress::from_peer(self.network.peer_id),
+                        address: NetworkAddress::from_record_key(key),
+                    });
+                    self.network.send_req_ignore_reply(request, peer)?
+                }
+                None => {
+                    trace!("Fetching {key:?} from the network, to be implemented");
+                }
+            }
         }
         Ok(())
     }

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -30,10 +30,6 @@ pub enum Cmd {
         #[debug(skip)]
         keys: Vec<NetworkAddress>,
     },
-    /// Notify peer to send back a replication list
-    ///
-    /// [`NetworkAddress`]: crate::NetworkAddress
-    RequestReplication(NetworkAddress),
 }
 
 impl Cmd {
@@ -41,7 +37,6 @@ impl Cmd {
     pub fn dst(&self) -> NetworkAddress {
         match self {
             Cmd::Replicate { holder, .. } => holder.clone(),
-            Cmd::RequestReplication(sender) => sender.clone(),
         }
     }
 }
@@ -56,9 +51,6 @@ impl std::fmt::Display for Cmd {
                     holder.as_peer_id(),
                     keys.len()
                 )
-            }
-            Cmd::RequestReplication(sender) => {
-                write!(f, "Cmd::RequestReplication({:?})", sender.as_peer_id(),)
             }
         }
     }


### PR DESCRIPTION
- Instead of triggering replication on every churn, we check if the churn has affected our close group and only then trigger the replication flow. 
-  The `ReplicationFetcher` is now updated on every successful PUT to our record store. 
- The `Cmd:RequestReplication` has been removed as well


This PR is part of the "Close group based replication PRs". 2/3
Depends on https://github.com/maidsafe/safe_network/pull/551
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Jul 23 06:44 UTC
This pull request includes the following changes:

- In the `record_store.rs` file:
  - The `get_record_keys_closest_to_target` method has been removed.
  - The `set_distance_range` method has been removed.
  - The `record_addresses_ref` method has been added.
  - The `read_from_disk` method signature has been updated.

- In the `event.rs` file:
  - An `import` statement for `sort_peers_by_address` has been added.
  - Two new variants `CloseGroupUpdated` and `KeysForReplication` have been added to the `NetworkEvent` enum.
  - The `check_for_change_in_our_close_group` function has been added.
  - The `get_all_local_peers` function has been added.
  - Calls to `check_for_change_in_our_close_group` have been added in the `handle_kademlia_event` and `handle_swarm_event` functions.
  - The `log_kbuckets` function now takes a reference to `peer` instead of `&PeerId`.

- In the `cmd.rs` file:
  - The `RequestReplication` variant of the `Cmd` enum has been removed.
  - The corresponding pattern in the `impl Cmd` block has been removed.

- In a separate file:
  - Several messages have been added and modified.
  - Import statements and functions have been added and updated.

- In the `lib.rs` file:
  - Various changes have been made, including import statements, method implementations, and method renames.

- In the `rpc.rs` file:
  - A new function `record_addresses` has been added to the `SafeNode` trait implementation.

- In the `log_markers.rs` file:
  - Import statements have been modified.
  - Enum variants and struct fields have been modified.

- In the `cmd.rs` file:
  - Variants have been moved, added, and removed, and their implementations have been updated.

- In the `event.rs` file:
  - Import statements have been added.
  - Serialization and deserialization capabilities have been added to the `NodeEvent` enum.
  - Methods for converting `NodeEvent` to and from bytes have been added.

- In the `log_markers.rs` file:
  - Import statements and enum variants have been modified.
  - A new method `fetching_keys_for_replication` has been added to the `Marker` struct.

- In the `cmd.rs` file:
  - Variants have been moved, added, and removed, and their implementations have been updated.

Please let me know if you need further explanations or have any questions about these changes.
<!-- reviewpad:summarize:end --> 
