### PR TITLE
test: prevent from self-encrypting same file twice in churn tests

### DIFF
--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -360,8 +360,11 @@ fn store_chunks_task(
             );
             sleep(delay).await;
 
-            match file_api.upload_with_proof(bytes, &proofs).await {
-                Ok(_) => content
+            match file_api
+                .upload_chunks_in_batches(chunks.into_iter(), &proofs, false)
+                .await
+            {
+                Ok(()) => content
                     .write()
                     .await
                     .push_back(NetworkAddress::ChunkAddress(ChunkAddress::new(addr))),


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jul 23 12:41 UTC
This pull request prevents the self-encryption of the same file twice in churn tests. It adds logic to only upload chunks in batches if they have not been previously uploaded.
<!-- reviewpad:summarize:end --> 
