### PR TITLE
Get record concensus

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -93,7 +93,7 @@ jobs:
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -244,13 +244,25 @@ jobs:
           fi
         if: always()
 
-      - name: Tar log files
+      - name: Tar node log files
         shell: bash
         continue-on-error: true
         run: |
           find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
           find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Tar client log files
+        shell: bash
+        continue-on-error: true
+        run: |
           find $CLIENT_LOG_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
+        if: failure()
+
+      - name: Tar log files for upload
+        shell: bash
+        continue-on-error: true
+        run: |
           find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
         if: failure()
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -193,7 +193,7 @@ jobs:
         run: cargo run --bin safe --release -- register create baobao
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 5
 
       - name: Start a client to get a register
         run: cargo run --bin safe --release -- register get baobao
@@ -205,7 +205,7 @@ jobs:
         run: cargo run --bin safe --release -- register edit baobao wood
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 5
 
       - name: Stop the local network and upload logs
         if: always()

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -18,7 +18,7 @@ use libp2p::{
     Multiaddr,
 };
 use sn_dbc::{DbcId, SignedSpend};
-use sn_networking::{multiaddr_is_global, NetworkEvent, PrettyPrintRecordKey, SwarmDriver};
+use sn_networking::{multiaddr_is_global, NetworkEvent, SwarmDriver};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::PaymentProof,
@@ -26,7 +26,7 @@ use sn_protocol::{
         try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, ChunkWithPayment,
         DbcAddress, RecordHeader, RecordKind, RegisterAddress,
     },
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_registers::SignedRegister;
 use sn_transfers::client_transfers::SpendRequest;
@@ -380,7 +380,8 @@ impl Client {
                 [one, two, ..] => {
                     error!("Found double spend for {address:?}");
                     Err(Error::CouldNotVerifyTransfer(format!(
-                "Found double spend for the dbc_id {dbc_id:?} - {key:?}: spend_one {:?} and spend_two {:?}", one.derived_key_sig, two.derived_key_sig
+                "Found double spend for the dbc_id {dbc_id:?} - {:?}: spend_one {:?} and spend_two {:?}",
+                PrettyPrintRecordKey::from(key), one.derived_key_sig, two.derived_key_sig
             )))
                 }
                 [signed_spend] => {

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -350,7 +350,7 @@ impl Client {
         trace!("Getting spend {dbc_id:?} with record_key {key:?}");
         let record = self
             .network
-            .get_record_from_network(key, None, true)
+            .get_record_from_network(key.clone(), None, true)
             .await
             .map_err(|err| {
                 Error::CouldNotVerifyTransfer(format!(
@@ -380,7 +380,7 @@ impl Client {
                 [one, two, ..] => {
                     error!("Found double spend for {address:?}");
                     Err(Error::CouldNotVerifyTransfer(format!(
-                "Found double spend for the dbc_id {dbc_id:?}: spend_one {one:?} and spend_two {two:?}"
+                "Found double spend for the dbc_id {dbc_id:?} - {key:?}: spend_one {:?} and spend_two {:?}", one.derived_key_sig, two.derived_key_sig
             )))
                 }
                 [signed_spend] => {

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -344,6 +344,7 @@ impl Client {
         let address = DbcAddress::from_dbc_id(dbc_id);
         let key = NetworkAddress::from_dbc_address(address).to_record_key();
 
+        trace!("Getting spend {dbc_id:?} with record_key {key:?}");
         let record = self
             .network
             .get_record_from_network(key)
@@ -354,7 +355,7 @@ impl Client {
                 ))
             })?;
         debug!(
-            "Got record from the network, {:?}",
+            "For spend {dbc_id:?} got record from the network, {:?}",
             PrettyPrintRecordKey::from(record.key.clone())
         );
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -250,7 +250,7 @@ impl Client {
 
         let record = self
             .network
-            .get_record_from_network(key)
+            .get_record_from_network(key, None, true)
             .await
             .map_err(|_| ProtocolError::RegisterNotFound(address))?;
         debug!(
@@ -308,7 +308,10 @@ impl Client {
     pub(super) async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
         info!("Getting chunk: {address:?}");
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
-        let record = self.network.get_record_from_network(key).await?;
+        let record = self
+            .network
+            .get_record_from_network(key, None, false)
+            .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {
             let chunk_with_payment: ChunkWithPayment = try_deserialize_record(&record)?;
@@ -347,7 +350,7 @@ impl Client {
         trace!("Getting spend {dbc_id:?} with record_key {key:?}");
         let record = self
             .network
-            .get_record_from_network(key)
+            .get_record_from_network(key, None, true)
             .await
             .map_err(|err| {
                 Error::CouldNotVerifyTransfer(format!(

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -55,9 +55,9 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
 
     println!("Verifying the transfer from genesis...");
     if let Err(error) = client.verify(&tokens).await {
-        println!("Could not verify the transfer from genesis, retrying after 10 secs...");
+        println!("Could not verify the transfer from genesis, retrying after 20 secs...");
         println!("The error was: {error:?}");
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(20)).await;
         if let Err(error) = client.verify(&tokens).await {
             println!("Could not verify the transfer from genesis: {error:?}");
         } else {

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -8,6 +8,7 @@ use sn_transfers::dbc_genesis::{create_faucet_wallet, load_genesis_wallet};
 use sn_transfers::wallet::LocalWallet;
 
 /// Returns a dbc with the requested number of tokens, for use by E2E test instances.
+/// Note this will create a faucet having a Genesis balance
 pub async fn get_tokens_from_faucet(amount: Token, to: PublicAddress, client: &Client) -> Dbc {
     send(
         load_faucet_wallet_from_genesis_wallet(client).await,
@@ -59,7 +60,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
         println!("The error was: {error:?}");
         tokio::time::sleep(Duration::from_secs(20)).await;
         if let Err(error) = client.verify(&dbc).await {
-            println!("Could not verify the transfer from genesis: {error:?}");
+            panic!("Could not verify the transfer from genesis: {error:?}");
         } else {
             println!("Successfully verified the transfer from genesis on the second try.");
         }

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -38,7 +38,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
 
     let faucet_balance = genesis_wallet.balance();
     println!("Sending {faucet_balance} from genesis to faucet wallet..");
-    let tokens = send(
+    let dbc = send(
         genesis_wallet,
         faucet_balance,
         faucet_wallet.address(),
@@ -46,7 +46,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
     )
     .await;
 
-    faucet_wallet.deposit(vec![tokens.clone()]);
+    faucet_wallet.deposit(vec![dbc.clone()]);
     faucet_wallet
         .store()
         .await
@@ -54,11 +54,11 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
     println!("Faucet wallet balance: {}", faucet_wallet.balance());
 
     println!("Verifying the transfer from genesis...");
-    if let Err(error) = client.verify(&tokens).await {
+    if let Err(error) = client.verify(&dbc).await {
         println!("Could not verify the transfer from genesis, retrying after 20 secs...");
         println!("The error was: {error:?}");
         tokio::time::sleep(Duration::from_secs(20)).await;
-        if let Err(error) = client.verify(&tokens).await {
+        if let Err(error) = client.verify(&dbc).await {
             println!("Could not verify the transfer from genesis: {error:?}");
         } else {
             println!("Successfully verified the transfer from genesis on the second try.");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -109,9 +109,9 @@ impl WalletClient {
             .await?;
 
         // send to network
-        trace!("Sending transfer to the network: {transfer:#?}");
+        trace!("Sending storage payment transfer to the network: {transfer:#?}");
         if let Err(error) = self.client.send(transfer.clone()).await {
-            warn!("The transfer was not successfully registered in the network: {error:?}. It will be retried later.");
+            warn!("The storage payment transfer was not successfully registered in the network: {error:?}. It will be retried later.");
             self.unconfirmed_txs.push(transfer);
             return Err(error);
         }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -150,7 +150,13 @@ impl SwarmDriver {
             }
             SwarmCmd::GetNetworkRecord { key, sender } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
-                let _ = self.pending_query.insert(query_id, sender);
+                if self
+                    .pending_get_record
+                    .insert(query_id, (sender, Default::default()))
+                    .is_some()
+                {
+                    warn!("An existing get_record task {query_id:?} got replaced");
+                }
             }
             SwarmCmd::GetLocalStoreCost { sender } => {
                 let cost = self.swarm.behaviour_mut().kademlia.store_mut().store_cost();

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -10,7 +10,7 @@ use super::{cmd::SwarmCmd, NetworkEvent};
 
 use bytes::Bytes;
 use libp2p::{
-    kad,
+    kad::{self, Record},
     request_response::{OutboundFailure, RequestId},
     swarm::DialError,
     TransportError,
@@ -85,6 +85,9 @@ pub enum Error {
 
     #[error("Record was not found locally")]
     RecordNotFound,
+
+    #[error("Get Record completed with non enough copies")]
+    RecordNotEnoughCopies(Record),
 
     #[error("Error putting record")]
     PutRecordError(#[from] kad::PutRecordError),

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -8,14 +8,13 @@
 
 use super::{cmd::SwarmCmd, NetworkEvent};
 
-use bytes::Bytes;
 use libp2p::{
     kad::{self, Record},
     request_response::{OutboundFailure, RequestId},
     swarm::DialError,
     TransportError,
 };
-use sn_protocol::messages::Response;
+use sn_protocol::{messages::Response, PrettyPrintRecordKey};
 use std::{io, path::PathBuf};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -97,34 +96,6 @@ pub enum Error {
 
     #[error("Failed to sign the message with the PeerId keypair")]
     SigningFailed(#[from] libp2p::identity::SigningError),
-}
-
-/// Pretty print a `kad::RecordKey` as a hex string.
-/// So clients can use the hex string for xorname and record keys interchangeably.
-/// This makes errors actionable for clients.
-/// The only cost is converting ked::RecordKey into it before sending it in errors: `record_key.into()`
-#[derive(Clone)]
-pub struct PrettyPrintRecordKey(kad::RecordKey);
-
-// seamless conversion from `kad::RecordKey` to `PrettyPrintRecordKey`
-impl From<kad::RecordKey> for PrettyPrintRecordKey {
-    fn from(key: kad::RecordKey) -> Self {
-        PrettyPrintRecordKey(key)
-    }
-}
-
-impl std::fmt::Display for PrettyPrintRecordKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let b: Vec<u8> = self.0.as_ref().to_vec();
-        let record_key_b = Bytes::from(b);
-        write!(f, "{:64x}", record_key_b)
-    }
-}
-
-impl std::fmt::Debug for PrettyPrintRecordKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
-    }
 }
 
 #[cfg(test)]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -382,8 +382,9 @@ impl SwarmDriver {
                 stats,
                 step,
             } => {
+                let content_hash = XorName::from_content(&peer_record.record.value);
                 trace!(
-                    "Query task {id:?} returned with record {:?} from peer {:?}, {stats:?} - {step:?}",
+                    "Query task {id:?} returned with record {:?}(content {content_hash:?}) from peer {:?}, {stats:?} - {step:?}",
                     PrettyPrintRecordKey::from(peer_record.record.key.clone()),
                     peer_record.peer
                 );

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -404,11 +404,17 @@ impl SwarmDriver {
                             record.key,
                             usize::from(step.count) - 1
                         );
+                        // Consider any early completion as Putting in progress or split.
+                        // Just send back the first record (for put verification only),
+                        // and not to update self
+                        sender
+                            .send(Err(Error::RecordNotEnoughCopies(record.clone())))
+                            .map_err(|_| Error::InternalMsgChannelDropped)?;
+                    } else {
+                        sender
+                            .send(Err(Error::RecordNotFound))
+                            .map_err(|_| Error::InternalMsgChannelDropped)?;
                     }
-                    // Consider any early completion as RecordNotFound, and not to update self
-                    sender
-                        .send(Err(Error::RecordNotFound))
-                        .map_err(|_| Error::InternalMsgChannelDropped)?;
                 }
             }
             KademliaEvent::OutboundQueryProgressed {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     close_group_majority, multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address,
-    PrettyPrintRecordKey, CLOSE_GROUP_SIZE, IDENTIFY_AGENT_STR,
+    CLOSE_GROUP_SIZE, IDENTIFY_AGENT_STR,
 };
 use itertools::Itertools;
 #[cfg(feature = "local-discovery")]
@@ -31,7 +31,7 @@ use libp2p::{
 };
 use sn_protocol::{
     messages::{Request, Response},
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -27,7 +27,7 @@ use self::{
     circular_vec::CircularVec,
     cmd::SwarmCmd,
     error::Result,
-    event::NodeBehaviour,
+    event::{GetRecordResultMap, NodeBehaviour},
     record_store::{
         DiskBackedRecordStore, DiskBackedRecordStoreConfig, REPLICATION_INTERVAL_LOWER_BOUND,
         REPLICATION_INTERVAL_UPPER_BOUND,
@@ -63,7 +63,6 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
-use xor_name::XorName;
 
 /// The maximum number of peers to return in a `GetClosestPeers` response.
 /// This is the group size used in safe network protocol to be responsible for
@@ -104,14 +103,7 @@ pub const fn close_group_majority() -> usize {
 }
 
 type PendingGetClosest = HashMap<QueryId, (oneshot::Sender<HashSet<PeerId>>, HashSet<PeerId>)>;
-// Usig XorName to differentiate different record content under the same key.
-type PendingGetRecord = HashMap<
-    QueryId,
-    (
-        oneshot::Sender<Result<Record>>,
-        HashMap<XorName, (Record, HashSet<PeerId>)>,
-    ),
->;
+type PendingGetRecord = HashMap<QueryId, (oneshot::Sender<Result<Record>>, GetRecordResultMap)>;
 
 /// `SwarmDriver` is responsible for managing the swarm of peers, handling
 /// swarm events, processing commands, and maintaining the state of pending

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -19,7 +19,7 @@ mod replication_fetcher;
 
 pub use self::{
     cmd::SwarmLocalState,
-    error::{Error, PrettyPrintRecordKey},
+    error::Error,
     event::{MsgResponder, NetworkEvent},
 };
 
@@ -52,7 +52,7 @@ use rand::Rng;
 use sn_dbc::Token;
 use sn_protocol::{
     messages::{Request, Response},
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -629,9 +629,9 @@ impl Network {
         &self,
         key: RecordKey,
         target_record: Option<Record>,
-        re_attampt: bool,
+        re_attempt: bool,
     ) -> Result<Record> {
-        let total_attempts = if re_attampt { VERIFICATION_ATTEMPTS } else { 1 };
+        let total_attempts = if re_attempt { VERIFICATION_ATTEMPTS } else { 1 };
 
         let mut verification_attempts = 0;
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -638,7 +638,7 @@ impl Network {
         while verification_attempts < total_attempts {
             verification_attempts += 1;
             debug!(
-                "Verification putting record of {key:?} attempts {verification_attempts:?}/{total_attempts:?}"
+                "Getting record of {key:?} attempts {verification_attempts:?}/{total_attempts:?}"
             );
 
             let (sender, receiver) = oneshot::channel();

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -26,6 +26,7 @@ use std::{
     vec,
 };
 use tokio::sync::mpsc;
+use xor_name::XorName;
 
 // Each node will have a replication interval between these bounds
 // This should serve to stagger the intense replication activity across the network
@@ -166,7 +167,11 @@ impl DiskBackedRecordStore {
     }
 
     pub fn put_verified(&mut self, r: Record) -> Result<()> {
-        trace!("PUT a verified Record: {:?}", r.key);
+        let content_hash = XorName::from_content(&r.value);
+        trace!(
+            "PUT a verified Record: {:?} (content_hash {content_hash:?})",
+            r.key
+        );
         if r.value.len() >= self.config.max_value_bytes {
             warn!(
                 "Record not stored. Value too large: {} bytes",

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -5,7 +5,7 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-use crate::{event::NetworkEvent, PrettyPrintRecordKey};
+use crate::event::NetworkEvent;
 use libp2p::{
     identity::PeerId,
     kad::{
@@ -16,7 +16,7 @@ use libp2p::{
 };
 use rand::Rng;
 use sn_dbc::Token;
-use sn_protocol::NetworkAddress;
+use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
 use std::{
     borrow::Cow,
     collections::{hash_set, HashSet},

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -9,14 +9,12 @@
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
 use libp2p::{autonat::NatStatus, identity::Keypair, kad::K_VALUE, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use sn_networking::{
-    MsgResponder, NetworkEvent, PrettyPrintRecordKey, SwarmDriver, SwarmLocalState,
-};
+use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::{Cmd, CmdResponse, Query, QueryResponse, ReplicatedData, Request, Response},
     storage::DbcAddress,
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
     collections::HashSet,

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -41,7 +41,7 @@ impl Node {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key)
+            .get_record_from_network(key, None, false)
             .await
             .map_err(|_| Error::ChunkNotFound(address))?;
         debug!(
@@ -61,11 +61,15 @@ impl Node {
         }
     }
 
-    pub(crate) async fn get_spend_from_network(&self, address: DbcAddress) -> Result<SignedSpend> {
+    pub(crate) async fn get_spend_from_network(
+        &self,
+        address: DbcAddress,
+        re_attempt: bool,
+    ) -> Result<SignedSpend> {
         let key = NetworkAddress::from_dbc_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key)
+            .get_record_from_network(key, None, re_attempt)
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!(
@@ -114,7 +118,7 @@ impl Node {
         let record_key = address.as_record_key().ok_or(error.clone())?;
         let record = self
             .network
-            .get_record_from_network(record_key)
+            .get_record_from_network(record_key, None, false)
             .await
             .map_err(|_| error.clone())?;
         let header = RecordHeader::from_record(&record).map_err(|_| error.clone())?;

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -8,7 +8,6 @@
 
 use crate::Node;
 use sn_dbc::{SignedSpend, Token};
-use sn_networking::PrettyPrintRecordKey;
 use sn_protocol::{
     error::{Error, Result},
     messages::ReplicatedData,
@@ -16,7 +15,7 @@ use sn_protocol::{
         try_deserialize_record, Chunk, ChunkAddress, ChunkWithPayment, DbcAddress, RecordHeader,
         RecordKind,
     },
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_registers::SignedRegister;
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -278,6 +278,11 @@ impl Node {
         // other info for verifications of valid payment.
         let mut tasks = JoinSet::new();
         spent_ids.iter().cloned().for_each(|dbc_id| {
+            trace!(
+                "Getting spend {:?} for chunk {:?} to prove payment",
+                dbc_id,
+                addr_name
+            );
             let self_clone = self.clone();
             let _ = tasks.spawn(async move {
                 let addr = DbcAddress::from_dbc_id(&dbc_id);

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -19,7 +19,7 @@ use sn_protocol::{
         try_deserialize_record, try_serialize_record, ChunkWithPayment, DbcAddress, RecordHeader,
         RecordKind,
     },
-    NetworkAddress,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_registers::SignedRegister;
 use sn_transfers::{
@@ -208,8 +208,9 @@ impl Node {
 
         let key = NetworkAddress::from_dbc_address(dbc_addr).to_record_key();
         debug!(
-            "validating and storing spends {:?} - {key:?}",
-            dbc_addr.name()
+            "validating and storing spends {:?} - {:?}",
+            dbc_addr.name(),
+            PrettyPrintRecordKey::from(key.clone())
         );
 
         let present_locally = self
@@ -236,18 +237,6 @@ impl Node {
             }
         };
 
-        // Notify the sender of any double spend
-        if validated_spends.len() > 1 {
-            warn!("Got a double spend for the SpendDbc PUT with dbc_id {dbc_id:?}",);
-            let mut proof = validated_spends.iter();
-            if let (Some(spend_one), Some(spend_two)) = (proof.next(), proof.next()) {
-                return Err(ProtocolError::DoubleSpendAttempt(
-                    Box::new(spend_one.to_owned()),
-                    Box::new(spend_two.to_owned()),
-                ))?;
-            }
-        }
-
         // store the record into the local storage
         let record = Record {
             key,
@@ -260,6 +249,18 @@ impl Node {
             error!("Cannot put spend {err:?}");
             err
         })?;
+
+        // Notify the sender of any double spend
+        if validated_spends.len() > 1 {
+            warn!("Got a double spend for the SpendDbc PUT with dbc_id {dbc_id:?}",);
+            let mut proof = validated_spends.iter();
+            if let (Some(spend_one), Some(spend_two)) = (proof.next(), proof.next()) {
+                return Err(ProtocolError::DoubleSpendAttempt(
+                    Box::new(spend_one.to_owned()),
+                    Box::new(spend_two.to_owned()),
+                ))?;
+            }
+        }
 
         Ok(CmdOk::StoredSuccessfully)
     }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -106,7 +106,10 @@ impl Node {
                     let node = self.clone();
                     let _handle: JoinHandle<Result<()>> = tokio::spawn(async move {
                         trace!("Fetching replication {key:?} from the network");
-                        let record = node.network.get_record_from_network(key.clone()).await?;
+                        let record = node
+                            .network
+                            .get_record_from_network(key.clone(), None, false)
+                            .await?;
                         trace!("Got Replication Record {key:?} from network, validating and storing it");
                         let _ = node.validate_and_store_record(record).await?;
                         Ok(())

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -79,7 +79,7 @@ pub async fn get_funded_wallet(
 
     println!("Getting {wallet_balance} tokens from the faucet...");
     let tokens = get_tokens_from_faucet(wallet_balance, local_wallet.address(), client).await;
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    std::thread::sleep(std::time::Duration::from_secs(20));
 
     println!("Verifying the transfer from faucet...");
     client.verify(&tokens).await?;

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -51,7 +51,7 @@ fn random_content(client: &Client) -> Result<(Files, Bytes, ChunkAddress, Vec<Ch
 async fn storage_payment_succeeds() -> Result<()> {
     init_logging();
 
-    let paying_wallet_balance = 500_000;
+    let paying_wallet_balance = 500_001;
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
@@ -171,7 +171,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
-    let paying_wallet_balance = 500_000;
+    let paying_wallet_balance = 500_002;
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
@@ -199,7 +199,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn storage_payment_chunk_upload_fails() -> Result<()> {
-    let paying_wallet_balance = 500_000;
+    let paying_wallet_balance = 500_003;
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -14,7 +14,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
-hex = "~0.4.3" 
+hex = "~0.4.3"
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -211,7 +211,7 @@ pub(super) fn split(
 pub async fn create_faucet_wallet() -> LocalWallet {
     let root_dir = get_faucet_dir().await;
 
-    println!("Creating faucet wallet... {:#?}", root_dir);
+    println!("Loading faucet wallet... {:#?}", root_dir);
     LocalWallet::load_from(&root_dir)
         .await
         .expect("Faucet wallet shall be created successfully.")

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -192,8 +192,16 @@ async fn load_from_path(wallet_dir: &Path) -> Result<(MainKey, KeyLessWallet)> {
         }
     };
     let wallet = match get_wallet(wallet_dir).await? {
-        Some(wallet) => wallet,
+        Some(wallet) => {
+            println!(
+                "Loaded wallet from {:#?} with balance {:?}",
+                wallet_dir,
+                wallet.balance()
+            );
+            wallet
+        }
         None => {
+            println!("Creating wallet at {:#?}", wallet_dir);
             let wallet = KeyLessWallet::new();
             store_wallet(wallet_dir, &wallet).await?;
             create_received_dbcs_dir(wallet_dir).await?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jul 23 14:32 UTC
This pull request includes changes in the `cmd.rs`, `event.rs`, and `lib.rs` files. 

In the `cmd.rs` file:
- Line 185-194: If an existing `get_record` task is replaced, a warning message is logged.

In the `event.rs` file:
- Line 366-393: The logic for handling `KademliaEvent::OutboundQueryProgressed` events related to `get_record` requests has been modified. The code now accumulates the successful `get_record` responses from peers and returns the record once a majority is reached. If the record is not found, an error is returned when the limit of requests is reached.
- Line 465-489: The logic for handling `KademliaEvent::OutboundQueryProgressed` events related to failed `get_record` requests has been modified. If the request reaches the end of the query and the record is not found, the code avoids waiting indefinitely for the response by returning an error.

In the `lib.rs` file:
- Line 94: The `PendingGetClosest` type has been defined to store pending `get_closest_peers` requests.
- Line 97: The `PendingGetRecord` type has been defined to store pending `get_record` requests.
- Line 109-110: The `pending_get_closest_peers` and `pending_get_record` fields have been added to the `SwarmDriver` struct to store pending requests.
- Line 383-407: The logic for handling `get_record` requests and responses has been modified. The code now accumulates the successful `get_record` responses from peers and returns the record once a majority is reached. The code also handles split resolvement policy and updates self when needed.

Overall, these changes improve the handling of `get_record` requests and responses in the code.
<!-- reviewpad:summarize:end --> 
