### PR TITLE
feat: add a retry to facuet genesis transfer

### DIFF
--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::wallet::send;
 use crate::Client;
 
@@ -53,7 +55,14 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
 
     println!("Verifying the transfer from genesis...");
     if let Err(error) = client.verify(&tokens).await {
-        println!("Could not verify the transfer from genesis: {error:?}");
+        println!("Could not verify the transfer from genesis, retrying after 10 secs...");
+        println!("The error was: {error:?}");
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        if let Err(error) = client.verify(&tokens).await {
+            println!("Could not verify the transfer from genesis: {error:?}");
+        } else {
+            println!("Successfully verified the transfer from genesis on the second try.");
+        }
     }
 
     faucet_wallet


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 02:38 UTC
This pull request adds a retry mechanism to the faucet genesis transfer. If the transfer verification fails, the code will retry after a 10-second delay. If the verification still fails after the retry, an error message will be printed. Otherwise, a success message will be printed after the second try.
<!-- reviewpad:summarize:end --> 
