### PR TITLE
Add Verify PUT option to APIs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -274,14 +274,14 @@ jobs:
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
-        timeout-minutes: 10
+        timeout-minutes: 25
 
       - name: execute the storage payment tests
         run: cargo test --release --features="local-discovery" storage_payment_ -- --nocapture
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
-        timeout-minutes: 10
+        timeout-minutes: 25
 
       - name: Stop the local network and upload logs
         if: always()

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -139,7 +139,7 @@ async fn upload_chunks(
         });
 
     file_api
-        .upload_chunks_in_batches(chunks_reader, payment_proofs, false)
+        .upload_chunks_in_batches(chunks_reader, payment_proofs, true)
         .await?;
     Ok(())
 }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -280,7 +280,12 @@ impl Client {
     }
 
     /// Store `Chunk` as a record.
-    pub(super) async fn store_chunk(&self, chunk: Chunk, payment: PaymentProof) -> Result<()> {
+    pub(super) async fn store_chunk(
+        &self,
+        chunk: Chunk,
+        payment: PaymentProof,
+        verify_store: bool,
+    ) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());
         let chunk_with_payment = ChunkWithPayment { chunk, payment };
         let record = Record {
@@ -290,7 +295,7 @@ impl Client {
             expires: None,
         };
 
-        Ok(self.network.put_record(record).await?)
+        Ok(self.network.put_record(record, verify_store).await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.
@@ -311,7 +316,11 @@ impl Client {
     }
 
     /// Send a `SpendDbc` request to the network
-    pub(crate) async fn network_store_spend(&self, spend: SpendRequest) -> Result<()> {
+    pub(crate) async fn network_store_spend(
+        &self,
+        spend: SpendRequest,
+        verify_store: bool,
+    ) -> Result<()> {
         let dbc_id = *spend.signed_spend.dbc_id();
         let dbc_addr = DbcAddress::from_dbc_id(&dbc_id);
 
@@ -323,7 +332,7 @@ impl Client {
             publisher: None,
             expires: None,
         };
-        Ok(self.network.put_record(record).await?)
+        Ok(self.network.put_record(record, verify_store).await?)
     }
 
     /// Get a dbc spend from network

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -164,11 +164,13 @@ impl WalletClient {
 }
 
 impl Client {
+    /// Send a spend request to the network.
+    /// This will verify the spend has been correctly stored before returning
     pub async fn send(&self, transfer: TransferOutputs) -> Result<()> {
         let mut tasks = Vec::new();
         for spend_request in &transfer.all_spend_requests {
             trace!("sending spend request to the network: {spend_request:#?}");
-            tasks.push(self.network_store_spend(spend_request.clone()));
+            tasks.push(self.network_store_spend(spend_request.clone(), true));
         }
 
         for spend_attempt_result in join_all(tasks).await {

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -207,7 +207,10 @@ impl SwarmDriver {
                     .kademlia
                     .put_record(record, Quorum::All)?;
                 trace!("Sending record {request_id:?} to network");
-                let _ = self.pending_record_put.insert(request_id, sender);
+
+                if let Err(err) = sender.send(Ok(())) {
+                    error!("Could not send response to PutRecord cmd: {:?}", err);
+                }
             }
             SwarmCmd::PutLocalRecord { record } => {
                 self.swarm

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
     #[error("Outgoing response has been dropped due to a conn being closed or timeout: {0}")]
     OutgoingResponseDropped(Response),
 
+    #[error("Could not retrieve the record after storing it: {0:?}")]
+    FailedToVerifyRecordWasStored(kad::RecordKey),
+
+    #[error(
+        "Record retrieved from the network does not match the one we attempted to store {0:?}"
+    )]
+    ReturnedRecordDoesNotMatch(kad::RecordKey),
+
     #[error("Could not create storage dir: {path:?}, error: {source}")]
     FailedToCreateRecordStoreDir {
         path: PathBuf,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -127,7 +127,6 @@ impl SwarmDriver {
         &mut self,
         event: SwarmEvent<NodeEvent, EventError>,
     ) -> Result<()> {
-        info!("Handling a swarm event");
         match event {
             SwarmEvent::Behaviour(NodeEvent::MsgReceived(event)) => {
                 if let Err(e) = self.handle_msg(event) {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -340,33 +340,6 @@ impl SwarmDriver {
             }
             KademliaEvent::OutboundQueryProgressed {
                 id,
-                result: QueryResult::PutRecord(put_record_res),
-                stats,
-                step,
-            } => {
-                trace!("PutRecord task {id:?} returned, {stats:?} - {step:?}",);
-                if let Some(sender) = self.pending_record_put.remove(&id) {
-                    match put_record_res {
-                        Ok(put_record_ok) => {
-                            trace!(
-                                "PutRecord task {id:?} of {:?} completed successfully.",
-                                put_record_ok.key
-                            );
-                            sender
-                                .send(Ok(()))
-                                .map_err(|_| Error::InternalMsgChannelDropped)?;
-                        }
-                        Err(err) => {
-                            warn!("PutRecord task {id:?} completed with error {:?}.", err);
-                            sender
-                                .send(Err(err.into()))
-                                .map_err(|_| Error::InternalMsgChannelDropped)?;
-                        }
-                    }
-                }
-            }
-            KademliaEvent::OutboundQueryProgressed {
-                id,
                 result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(peer_record))),
                 stats,
                 step,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -107,7 +107,6 @@ pub struct SwarmDriver {
     pending_get_closest_peers: PendingGetClosest,
     pending_requests: HashMap<RequestId, Option<oneshot::Sender<Result<Response>>>>,
     pending_query: HashMap<QueryId, oneshot::Sender<Result<Record>>>,
-    pending_record_put: HashMap<QueryId, oneshot::Sender<Result<()>>>,
     replication_fetcher: ReplicationFetcher,
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
@@ -384,7 +383,6 @@ impl SwarmDriver {
             pending_get_closest_peers: Default::default(),
             pending_requests: Default::default(),
             pending_query: Default::default(),
-            pending_record_put: Default::default(),
             replication_fetcher: Default::default(),
             local,
             // We use 63 here, as in practice the capactiy will be rounded to the nearest 2^(n-1).

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -95,9 +95,9 @@ async fn dbc_transfer_double_spend_fail() -> Result<()> {
     // send both transfers to the network
     // upload won't error out, only error out during verification.
     println!("Sending both transfers to the network...");
-    let res = client.send(transfer_to_2.clone()).await;
+    let res = client.send_without_verify(transfer_to_2.clone()).await;
     assert!(res.is_ok());
-    let res = client.send(transfer_to_3.clone()).await;
+    let res = client.send_without_verify(transfer_to_3.clone()).await;
     assert!(res.is_ok());
 
     // check the DBCs, it should fail

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -104,13 +104,9 @@ async fn storage_payment_fails() -> Result<()> {
     invalid_signed_spend.spend.spent_tx.fee.token = Token::from_nano(random_num_of_addrs + 1);
     transfer.all_spend_requests[0].signed_spend = invalid_signed_spend;
 
-    // Sending will always return with OK, only verification will error out.
-    let res = client.send(transfer.clone()).await;
-    assert!(res.is_ok());
+    // Sending now verifies
+    let should_err = client.send(transfer.clone()).await;
 
-    std::thread::sleep(std::time::Duration::from_secs(5));
-
-    let should_err = client.verify(&transfer.change_dbc.unwrap()).await;
     println!("Verified with fail: {should_err:?}");
     assert!(should_err.is_err());
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 07:54 UTC
This pull request includes the following changes:

In the file `cmd.rs`, a new line was added at line 207. The code `let _ = self.pending_record_put.insert(request_id, sender);` was modified to be wrapped inside an if-let statement, which includes error logging for the `PutRecord` command.

In the file `error.rs`, a new variant was added to the `Error` enum called `FailedToVerifyRecordWasStored`, taking a `kad::RecordKey` as its argument. Another new variant called `ReturnedRecordDoesNotMatch` was also added, taking a `kad::RecordKey` as its argument. An error message was added for the `FailedToCreateRecordStoreDir` variant, including the path of the record store directory and the error source.

The file `file_apis.rs` mainly involves changes in the `Files` struct implementation. The `verify` parameter in the `upload_batches` method was renamed to `verify_store`. The logic inside the closure passed to `task::spawn` in the `upload_batches` method was modified, replacing the `verify` parameter with `verify_store` in the `store_chunk` method call. The `verify` parameter in the `store_small` method was also renamed to `verify_store`. The logic inside the `store_small` method was modified to use the `verify_store` parameter in the `store_chunk` method call. The `verify_chunk_is_stored` method was removed, while the `read_all` method remains unchanged. These changes appear to be related to handling verification of stored chunks during file uploads and storing smaller files.

In the file `register.rs` within the `sn_client/src` directory, the following changes were made: 

- A new comment was added in the `sync` method explaining its purpose.
- The `publish_register` method was modified to accept a boolean parameter `verify_store`, with the method implementation updated accordingly.
- The `push` method was modified to call `publish_register` with the `verify_store` parameter set to `true`.
- The implementation of the `publish_register` method was updated to handle the `verify_store` parameter and use it in the method logic.
- The `put_record` method call in the `publish_register` method was updated to include the `verify_store` parameter.

The diff of the file `files.rs` shows a change on line 139 where the `upload_chunks_in_batches` function call was modified to set the third parameter to `true` instead of `false`. This change could impact the behavior of the code.

The file diff of `api.rs` in the `sn_client` module includes the following changes: the `store_chunk` function now takes an additional parameter `verify_store` of type `bool`, and the `network_store_spend` function now also takes an additional parameter `verify_store` of type `bool`.

A code block handling the `OutboundQueryProgressed` event for `PutRecord` tasks was removed from another file, which included result processing through channel messaging and logging statements.

In the `wallet.rs` file, a new comment was added in the `send` function of the `Client` struct for clarity. The `network_store_spend` function call was also modified to include an additional parameter, `true`, when pushing tasks to the `tasks` vector.

In general, these changes involve improvements in verification of stored records, modifications to function parameters, and code adjustments for handling file uploads and storage.
<!-- reviewpad:summarize:end --> 
