### PR TITLE
chore(ci): speed up CI by restricting cargo build

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -45,7 +45,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build churn tests 
-        run: cargo test --release -p sn_node --no-run
+        run: cargo test --release -p sn_node --test data_with_churn --no-run
         timeout-minutes: 30
 
       - name: Start a heaptracked node instance to compare memory usage

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -141,9 +141,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build node and client
-        run: |
-          cargo build --release --bin safenode
-          cargo build --release --bin safe
+        run: cargo build --release --bin safenode --bin safe --bin faucet
         timeout-minutes: 30
 
       - name: Start a local network

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -96,8 +96,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build tests before running
-        run: cargo test --no-run --release
+      - name: Build unit tests before running
+        run: cargo test --release --lib --bins --no-run 
         timeout-minutes: 30
 
       - name: Run testnet tests
@@ -246,7 +246,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release --features local-discovery dbc_transfer_,storage_payment_ --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
         env:
           CARGO_TARGET_DIR: "./transfer-target"
@@ -270,14 +270,14 @@ jobs:
           fi
 
       - name: execute the dbc spend test
-        run: cargo test --release --features="local-discovery" dbc_transfer_ -- --nocapture
+        run: cargo test --release --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 25
 
       - name: execute the storage payment tests
-        run: cargo test --release --features="local-discovery" storage_payment_ -- --nocapture
+        run: cargo test --release --features="local-discovery" --test storage_payments -- --nocapture
         env:
           SN_LOG: "all"
           CARGO_TARGET_DIR: "./transfer-target"
@@ -317,7 +317,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build churn tests
-        run: cargo test --release -p sn_node --features="local-discovery" --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
         # new output folder to avoid linker issues w/ windows
         env:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -239,10 +239,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build node and client
-        run: |
-          cargo build --release --features local-discovery --bin safenode
-          cargo build --release --features local-discovery --bin safe
+      - name: Build safenode
+        run: cargo build --release --features local-discovery --bin safenode
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -312,8 +310,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build sn bins
-        run: cargo build --release --bins --features local-discovery
+      - name: Build safenode
+        run: cargo build --release --features local-discovery --bin safenode
         timeout-minutes: 30
 
       - name: Build churn tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,9 +29,7 @@ jobs:
         continue-on-error: true
 
       - name: Build node and client
-        run: |
-          cargo build --release --bin safenode
-          cargo build --release --bin safe
+        run: cargo build --release --bin safenode --bin safe --bin faucet
         timeout-minutes: 30
 
       - name: Start a local network

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,18 +123,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: Build tests before running
-        run: cargo test --no-run --release
+      - name: Build unit tests before running
+        run: cargo test --release --lib --bins --no-run 
         timeout-minutes: 30
 
+      - name: Run testnet tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_testnet
+
       - name: Run network tests
-        # Only run on PRs w/ ubuntu
         timeout-minutes: 25
         run: cargo test --release -p sn_networking
 
       - name: Run protocol tests
         timeout-minutes: 25
         run: cargo test --release -p sn_protocol
+
+      - name: Run transfers tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_transfers
 
       - name: Run register tests
         shell: bash
@@ -175,7 +182,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release multiple_sequential_transfers_succeed --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
         env:
           CARGO_TARGET_DIR: "./transfer-target"
@@ -189,7 +196,14 @@ jobs:
           platform: ${{ matrix.os }}
 
       - name: execute the dbc spend test
-        run: cargo test --release --features="local-discovery" multiple_sequential_transfers_succeed  -- --nocapture
+        run: cargo test --release --features="local-discovery" --test sequential_transfers -- --nocapture
+        env:
+          CARGO_TARGET_DIR: "./transfer-target"
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: execute the storage payment tests
+        run: cargo test --release --features="local-discovery" --test storage_payments -- --nocapture
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
@@ -234,10 +248,6 @@ jobs:
           cargo build --release --features local-discovery --bin safe
         timeout-minutes: 30
 
-      - name: Build churn tests 
-        run: cargo test --release -p sn_node --features="local-discovery" --no-run
-        timeout-minutes: 30
-
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
         with:
@@ -247,7 +257,7 @@ jobs:
           platform: ${{ matrix.os }}
 
       - name: Build churn tests 
-        run: cargo test --release -p sn_node --features="local-discovery" --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
         # new output folder to avoid linker issues w/ windows
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,10 +175,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: Build node and client
-        run: |
-          cargo build --release --features local-discovery --bin safenode
-          cargo build --release --features local-discovery --bin safe
+      - name: Build safenode
+        run: cargo build --release --features local-discovery --bin safenode
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -242,10 +240,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: Build node and client
-        run: |
-          cargo build --release --features local-discovery --bin safenode
-          cargo build --release --features local-discovery --bin safe
+      - name: Build safenode
+        run: cargo build --release --features local-discovery --bin safenode
         timeout-minutes: 30
 
       - name: Start a local network


### PR DESCRIPTION
Speeds up the CI run by building only the tests/bins that we need
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 14:26 UTC
This pull request includes two patches. 

The first patch updates the build command in the memcheck.yml, merge.yml, and nightly.yml files. It modifies the cargo test command to build only the required tests for the sn_node crate. This change optimizes the build process by excluding unnecessary tests.

The second patch modifies the build command in the merge.yml and nightly.yml files. It changes the cargo build command to build only the safenode binary instead of both the safenode and safe client binaries. This change reduces build time and improves efficiency.
<!-- reviewpad:summarize:end --> 
