### PR TITLE
chore(testnet): always start the faucet

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -83,12 +83,6 @@ jobs:
         shell: bash
         run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"
 
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -164,12 +164,6 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,12 +45,6 @@ jobs:
       - name: Check contact peer
         shell: bash
         run: echo "Peer is $SAFE_PEERS"
-    
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
 
       - name: Create and fund a wallet to pay for files storage
         run: |

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -62,12 +62,6 @@ struct Cmd {
     #[clap(long, short = 'f')]
     flame: bool,
 
-    /// Launch the DBC faucet server
-    ///
-    /// The server will be listening on port 8000
-    #[clap(long, short = 'd')]
-    dbc_faucet: bool,
-
     /// Build the node from source.
     ///
     /// This assumes the process is running from the `safe_network` repository.
@@ -191,20 +185,19 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    if args.dbc_faucet {
-        let mut faucet_bin_path = cargo_target_dir.clone();
-        if args.build_node {
-            build_node().await?;
-            faucet_bin_path.push("target");
-            faucet_bin_path.push("release");
-            faucet_bin_path.push(FAUCET_BIN_NAME);
-        } else {
-            faucet_bin_path.push(FAUCET_BIN_NAME);
-        }
-        info!("Launching DBC faucet server");
-        run_faucet(faucet_bin_path).await?;
+    let mut faucet_bin_path = cargo_target_dir.clone();
+    if args.build_node {
+        build_node().await?;
+        faucet_bin_path.push("target");
+        faucet_bin_path.push("release");
+        faucet_bin_path.push(FAUCET_BIN_NAME);
+    } else {
+        faucet_bin_path.push(FAUCET_BIN_NAME);
     }
+    info!("Launching DBC faucet server");
+    run_faucet(faucet_bin_path).await?;
 
+    println!("Testnet and faucet launched successfully");
     Ok(())
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 19:17 UTC
This pull request updates the code related to the testnet and faucet in the project. It removes the option to launch the DBC faucet server and instead always starts it. It also includes some code refactoring and cleanup. After the changes, the testnet and faucet are launched successfully.
<!-- reviewpad:summarize:end --> 
