### PR TITLE
feat(registers): make Registers to be stored and addressable based on its own metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,6 +3928,7 @@ dependencies = [
  "rand 0.8.5",
  "self_encryption",
  "serde",
+ "serde_json",
  "thiserror",
  "tiny-keccak",
  "xor_name",

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -8,7 +8,7 @@
 
 use clap::Subcommand;
 use color_eyre::Result;
-use sn_client::{Client, ClientRegister, Error as ClientError};
+use sn_client::{Client, ClientRegister, Error as ClientError, Metadata};
 use xor_name::XorName;
 
 #[derive(Subcommand, Debug)]
@@ -45,19 +45,22 @@ pub(crate) async fn register_cmds(cmds: RegisterCmds, client: &Client) -> Result
 
 async fn create_register(name: String, client: &Client) -> Result<()> {
     let tag = 3006;
-    let xorname = XorName::from_content(name.as_bytes());
-    println!("Creating Register with '{name}' at xorname: {xorname:x} and tag {tag}");
+    let metadata = Metadata::new(name.as_bytes())?;
+    println!("Creating Register with '{name}' and tag {tag}");
 
     // clients currently only support public registers as we create a new key at each run
-    let _register = ClientRegister::create_public_online(client.clone(), xorname, tag).await?;
-    println!("Successfully created register '{name}' at {xorname:?}, {tag}!");
+    let register = ClientRegister::create_public_online(client.clone(), metadata, tag).await?;
+    println!(
+        "Successfully created register '{name}' at {:?}, {tag}!",
+        register.name()
+    );
     Ok(())
 }
 
 async fn edit_register(name: String, entry: String, client: &Client) -> Result<()> {
     let tag = 3006;
-    let xorname = XorName::from_content(name.as_bytes());
-    println!("Trying to retrieve Register from {xorname:?}, {tag}");
+    let xorname = Metadata::new(name.as_bytes())?.xorname();
+    println!("Trying to retrieve Register ('{name}') from {xorname:?}, {tag}");
 
     match client.get_register(xorname, tag).await {
         Ok(mut register) => {

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -44,25 +44,23 @@ pub(crate) async fn register_cmds(cmds: RegisterCmds, client: &Client) -> Result
 }
 
 async fn create_register(name: String, client: &Client) -> Result<()> {
-    let tag = 3006;
     let metadata = Metadata::new(name.as_bytes())?;
-    println!("Creating Register with '{name}' and tag {tag}");
+    println!("Creating Register with '{name}'");
 
     // clients currently only support public registers as we create a new key at each run
-    let register = ClientRegister::create_public_online(client.clone(), metadata, tag).await?;
+    let register = ClientRegister::create_public_online(client.clone(), metadata).await?;
     println!(
-        "Successfully created register '{name}' at {:?}, {tag}!",
+        "Successfully created register '{name}' at {:?}!",
         register.name()
     );
     Ok(())
 }
 
 async fn edit_register(name: String, entry: String, client: &Client) -> Result<()> {
-    let tag = 3006;
     let xorname = Metadata::new(name.as_bytes())?.xorname();
-    println!("Trying to retrieve Register ('{name}') from {xorname:?}, {tag}");
+    println!("Trying to retrieve Register ('{name}') from {xorname:?}");
 
-    match client.get_register(xorname, tag).await {
+    match client.get_register(xorname).await {
         Ok(mut register) => {
             println!(
                 "Successfully retrieved Register '{name}' from {:?}!",
@@ -95,14 +93,13 @@ async fn edit_register(name: String, entry: String, client: &Client) -> Result<(
 }
 
 async fn get_registers(names: Vec<String>, client: &Client) -> Result<()> {
-    let tag = 3006;
     for name in names {
         println!("Register name passed in via `register get` is '{name}'...");
         let xorname = XorName::from_content(name.as_bytes());
 
-        println!("Trying to retrieve Register from {xorname:?}, {tag}");
+        println!("Trying to retrieve Register from {xorname:?}");
 
-        match client.get_register(xorname, tag).await {
+        match client.get_register(xorname).await {
             Ok(register) => {
                 println!(
                     "Successfully retrieved Register '{name}' from {:?}!",

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -28,7 +28,7 @@ use sn_protocol::{
     },
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_registers::SignedRegister;
+use sn_registers::{Metadata, SignedRegister};
 use sn_transfers::client_transfers::SpendRequest;
 use std::time::Duration;
 use tokio::task::spawn;
@@ -279,9 +279,9 @@ impl Client {
     }
 
     /// Create a new Register on the Network.
-    pub async fn create_register(&self, xorname: XorName, tag: u64) -> Result<ClientRegister> {
-        info!("Instantiating a new Register replica with name {xorname} and tag {tag}");
-        ClientRegister::create_online(self.clone(), xorname, tag).await
+    pub async fn create_register(&self, metadata: Metadata, tag: u64) -> Result<ClientRegister> {
+        info!("Instantiating a new Register replica with tag {tag}, and metadata: {metadata:?}");
+        ClientRegister::create_online(self.clone(), metadata, tag).await
     }
 
     /// Store `Chunk` as a record.

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -273,15 +273,15 @@ impl Client {
     }
 
     /// Retrieve a Register from the network.
-    pub async fn get_register(&self, xorname: XorName, tag: u64) -> Result<ClientRegister> {
-        info!("Retrieving a Register replica with name {xorname} and tag {tag}");
-        ClientRegister::retrieve(self.clone(), xorname, tag).await
+    pub async fn get_register(&self, xorname: XorName) -> Result<ClientRegister> {
+        info!("Retrieving a Register replica with name {xorname}");
+        ClientRegister::retrieve(self.clone(), xorname).await
     }
 
     /// Create a new Register on the Network.
-    pub async fn create_register(&self, metadata: Metadata, tag: u64) -> Result<ClientRegister> {
-        info!("Instantiating a new Register replica with tag {tag}, and metadata: {metadata:?}");
-        ClientRegister::create_online(self.clone(), metadata, tag).await
+    pub async fn create_register(&self, metadata: Metadata) -> Result<ClientRegister> {
+        info!("Instantiating a new Register replica with metadata: {metadata:?}");
+        ClientRegister::create_online(self.clone(), metadata).await
     }
 
     /// Store `Chunk` as a record.

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::{
     event::{ClientEvent, ClientEventsReceiver},
     faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
     file_apis::Files,
-    register::ClientRegister,
+    register::{ClientRegister, Metadata},
     wallet::{send, WalletClient},
 };
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -161,7 +161,7 @@ impl ClientRegister {
             .check_user_permissions(User::Key(public_key))?;
 
         let (_hash, mut op) = self.register.write(entry.into(), children)?;
-        let signature = self.client.sign(op.bytes_for_signing()?);
+        let signature = self.client.sign(op.bytes_for_signing());
         op.add_signature(public_key, signature)?;
         let cmd = RegisterCmd::Edit(op);
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -16,6 +16,7 @@ use sn_protocol::{
     storage::{try_serialize_record, RecordKind},
     NetworkAddress,
 };
+pub use sn_registers::Metadata;
 use sn_registers::{
     Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister, User,
 };
@@ -36,13 +37,13 @@ impl ClientRegister {
     /// Central helper func to create a client register
     fn create_register(
         client: Client,
-        name: XorName,
+        metadata: Metadata,
         tag: u64,
         perms: Permissions,
     ) -> Result<Self> {
         let public_key = client.signer_pk();
 
-        let register = Register::new(public_key, name, tag, perms);
+        let register = Register::new(public_key, metadata, tag, perms);
         let reg = Self {
             client,
             register,
@@ -53,20 +54,24 @@ impl ClientRegister {
     }
 
     /// Create a new Register Locally.
-    pub fn create(client: Client, name: XorName, tag: u64) -> Result<Self> {
-        Self::create_register(client, name, tag, Permissions::new_owner_only())
+    pub fn create(client: Client, metadata: Metadata, tag: u64) -> Result<Self> {
+        Self::create_register(client, metadata, tag, Permissions::new_owner_only())
     }
 
     /// Create a new public Register (Anybody can write to it) and send it so the Network.
-    pub async fn create_public_online(client: Client, name: XorName, tag: u64) -> Result<Self> {
-        let mut reg = Self::create_register(client, name, tag, Permissions::new_owner_only())?;
+    pub async fn create_public_online(
+        client: Client,
+        metadata: Metadata,
+        tag: u64,
+    ) -> Result<Self> {
+        let mut reg = Self::create_register(client, metadata, tag, Permissions::new_owner_only())?;
         reg.sync().await?;
         Ok(reg)
     }
 
     /// Create a new Register and send it to the Network.
-    pub async fn create_online(client: Client, name: XorName, tag: u64) -> Result<Self> {
-        let mut reg = Self::create_register(client, name, tag, Permissions::new_owner_only())?;
+    pub async fn create_online(client: Client, metadata: Metadata, tag: u64) -> Result<Self> {
+        let mut reg = Self::create_register(client, metadata, tag, Permissions::new_owner_only())?;
         reg.sync().await?;
         Ok(reg)
     }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -181,7 +181,7 @@ impl ClientRegister {
                 self.register.clone()
             }
         };
-        self.register.merge(remote_replica);
+        self.register.merge(remote_replica)?;
         self.push().await
     }
 

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -43,22 +43,17 @@ async fn main() -> Result<()> {
 
     // we'll retrieve (or create if not found) a Register, and write on it
     // in offline mode, syncing with the network periodically.
-    let tag = 5000;
     let metadata = Metadata::new(reg_nickname.as_bytes())?;
     let xorname = metadata.xorname();
     println!("Retrieving Register '{reg_nickname}' from SAFE, as user '{user}'");
-    let mut reg_replica = match client.get_register(xorname, tag).await {
+    let mut reg_replica = match client.get_register(xorname).await {
         Ok(register) => {
-            println!(
-                "Register '{reg_nickname}' found at {}, {}!",
-                register.name(),
-                register.tag(),
-            );
+            println!("Register '{reg_nickname}' found at {}!", register.name(),);
             register
         }
         Err(_) => {
-            println!("Register '{reg_nickname}' not found, creating it with tag {tag}",);
-            client.create_register(metadata, tag).await?
+            println!("Register '{reg_nickname}' not found, creating it...",);
+            client.create_register(metadata).await?
         }
     };
     println!("Register owned by: {:?}", reg_replica.owner());

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -93,6 +93,11 @@ impl Node {
         let chunk_name = *chunk_with_payment.chunk.name();
         debug!("validating and storing chunk {chunk_name:?}");
 
+        if !chunk_with_payment.chunk.verify_address() {
+            warn!("Chunk's address is incorrect as per its own data: {chunk_name}");
+            return Err(ProtocolError::ChunkNotStored(chunk_name));
+        }
+
         let key =
             NetworkAddress::from_chunk_address(*chunk_with_payment.chunk.address()).to_record_key();
         let present_locally = self
@@ -141,6 +146,11 @@ impl Node {
     ) -> Result<CmdOk, ProtocolError> {
         let reg_addr = register.address();
         debug!("Validating and storing register {reg_addr:?}");
+
+        if !register.verify_address() {
+            warn!("Register's address is incorrect as per its own metadata: {reg_addr:?}");
+            return Err(ProtocolError::RegisterNotStored(*reg_addr.name()));
+        }
 
         // check if the Register is present locally
         let key = NetworkAddress::from_register_address(*reg_addr).to_record_key();

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -313,16 +313,12 @@ fn create_registers_task(client: Client, content: ContentList, churn_period: Dur
         loop {
             let metadata = Metadata::new(&rand::thread_rng().gen::<[u8; 32]>())
                 .expect("Failed to generate random metadata for new Register");
-            let tag = rand::random();
 
-            let addr = RegisterAddress {
-                name: metadata.xorname(),
-                tag,
-            };
+            let addr = RegisterAddress::new(metadata.xorname());
             println!("Creating Register at {addr:?} in {delay:?}");
             sleep(delay).await;
 
-            match client.create_register(metadata, tag).await {
+            match client.create_register(metadata).await {
                 Ok(_) => content
                     .write()
                     .await
@@ -602,7 +598,7 @@ async fn query_content(
             }
         }
         NetworkAddress::RegisterAddress(addr) => {
-            let _ = client.get_register(*addr.name(), addr.tag()).await?;
+            let _ = client.get_register(*addr.name()).await?;
             Ok(())
         }
         NetworkAddress::ChunkAddress(addr) => {

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -21,7 +21,6 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
-use xor_name::XorName;
 
 /// This is the address in the network by which proximity/distance
 /// to other items (whether nodes or data chunks) are calculated.
@@ -77,7 +76,7 @@ impl NetworkAddress {
             NetworkAddress::PeerId(bytes) | NetworkAddress::RecordKey(bytes) => bytes.to_vec(),
             NetworkAddress::ChunkAddress(chunk_address) => chunk_address.name().0.to_vec(),
             NetworkAddress::DbcAddress(dbc_address) => dbc_address.name().0.to_vec(),
-            NetworkAddress::RegisterAddress(register_address) => register_address.id().0.to_vec(),
+            NetworkAddress::RegisterAddress(register_address) => register_address.name().0.to_vec(),
         }
     }
 
@@ -106,9 +105,7 @@ impl NetworkAddress {
             NetworkAddress::RecordKey(bytes) => RecordKey::new(bytes),
             NetworkAddress::ChunkAddress(chunk_address) => RecordKey::new(chunk_address.name()),
             NetworkAddress::RegisterAddress(register_address) => {
-                let mut reg_name: Vec<u8> = register_address.name().to_vec();
-                reg_name.extend(register_address.tag.to_be_bytes());
-                RecordKey::new(&XorName::from_content(&reg_name))
+                RecordKey::new(register_address.name())
             }
             NetworkAddress::DbcAddress(dbc_address) => RecordKey::new(dbc_address.name()),
             NetworkAddress::PeerId(bytes) => RecordKey::new(bytes),
@@ -153,7 +150,7 @@ impl Debug for NetworkAddress {
             }
             NetworkAddress::RegisterAddress(register_address) => format!(
                 "NetworkAddress::RegisterAddress({:?} - ",
-                register_address.id()
+                register_address.name()
             ),
             NetworkAddress::RecordKey(_) => "NetworkAddress::RecordKey(".to_string(),
         };

--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -47,6 +47,11 @@ impl Chunk {
         self.address.name()
     }
 
+    /// Verifies the address is correct for this chunk's data
+    pub fn verify_address(&self) -> bool {
+        self.address() == &ChunkAddress::new(XorName::from_content(self.value()))
+    }
+
     /// Returns size of contained value.
     pub fn payload_size(&self) -> usize {
         self.value.len()

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -25,3 +25,4 @@ xor_name = "5.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 proptest = { version = "1.0.0" }
 eyre = "0.6.8"
+serde_json = "1.0"

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -11,7 +11,9 @@ use std::hash::Hash;
 use xor_name::XorName;
 
 /// Address of a Register on the SAFE Network
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(
+    Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug,
+)]
 pub struct RegisterAddress(XorName);
 
 impl RegisterAddress {

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -12,36 +12,16 @@ use xor_name::XorName;
 
 /// Address of a Register on the SAFE Network
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
-pub struct RegisterAddress {
-    /// Name.
-    pub name: XorName,
-    /// Tag.
-    pub tag: u64,
-}
+pub struct RegisterAddress(XorName);
 
 impl RegisterAddress {
-    /// Construct a new `RegisterAddress` given `name` and `tag`.
-    pub fn new(name: XorName, tag: u64) -> Self {
-        Self { name, tag }
-    }
-
-    /// Return the identifier of the register.
-    /// This is used to locate the register on the network.
-    pub fn id(&self) -> XorName {
-        let mut bytes = vec![];
-        bytes.extend_from_slice(&self.name.0);
-        bytes.extend_from_slice(&self.tag.to_be_bytes());
-        XorName::from_content(&bytes)
+    /// Construct a new `RegisterAddress`.
+    pub fn new(xor_name: XorName) -> Self {
+        Self(xor_name)
     }
 
     /// Return the name.
-    /// This is not a unique identifier.
     pub fn name(&self) -> &XorName {
-        &self.name
-    }
-
-    /// Return the tag.
-    pub fn tag(&self) -> u64 {
-        self.tag
+        &self.0
     }
 }

--- a/sn_registers/src/error.rs
+++ b/sn_registers/src/error.rs
@@ -24,6 +24,14 @@ pub enum Error {
         /// Targeted Register's address
         reg_addr: RegisterAddress,
     },
+    /// Metadata is too big to create a register
+    #[error("Metadata is too big to create a register: {size}, max: {max}")]
+    MetadataTooBig {
+        /// Size of the metadata
+        size: usize,
+        /// Maximum metadata size allowed
+        max: usize,
+    },
     /// Entry is too big to fit inside a register
     #[error("Entry is too big to fit inside a register: {size}, max: {max}")]
     EntryTooBig {

--- a/sn_registers/src/lib.rs
+++ b/sn_registers/src/lib.rs
@@ -17,7 +17,7 @@ mod register_op;
 pub use self::{
     address::RegisterAddress,
     error::Error,
-    metadata::{Entry, EntryHash},
+    metadata::{Entry, EntryHash, Metadata},
     permissions::{Permissions, User},
     register::{Register, SignedRegister},
     register_op::RegisterOp,

--- a/sn_registers/src/metadata.rs
+++ b/sn_registers/src/metadata.rs
@@ -22,6 +22,7 @@ use xor_name::XorName;
 pub struct Metadata(Vec<u8>);
 
 impl Metadata {
+    /// Creates a new Metadata checking the data length is not larger than the allowed max size.
     pub fn new(metadata: &[u8]) -> Result<Self, Error> {
         let data = metadata.to_vec();
         if data.len() > MAX_REG_ENTRY_SIZE {
@@ -34,6 +35,7 @@ impl Metadata {
         Ok(Self(data))
     }
 
+    /// Returns the xorname this metadata would be mapped to.
     pub fn xorname(&self) -> XorName {
         XorName::from_content(&self.0)
     }

--- a/sn_registers/src/metadata.rs
+++ b/sn_registers/src/metadata.rs
@@ -6,8 +6,38 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::{register::MAX_REG_ENTRY_SIZE, Error};
+
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use std::{
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    result::Result,
+};
+use xor_name::XorName;
+
+/// Metadata of a Register, provided by the creator (end user) upon creation, which becomes immutable,
+/// and it defines this Register's address on the network, i.e. this Register is stored by the network
+/// at: XorName(hash(medatada)) (note that the size is limited: `MAX_REG_ENTRY_SIZE`).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd)]
+pub struct Metadata(Vec<u8>);
+
+impl Metadata {
+    pub fn new(metadata: &[u8]) -> Result<Self, Error> {
+        let data = metadata.to_vec();
+        if data.len() > MAX_REG_ENTRY_SIZE {
+            return Err(Error::MetadataTooBig {
+                size: data.len(),
+                max: MAX_REG_ENTRY_SIZE,
+            });
+        }
+
+        Ok(Self(data))
+    }
+
+    pub fn xorname(&self) -> XorName {
+        XorName::from_content(&self.0)
+    }
+}
 
 /// An entry in a Register (note that the `vec<u8>` is size limited: `MAX_REG_ENTRY_SIZE`)
 pub type Entry = Vec<u8>;

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -45,10 +45,10 @@ impl Display for RegisterCrdt {
 }
 
 impl RegisterCrdt {
-    /// Constructs a new '`RegisterCrdtImpl`'.
-    pub(crate) fn new(metadata: Metadata, tag: u64) -> Self {
+    /// Constructs a new '`RegisterCrdt`' with address derived from the given metadata.
+    pub(crate) fn new(metadata: Metadata) -> Self {
         Self {
-            address: RegisterAddress::new(metadata.xorname(), tag),
+            address: RegisterAddress::new(metadata.xorname()),
             metadata,
             data: MerkleReg::new(),
         }
@@ -99,7 +99,7 @@ impl RegisterCrdt {
         Ok((EntryHash(hash), op))
     }
 
-    /// Apply a remote data CRDT operation to this replica of the `RegisterCrdtImpl`.
+    /// Apply a remote data CRDT operation to this replica of the `RegisterCrdt`.
     pub(crate) fn apply_op(&mut self, op: RegisterOp) -> Result<()> {
         // Let's first check the op is validly signed.
         // Note: Perms and valid sig for the op are checked at the upper Register layer.
@@ -149,25 +149,24 @@ mod tests {
         let mut rng = rand::thread_rng();
         let metadata_1 = Metadata::new(&rng.gen::<[u8; 32]>())?;
         let metadata_2 = Metadata::new(&rng.gen::<[u8; 32]>())?;
-        let tag = 0;
 
-        let mut crdt_1 = RegisterCrdt::new(metadata_1, tag);
-        let mut crdt_2 = RegisterCrdt::new(metadata_2, tag);
+        let mut crdt_1 = RegisterCrdt::new(metadata_1);
+        let mut crdt_2 = RegisterCrdt::new(metadata_2);
         let mut parents = BTreeSet::new();
 
         let entry_1 = vec![0x1, 0x1];
-        // Different RegisterCrdtImpl shall create same hashes for the same entry from root
+        // Different RegisterCrdt shall create same hashes for the same entry from root
         let (entry_hash_1, _) = crdt_1.write(entry_1.clone(), parents.clone(), User::Anyone)?;
         let (entry_hash_2, _) = crdt_2.write(entry_1, parents.clone(), User::Anyone)?;
         assert!(entry_hash_1 == entry_hash_2);
 
         let entry_2 = vec![0x2, 0x2];
-        // RegisterCrdtImpl shall create differnt hashes for different entries from root
+        // RegisterCrdt shall create differnt hashes for different entries from root
         let (entry_hash_1_2, _) = crdt_1.write(entry_2, parents.clone(), User::Anyone)?;
         assert!(entry_hash_1 != entry_hash_1_2);
 
         let entry_3 = vec![0x3, 0x3];
-        // Different RegisterCrdtImpl shall create same hashes for the same entry from same parents
+        // Different RegisterCrdt shall create same hashes for the same entry from same parents
         let _ = parents.insert(entry_hash_1);
         let (entry_hash_1_3, _) = crdt_1.write(entry_3.clone(), parents.clone(), User::Anyone)?;
         let (entry_hash_2_3, _) = crdt_1.write(entry_3, parents, User::Anyone)?;

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -20,9 +20,10 @@ use std::{
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd)]
 pub(crate) struct RegisterCrdt {
     /// Address on the network of this piece of data
-    /// Network address. Omitted when serialising and
+    /// Omitted when serialising and
     /// calculated from the `metadata` when deserialising.
-    address: RegisterAddress,
+    #[serde(skip)]
+    pub(super) address: RegisterAddress,
     /// Metadata provided by the creator of this Register, which becomes immutable,
     /// and it defines this Register's address on the network, i.e. this Register is
     /// stored by the network at: XorName(hash(medatada)).

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -33,12 +33,9 @@ pub(crate) struct RegisterCrdt {
 
 impl Display for RegisterCrdt {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        for (i, entry) in self.data.read().values().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "<{entry:?}>")?;
+        write!(f, "(<<{:?}>>", self.metadata)?;
+        for entry in self.data.read().values() {
+            write!(f, ", <{entry:?}>")?;
         }
         write!(f, ")")
     }
@@ -60,8 +57,7 @@ impl RegisterCrdt {
     }
 
     /// Merge another register into this one.
-    pub(crate) fn merge(&mut self, other: Self) {
-        /* FIXME: check if addresses match first
+    pub(crate) fn merge(&mut self, other: Self) -> Result<()> {
         // Check the targetting address is correct
         if self.address != other.address {
             return Err(Error::RegisterAddrMismatch {
@@ -69,8 +65,10 @@ impl RegisterCrdt {
                 reg_addr: other.address,
             });
         }
-        */
+
         self.data.merge(other.data);
+
+        Ok(())
     }
 
     /// Returns total number of items in the register.

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -374,7 +374,7 @@ mod tests {
         let item1 = random_register_entry();
         let (_, op1) = replica1.write(item1, BTreeSet::new())?;
         let mut signed_write_op1 = op1;
-        signed_write_op1.sign_with(&authority_sk1)?;
+        signed_write_op1.sign_with(&authority_sk1);
 
         // Let's assert current state on both replicas
         assert_eq!(replica1.size(), 1);
@@ -384,7 +384,7 @@ mod tests {
         let item2 = random_register_entry();
         let (_, op2) = replica2.write(item2, BTreeSet::new())?;
         let mut signed_write_op2 = op2;
-        signed_write_op2.sign_with(&authority_sk2)?;
+        signed_write_op2.sign_with(&authority_sk2);
 
         // Item should be writeed on replica2
         assert_eq!(replica2.size(), 1);
@@ -633,7 +633,7 @@ mod tests {
             // Write an item on replicas
             let (_, op) = replica1.write(random_register_entry(), BTreeSet::new())?;
             let mut write_op = op;
-            write_op.sign_with(&owner_sk)?;
+            write_op.sign_with(&owner_sk);
             replica2.apply_op(write_op)?;
 
             verify_data_convergence(vec![replica1, replica2], 1)?;
@@ -667,7 +667,7 @@ mod tests {
                 // Write an item on replica1
                 let (hash, op) = replica1.write(random_register_entry(), children.clone())?;
                 let mut write_op = op;
-                write_op.sign_with(&owner_sk)?;
+                write_op.sign_with(&owner_sk);
                 // now apply that op to replica 2
                 replica2.apply_op(write_op)?;
                 children = vec![hash].into_iter().collect();
@@ -709,7 +709,7 @@ mod tests {
                 // Write an item on replica1 using the randomly generated set of children
                 let (hash, op) = replica1.write(random_register_entry(), children)?;
                 let mut write_op = op;
-                write_op.sign_with(&owner_sk)?;
+                write_op.sign_with(&owner_sk);
 
                 // now apply that op to replica 2
                 replica2.apply_op(write_op)?;
@@ -733,7 +733,7 @@ mod tests {
                 // first generate an op from one replica...
                 let (hash, op)= replicas[0].write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
 
                 // then apply this to all replicas
                 for replica in &mut replicas {
@@ -761,7 +761,7 @@ mod tests {
             for _data in dataset {
                 let (hash, op) = replicas[0].write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
                 ops.push(signed_op);
                 children = vec![hash].into_iter().collect();
             }
@@ -795,7 +795,7 @@ mod tests {
                 {
                     let (hash, op) = replica.write(random_register_entry(), children)?;
                     let mut signed_op = op;
-                    signed_op.sign_with(&owner_sk)?;
+                    signed_op.sign_with(&owner_sk);
                     ops.push(signed_op);
                     children = vec![hash].into_iter().collect();
                 }
@@ -844,7 +844,7 @@ mod tests {
             for (_data, delivery_chance) in dataset {
                 let (hash, op)= replica1.write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
 
                 ops.push((signed_op, delivery_chance));
                 children = vec![hash].into_iter().collect();
@@ -888,7 +888,7 @@ mod tests {
 
                 let (hash, op)=replica.write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
                 ops.push((signed_op, delivery_chance));
                 children = vec![hash].into_iter().collect();
             }
@@ -936,7 +936,7 @@ mod tests {
                 {
                     let (hash, op)=replica.write(random_register_entry(), children)?;
                     let mut signed_op = op;
-                    signed_op.sign_with(&owner_sk)?;
+                    signed_op.sign_with(&owner_sk);
                     ops.push(signed_op);
                     children = vec![hash].into_iter().collect();
                 }
@@ -953,7 +953,7 @@ mod tests {
             for _data in bogus_dataset {
                 let (hash, op)=bogus_replica.write(random_register_entry(), children)?;
                 let mut bogus_op = op;
-                bogus_op.sign_with(&random_owner_sk)?;
+                bogus_op.sign_with(&random_owner_sk);
                 bogus_replica.apply_op(bogus_op.clone())?;
                 ops.push(bogus_op);
                 children = vec![hash].into_iter().collect();

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -82,7 +82,7 @@ impl SignedRegister {
     }
 
     pub fn verify_with_address(&self, address: RegisterAddress) -> Result<()> {
-        if self.base_register.address() != &address {
+        if self.base_register.address() != &address || !self.verify_address() {
             return Err(Error::InvalidRegisterAddress {
                 requested: address,
                 got: *self.address(),

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -76,6 +76,15 @@ impl SignedRegister {
         Ok(())
     }
 
+    /// Verifies the address is correct for this Register's metadata
+    pub fn verify_address(&self) -> bool {
+        self.address()
+            == &RegisterAddress::new(
+                self.base_register.metadata().xorname(),
+                self.base_register.tag(),
+            )
+    }
+
     pub fn verify_with_address(&self, address: RegisterAddress) -> Result<()> {
         if self.base_register.address() != &address {
             return Err(Error::InvalidRegisterAddress {

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -242,8 +242,8 @@ impl Register {
     }
 
     /// Merge another Register into this one.
-    pub fn merge(&mut self, other: Self) {
-        self.crdt.merge(other.crdt);
+    pub fn merge(&mut self, other: Self) -> Result<()> {
+        self.crdt.merge(other.crdt)
     }
 
     /// Check if a register op is valid for our current register

--- a/sn_registers/src/register_op.rs
+++ b/sn_registers/src/register_op.rs
@@ -83,7 +83,9 @@ impl RegisterOp {
     /// Returns a bytes version of the RegisterOp used for signing
     /// Use this API when you want to sign a RegisterOp withtout providing a secret key to the RegisterOp API
     pub fn bytes_for_signing(&self) -> Vec<u8> {
-        self.crdt_op.hash().to_vec()
+        let mut bytes: Vec<u8> = self.address.name().to_vec();
+        bytes.extend(self.crdt_op.hash());
+        bytes
     }
 
     /// Check signature of register Op against provided public key


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 19:22 UTC
This pull request includes the following changes:

1. In the `lib.rs` file:
- Added the module `Metadata` in the `register` module.
- Added import statement for `Metadata` from `sn_registers`.
- Changed the argument of the `create_register` function from `xorname` to `metadata`.
- Updated the log message in the `create_register` function to include the `metadata` parameter.

2. In the `registers.rs` file:
- Import the `Metadata` struct from the `sn_client` crate is added.
- The `xor_name` module import and usage is removed.
- The code now creates a `Metadata` instance using `reg_nickname` and retrieves the `XorName` from it.
- The print statement for log messages is updated to include the register nickname.
- The code to create a register is updated to use the `create_register` method with the `metadata` parameter instead of the `xorname` parameter.

3. In the `sn_cli/src/subcommands/register.rs` file:
- Import `Metadata` from `sn_client::{Client, ClientRegister, Error as ClientError, Metadata}` has been added.
- The `create_register` function now creates a register using `Metadata` instead of `XorName`.
- The `create_register` function now prints the register name after successfully creating it.
- The `edit_register` function now retrieves the register using `Metadata` instead of `XorName`.
- The `edit_register` function now prints the register name when trying to retrieve it.

4. In the `reg_crdt.rs` file:
- Added import statement for the `Metadata` type.
- Modified the `RegisterCrdt` struct to include a `metadata` field of type `Metadata`.
- Created a new method `new` in the `RegisterCrdt` struct that takes `metadata` and `tag` as inputs and sets the `address` field using the `metadata` and `tag`.
- Modified the `merge` method to check if the addresses match before merging the data.
- Added a new method `metadata` in the `RegisterCrdt` struct to retrieve the metadata of the register.
- Modified the creation of `RegisterCrdt` instances in the test module to use randomly generated `Metadata` instead of `RegisterAddress`.
- Added a `tag` variable for the `new` method in the `RegisterCrdt` struct.

5. In the `error.rs` file:
- Added a new variant `MetadataTooBig` to the `Error` enum.
- The `MetadataTooBig` variant contains two fields: `size` of type usize and `max` of type usize.
- Added a new error message for the `MetadataTooBig` variant.
- The `EntryTooBig` variant has not been changed.

6. In the `data_with_churn.rs` file:
- Imported `Metadata` module from `sn_client`.
- Removed unused import of `XorName` from `xor_name` module.
- Updated the implementation of creating registers by using `Metadata` instead of `XorName` and `RegisterAddress`.
- Replaced the address of the newly created register with the address obtained from the `Metadata` object.
- Updated the error handling when creating registers to include the tag value in the error message.

7. In the `metadata.rs` file:
- Added the `use super::{register::MAX_REG_ENTRY_SIZE, Error};` statement.
- Modified the `std` import to include `std::result::Result`.
- Added the `xor_name::XorName` import.
- Added a new struct `Metadata` with its implementation.
- Added a new function `new` in the `Metadata` implementation.
- Added a new function `xor_name` in the `Metadata` implementation.
- Changed the type of `Entry` from `Vec<u8>` to `pub type Entry = Vec<u8>`.

In summary, this pull request includes changes to various files to introduce the `Metadata` struct, update function arguments and implementations related to registers, and add new error variants.
<!-- reviewpad:summarize:end --> 
