### PR TITLE
fix(register): Registers with same name but different tags were not being stored by the network

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -26,6 +26,7 @@ use sn_protocol::{
         try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, ChunkWithPayment,
         DbcAddress, RecordHeader, RecordKind, RegisterAddress,
     },
+    NetworkAddress,
 };
 use sn_registers::SignedRegister;
 use sn_transfers::client_transfers::SpendRequest;
@@ -245,9 +246,11 @@ impl Client {
         &self,
         address: RegisterAddress,
     ) -> Result<SignedRegister> {
+        let key = NetworkAddress::from_register_address(address).to_record_key();
+
         let record = self
             .network
-            .get_record_from_network(RecordKey::new(address.name()))
+            .get_record_from_network(key)
             .await
             .map_err(|_| ProtocolError::RegisterNotFound(address))?;
         debug!("Got record from the network, {:?}", record.key);

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -9,11 +9,12 @@
 use crate::{Client, Error, Result};
 
 use bls::PublicKey;
-use libp2p::kad::{Record, RecordKey};
+use libp2p::kad::Record;
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::RegisterCmd,
     storage::{try_serialize_record, RecordKind},
+    NetworkAddress,
 };
 use sn_registers::{
     Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister, User,
@@ -288,9 +289,10 @@ impl ClientRegister {
             }
         };
 
-        let reg_addr = register.address();
+        let key = NetworkAddress::from_register_address(*register.address()).to_record_key();
+
         let record = Record {
-            key: RecordKey::new(reg_addr.name()),
+            key,
             value: try_serialize_record(&register, RecordKind::Register)?,
             publisher: None,
             expires: None,

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -285,16 +285,13 @@ impl Node {
     async fn handle_response(&mut self, response: Response) -> Result<()> {
         match response {
             Response::Query(QueryResponse::GetReplicatedData(Ok((_holder, replicated_data)))) => {
-                let _address = match replicated_data {
+                match replicated_data {
                     ReplicatedData::Chunk(chunk_with_payment) => {
                         let chunk_addr = *chunk_with_payment.chunk.address();
                         debug!("Chunk received for replication: {:?}", chunk_addr.name());
-                        let addr =
-                            NetworkAddress::from_record_key(RecordKey::new(chunk_addr.name()));
 
                         let success = self.validate_and_store_chunk(chunk_with_payment).await?;
                         trace!("ReplicatedData::Chunk with {chunk_addr:?} has been validated and stored. {success:?}");
-                        addr
                     }
                     ReplicatedData::DbcSpend(signed_spend) => {
                         if let Some(spend) = signed_spend.first() {
@@ -305,7 +302,6 @@ impl Node {
 
                             let success = self.validate_and_store_spends(signed_spend).await?;
                             trace!("ReplicatedData::Dbc with {addr:?} has been validated and stored. {success:?}");
-                            addr
                         } else {
                             // Put validations make sure that we have >= 1 spends and with the same
                             // dbc_id
@@ -319,14 +315,11 @@ impl Node {
                             "Register received for replication: {:?}",
                             register_addr.name()
                         );
-                        let addr =
-                            NetworkAddress::from_record_key(RecordKey::new(register_addr.name()));
 
                         let success = self.validate_and_store_register(register).await?;
                         trace!("ReplicatedData::Register with {register_addr:?} has been validated and stored. {success:?}");
-                        addr
                     }
-                };
+                }
             }
             Response::Query(QueryResponse::GetReplicatedData(Err(
                 ProtocolError::ReplicatedDataNotFound { holder, address },

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -7,12 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
-use libp2p::{
-    autonat::NatStatus,
-    identity::Keypair,
-    kad::{RecordKey, K_VALUE},
-    Multiaddr, PeerId,
-};
+use libp2p::{autonat::NatStatus, identity::Keypair, kad::K_VALUE, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
 use sn_protocol::{
@@ -297,8 +292,7 @@ impl Node {
                         if let Some(spend) = signed_spend.first() {
                             let dbc_addr = DbcAddress::from_dbc_id(spend.dbc_id());
                             debug!("DbcSpend received for replication: {:?}", dbc_addr.name());
-                            let addr =
-                                NetworkAddress::from_record_key(RecordKey::new(dbc_addr.name()));
+                            let addr = NetworkAddress::from_dbc_address(dbc_addr);
 
                             let success = self.validate_and_store_spends(signed_spend).await?;
                             trace!("ReplicatedData::Dbc with {addr:?} has been validated and stored. {success:?}");

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::Node;
-use libp2p::kad::RecordKey;
 use sn_dbc::SignedSpend;
 use sn_protocol::{
     error::{Error, Result},
@@ -22,9 +21,10 @@ use sn_registers::SignedRegister;
 
 impl Node {
     pub(crate) async fn get_chunk_from_network(&self, address: ChunkAddress) -> Result<Chunk> {
+        let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(RecordKey::new(address.name()))
+            .get_record_from_network(key)
             .await
             .map_err(|_| Error::ChunkNotFound(address))?;
         debug!("Got record from the network, {:?}", record.key);
@@ -42,9 +42,10 @@ impl Node {
     }
 
     pub(crate) async fn get_spend_from_network(&self, address: DbcAddress) -> Result<SignedSpend> {
+        let key = NetworkAddress::from_dbc_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(RecordKey::new(address.name()))
+            .get_record_from_network(key)
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!("Got record from the network, {:?}", record.key);

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -20,6 +20,7 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
+use xor_name::XorName;
 
 /// This is the address in the network by which proximity/distance
 /// to other items (whether nodes or data chunks) are calculated.
@@ -101,18 +102,18 @@ impl NetworkAddress {
         }
     }
 
-    // For track and logging purpose, return the convertable `RecordKey`.
-    fn to_record_key(&self) -> Option<RecordKey> {
+    /// Return the convertable `RecordKey`.
+    pub fn to_record_key(&self) -> RecordKey {
         match self {
-            NetworkAddress::RecordKey(bytes) => Some(RecordKey::new(bytes)),
-            NetworkAddress::ChunkAddress(chunk_address) => {
-                Some(RecordKey::new(chunk_address.name()))
-            }
+            NetworkAddress::RecordKey(bytes) => RecordKey::new(bytes),
+            NetworkAddress::ChunkAddress(chunk_address) => RecordKey::new(chunk_address.name()),
             NetworkAddress::RegisterAddress(register_address) => {
-                Some(RecordKey::new(register_address.name()))
+                let mut reg_name: Vec<u8> = register_address.name().to_vec();
+                reg_name.extend(register_address.tag.to_be_bytes());
+                RecordKey::new(&XorName::from_content(&reg_name))
             }
-            NetworkAddress::DbcAddress(dbc_address) => Some(RecordKey::new(dbc_address.name())),
-            _ => None,
+            NetworkAddress::DbcAddress(dbc_address) => RecordKey::new(dbc_address.name()),
+            NetworkAddress::PeerId(bytes) => RecordKey::new(bytes),
         }
     }
 

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -82,16 +82,13 @@ impl NetworkAddress {
 
     /// Try to return the represented `PeerId`.
     pub fn as_peer_id(&self) -> Option<PeerId> {
-        match self {
-            NetworkAddress::PeerId(bytes) => {
-                if let Ok(peer_id) = PeerId::from_bytes(bytes) {
-                    Some(peer_id)
-                } else {
-                    None
-                }
+        if let NetworkAddress::PeerId(bytes) = self {
+            if let Ok(peer_id) = PeerId::from_bytes(bytes) {
+                return Some(peer_id);
             }
-            _ => None,
         }
+
+        None
     }
 
     /// Try to return the represented `RecordKey`.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 20:52 UTC
This pull request fixes an issue where registers with the same name but different tags were not being stored by the network. The patch modifies the code in several files to properly handle registers with different tags.
<!-- reviewpad:summarize:end --> 
