### PR TITLE
chore(ci): build faucet during benchmark

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -52,10 +52,8 @@ jobs:
         shell: bash
         run: wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
      
-      - name: Build node and client
-        run: |
-          cargo build --release --features local-discovery --bin safenode
-          cargo build --release --features local-discovery --bin safe
+      - name: Build safe binaries
+        run: cargo build --release --features local-discovery --bin safenode --bin safe --bin faucet
         timeout-minutes: 30
 
       - name: Start a local network

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Command, Stdio};
-use tracing::{debug, info};
+use tracing::info;
 
 pub const DEFAULT_NODE_LAUNCH_INTERVAL: u64 = 1000;
 #[cfg(not(target_os = "windows"))]
@@ -54,7 +54,7 @@ pub trait RpcClient {
 pub struct SafeNodeLauncher {}
 impl NodeLauncher for SafeNodeLauncher {
     fn launch(&self, node_bin_path: &Path, args: Vec<String>) -> Result<()> {
-        debug!("Running {:#?} with args: {:#?}", node_bin_path, args);
+        println!("Running {:#?} with args: {:#?}", node_bin_path, args);
         Command::new(node_bin_path)
             .args(args)
             .stdout(Stdio::inherit())

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -137,17 +137,7 @@ async fn main() -> Result<()> {
         return Err(eyre!("Flamegraph cannot be used on Windows"));
     }
 
-    let cargo_target_dir = match std::env::var("CARGO_TARGET_DIR") {
-        Ok(dir) => {
-            let mut dir = PathBuf::from(dir);
-            let _ = dir.pop();
-            debug!("CARGO_TARGET_DIR is enabled, the path is {dir:?}");
-            dir
-        }
-        Err(_) => PathBuf::new(),
-    };
-
-    let mut node_bin_path = cargo_target_dir.clone();
+    let mut node_bin_path = PathBuf::new();
     if let Some(node_path) = args.node_path {
         node_bin_path.push(node_path);
     } else if args.build_node {
@@ -185,7 +175,7 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let mut faucet_bin_path = cargo_target_dir.clone();
+    let mut faucet_bin_path = PathBuf::new();
     if args.build_node {
         build_node().await?;
         faucet_bin_path.push("target");
@@ -254,10 +244,6 @@ async fn build_node() -> Result<()> {
 
     let mut build_result = Command::new("cargo");
     let _ = build_result.args(args.clone());
-
-    if let Ok(val) = std::env::var("CARGO_TARGET_DIR") {
-        let _ = build_result.env("CARGO_TARGET_DIR", val);
-    }
 
     let build_result = build_result
         .current_dir("sn_node")


### PR DESCRIPTION
Prevents failure due to timeout as seen here https://github.com/maidsafe/safe_network/actions/runs/5665119669/job/15349428588
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 06:47 UTC
This pull request includes changes to the CI workflow for benchmarking. It modifies the build steps to include building the faucet alongside the safenode and safe binaries. Additionally, it updates the workflow for generating benchmark charts by including the faucet binary in the build step.
<!-- reviewpad:summarize:end --> 
