### PR TITLE
ci: increase time allowed for setting up wallets now we validate

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -79,7 +79,7 @@ jobs:
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       - name: Start a heaptracked node instance to compare memory usage
         run: |


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 07:40 UTC
This pull request increases the allowed time for setting up wallets during validation in the ci workflow. The timeout-minutes value has been changed from 2 to 10.
<!-- reviewpad:summarize:end --> 
