### PR TITLE
feat(testnet): provide args to build/run faucet

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -59,6 +59,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ubuntu-latest
 
       - name: Check SAFE_PEERS was set

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -53,9 +53,7 @@ jobs:
         run: wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
      
       - name: Build node and client
-        run: |
-          cargo build --release --features local-discovery --bin safenode
-          cargo build --release --features local-discovery --bin safe
+        run: cargo build --release --features local-discovery --bin safenode --bin safe --bin faucet
         timeout-minutes: 30
 
       - name: Start a local network
@@ -64,6 +62,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ubuntu-latest
 
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -75,6 +75,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: "ubuntu-latest"
           set-safe-peers: false
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -150,6 +150,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: Check SAFE_PEERS was set
@@ -231,8 +232,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build safenode
-        run: cargo build --release --features local-discovery --bin safenode
+      - name: Build safe bins
+        run: cargo build --release --features local-discovery --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -247,6 +248,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: Check SAFE_PEERS was set
@@ -302,8 +304,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build safenode
-        run: cargo build --release --features local-discovery --bin safenode
+      - name: Build safe bins
+        run: cargo build --release --features local-discovery --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build churn tests
@@ -319,6 +321,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: Check SAFE_PEERS was set

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: Check contact peer
@@ -167,8 +168,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: Build safenode
-        run: cargo build --release --features local-discovery --bin safenode
+      - name: Build safe bins
+        run: cargo build --release --features local-discovery --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable
@@ -183,6 +184,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: execute the dbc spend test
@@ -232,8 +234,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - name: Build safenode
-        run: cargo build --release --features local-discovery --bin safenode
+      - name: Build safe bins
+        run: cargo build --release --features local-discovery --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Start a local network
@@ -242,6 +244,7 @@ jobs:
           action: start
           interval: 2000
           node-path: target/release/safenode
+          faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
       - name: Build churn tests 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 08:34 UTC
This pull request adds the ability to provide arguments to build and run the faucet in the testnet. It introduces the `build_faucet` flag to build the faucet from source and the `faucet_path` option to specify the path to the faucet binary. If the `faucet_path` option is not provided, it will assume that the faucet is on the PATH.
<!-- reviewpad:summarize:end --> 
