### PR TITLE
feat(networking): add in a basic store cost calculation based on reco…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ dependencies = [
  "rand 0.8.5",
  "rmp-serde",
  "serde",
+ "sn_dbc",
  "sn_protocol",
  "thiserror",
  "tokio",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -24,6 +24,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.3.1" }
+sn_dbc = { version = "19.1.1", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -83,9 +83,9 @@ const IDENTIFY_CLIENT_VERSION_STR: &str = concat!("safe/client/", env!("CARGO_PK
 const IDENTIFY_PROTOCOL_STR: &str = concat!("safe/", env!("CARGO_PKG_VERSION"));
 
 /// Duration to wait for verification
-const VERIFICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+const REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_secs(3);
 /// Number of attempts to verify a record
-const VERIFICATION_ATTEMPTS: usize = 3;
+const VERIFICATION_ATTEMPTS: usize = 30;
 
 const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 /// Majority of a given group (i.e. > 1/2).
@@ -671,7 +671,7 @@ impl Network {
             }
 
             // wait for a bit before trying againq
-            tokio::time::sleep(VERIFICATION_TIMEOUT).await;
+            tokio::time::sleep(REVERIFICATION_WAIT_TIME_S).await;
         }
 
         if something_different_was_found {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -15,6 +15,7 @@ use libp2p::{
     },
 };
 use rand::Rng;
+use sn_dbc::Token;
 use sn_protocol::NetworkAddress;
 use std::{
     borrow::Cow,
@@ -209,6 +210,33 @@ impl DiskBackedRecordStore {
         } else {
             warn!("Record storage didn't have the distance_range setup yet.");
         }
+    }
+
+    #[allow(dead_code)]
+    /// Calculate the cost to store data for our current store state
+    pub fn store_cost(&self) -> Token {
+        let records_len = self.records().count();
+
+        let mut cost = Token::from_nano(1);
+        const NANOS_PER_SNT: u64 = 1_000_000_000;
+
+        // if we imagine that at FULL capacity we want _all the money_ (ie, we never want to reach full capacity)
+        // So we get the total amount of nanos in the network,
+        // we divide that number by our MAX_RECORD_COUNT to know
+        // what to charge for each additional record
+        let step_per_record = ((2 ^ 32) * NANOS_PER_SNT) / MAX_RECORDS_COUNT as u64;
+        let step_amount = Token::from_nano(step_per_record);
+
+        // we want to spread the cost of storing data across the MAX_CAPACITY
+        // doubling the cost for each record store
+        for _ in 0..records_len {
+            if let Some(new_cost) = cost.checked_add(step_amount) {
+                cost = new_cost;
+            }
+        }
+
+        trace!("Cost is now {cost:?}");
+        cost
     }
 }
 
@@ -416,9 +444,12 @@ mod tests {
             Some(network_event_sender),
         );
 
+        let store_cost_before = store.store_cost();
         // An initial unverified put should not write to disk
         assert!(store.put(r.clone()).is_ok());
         assert!(store.get(&r.key).is_none());
+        // Store cost should not change if no PUT has been added
+        assert!(store.store_cost() == store_cost_before);
 
         let returned_record = if let Some(event) = network_event_receiver.recv().await {
             if let NetworkEvent::UnverifiedRecord(record) = event {
@@ -430,6 +461,8 @@ mod tests {
             panic!("Failed recevied the record for further verification");
         };
 
+        let store_cost_before = store.store_cost();
+
         assert!(store.put_verified(returned_record).is_ok());
 
         // loop over store.get 10 times to make sure async disk write has had time to complete
@@ -440,12 +473,19 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
+        let cost_after_put = store.store_cost();
+        // store cost should have increased
+        assert!(cost_after_put > store_cost_before);
+
         assert_eq!(
             Some(Cow::Borrowed(&r)),
             store.get(&r.key),
             "record can be retrieved after put"
         );
         store.remove(&r.key);
+
+        // now we've removed a record, the cost should decrease
+        assert!(cost_after_put > store.store_cost());
         assert!(store.get(&r.key).is_none());
     }
 }


### PR DESCRIPTION
…rd_store capacity

fixes #567

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 09:32 UTC
This pull request adds a basic store cost calculation based on the capacity of the record store. It introduces a new dependency, "sn_dbc", and modifies the `Cargo.toml` file to include it. It also adds a `store_cost` function to the `DiskBackedRecordStore` implementation that calculates the cost of storing data based on the current store state. Tests have been added to verify the functionality of this feature.
<!-- reviewpad:summarize:end --> 
