### PR TITLE
feat(node): add markers for initial connection attempt/timeout

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -302,6 +302,11 @@ impl SwarmDriver {
     /// Dials the given multiaddress. If address contains a peer ID, simultaneous
     /// dials to that peer are prevented.
     pub(crate) fn dial(&mut self, mut addr: Multiaddr) -> Result<(), DialError> {
+        self.num_dials += 1;
+        if self.num_dials == 1 {
+            self.send_event(NetworkEvent::AttemptingNetworkConnection);
+        }
+        
         debug!(%addr, "Dialing manually");
 
         let peer_id = multiaddr_pop_p2p(&mut addr);

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -113,6 +113,7 @@ pub struct SwarmDriver {
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
     dialed_peers: CircularVec<PeerId>,
+    num_dials: usize,
     /// The peers that are closer to our PeerId
     close_group: Vec<PeerId>,
     is_client: bool,
@@ -394,6 +395,7 @@ impl SwarmDriver {
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
+            num_dials: 0,
             close_group: Default::default(),
             is_client,
         };

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -190,11 +190,15 @@ impl Node {
             },
             // These events do not need to wait until there are enough peers
             NetworkEvent::PeerAdded(_)
+            | NetworkEvent::AttemptingNetworkConnection
             | NetworkEvent::PeerRemoved(_)
             | NetworkEvent::NewListenAddr(_)
             | NetworkEvent::NatStatusChanged(_) => {}
         }
         match event {
+            NetworkEvent::AttemptingNetworkConnection => {
+                self.events_channel.broadcast(NodeEvent::AttemptingNetworkConnection);
+            }
             NetworkEvent::RequestReceived { req, channel } => {
                 trace!("RequestReceived: {req:?}");
                 self.handle_request(req, channel).await;

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -45,6 +45,8 @@ impl NodeEventsChannel {
 /// Type of events broadcasted by the node to the public API.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum NodeEvent {
+    /// Dialing an initial peer and attempting to connect to the network
+    AttemptingNetworkConnection,
     /// The node has been connected to the network
     ConnectedToNetwork,
     /// A Chunk has been stored in local storage

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -17,6 +17,12 @@ use strum::Display;
 /// Changing these log markers is a breaking change.
 #[derive(Debug, Clone, Display)]
 pub enum Marker<'a> {
+    /// Dialing an initial peer and attempting to connect to the network
+    AttemptingNetworkConnection,
+
+    /// Attempt to dial initial peers and connect to the network is timing out after a period of time
+    NetworkConnectionTimingOut,
+    
     /// The node has started
     NodeConnectedToNetwork,
 


### PR DESCRIPTION
Added AttemptingNetworkConnection marker for attempt to dial initial peers and NetworkConnectionTimingOut marker if timing out.