### PR TITLE
Add in GetStoreCost messaging

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -16,6 +16,7 @@ use libp2p::{
     },
     Multiaddr, PeerId,
 };
+use sn_dbc::Token;
 use sn_protocol::{
     messages::{Request, Response},
     NetworkAddress,
@@ -86,6 +87,10 @@ pub enum SwarmCmd {
         key: RecordKey,
         sender: oneshot::Sender<Result<Record>>,
     },
+    /// GetLocalStoreCost from the Kad network
+    GetLocalStoreCost {
+        sender: oneshot::Sender<Token>,
+    },
     /// Get data from the local RecordStore
     GetLocalRecord {
         key: RecordKey,
@@ -146,6 +151,11 @@ impl SwarmDriver {
             SwarmCmd::GetNetworkRecord { key, sender } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
                 let _ = self.pending_query.insert(query_id, sender);
+            }
+            SwarmCmd::GetLocalStoreCost { sender } => {
+                let cost = self.swarm.behaviour_mut().kademlia.store_mut().store_cost();
+
+                let _res = sender.send(cost);
             }
             SwarmCmd::GetLocalRecord { key, sender } => {
                 let record = self

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -91,6 +91,9 @@ pub enum Error {
 
     #[error("No SwarmCmd channel capacity")]
     NoSwarmCmdChannelCapacity,
+
+    #[error("Failed to sign the message with the PeerId keypair")]
+    SigningFailed(#[from] libp2p::identity::SigningError),
 }
 
 /// Pretty print a `kad::RecordKey` as a hex string.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -630,7 +630,7 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)?
     }
 
-    /// Get the the cost of storing the next record from the network
+    /// Get the cost of storing the next record from the network
     pub async fn get_local_storecost(&self) -> Result<Token> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetLocalStoreCost { sender })?;
@@ -778,7 +778,7 @@ impl Network {
         self.send_swarm_cmd(SwarmCmd::SetRecordDistanceRange { distance })
     }
 
-    /// Send `Request` to the the given `PeerId` and await for the response. If `self` is the recipient,
+    /// Send `Request` to the given `PeerId` and await for the response. If `self` is the recipient,
     /// then the `Request` is forwarded to itself and handled, and a corresponding `Response` is created
     /// and returned to itself. Hence the flow remains the same and there is no branching at the upper
     /// layers.
@@ -792,7 +792,7 @@ impl Network {
         receiver.await?
     }
 
-    /// Send `Request` to the the given `PeerId` and do _not_ await a response here.
+    /// Send `Request` to the given `PeerId` and do _not_ await a response here.
     /// Instead the Response will be handled by the common `response_handler`
     pub fn send_req_ignore_reply(&self, req: Request, peer: PeerId) -> Result<()> {
         let swarm_cmd = SwarmCmd::SendRequest {

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -346,7 +346,12 @@ impl Node {
     }
 
     async fn handle_query(&self, query: Query) -> Response {
-        let resp = match query {
+        let resp: QueryResponse = match query {
+            Query::GetStoreCost(_address) => {
+                trace!("Got GetStoreCost");
+                let result = self.current_storecost().await;
+                QueryResponse::GetStoreCost(result)
+            }
             Query::GetChunk(address) => {
                 trace!("Got GetChunk query for {address:?}");
                 let result = self.get_chunk_from_network(address).await;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
     SpendIsEmpty,
 
     // ---------- payment errors
-    /// Failed to get the storecost from kademlia stoe
+    /// Failed to get the storecost from kademlia store
     #[error("There was an error getting the storecost from kademlia store")]
     GetStoreCostFailed,
     #[error("There was an error signing the storecost from kademlia store")]

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -55,6 +55,11 @@ pub enum Error {
     SpendIsEmpty,
 
     // ---------- payment errors
+    /// Failed to get the storecost from kademlia stoe
+    #[error("There was an error getting the storecost from kademlia store")]
+    GetStoreCostFailed,
+    #[error("There was an error signing the storecost from kademlia store")]
+    SignStoreCostFailed,
     /// The amount paid by payment proof is not the required for the received content
     #[error("The amount paid by payment proof is not the required for the received content, paid {paid}, expected {expected}")]
     PaymentProofInsufficientAmount { paid: usize, expected: usize },

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, PartialOrd, Clone, Serialize, Deserialize, Debug)]
 pub enum Query {
+    /// Retrieve the cost of storing a record at the given address.
+    GetStoreCost(NetworkAddress),
     /// Retrieve a [`Chunk`] at the given address.
     ///
     /// This should eventually lead to a [`GetChunk`] response.
@@ -44,6 +46,7 @@ impl Query {
     /// Used to send a query to the close group of the address.
     pub fn dst(&self) -> NetworkAddress {
         match self {
+            Query::GetStoreCost(address) => address.clone(),
             Query::GetChunk(address) => NetworkAddress::from_chunk_address(*address),
             Query::GetReplicatedData { address, .. } => address.clone(),
         }
@@ -53,6 +56,9 @@ impl Query {
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Query::GetStoreCost(address) => {
+                write!(f, "Query::GetStoreCost({address:?})")
+            }
             Query::GetChunk(address) => {
                 write!(f, "Query::GetChunk({address:?})")
             }

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -8,12 +8,15 @@
 
 use crate::{error::Result, messages::ReplicatedData, storage::Chunk, NetworkAddress};
 use serde::{Deserialize, Serialize};
+use sn_dbc::Token;
 use std::fmt::Debug;
 
 /// The response to a query, containing the query result.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 pub enum QueryResponse {
+    /// The store cost in nanos for storing the next record, and the node's singature over that cost.
+    GetStoreCost(Result<(Token, Vec<u8>)>),
     //
     // ===== Chunk =====
     //


### PR DESCRIPTION
Atop the store cost work.

This adds basic protocol support for retrieving StoreCost from nodes.

I'm imagining we'd first do `GetClosest<PaymentRoot>`, and then query each for their storecost (which will need to be signed).

I'm not sure if we can roll that easily into one command over kad, or it'll need to be such a combo of calls? (or indeed if this is a bit of a naiive approach altogether?)

TODO: 

- [x] Sign the token payload as well (I'm not sure how/where to sign at the moment 🤔 )

reviewpad:summary 
