### PR TITLE
Tweak store cost + one in one out for data

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -65,13 +65,6 @@ jobs:
           faucet-path: target/release/faucet
           platform: ubuntu-latest
 
-
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -93,7 +93,7 @@ jobs:
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!
@@ -106,7 +106,7 @@ jobs:
           cargo run --bin safe --release -- files upload -- "./target/release/testnet"
         env:
           SN_LOG: "all"
-        timeout-minutes: 10
+        timeout-minutes: 25
 
       - name: Chunks data integrity during nodes churn
         run: cargo test --release -p sn_node --test data_with_churn -- --nocapture 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -181,7 +181,7 @@ jobs:
         run: cargo run --bin safe --release -- files upload -- "./resources" 
         env:
           SN_LOG: "all"
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       - name: Start a client to download files
         run: cargo run --bin safe --release -- files download

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "serde",
  "sn_dbc",
  "sn_protocol",
+ "sn_transfers",
  "thiserror",
  "tokio",
  "tracing",

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -355,7 +355,7 @@ impl Client {
         trace!("Getting spend {dbc_id:?} with record_key {key:?}");
         let record = self
             .network
-            .get_record_from_network(key.clone(), None, false)
+            .get_record_from_network(key.clone(), None, true)
             .await
             .map_err(|err| {
                 Error::CouldNotVerifyTransfer(format!("dbc_id {dbc_id:?} errored: {err:?}"))

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -358,9 +358,7 @@ impl Client {
             .get_record_from_network(key.clone(), None, false)
             .await
             .map_err(|err| {
-                Error::CouldNotVerifyTransfer(format!(
-                    "Can't find record for the dbc_id {dbc_id:?} with error {err:?}"
-                ))
+                Error::CouldNotVerifyTransfer(format!("dbc_id {dbc_id:?} errored: {err:?}"))
             })?;
         debug!(
             "For spend {dbc_id:?} got record from the network, {:?}",

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use super::wallet::send;
 use crate::Client;
 
@@ -46,7 +44,6 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
         faucet_balance,
         faucet_wallet.address(),
         client,
-        // we should not need to wait for this
         true,
     )
     .await;
@@ -60,14 +57,9 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
 
     println!("Verifying the transfer from genesis...");
     if let Err(error) = client.verify(&dbc).await {
-        println!("Could not verify the transfer from genesis, retrying after 20 secs...");
-        println!("The error was: {error:?}");
-        tokio::time::sleep(Duration::from_secs(20)).await;
-        if let Err(error) = client.verify(&dbc).await {
-            panic!("Could not verify the transfer from genesis: {error:?}");
-        } else {
-            println!("Successfully verified the transfer from genesis on the second try.");
-        }
+        panic!("Could not verify the transfer from genesis: {error:?}");
+    } else {
+        println!("Successfully verified the transfer from genesis on the second try.");
     }
 
     faucet_wallet

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -25,6 +25,7 @@ rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.4.2" }
 sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_transfers = { path = "../sn_transfers", version = "0.10.17"}
 thiserror = "1.0.23"
 tokio = { version = "1.17.0", features = ["fs", "io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -485,7 +485,11 @@ mod tests {
         assert!(store.put(r.clone()).is_ok());
         assert!(store.get(&r.key).is_none());
         // Store cost should not change if no PUT has been added
-        assert!(store.store_cost() == store_cost_before);
+        assert_eq!(
+            store.store_cost(),
+            store_cost_before,
+            "store cost should not change over unverified put"
+        );
 
         let returned_record = if let Some(event) = network_event_receiver.recv().await {
             if let NetworkEvent::UnverifiedRecord(record) = event {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -211,10 +211,6 @@ impl DiskBackedRecordStore {
     fn prune_storage_if_needed(&mut self) -> Result<()> {
         let num_records = self.records.len();
         let mut should_prune = num_records >= self.config.max_records;
-        if !should_prune {
-            // check the modulo of record count over 10, if 0 we should prune
-            should_prune = num_records % PRUNE_ONCE_EVERY_PUTS == 0;
-        }
 
         if should_prune {
             self.prune_storage();

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -17,6 +17,7 @@ use libp2p::{
 use rand::Rng;
 use sn_dbc::Token;
 use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
+use sn_transfers::dbc_genesis::TOTAL_SUPPLY;
 use std::{
     borrow::Cow,
     collections::{hash_set, HashSet},
@@ -254,7 +255,7 @@ impl DiskBackedRecordStore {
         // So we get the total amount of nanos in the network,
         // we divide that number by our MAX_RECORD_COUNT to know
         // what to charge for each additional record
-        let step_per_record = ((2 ^ 32) * NANOS_PER_SNT) / MAX_RECORDS_COUNT as u64;
+        let step_per_record = TOTAL_SUPPLY / MAX_RECORDS_COUNT as u64;
         let step_amount = Token::from_nano(step_per_record);
 
         // we want to spread the cost of storing data across the MAX_CAPACITY

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -183,10 +183,8 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
     println!("Paying for {} random addresses...", chunks.len());
 
     let proofs = wallet_client
-        .pay_for_storage(chunks.iter().map(|c| c.name()), false)
+        .pay_for_storage(chunks.iter().map(|c| c.name()), true)
         .await?;
-
-    sleep(Duration::from_secs(5)).await;
 
     files_api
         .upload_with_proof(content_bytes, &proofs, true)

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -30,7 +30,7 @@ pub(super) const GENESIS_DBC_AMOUNT: u64 = (0.3 * TOTAL_SUPPLY as f64) as u64;
 pub(super) type GenesisResult<T> = Result<T, Error>;
 
 /// Total supply of tokens that will eventually exist in the network: 4,294,967,295 * 10^9 = 4,294,967,295,000,000,000.
-const TOTAL_SUPPLY: u64 = u32::MAX as u64 * u64::pow(10, 9);
+pub const TOTAL_SUPPLY: u64 = u32::MAX as u64 * u64::pow(10, 9);
 
 /// The secret key for the genesis DBC.
 ///


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 05:18 UTC
This pull request includes the following changes:

- Added the "sn_transfers" dependency to the Cargo.lock and Cargo.toml files in the sn_networking module.
- Modified the VERIFICATION_ATTEMPTS constant from 30 to 10 in the lib.rs file of the sn_networking module.
- Made changes to the record_store.rs file in the sn_networking module:
  - Added the "sn_transfers" import.
  - Used the TOTAL_SUPPLY constant from the sn_transfers module.
  - Removed the PRUNE_ONCE_EVERY_PUTS constant.
  - Updated the prune_storage_if_needed_for_record method to prune records based on the distance to the local key, instead of using PRUNE_ONCE_EVERY_PUTS.
- Updated the TOTAL_SUPPLY constant to be pub in the dbc_genesis.rs file of the sn_transfers module.
<!-- reviewpad:summarize:end --> 
