### PR TITLE
fix(node): set distance range to prune records

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -9,7 +9,7 @@
 use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
 use crate::{error::Result, multiaddr_pop_p2p, CLOSE_GROUP_SIZE};
 use libp2p::{
-    kad::{store::RecordStore, Quorum, Record, RecordKey},
+    kad::{store::RecordStore, KBucketDistance as Distance, Quorum, Record, RecordKey},
     swarm::{
         dial_opts::{DialOpts, PeerCondition},
         DialError,
@@ -105,6 +105,10 @@ pub enum SwarmCmd {
         peer: PeerId,
         keys: Vec<NetworkAddress>,
     },
+    // Set the acceptable range of `Record` entry. Records outside this range are pruned.
+    SetRecordDistanceRange {
+        distance: Distance,
+    },
 }
 
 /// Snapshot of information kept in the Swarm's local state
@@ -131,6 +135,13 @@ impl SwarmDriver {
                 if !keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }
+            }
+            SwarmCmd::SetRecordDistanceRange { distance } => {
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .set_distance_range(distance);
             }
             SwarmCmd::GetNetworkRecord { key, sender } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -432,7 +432,7 @@ impl SwarmDriver {
         Ok(())
     }
 
-    // get all the peers from our local RoutingTable
+    // get all the peers from our local RoutingTable. Contains self
     pub(super) fn get_all_local_peers(&mut self) -> Vec<PeerId> {
         let mut all_peers: Vec<PeerId> = vec![];
         for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
@@ -451,7 +451,7 @@ impl SwarmDriver {
             sort_peers_by_address(
                 all_peers,
                 &NetworkAddress::from_peer(self.self_peer_id),
-                CLOSE_GROUP_SIZE + 1,
+                CLOSE_GROUP_SIZE,
             )
             .ok()?
         };

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -39,7 +39,10 @@ use futures::{future::select_all, StreamExt};
 use libp2p::mdns;
 use libp2p::{
     identity::Keypair,
-    kad::{KBucketKey, Kademlia, KademliaConfig, QueryId, Record, RecordKey},
+    kad::{
+        KBucketDistance as Distance, KBucketKey, Kademlia, KademliaConfig, QueryId, Record,
+        RecordKey,
+    },
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{behaviour::toggle::Toggle, StreamProtocol, Swarm, SwarmBuilder},
@@ -722,6 +725,12 @@ impl Network {
         keys: Vec<NetworkAddress>,
     ) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { peer, keys })
+    }
+
+    /// Set the acceptable range of record entry. A record is removed from the storage if the
+    /// distance between the record and the node is greater than the provided `distance`.
+    pub fn set_record_distance_range(&self, distance: Distance) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::SetRecordDistanceRange { distance })
     }
 
     /// Send `Request` to the the given `PeerId` and await for the response. If `self` is the recipient,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -66,6 +66,7 @@ use tracing::warn;
 /// The maximum number of peers to return in a `GetClosestPeers` response.
 /// This is the group size used in safe network protocol to be responsible for
 /// an item in the network.
+/// The peer should be present among the CLOSE_GROUP_SIZE if we're fetching the close_group(peer)
 pub const CLOSE_GROUP_SIZE: usize = 8;
 
 // Timeout for requests sent/received through the request_response behaviour.
@@ -116,7 +117,7 @@ pub struct SwarmDriver {
     local: bool,
     /// A list of the most recent peers we have dialed ourselves.
     dialed_peers: CircularVec<PeerId>,
-    /// The peers that are closer to our PeerId
+    /// The peers that are closer to our PeerId. Includes self.
     close_group: Vec<PeerId>,
     is_client: bool,
 }

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -263,6 +263,11 @@ impl DiskBackedRecordStore {
         trace!("Cost is now {cost:?}");
         cost
     }
+
+    /// Setup the distance range.
+    pub fn set_distance_range(&mut self, distance_range: Distance) {
+        self.distance_range = Some(distance_range);
+    }
 }
 
 impl RecordStore for DiskBackedRecordStore {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -54,6 +54,16 @@ impl Node {
             }
             self.send_replicate_cmd_without_wait(&our_address, &peer_id, remaining_keys.to_vec())?;
         }
+
+        // set the distance range used for pruning
+        let distance_range = match our_close_group.get(CLOSE_GROUP_SIZE) {
+            Some(peer) => NetworkAddress::from_peer(*peer).distance(&our_address),
+            None => {
+                debug!("Could not obtain distance_range");
+                return Ok(());
+            }
+        };
+        self.network.set_record_distance_range(distance_range)?;
         Ok(())
     }
 


### PR DESCRIPTION
Sets the distance range as the distance to our 8th closest node.
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 07:05 UTC
This pull request includes two patches. 

First patch: 
- In the `sn_networking/src/event.rs` file, the `get_all_local_peers` function has been modified to remove self from the peers obtained from the local routing table. 
- In the `sn_networking/src/event.rs` file, the `check_for_change_in_our_close_group` function has been modified to remove self from the closest peers if they are not empty.

Second patch: 
- In the `sn_networking/src/lib.rs` file, the `SwarmCmd` enum has been modified to include a new command `SetRecordDistanceRange` that sets the acceptable range of `Record` entry. 
- In the `sn_networking/src/lib.rs` file, the `set_record_distance_range` function has been added to the `Network` struct to set the acceptable range of record entry. 
- In the `sn_networking/src/cmd.rs` file, the `SetRecordDistanceRange` command has been implemented to set the distance range in the `DiskBackedRecordStore` struct. 
- In the `sn_networking/src/record_store.rs` file, the `set_distance_range` function has been added to the `DiskBackedRecordStore` struct to set the distance range used for pruning. 
- In the `sn_node/src/replication.rs` file, the `replicate` function has been modified to calculate the distance range based on the last element of the close group and set it using the `set_record_distance_range` function.

Overall, these patches fix issues related to the inclusion of self in the close group and set the distance range for record entry pruning.
<!-- reviewpad:summarize:end --> 
