### PR TITLE
chore(testnet): build only the provided binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This is the Safe Network as it was supposed to be, on a kademlia network, enable
 You'll need to set the `SAFE_PEERS` env variable to the multiaddress of a node when you set up a testnet.
 You can do this automatically at network startup using the following command (if you have ripgrep installed)
 ```bash
-killall safenode || true && RUST_LOG=safenode,safe cargo run --bin testnet -- -b --interval 100  && export SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')
+killall safenode || true && RUST_LOG=safenode,safe cargo run --bin testnet -- --build-node --build-faucet --interval 100  && export SAFE_PEERS=$(rg "listening on \".+\"" ~/.safe -u | rg '/ip4.*$' -m1 -o | rg '"' -r '')
 ```
 
 This will set the env var for you and so you can run the client without needing to manually pass in `--peer` args.
 
 Or alternatively run with local discovery enabled (mDNS)
-`killall safenode || true && RUST_LOG=safenode,safe cargo run --bin testnet --features local-discovery -- -b --interval 100`
+`killall safenode || true && RUST_LOG=safenode,safe cargo run --bin testnet --features local-discovery -- --build-node --build-faucet --interval 100`
 
 ## Actions undertaken by a client accessing the network
 


### PR DESCRIPTION
Build only the specific binary instead of building everything.
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 08:36 UTC
This pull request includes two patches. 

The first patch modifies the `main.rs` file in the `sn_testnet` directory. It changes the logic for building binaries. Instead of building all binaries, it now builds only the provided binaries specified in the `build_binaries` function, which is called by the `main` function. This change allows for more flexibility in building specific binaries.

The second patch modifies the `README.md` file. It updates the command examples for launching the testnet to include the `--build-node` and `--build-faucet` arguments. This change ensures that the node and faucet binaries are built before launching the testnet.

Overall, these changes improve the build process and make it easier to launch the testnet with the desired binaries.
<!-- reviewpad:summarize:end --> 
