### PR TITLE
ci: try using mold linker on ci

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -90,6 +90,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: rui314/setup-mold@v1
+
       - uses: actions/checkout@v3
 
       - name: Install Rust
@@ -147,6 +148,14 @@ jobs:
       - name: Build node and client
         run: cargo build --release --bin safenode --bin safe --bin faucet
         timeout-minutes: 30
+
+      - name: install readelf
+        if : matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y binutils          
+        
+      - name: check mold is used in compilation
+        if : matrix.os == 'ubuntu-latest'
+        run : readelf -p .comment ./target/release/safenode
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,6 +18,7 @@ jobs:
     name: Unused dependency check
     runs-on: ubuntu-latest
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
 
       - name: Install Rust
@@ -51,6 +52,7 @@ jobs:
     name: various checks
     runs-on: ubuntu-latest
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
 
       - name: Install Rust
@@ -87,6 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
 
       - name: Install Rust
@@ -133,6 +136,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -223,6 +227,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
 
       - name: Install Rust
@@ -297,6 +302,7 @@ jobs:
           - os: macos-latest
             node_data_path: /Users/runner/Library/Application Support/safe/node
     steps:
+      - uses: rui314/setup-mold@v1
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 08:48 UTC
This pull request updates the CI configuration to use the mold linker in the continuous integration (CI) process. It adds the `rui314/setup-mold` action to the workflow file, which sets up the mold linker. This allows for various checks and tests to be run on different operating systems using the mold linker. The patch also includes additional steps to install Rust and set the Rust toolchain. Overall, this update aims to improve the CI process by incorporating the mold linker.
<!-- reviewpad:summarize:end --> 
