### PR TITLE
Put record error improvements

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -18,7 +18,7 @@ use libp2p::{
     Multiaddr,
 };
 use sn_dbc::{DbcId, SignedSpend};
-use sn_networking::{multiaddr_is_global, NetworkEvent, SwarmDriver};
+use sn_networking::{multiaddr_is_global, NetworkEvent, PrettyPrintRecordKey, SwarmDriver};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::PaymentProof,
@@ -253,7 +253,10 @@ impl Client {
             .get_record_from_network(key)
             .await
             .map_err(|_| ProtocolError::RegisterNotFound(address))?;
-        debug!("Got record from the network, {:?}", record.key);
+        debug!(
+            "Got record from the network, {:?}",
+            PrettyPrintRecordKey::from(record.key.clone())
+        );
         let header = RecordHeader::from_record(&record)
             .map_err(|_| ProtocolError::RegisterNotFound(address))?;
 
@@ -350,7 +353,10 @@ impl Client {
                     "Can't find record for the dbc_id {dbc_id:?} with error {err:?}"
                 ))
             })?;
-        debug!("Got record from the network, {:?}", record.key);
+        debug!(
+            "Got record from the network, {:?}",
+            PrettyPrintRecordKey::from(record.key.clone())
+        );
 
         let header = RecordHeader::from_record(&record).map_err(|err| {
             Error::CouldNotVerifyTransfer(format!(

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -12,8 +12,8 @@ use super::{
     SwarmDriver,
 };
 use crate::{
-    multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE,
-    IDENTIFY_AGENT_STR,
+    multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, PrettyPrintRecordKey,
+    CLOSE_GROUP_SIZE, IDENTIFY_AGENT_STR,
 };
 use itertools::Itertools;
 #[cfg(feature = "local-discovery")]
@@ -359,7 +359,7 @@ impl SwarmDriver {
                 if let Some(sender) = self.pending_query.remove(&id) {
                     trace!(
                         "Query task {id:?} returned with record {:?} from peer {:?}, {stats:?} - {step:?}",
-                        peer_record.record.key,
+                        PrettyPrintRecordKey::from(peer_record.record.key.clone()),
                         peer_record.peer
                     );
                     sender

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -17,6 +17,8 @@ mod msg;
 mod record_store;
 mod replication_fetcher;
 
+use crate::error::PrettyPrintRecordKey;
+
 pub use self::{
     cmd::SwarmLocalState,
     error::Error,
@@ -662,8 +664,9 @@ impl Network {
 
     async fn put_record_once(&self, record: Record, verify_store: bool) -> Result<()> {
         let the_record = record.clone();
+        let pretty = PrettyPrintRecordKey::from(record.key.clone());
         debug!(
-            "Putting record of {:?} - length {:?} to network",
+            "Putting record of {:?}({pretty}) - length {:?} to network",
             the_record.key,
             record.value.len()
         );

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -679,9 +679,9 @@ impl Network {
         }
 
         if something_different_was_found {
-            Err(Error::ReturnedRecordDoesNotMatch(the_record.key))
+            Err(Error::ReturnedRecordDoesNotMatch(the_record.key.into()))
         } else {
-            Err(Error::FailedToVerifyRecordWasStored(the_record.key))
+            Err(Error::FailedToVerifyRecordWasStored(the_record.key.into()))
         }
     }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -17,11 +17,9 @@ mod msg;
 mod record_store;
 mod replication_fetcher;
 
-use crate::error::PrettyPrintRecordKey;
-
 pub use self::{
     cmd::SwarmLocalState,
-    error::Error,
+    error::{Error, PrettyPrintRecordKey},
     event::{MsgResponder, NetworkEvent},
 };
 
@@ -664,10 +662,9 @@ impl Network {
 
     async fn put_record_once(&self, record: Record, verify_store: bool) -> Result<()> {
         let the_record = record.clone();
-        let pretty = PrettyPrintRecordKey::from(record.key.clone());
         debug!(
-            "Putting record of {:?}({pretty}) - length {:?} to network",
-            the_record.key,
+            "Putting record of {} - length {:?} to network",
+            PrettyPrintRecordKey::from(record.key.clone()),
             record.value.len()
         );
         // Waiting for a response to avoid flushing to network too quick that causing choke
@@ -697,7 +694,7 @@ impl Network {
                 Err(error) => {
                     verification_attempts += 1;
                     warn!(
-                        "Did not retrieve Record '{:?}' from all nodes in the close group!. Retrying...", the_record.key
+                        "Did not retrieve Record '{:?}' from all nodes in the close group!. Retrying...", PrettyPrintRecordKey::from(the_record.key.clone()),
                     );
                     error!("{error:?}");
                 }
@@ -719,7 +716,7 @@ impl Network {
     pub fn put_local_record(&self, record: Record) -> Result<()> {
         debug!(
             "Writing Record locally, for {:?} - length {:?}",
-            record.key,
+            PrettyPrintRecordKey::from(record.key.clone()),
             record.value.len()
         );
         self.send_swarm_cmd(SwarmCmd::PutLocalRecord { record })

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -5,7 +5,7 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-use crate::event::NetworkEvent;
+use crate::{event::NetworkEvent, PrettyPrintRecordKey};
 use libp2p::{
     identity::PeerId,
     kad::{
@@ -289,13 +289,16 @@ impl RecordStore for DiskBackedRecordStore {
 
     fn put(&mut self, record: Record) -> Result<()> {
         if self.records.contains(&record.key) {
-            trace!("Unverified Record {:?} already exists.", record.key);
+            trace!(
+                "Unverified Record {:?} already exists.",
+                PrettyPrintRecordKey::from(record.key.clone())
+            );
             // Blindly sent to validation to allow double spend can be detected.
             // TODO: consider avoid throw duplicated chunk to validation.
         }
         trace!(
             "Unverified Record {:?} try to validate and store",
-            record.key
+            PrettyPrintRecordKey::from(record.key.clone())
         );
         if let Some(event_sender) = self.event_sender.clone() {
             // push the event off thread so as to be non-blocking

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -9,7 +9,9 @@
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
 use libp2p::{autonat::NatStatus, identity::Keypair, kad::K_VALUE, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
+use sn_networking::{
+    MsgResponder, NetworkEvent, PrettyPrintRecordKey, SwarmDriver, SwarmLocalState,
+};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::{Cmd, CmdResponse, Query, QueryResponse, ReplicatedData, Request, Response},
@@ -265,7 +267,7 @@ impl Node {
                 }
             }
             NetworkEvent::UnverifiedRecord(record) => {
-                let key = record.key.clone();
+                let key = PrettyPrintRecordKey::from(record.key.clone());
                 match self.validate_and_store_record(record).await {
                     Ok(cmdok) => trace!("UnverifiedRecord {key:?} stored with {cmdok:?}."),
                     Err(err) => {

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -8,6 +8,7 @@
 
 use crate::Node;
 use sn_dbc::SignedSpend;
+use sn_networking::PrettyPrintRecordKey;
 use sn_protocol::{
     error::{Error, Result},
     messages::ReplicatedData,
@@ -27,7 +28,10 @@ impl Node {
             .get_record_from_network(key)
             .await
             .map_err(|_| Error::ChunkNotFound(address))?;
-        debug!("Got record from the network, {:?}", record.key);
+        debug!(
+            "Got record from the network, {:?}",
+            PrettyPrintRecordKey::from(record.key.clone())
+        );
         let header =
             RecordHeader::from_record(&record).map_err(|_| Error::ChunkNotFound(address))?;
 
@@ -48,7 +52,10 @@ impl Node {
             .get_record_from_network(key)
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
-        debug!("Got record from the network, {:?}", record.key);
+        debug!(
+            "Got record from the network, {:?}",
+            PrettyPrintRecordKey::from(record.key.clone())
+        );
         let header =
             RecordHeader::from_record(&record).map_err(|_| Error::SpendNotFound(address))?;
 


### PR DESCRIPTION
## Description

- make errors actionable by printing `XorName` formatted `kad::RecordKeys` so client can copy paste them and get the failing record manually
- records put retries up to 3 times when `verify` is activated and fails

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jul 23 09:45 UTC
This pull request introduces two new features. 

In the first patch, the `sn_networking` module now provides actionable error messages for record key errors. Previously, the error messages only displayed the `kad::RecordKey` type, which was not very useful for clients. Now, the `Error` enum includes a new variant `FailedToVerifyRecordWasStored` that wraps a `PrettyPrintRecordKey` struct. This struct implements `std::fmt::Display` and `std::fmt::Debug` to generate a hex-string representation of the record key, making it more actionable for clients. The patch also includes a new test that ensures the hex-string representation of `kad::RecordKey` matches the representation of the corresponding `xor_name::XorName`.

In the second patch, the `Network` struct now supports retries when putting records to the network. There is a new constant `PUT_RECORD_RETRIES` that determines the number of retries. The `put_record` method has been split into two private methods: `put_record_with_retries` and `put_record_once`. The former performs the actual putting of the record and verifies its storage, while the latter is used for a single attempt without verification. If verification fails, the method will retry according to the specified number of retries. If verification still fails after all retries, an error is returned.
<!-- reviewpad:summarize:end --> 
