### PR TITLE
chore(CI): more tracable wallet setup for memcheck

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -86,7 +86,10 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) > initial_balance_from_faucet
+          cat initial_balance_from_faucet
+          cat initial_balance_from_faucet | tail -n 1 > dbc_hex
+          cat dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jul 23 11:37 UTC
This pull request updates the memcheck workflow by adding more traceability to the wallet setup for memcheck. It modifies the ".github/workflows/memcheck.yml" file, specifically the "Create and fund a wallet to pay for files storage" step. Now, it not only saves the initial balance from the faucet to "initial_balance_from_faucet", but also displays its content with "cat", saves the last line to "dbc_hex", and displays its content as well. Finally, it deposits the content of "dbc_hex" into the wallet.
<!-- reviewpad:summarize:end --> 
