### PR TITLE
fix(ci): use testnet_action to upload node,client log files

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -152,13 +152,33 @@ jobs:
           fi
         if: always()
 
+      ########################
+      ### Clean            ###
+      ########################
+
       - name: Stop the local network and upload logs
         if: always()
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_benchmark
+          log_file_prefix: safe_test_logs_benchmark_prs
           platform: ${{ matrix.os }}
+
+      - name: Tar heapnode files
+        shell: bash
+        continue-on-error: true
+        run: |
+          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
+          find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
+        if: always()
+
+      - name: Upload heapnode logs
+        uses: actions/upload-artifact@main
+        with:
+          name: heapnode_benchmark_prs
+          path: log_files.tar.gz
+        if: always()
+        continue-on-error: true
       
       #########################
       ### Node Mem Analysis ###

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -152,35 +152,13 @@ jobs:
           fi
         if: always()
 
-      ########################
-      ### Clean            ###
-      ########################
-      - name: Kill all nodes
-        shell: bash
-        timeout-minutes: 1
-        if: failure()
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files
-        shell: bash
-        continue-on-error: true
-        run: |
-          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
-          find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
-          find $CLIENT_DATA_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
-          find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
+      - name: Stop the local network and upload logs
         if: always()
-
-      - name: Upload Logs
-        uses: actions/upload-artifact@main
+        uses: maidsafe/sn-local-testnet-action@main
         with:
-          name: sn_node_logs_benchmark_prs
-          path: log_files.tar.gz
-        if: always()
-        continue-on-error: true
+          action: stop
+          log_file_prefix: safe_test_logs_benchmark
+          platform: ${{ matrix.os }}
       
       #########################
       ### Node Mem Analysis ###

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Start a heaptracked client instance to compare memory usage
         shell: bash
-        run: heaptrack ./target/release/safe --log-output-dest data-dir files upload the-test-data.zip
+        run: heaptrack ./target/release/safe --log-output-dest=data-dir files upload the-test-data.zip
         env:
           SN_LOG: "all"
 

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Start a heaptracked client instance to compare memory usage
         shell: bash
-        run: heaptrack ./target/release/safe --log-output-dest data-dir files upload the-test-data.zip
+        run: heaptrack ./target/release/safe --log-output-dest=data-dir files upload the-test-data.zip
         env:
           SN_LOG: "all"
 

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -122,35 +122,13 @@ jobs:
         env:
           SN_LOG: "all"
 
-      ########################
-      ### Clean            ###
-      ########################
-      - name: Kill all nodes
-        shell: bash
-        timeout-minutes: 1
+      - name: Stop the local network and upload logs
         if: always()
-        continue-on-error: true
-        run: |
-          pkill safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
-
-      - name: Tar log files
-        shell: bash
-        continue-on-error: true
-        run: |
-          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
-          find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
-          find $CLIENT_DATA_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
-          find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
-        if: always()
-
-      - name: Upload Logs
-        uses: actions/upload-artifact@main
+        uses: maidsafe/sn-local-testnet-action@main
         with:
-          name: sn_logs_benchmark_chart_generation
-          path: log_files.tar.gz
-        if: always()
-        continue-on-error: true
+          action: stop
+          log_file_prefix: safe_test_logs_benchmark_charts
+          platform: ${{ matrix.os }}
       
       #########################
       ### Node Mem Analysis ###

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -122,6 +122,9 @@ jobs:
         env:
           SN_LOG: "all"
 
+      ########################
+      ### Clean            ###
+      ########################
       - name: Stop the local network and upload logs
         if: always()
         uses: maidsafe/sn-local-testnet-action@main
@@ -129,6 +132,22 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_benchmark_charts
           platform: ${{ matrix.os }}
+
+      - name: Tar heapnode log files
+        shell: bash
+        continue-on-error: true
+        run: |
+          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
+          find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
+        if: always()
+
+      - name: Upload heapnode Logs
+        uses: actions/upload-artifact@main
+        with:
+          name: heapnode_benchmark_chart_generation
+          path: log_files.tar.gz
+        if: always()
+        continue-on-error: true
       
       #########################
       ### Node Mem Analysis ###

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
-  CLIENT_LOG_PATH: /tmp/safe-client
   NODE_DATA_PATH: /home/runner/.local/share/safe/node
   HEAPNODE_DATA_PATH: /home/runner/.local/share/safe/heapnode
 
@@ -192,14 +191,13 @@ jobs:
         run: pgrep safenode | wc -l
         if: always()
 
-      - name: Kill all nodes
-        shell: bash
-        timeout-minutes: 1
-        continue-on-error: true
-        run: |
-          killall safenode
-          echo "$(pgrep safenode | wc -l) nodes still running"
+      - name: Stop the local network and upload logs
         if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_memcheck
+          platform: ${{ matrix.os }}
 
       - name: Check for heaptrack file
         run: ls -la
@@ -244,28 +242,6 @@ jobs:
           fi
         if: always()
 
-      - name: Tar node log files
-        shell: bash
-        continue-on-error: true
-        run: |
-          find $HEAPNODE_DATA_PATH -iname '*.log*' | tar -zcvf heap_node_log_files.tar.gz --files-from -
-          find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
-        if: failure()
-
-      - name: Tar client log files
-        shell: bash
-        continue-on-error: true
-        run: |
-          find $CLIENT_LOG_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
-        if: failure()
-
-      - name: Tar log files for upload
-        shell: bash
-        continue-on-error: true
-        run: |
-          find . -iname '*log_files.tar.gz' | tar -zcvf log_files.tar.gz --files-from -
-        if: failure()
-
       - name: Upload Heaptrack
         uses: actions/upload-artifact@main
         with:
@@ -273,11 +249,3 @@ jobs:
           path: heaptrack.safenode.*
         continue-on-error: true
         if: always()
-
-      - name: Upload Node Logs
-        uses: actions/upload-artifact@main
-        with:
-          name: sn_node_logs_memcheck
-          path: log_files.tar.gz
-        if: failure()
-        continue-on-error: true

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -85,11 +85,11 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) > initial_balance_from_faucet
+          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet
           cat initial_balance_from_faucet
           cat initial_balance_from_faucet | tail -n 1 > dbc_hex
           cat dbc_hex
-          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+          cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -99,10 +99,10 @@ jobs:
       - name: Start a client to upload files
         run: |
           ls -l ./target/release
-          cargo run --bin safe --release -- files upload -- "./target/release/faucet"
-          cargo run --bin safe --release -- files upload -- "./target/release/safe"
-          cargo run --bin safe --release -- files upload -- "./target/release/safenode"
-          cargo run --bin safe --release -- files upload -- "./target/release/testnet"
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/faucet"
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/safe"
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/safenode"
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/testnet"
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -173,7 +173,7 @@ jobs:
 
       - name: Start a client to download files
         run: |
-          cargo run --bin safe --release -- files download
+          cargo run --bin safe --release -- --log-output-dest=data-dir files download
           ls -l $CLIENT_DATA_PATH/downloaded_files
           downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
           if [ $downloaded_files -lt 4 ]; then

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -165,44 +165,44 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
-          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"
         timeout-minutes: 5
 
       - name: Start a client to pay for files storage
-        run: cargo run --bin safe --release -- wallet pay "./resources" 
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir wallet pay "./resources"
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: Start a client to upload files
-        run: cargo run --bin safe --release -- files upload -- "./resources" 
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./resources"
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: Start a client to download files
-        run: cargo run --bin safe --release -- files download
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files download
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to create a register
-        run: cargo run --bin safe --release -- register create baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: Start a client to get a register
-        run: cargo run --bin safe --release -- register get baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to edit a register
-        run: cargo run --bin safe --release -- register edit baobao wood
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit baobao wood
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,38 +47,38 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
-          cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
+          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to pay for files storage
-        run: cargo run --bin safe --release -- wallet pay "./resources"
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir wallet pay "./resources"
         env:
           SN_LOG: "all"
         timeout-minutes: 2
     
       - name: Start a client to carry out chunk actions
-        run: cargo run --bin safe --release -- files upload "./resources"
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources"
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to create a register
-        run: cargo run --bin safe --release -- register create baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to get a register
-        run: cargo run --bin safe --release -- register get baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to edit a register
-        run: cargo run --bin safe --release -- register edit baobao wood
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit baobao wood
         env:
           SN_LOG: "all"
         timeout-minutes: 2


### PR DESCRIPTION
- use `testnet_action` to upload client and node logs
- provide `log-output-dest` to `safe` bin to enable logging
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jul 23 16:46 UTC
This pull request includes the following changes:

1. Removed the `CLIENT_LOG_PATH` environment variable.
2. Modified the command `cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- wallet address | tail -n 1) > initial_balance_from_faucet` to `cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet`.
3. Modified the command `cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin` to `cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin`.
4. Modified the commands for uploading files with the `safe` binary to include the `--log-output-dest=data-dir` flag.
5. Modified the command `cargo run --bin safe --release -- files download` to `cargo run --bin safe --release -- --log-output-dest=data-dir files download`.
6. Removed the step for tarring log files.
7. Added a new step to stop the local network and upload logs using the `maidsafe/sn-local-testnet-action@main` action.
8. Removed the step for uploading node logs.

This file diff includes changes to the ".github/workflows/benchmark-prs.yml" file. 

Here are the summarized changes:
1. In the "jobs" section, the "run" command in the "heaptracked client instance" step has been modified to include the "--log-output-dest=data-dir" parameter. 
2. The "Kill all nodes" and "Tar log files" steps have been removed.
3. The "Stop the local network and upload logs" step has been added, using the maidsafe/sn-local-testnet-action@main action.
4. The "Upload Logs" step has been modified to include the "action: stop" parameter and the "log_file_prefix: safe_test_logs_benchmark" and "platform: ${{ matrix.os }}" parameters.

This file diff makes the following changes:

- Line 5: The `--log-output-dest` argument in the `run` command is modified to `--log-output-dest=data-dir` instead of `--log-output-dest data-dir`.
- Lines 26-36: The section for cleaning nodes is removed, including killing all nodes, tar'ing log files, and uploading the logs as artifacts.
- Lines 39-48: The `uses` field in the `Upload Logs` step is modified to use `maidsafe/sn-local-testnet-action` instead of `actions/upload-artifact@main`. It also sets additional parameters such as `action: stop`, `log_file_prefix: safe_test_logs_benchmark_charts`, and `platform: ${{ matrix.os }}`.

The diff of the file `.github/workflows/merge.yml` shows changes in the commands run by the workflow. The `cargo run` commands now include the flag `--log-output-dest=data-dir`, which specifies the directory for log output. This change ensures that the log output is directed to the `data-dir` directory.

Summary of Changes in ".github/workflows/nightly.yml":

- Revised the commands in the "Create and fund a wallet to pay for files storage" step to include the `--log-output-dest=data-dir` flag.
- Revised the commands in the "Start a client to pay for files storage" step to include the `--log-output-dest=data-dir` flag.
- Revised the commands in the "Start a client to carry out chunk actions" step to include the `--log-output-dest=data-dir` flag.
- Revised the commands in the "Start a client to create a register" step to include the `--log-output-dest=data-dir` flag.
- Revised the commands in the "Start a client to get a register" step to include the `--log-output-dest=data-dir` flag.
- Revised the commands in the "Start a client to edit a register" step to include the `--log-output-dest=data-dir` flag.

These changes add the `--log-output-dest=data-dir` flag to each command, which specifies the directory where log outputs will be saved.
<!-- reviewpad:summarize:end --> 
