### PR TITLE
refactor(register)!: hashing the node of a Register to sign it instead of bincode-serialising it

### DIFF
--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -161,7 +161,7 @@ impl ClientRegister {
             .check_user_permissions(User::Key(public_key))?;
 
         let (_hash, mut op) = self.register.write(entry.into(), children)?;
-        let signature = self.client.sign(op.bytes_for_signing()?);
+        let signature = self.client.sign(op.bytes_for_signing());
         op.add_signature(public_key, signature)?;
         let cmd = RegisterCmd::Edit(op);
 

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -374,7 +374,7 @@ mod tests {
         let item1 = random_register_entry();
         let (_, op1) = replica1.write(item1, BTreeSet::new())?;
         let mut signed_write_op1 = op1;
-        signed_write_op1.sign_with(&authority_sk1)?;
+        signed_write_op1.sign_with(&authority_sk1);
 
         // Let's assert current state on both replicas
         assert_eq!(replica1.size(), 1);
@@ -384,7 +384,7 @@ mod tests {
         let item2 = random_register_entry();
         let (_, op2) = replica2.write(item2, BTreeSet::new())?;
         let mut signed_write_op2 = op2;
-        signed_write_op2.sign_with(&authority_sk2)?;
+        signed_write_op2.sign_with(&authority_sk2);
 
         // Item should be writeed on replica2
         assert_eq!(replica2.size(), 1);
@@ -633,7 +633,7 @@ mod tests {
             // Write an item on replicas
             let (_, op) = replica1.write(random_register_entry(), BTreeSet::new())?;
             let mut write_op = op;
-            write_op.sign_with(&owner_sk)?;
+            write_op.sign_with(&owner_sk);
             replica2.apply_op(write_op)?;
 
             verify_data_convergence(vec![replica1, replica2], 1)?;
@@ -667,7 +667,7 @@ mod tests {
                 // Write an item on replica1
                 let (hash, op) = replica1.write(random_register_entry(), children.clone())?;
                 let mut write_op = op;
-                write_op.sign_with(&owner_sk)?;
+                write_op.sign_with(&owner_sk);
                 // now apply that op to replica 2
                 replica2.apply_op(write_op)?;
                 children = vec![hash].into_iter().collect();
@@ -709,7 +709,7 @@ mod tests {
                 // Write an item on replica1 using the randomly generated set of children
                 let (hash, op) = replica1.write(random_register_entry(), children)?;
                 let mut write_op = op;
-                write_op.sign_with(&owner_sk)?;
+                write_op.sign_with(&owner_sk);
 
                 // now apply that op to replica 2
                 replica2.apply_op(write_op)?;
@@ -733,7 +733,7 @@ mod tests {
                 // first generate an op from one replica...
                 let (hash, op)= replicas[0].write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
 
                 // then apply this to all replicas
                 for replica in &mut replicas {
@@ -761,7 +761,7 @@ mod tests {
             for _data in dataset {
                 let (hash, op) = replicas[0].write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
                 ops.push(signed_op);
                 children = vec![hash].into_iter().collect();
             }
@@ -795,7 +795,7 @@ mod tests {
                 {
                     let (hash, op) = replica.write(random_register_entry(), children)?;
                     let mut signed_op = op;
-                    signed_op.sign_with(&owner_sk)?;
+                    signed_op.sign_with(&owner_sk);
                     ops.push(signed_op);
                     children = vec![hash].into_iter().collect();
                 }
@@ -844,7 +844,7 @@ mod tests {
             for (_data, delivery_chance) in dataset {
                 let (hash, op)= replica1.write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
 
                 ops.push((signed_op, delivery_chance));
                 children = vec![hash].into_iter().collect();
@@ -888,7 +888,7 @@ mod tests {
 
                 let (hash, op)=replica.write(random_register_entry(), children)?;
                 let mut signed_op = op;
-                signed_op.sign_with(&owner_sk)?;
+                signed_op.sign_with(&owner_sk);
                 ops.push((signed_op, delivery_chance));
                 children = vec![hash].into_iter().collect();
             }
@@ -936,7 +936,7 @@ mod tests {
                 {
                     let (hash, op)=replica.write(random_register_entry(), children)?;
                     let mut signed_op = op;
-                    signed_op.sign_with(&owner_sk)?;
+                    signed_op.sign_with(&owner_sk);
                     ops.push(signed_op);
                     children = vec![hash].into_iter().collect();
                 }
@@ -953,7 +953,7 @@ mod tests {
             for _data in bogus_dataset {
                 let (hash, op)=bogus_replica.write(random_register_entry(), children)?;
                 let mut bogus_op = op;
-                bogus_op.sign_with(&random_owner_sk)?;
+                bogus_op.sign_with(&random_owner_sk);
                 bogus_replica.apply_op(bogus_op.clone())?;
                 ops.push(bogus_op);
                 children = vec![hash].into_iter().collect();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jul 23 17:58 UTC
This pull request refactors the `register.rs` and `register_op.rs` files. Specifically, it implements a change to hash the node of a Register to sign it instead of bincode-serializing it. The patch includes several modifications to sign register operations and verify signatures using secret and public keys. Overall, these changes aim to improve the signing process and ensure integrity in the register operations.
<!-- reviewpad:summarize:end --> 
