### PR TITLE
chore: cleanup old dead API

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -353,11 +353,6 @@ impl Node {
                 let result = self.current_storecost().await;
                 QueryResponse::GetStoreCost(result)
             }
-            Query::GetChunk(address) => {
-                trace!("Got GetChunk query for {address:?}");
-                let result = self.get_chunk_from_network(address).await;
-                QueryResponse::GetChunk(result)
-            }
             Query::GetReplicatedData {
                 requester: _,
                 address,

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{storage::ChunkAddress, NetworkAddress};
+use crate::NetworkAddress;
 
 use serde::{Deserialize, Serialize};
 
@@ -21,13 +21,6 @@ use serde::{Deserialize, Serialize};
 pub enum Query {
     /// Retrieve the cost of storing a record at the given address.
     GetStoreCost(NetworkAddress),
-    /// Retrieve a [`Chunk`] at the given address.
-    ///
-    /// This should eventually lead to a [`GetChunk`] response.
-    ///
-    /// [`Chunk`]:  crate::storage::Chunk
-    /// [`GetChunk`]: super::QueryResponse::GetChunk
-    GetChunk(ChunkAddress),
     /// Retrieve a [`ReplicatedData`] at the given address.
     ///
     /// This should eventually lead to a [`GetReplicatedData`] response.
@@ -47,7 +40,6 @@ impl Query {
     pub fn dst(&self) -> NetworkAddress {
         match self {
             Query::GetStoreCost(address) => address.clone(),
-            Query::GetChunk(address) => NetworkAddress::from_chunk_address(*address),
             Query::GetReplicatedData { address, .. } => address.clone(),
         }
     }
@@ -58,9 +50,6 @@ impl std::fmt::Display for Query {
         match self {
             Query::GetStoreCost(address) => {
                 write!(f, "Query::GetStoreCost({address:?})")
-            }
-            Query::GetChunk(address) => {
-                write!(f, "Query::GetChunk({address:?})")
             }
             Query::GetReplicatedData { requester, address } => {
                 write!(

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{error::Result, messages::ReplicatedData, storage::Chunk, NetworkAddress};
+use crate::{error::Result, messages::ReplicatedData, NetworkAddress};
 use serde::{Deserialize, Serialize};
 use sn_dbc::Token;
 use std::fmt::Debug;
@@ -17,14 +17,6 @@ use std::fmt::Debug;
 pub enum QueryResponse {
     /// The store cost in nanos for storing the next record, and the node's singature over that cost.
     GetStoreCost(Result<(Token, Vec<u8>)>),
-    //
-    // ===== Chunk =====
-    //
-    /// Response to [`GetChunk`]
-    ///
-    /// [`GetChunk`]: crate::messages::Query::GetChunk
-    GetChunk(Result<Chunk>),
-    //
     // ===== ReplicatedData =====
     //
     /// Response to [`GetReplicatedData`]


### PR DESCRIPTION
Now that we use the kad routines for this, these flows are dead code. 

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Aug 23 05:52 UTC
This pull request includes a cleanup of old dead API. It removes the `GetChunk` query and its corresponding implementation, as well as some related code. Overall, this patch reduces code complexity by removing unused functionality.
<!-- reviewpad:summarize:end --> 
