### PR TITLE
ci: remove duplicate faucet claim

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -65,13 +65,6 @@ jobs:
           faucet-path: target/release/faucet
           platform: ubuntu-latest
 
-
-      - name: Start a faucet client to claim genesis
-        run: cargo run --bin faucet --release -- claim-genesis
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Aug 23 06:56 UTC
This pull request increases the timeout for funding genesis in the CI workflow. The timeout-minutes value is changed from 2 to 10 in generate-benchmark-charts.yml file.
<!-- reviewpad:summarize:end --> 
