### PR TITLE
fix: prunning record incorrectly

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet
-          cat initial_balance_from_faucet
-          cat initial_balance_from_faucet | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
+          cat initial_balance_from_faucet.txt
+          cat initial_balance_from_faucet.txt | tail -n 1 > dbc_hex
           cat dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
@@ -247,5 +247,21 @@ jobs:
         with:
           name: heaptrack_safenode
           path: heaptrack.safenode.*
+        continue-on-error: true
+        if: always()
+
+      - name: Upload payment wallet initialization log
+        uses: actions/upload-artifact@main
+        with:
+          name: payment_wallet_initialization_log
+          path: initial_balance_from_faucet.txt
+        continue-on-error: true
+        if: always()
+
+      - name: Upload Faucet folder
+        uses: actions/upload-artifact@main
+        with:
+          name: faucet_folder
+          path: /home/runner/.local/share/safe/test_faucet
         continue-on-error: true
         if: always()

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -336,10 +336,7 @@ jobs:
 
       - name: Chunks data integrity during nodes churn (during 10min) - Linux/MacOS
         if: matrix.os != 'windows-latest'
-        # wait little bit to allow the facuet created within testnet to be fully settled
-        run: |
-          sleep 10
-          cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"
@@ -350,9 +347,7 @@ jobs:
 
       - name: Chunks data integrity during nodes churn (during 10min) - Windows
         if: matrix.os == 'windows-latest'
-        # wait little bit to allow the facuet created within testnet to be fully settled
-        run: |
-          cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -336,7 +336,10 @@ jobs:
 
       - name: Chunks data integrity during nodes churn (during 10min) - Linux/MacOS
         if: matrix.os != 'windows-latest'
-        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        # wait little bit to allow the facuet created within testnet to be fully settled
+        run: |
+          sleep 10
+          cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"
@@ -347,7 +350,9 @@ jobs:
 
       - name: Chunks data integrity during nodes churn (during 10min) - Windows
         if: matrix.os == 'windows-latest'
-        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        # wait little bit to allow the facuet created within testnet to be fully settled
+        run: |
+          cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           # new output folder to avoid linker issues w/ windows
           CARGO_TARGET_DIR: "./churn-target"

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -22,9 +22,6 @@ pub async fn get_tokens_from_faucet(amount: Token, to: PublicAddress, client: &C
 /// Use the client to load the faucet wallet from the genesis Wallet.
 /// With all balance transferred from the genesis_wallet to the faucet_wallet.
 pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWallet {
-    println!("Loading genesis...");
-    let genesis_wallet = load_genesis_wallet().await;
-
     println!("Loading faucet...");
     let mut faucet_wallet = create_faucet_wallet().await;
 
@@ -33,6 +30,9 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> LocalWal
         println!("Faucet wallet balance: {faucet_balance}");
         return faucet_wallet;
     }
+
+    println!("Loading genesis...");
+    let genesis_wallet = load_genesis_wallet().await;
 
     // Transfer to faucet. We will transfer almost all of the genesis wallet's
     // balance to the faucet,.

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -153,7 +153,7 @@ impl DiskBackedRecordStore {
         let content_hash = XorName::from_content(&r.value);
         trace!(
             "PUT a verified Record: {:?} (content_hash {content_hash:?})",
-            r.key
+            PrettyPrintRecordKey::from(r.key.clone())
         );
         if r.value.len() >= self.config.max_value_bytes {
             warn!(
@@ -295,7 +295,10 @@ impl RecordStore for DiskBackedRecordStore {
         // When a client calls GET, the request is forwarded to the nodes until one node returns
         // with the record. Thus a node can be bombarded with GET reqs for random keys. These can be safely
         // ignored if we don't have the record locally.
-        trace!("GET request for Record key: {k:?}");
+        trace!(
+            "GET request for Record key: {:?}",
+            PrettyPrintRecordKey::from(k.clone())
+        );
         if !self.records.contains(k) {
             trace!("Record not found locally");
             return None;

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -302,6 +302,9 @@ async fn run_faucet(bin_path: PathBuf) -> Result<()> {
     let launch_bin = testnet.node_bin_path;
     let args = vec!["server".to_string()];
     testnet.launcher.launch(&launch_bin, args)?;
+    // The launch will immediately complete after fire the cmd out.
+    // Have to wait some extra time to allow the faucet to be properly created and funded
+    std::thread::sleep(std::time::Duration::from_secs(30));
     Ok(())
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Aug 23 11:36 UTC
This pull request includes two patches. 

The first patch "chore: more places to log RecordKey in pretty format" adds logging statements to log the RecordKey in a pretty format in various places in the codebase. The patch modifies the event.rs and record_store.rs files to include the new logging statements.

The second patch "fix(node): expand distance_range of record_store" expands the distance range of the record store in the node. It modifies the record_store.rs file to use the ilog2 value instead of a specific peer distance when pruning storage. This change ensures that nodes clustered within a sub-prefix bucket are properly handled. The patch also includes logging statements to track the pruning process.

Overall, these patches improve logging and enhance the distance range handling in the codebase.
<!-- reviewpad:summarize:end --> 
