### PR TITLE
feat(networking): log external address events

### DIFF
--- a/sn_networking/src/behavior/mod.rs
+++ b/sn_networking/src/behavior/mod.rs
@@ -1,0 +1,88 @@
+use libp2p::core::{Endpoint, Multiaddr};
+use libp2p::identity::PeerId;
+use libp2p::swarm::{
+    derive_prelude::ExternalAddrConfirmed, dummy, ConnectionDenied, ConnectionId,
+    ExternalAddrExpired, FromSwarm, NetworkBehaviour, NewExternalAddrCandidate, PollParameters,
+    THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+};
+use std::task::{Context, Poll};
+
+#[derive(Default, Debug)]
+pub struct ExternalAddrLogBehaviour;
+
+impl ExternalAddrLogBehaviour {}
+
+impl NetworkBehaviour for ExternalAddrLogBehaviour {
+    type ConnectionHandler = dummy::ConnectionHandler;
+    type ToSwarm = ();
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _peer: PeerId,
+        _: &Multiaddr,
+        _: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _peer: Option<PeerId>,
+        _: &[Multiaddr],
+        _: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        Ok(vec![])
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _peer: PeerId,
+        _: &Multiaddr,
+        _: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            FromSwarm::ConnectionClosed(_) => {}
+            FromSwarm::ConnectionEstablished(_) => {}
+            FromSwarm::AddressChange(_) => {}
+            FromSwarm::DialFailure(_) => {}
+            FromSwarm::ListenFailure(_) => {}
+            FromSwarm::NewListener(_) => {}
+            FromSwarm::NewListenAddr(_) => {}
+            FromSwarm::ExpiredListenAddr(_) => {}
+            FromSwarm::ListenerError(_) => {}
+            FromSwarm::ListenerClosed(_) => {}
+            FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr }) => {
+                trace!("NewExternalAddrCandidate: {addr}");
+            }
+            FromSwarm::ExternalAddrExpired(ExternalAddrExpired { addr }) => {
+                trace!("ExternalAddrExpired: {addr}");
+            }
+            FromSwarm::ExternalAddrConfirmed(ExternalAddrConfirmed { addr }) => {
+                trace!("ExternalAddrConfirmed: {addr}");
+            }
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _id: PeerId,
+        _: ConnectionId,
+        _event: THandlerOutEvent<Self>,
+    ) {
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+        _: &mut impl PollParameters,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        Poll::Pending
+    }
+}

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -48,6 +48,7 @@ pub(super) type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "NodeEvent")]
 pub(super) struct NodeBehaviour {
+    pub(super) debug_behavior: crate::behavior::ExternalAddrLogBehaviour,
     pub(super) request_response: request_response::cbor::Behaviour<Request, Response>,
     pub(super) kademlia: Kademlia<DiskBackedRecordStore>,
     #[cfg(feature = "local-discovery")]
@@ -58,12 +59,19 @@ pub(super) struct NodeBehaviour {
 
 #[derive(Debug)]
 pub(super) enum NodeEvent {
+    ExternalAddrLogEvent,
     MsgReceived(request_response::Event<Request, Response>),
     Kademlia(KademliaEvent),
     #[cfg(feature = "local-discovery")]
     Mdns(Box<mdns::Event>),
     Identify(Box<libp2p::identify::Event>),
     Autonat(autonat::Event),
+}
+
+impl From<()> for NodeEvent {
+    fn from(_event: ()) -> Self {
+        NodeEvent::ExternalAddrLogEvent
+    }
 }
 
 impl From<request_response::Event<Request, Response>> for NodeEvent {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 extern crate tracing;
 
+mod behavior;
 mod circular_vec;
 mod cmd;
 mod error;
@@ -378,6 +379,7 @@ impl SwarmDriver {
         let autonat = Toggle::from(autonat);
 
         let behaviour = NodeBehaviour {
+            debug_behavior: crate::behavior::ExternalAddrLogBehaviour,
             request_response,
             kademlia,
             identify,


### PR DESCRIPTION
This adds quite a bit of logging as far as I can see (by running a testnet).

The context to this PR is that it might be that some nodes do not get a confirmed external address and that means other nodes might not be adding nodes to their routing tables. Other nodes might then report `UnroutablePeer`.