### PR TITLE
fix(ci): provide correct platform value

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           action: stop
           log_file_prefix: safe_test_logs_benchmark_prs
-          platform: ${{ matrix.os }}
+          platform: ubuntu-latest
 
       - name: Tar heapnode files
         shell: bash

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           action: stop
           log_file_prefix: safe_test_logs_benchmark_charts
-          platform: ${{ matrix.os }}
+          platform: ubuntu-latest
 
       - name: Tar heapnode log files
         shell: bash

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -75,7 +75,7 @@ jobs:
           interval: 2000
           node-path: target/release/safenode
           faucet-path: target/release/faucet
-          platform: "ubuntu-latest"
+          platform: ubuntu-latest
           set-safe-peers: false
 
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
@@ -197,7 +197,7 @@ jobs:
         with:
           action: stop
           log_file_prefix: safe_test_logs_memcheck
-          platform: ${{ matrix.os }}
+          platform: ubuntu-latest
 
       - name: Check for heaptrack file
         run: ls -la


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Aug 23 17:48 UTC
This pull request fixes the incorrect platform value in the GitHub workflows for benchmarking and memcheck. It changes the platform value from the matrix.os variable to "ubuntu-latest" in order to provide the correct platform value for the respective workflows.
<!-- reviewpad:summarize:end --> 
