### PR TITLE
fix(node): dont loop waiting for contacts for NodeEvent

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
-use libp2p::{autonat::NatStatus, identity::Keypair, kad::K_VALUE, Multiaddr, PeerId};
+use libp2p::{autonat::NatStatus, identity::Keypair, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
 use sn_protocol::{
@@ -21,17 +21,12 @@ use std::{
     net::SocketAddr,
     path::PathBuf,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     time::Duration,
 };
 use tokio::task::spawn;
-
-// returns the primitive K_VALUE
-const fn k_value() -> usize {
-    K_VALUE.get()
-}
 
 /// Once a node is started and running, the user obtains
 /// a `NodeRunning` object which can be used to interact with it.
@@ -112,7 +107,6 @@ impl Node {
         let mut rng = StdRng::from_entropy();
 
         let initial_join_flows_done = Arc::new(AtomicBool::new(false));
-        let peers_connected = Arc::new(AtomicUsize::new(0));
 
         let _handle = spawn(swarm_driver.run());
         let _handle = spawn(async move {
@@ -123,7 +117,6 @@ impl Node {
                 let inactivity_timeout = Duration::from_secs(inactivity_timeout as u64);
 
                 let initial_join_flows_done = initial_join_flows_done.clone();
-                let peers_connected = peers_connected.clone();
 
                 tokio::select! {
                     net_event = network_event_receiver.recv() => {
@@ -131,7 +124,7 @@ impl Node {
                             Some(event) => {
                                 let mut stateless_node_copy = node.clone();
                                 let _handle =
-                                    spawn(async move { stateless_node_copy.handle_network_event(event, peers_connected, initial_join_flows_done).await });
+                                    spawn(async move { stateless_node_copy.handle_network_event(event, initial_join_flows_done).await });
                             }
                             None => {
                                 error!("The `NetworkEvent` channel is closed");
@@ -167,33 +160,8 @@ impl Node {
     async fn handle_network_event(
         &mut self,
         event: NetworkEvent,
-        peers_connected: Arc<AtomicUsize>,
         initial_join_underway_or_done: Arc<AtomicBool>,
     ) {
-        if peers_connected.load(Ordering::Relaxed) < k_value() {
-            // when the node has not been connected to enough peers, it should not perform activities
-            // that might require peers in the RT to succeed.
-            match &event {
-                // these activities requires the node to be connected to some peer to be able to carry
-                // out get kad.get_record etc. This happens during replication/PUT. So we should wait
-                // until we have enough nodes, else these might fail.
-                NetworkEvent::RequestReceived { .. }
-                | NetworkEvent::UnverifiedRecord(_)
-                | NetworkEvent::ResponseReceived { .. }
-                | NetworkEvent::CloseGroupUpdated(_)
-                | NetworkEvent::KeysForReplication(_) => {
-                    warn!("Ignoring event {:?} as the node is not connected to enough peers yet", event);
-                    return;
-                }
-                ,
-                // These events do not need to wait until there are enough peers
-                NetworkEvent::PeerAdded(_)
-                | NetworkEvent::PeerRemoved(_)
-                | NetworkEvent::NewListenAddr(_)
-                | NetworkEvent::NatStatusChanged(_) => {}
-            }
-        }
-
         match event {
             NetworkEvent::RequestReceived { req, channel } => {
                 trace!("RequestReceived: {req:?}");
@@ -206,11 +174,6 @@ impl Node {
                 }
             }
             NetworkEvent::PeerAdded(peer_id) => {
-                // increment peers_connected and send ConnectedToNetwork event if have connected to K_VALUE peers
-                let _ = peers_connected.fetch_add(1, Ordering::SeqCst);
-                if peers_connected.load(Ordering::SeqCst) == k_value() {
-                    self.events_channel.broadcast(NodeEvent::ConnectedToNetwork);
-                }
                 Marker::PeerAddedToRoutingTable(peer_id).log();
 
                 // perform a get_closest query to self on node join. This should help populate the node's RT

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -271,12 +271,18 @@ impl Node {
             }
             NetworkEvent::UnverifiedRecord(record) => {
                 let key = PrettyPrintRecordKey::from(record.key.clone());
-                match self.validate_and_store_record(record).await {
-                    Ok(cmdok) => trace!("UnverifiedRecord {key:?} stored with {cmdok:?}."),
-                    Err(err) => {
-                        trace!("UnverifiedRecord {key:?} failed to be stored with error {err:?}.")
+
+                let node = self.clone();
+                let _handle = spawn(async move {
+                    match node.validate_and_store_record(record).await {
+                        Ok(cmdok) => trace!("UnverifiedRecord {key:?} stored with {cmdok:?}."),
+                        Err(err) => {
+                            trace!(
+                                "UnverifiedRecord {key:?} failed to be stored with error {err:?}."
+                            )
+                        }
                     }
-                }
+                });
             }
         }
     }


### PR DESCRIPTION
This can stall any/all node event handling## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 10:34 UTC
This pull request includes three patches:

Patch 1/3: fix(node): don't loop waiting for contacts for NodeEvent
 - Fixes a bug where the node could stall when handling node events
 - Changes the condition for waiting on certain activities until the node is connected to enough peers

Patch 2/3: chore(node): move validate and store off thread
 - Moves the validation and storage of unverified records to a separate thread
 - Improves performance by offloading the validation and storage process from the main thread

Patch 3/3: chore(node): remove peer_connected altogether
 - Removes the usage of the `peers_connected` atomic variable
 - Simplifies the handling of network events and peer connection management
<!-- reviewpad:summarize:end --> 
