### PR TITLE
chore(node): remove unused mut

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -129,7 +129,7 @@ impl Node {
                     net_event = network_event_receiver.recv() => {
                         match net_event {
                             Some(event) => {
-                                let mut stateless_node_copy = node.clone();
+                                let stateless_node_copy = node.clone();
                                 let _handle =
                                     spawn(async move { stateless_node_copy.handle_network_event(event, peers_connected, initial_join_flows_done).await });
                             }
@@ -165,7 +165,7 @@ impl Node {
     // **** Private helpers *****
 
     async fn handle_network_event(
-        &mut self,
+        &self,
         event: NetworkEvent,
         peers_connected: Arc<AtomicUsize>,
         initial_join_underway_or_done: Arc<AtomicBool>,
@@ -280,7 +280,7 @@ impl Node {
     }
 
     // Handle the response that was not awaited at the call site
-    async fn handle_response(&mut self, response: Response) -> Result<()> {
+    async fn handle_response(&self, response: Response) -> Result<()> {
         match response {
             Response::Query(QueryResponse::GetReplicatedData(Ok((_holder, replicated_data)))) => {
                 match replicated_data {
@@ -337,7 +337,7 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_request(&mut self, request: Request, response_channel: MsgResponder) {
+    async fn handle_request(&self, request: Request, response_channel: MsgResponder) {
         trace!("Handling request: {request:?}");
         let response = match request {
             Request::Cmd(cmd) => self.handle_node_cmd(cmd),
@@ -373,7 +373,7 @@ impl Node {
         Response::Query(resp)
     }
 
-    fn handle_node_cmd(&mut self, cmd: Cmd) -> Response {
+    fn handle_node_cmd(&self, cmd: Cmd) -> Response {
         Marker::NodeCmdReceived(&cmd).log();
         let resp = match cmd {
             Cmd::Replicate { holder, keys } => {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -23,7 +23,7 @@ const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
 
 impl Node {
     /// Replication is triggered when is there is a change in our close group
-    pub(crate) async fn try_trigger_replication(&mut self) -> Result<()> {
+    pub(crate) async fn try_trigger_replication(&self) -> Result<()> {
         Marker::ReplicationTriggered.log();
         let our_close_group = self.network.get_our_close_group().await?;
         let our_peer_id = self.network.peer_id;
@@ -71,7 +71,7 @@ impl Node {
     /// Add a list of keys to the Replication fetcher. These keys are later fetched from the peer through the
     /// replication process.
     pub(crate) fn add_keys_to_replication_fetcher(
-        &mut self,
+        &self,
         peer: NetworkAddress,
         keys: Vec<NetworkAddress>,
     ) -> Result<()> {
@@ -122,7 +122,7 @@ impl Node {
 
     // Utility to send `Cmd::Replicate` without awaiting for the `Response` at the call site.
     fn send_replicate_cmd_without_wait(
-        &mut self,
+        &self,
         our_address: &NetworkAddress,
         peer_id: &PeerId,
         keys: Vec<NetworkAddress>,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 10:35 UTC
This pull request removes unused mutable variables and converts several mutable references to immutable references in the code. The changes are made in the `sn_node/src/api.rs` and `sn_node/src/replication.rs` files.
<!-- reviewpad:summarize:end --> 
