### PR TITLE
feat(faucet): enable logging for faucets

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
           cat initial_balance_from_faucet.txt
           cat initial_balance_from_faucet.txt | tail -n 1 > dbc_hex
           cat dbc_hex

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 11:02 UTC
This pull request includes three patches. 

The first patch enables logging for faucets in the `main.rs` file of the `sn_node/src/bin/faucet` directory. It adds logging for various components and allows specifying the logging output destination.

The second patch provides log arguments for the faucet in the `.github/workflows/generate-benchmark-charts.yml`, `.github/workflows/memcheck.yml`, `.github/workflows/merge.yml`, and `.github/workflows/nightly.yml` files. It modifies the commands that run the faucet by adding the `--log-output-dest=data-dir` argument.

The third patch provides a faucet log argument in the `main.rs` file of the `sn_testnet/src` directory. It adds a log directory for the faucet server logs and updates the faucet launch arguments accordingly.
<!-- reviewpad:summarize:end --> 
