### PR TITLE
chore(node): move inactivity search off thread + remove peer_connected

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -329,6 +329,8 @@ impl RecordStore for DiskBackedRecordStore {
                 {
                     error!("SwarmDriver failed to send event: {}", error);
                 }
+
+                debug!("Unverified record sent");
             });
         } else {
             error!("Record store doesn't have event_sender setup");

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{error::Result, event::NodeEventsChannel, Marker, Network, Node, NodeEvent};
-use libp2p::{autonat::NatStatus, identity::Keypair, kad::K_VALUE, Multiaddr, PeerId};
+use libp2p::{autonat::NatStatus, identity::Keypair, Multiaddr, PeerId};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use sn_networking::{MsgResponder, NetworkEvent, SwarmDriver, SwarmLocalState};
 use sn_protocol::{
@@ -21,17 +21,12 @@ use std::{
     net::SocketAddr,
     path::PathBuf,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     time::Duration,
 };
 use tokio::task::spawn;
-
-// returns the primitive K_VALUE
-const fn k_value() -> usize {
-    K_VALUE.get()
-}
 
 /// Once a node is started and running, the user obtains
 /// a `NodeRunning` object which can be used to interact with it.
@@ -112,26 +107,23 @@ impl Node {
         let mut rng = StdRng::from_entropy();
 
         let initial_join_flows_done = Arc::new(AtomicBool::new(false));
-        let peers_connected = Arc::new(AtomicUsize::new(0));
 
         let _handle = spawn(swarm_driver.run());
         let _handle = spawn(async move {
+            // use a random inactivity timeout to ensure that the nodes do not sync when messages
+            // are being transmitted.
+            let inactivity_timeout: i32 = rng.gen_range(20..40);
+            let inactivity_timeout = Duration::from_secs(inactivity_timeout as u64);
+
             loop {
-                // use a random inactivity timeout to ensure that the nodes do not sync when messages
-                // are being transmitted.
-                let inactivity_timeout: i32 = rng.gen_range(20..40);
-                let inactivity_timeout = Duration::from_secs(inactivity_timeout as u64);
-
-                let initial_join_flows_done = initial_join_flows_done.clone();
-                let peers_connected = peers_connected.clone();
-
                 tokio::select! {
                     net_event = network_event_receiver.recv() => {
+                        let initial_join_flows_done = initial_join_flows_done.clone();
                         match net_event {
                             Some(event) => {
                                 let mut stateless_node_copy = node.clone();
                                 let _handle =
-                                    spawn(async move { stateless_node_copy.handle_network_event(event, peers_connected, initial_join_flows_done).await });
+                                    spawn(async move { stateless_node_copy.handle_network_event(event, initial_join_flows_done).await });
                             }
                             None => {
                                 error!("The `NetworkEvent` channel is closed");
@@ -171,31 +163,8 @@ impl Node {
     async fn handle_network_event(
         &mut self,
         event: NetworkEvent,
-        peers_connected: Arc<AtomicUsize>,
         initial_join_underway_or_done: Arc<AtomicBool>,
     ) {
-        // when the node has not been connected to enough peers, it should not perform activities
-        // that might require peers in the RT to succeed.
-        match &event {
-            // these activities requires the node to be connected to some peer to be able to carry
-            // out get kad.get_record etc. This happens during replication/PUT. So we should wait
-            // until we have enough nodes, else these might fail.
-            NetworkEvent::RequestReceived { .. }
-            | NetworkEvent::UnverifiedRecord(_)
-            | NetworkEvent::ResponseReceived { .. }
-            | NetworkEvent::CloseGroupUpdated(_)
-            | NetworkEvent::KeysForReplication(_) => loop {
-                if peers_connected.load(Ordering::Relaxed) >= k_value() {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            },
-            // These events do not need to wait until there are enough peers
-            NetworkEvent::PeerAdded(_)
-            | NetworkEvent::PeerRemoved(_)
-            | NetworkEvent::NewListenAddr(_)
-            | NetworkEvent::NatStatusChanged(_) => {}
-        }
         match event {
             NetworkEvent::RequestReceived { req, channel } => {
                 trace!("RequestReceived: {req:?}");
@@ -208,11 +177,6 @@ impl Node {
                 }
             }
             NetworkEvent::PeerAdded(peer_id) => {
-                // increment peers_connected and send ConnectedToNetwork event if have connected to K_VALUE peers
-                let _ = peers_connected.fetch_add(1, Ordering::SeqCst);
-                if peers_connected.load(Ordering::SeqCst) == k_value() {
-                    self.events_channel.broadcast(NodeEvent::ConnectedToNetwork);
-                }
                 Marker::PeerAddedToRoutingTable(peer_id).log();
 
                 // perform a get_closest query to self on node join. This should help populate the node's RT


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 11:20 UTC
This pull request includes two patches. The first patch moves the inactivity search off the thread in the `api.rs` file. It adds a new async block that performs a random get_closest query when there is no network activity for a specified timeout. The second patch removes the `peer_connected` functionality altogether during the `NodeEvent` handler in the `api.rs` file. It also adds a debug message when an unverified record is sent in the `record_store.rs` file.
<!-- reviewpad:summarize:end --> 
