### PR TITLE
chore: reduce the wait after create faucet server

### DIFF
--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -317,7 +317,7 @@ async fn run_faucet(bin_path: PathBuf) -> Result<()> {
     testnet.launcher.launch(&launch_bin, args)?;
     // The launch will immediately complete after fire the cmd out.
     // Have to wait some extra time to allow the faucet to be properly created and funded
-    std::thread::sleep(std::time::Duration::from_secs(30));
+    std::thread::sleep(std::time::Duration::from_secs(5));
     Ok(())
 }
 


### PR DESCRIPTION
This is to confirm the delayed event handling is resolved. The creation of faucet and balance update shall be completed quickly with the delaying resolved.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 14:40 UTC
This pull request reduces the wait time after creating the faucet server. The delay in event handling has been resolved, so the creation of the faucet and balance update should be completed quickly. The sleep duration has been reduced from 30 seconds to 5 seconds.
<!-- reviewpad:summarize:end --> 
