### PR TITLE
feat(transfers): add basic GetStoreCost and use it

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000000 $(cargo run --bin safe --release -- wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- wallet deposit --stdin
         env:
           SN_LOG: "all"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- --log-output-dest=data-dir send 500 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 5000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
           cat initial_balance_from_faucet.txt
           cat initial_balance_from_faucet.txt | tail -n 1 > dbc_hex
           cat dbc_hex

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
-          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 1000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > dbc_hex
           cat dbc_hex | cargo run --bin safe --release -- --log-output-dest=data-dir wallet deposit --stdin
         env:
           SN_LOG: "all"

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -23,7 +23,9 @@ fn safe_files_upload(dir: &str) {
         .expect("Failed to execute command");
 
     if !output.status.success() {
-        panic!("Upload command executed with failing error code");
+        let err = output.stderr;
+        let err_string = String::from_utf8(err).unwrap();
+        panic!("Upload command executed with failing error code: {err_string:?}");
     }
 }
 

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -69,10 +69,10 @@ fn fund_cli_wallet() {
 
     let output = Command::new("./target/release/faucet")
         .arg("send")
-        .arg("10000")
+        .arg("10000000000000")
         .arg(addr)
         .output()
-        .expect("Failed to execute 'faucet send 10000' command");
+        .expect("Failed to execute 'faucet send 10000000000000' command");
 
     let str = String::from_utf8(output.stdout).unwrap();
     let dbc_hex = str.lines().last().unwrap();

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -1,9 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use std::process::{exit, Command};
-use std::time::Duration;
+use std::{
+    fs::File,
+    io::Write,
+    path::Path,
+    process::{exit, Command},
+    time::Duration,
+};
 use tempfile::tempdir;
 
 const SAMPLE_SIZE: usize = 50;
@@ -53,37 +55,14 @@ fn create_file(size_mb: u64) -> tempfile::TempDir {
 }
 
 fn fund_cli_wallet() {
-    let output = Command::new("./target/release/safe")
-        .arg("wallet")
-        .arg("address")
-        .output()
-        .expect("Failed to execute 'safe wallet address' command");
-
-    let str = String::from_utf8(output.stdout).unwrap();
-    let addr = str.lines().last().unwrap();
-
-    let _ = Command::new("./target/release/faucet")
-        .arg("claim-genesis")
-        .output()
-        .expect("Failed to execute 'faucet claim-genesis");
-
-    let output = Command::new("./target/release/faucet")
-        .arg("send")
-        .arg("10000000000000")
-        .arg(addr)
-        .output()
-        .expect("Failed to execute 'faucet send 10000000000000' command");
-
-    let str = String::from_utf8(output.stdout).unwrap();
-    let dbc_hex = str.lines().last().unwrap();
+    println!("Setting up CLI wallet");
 
     let _ = Command::new("./target/release/safe")
         .arg("wallet")
-        .arg("deposit")
-        .arg("--dbc")
-        .arg(dbc_hex)
+        .arg("get-faucet")
+        .arg("127.0.0.1:8000")
         .output()
-        .expect("Failed to execute 'safe wallet deposit' command");
+        .expect("Failed to execute 'safe wallet get-faucet' command");
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -302,7 +302,7 @@ pub(super) async fn chunk_and_pay_for_storage(
         chunked_files.len()
     );
 
-    let proofs = wallet_client
+    let (proofs, _cost) = wallet_client
         .pay_for_storage(
             chunked_files
                 .values()

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -418,7 +418,8 @@ impl Client {
             Err(ProtocolError::RecordKindMismatch(RecordKind::DbcSpend).into())
         }
     }
-    /// Get a dbc spend from network
+
+    /// get_store_cost_for_dbc_id
     pub async fn get_store_cost_for_dbc_id(&self, dbc_id: &DbcId) -> Result<Token> {
         let address = DbcAddress::from_dbc_id(dbc_id);
         let net_address = NetworkAddress::from_dbc_address(address);

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -17,7 +17,7 @@ use libp2p::{
     kad::{Record, K_VALUE},
     Multiaddr,
 };
-use sn_dbc::{DbcId, SignedSpend};
+use sn_dbc::{DbcId, SignedSpend, Token};
 use sn_networking::{multiaddr_is_global, NetworkEvent, SwarmDriver};
 use sn_protocol::{
     error::Error as ProtocolError,
@@ -417,5 +417,17 @@ impl Client {
             error!("RecordKind mismatch while trying to retrieve a dbc spend");
             Err(ProtocolError::RecordKindMismatch(RecordKind::DbcSpend).into())
         }
+    }
+    /// Get a dbc spend from network
+    pub async fn get_store_cost_for_dbc_id(&self, dbc_id: &DbcId) -> Result<Token> {
+        let address = DbcAddress::from_dbc_id(dbc_id);
+        let net_address = NetworkAddress::from_dbc_address(address);
+
+        trace!("Getting store cost at {dbc_id:?}");
+
+        Ok(self
+            .network
+            .get_store_cost_from_network(net_address.clone())
+            .await?)
     }
 }

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -56,4 +56,8 @@ pub enum Error {
 
     #[error("Missing a payment proof for address {0:?}")]
     MissingPaymentProof(ChunkAddress),
+
+    /// A general error when a transfer fails.
+    #[error("Failed to send tokens due to {0}")]
+    CouldNotSendTokens(String),
 }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -87,7 +87,7 @@ pub enum SwarmCmd {
         key: RecordKey,
         sender: oneshot::Sender<Result<Record>>,
     },
-    /// GetLocalStoreCost from the Kad network
+    /// GetLocalStoreCost for this node
     GetLocalStoreCost {
         sender: oneshot::Sender<Token>,
     },

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -25,6 +25,9 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("No store cost returned from the network")]
+    NoStoreCostReturned,
+
     #[error("Close group size must be a non-zero usize")]
     InvalidCloseGroupSize,
 

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -25,6 +25,10 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error(
+        "Not enough store cost quotes returned from the network to ensure a valid fee is paid"
+    )]
+    NotEnoughCostQuotes,
     #[error("No store cost returned from the network")]
     NoStoreCostReturned,
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -645,7 +645,7 @@ impl Network {
         // loop over responses, generating an avergae fee and storing all responses along side
         let mut all_costs = vec![];
         for response in responses.into_iter().flatten() {
-            if let Response::Query(QueryResponse::GetStoreCost(Ok((cost, _sig)))) = response {
+            if let Response::Query(QueryResponse::GetStoreCost(Ok(cost))) = response {
                 all_costs.push(cost);
             }
         }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -624,7 +624,7 @@ impl Network {
 
     pub async fn get_store_cost_from_network(&self, dbc_id_key: NetworkAddress) -> Result<Token> {
         let (sender, receiver) = oneshot::channel();
-
+        debug!("Attempting to get store cost");
         // first we need to get CLOSE_GROUP of the dbc_id
         self.send_swarm_cmd(SwarmCmd::GetClosestPeers {
             key: dbc_id_key.clone(),

--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -48,7 +48,7 @@ pub async fn run_faucet_server(client: &Client) -> Result<()> {
         );
         let key = request.url().trim_matches(path::is_separator);
 
-        match send_tokens(client, "10", key).await {
+        match send_tokens(client, "1000000", key).await {
             Ok(dbc) => {
                 println!("Sent tokens to {}", key);
                 let response = Response::from_string(dbc);

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -19,19 +19,14 @@ use sn_registers::SignedRegister;
 impl Node {
     /// Get the current storecost in nanos from our local kademlia store
     /// Returns cost and our node's signature over that cost
-    pub(crate) async fn current_storecost(&self) -> Result<(Token, Vec<u8>)> {
+    pub(crate) async fn current_storecost(&self) -> Result<Token> {
         let cost = self
             .network
             .get_local_storecost()
             .await
             .map_err(|_| Error::GetStoreCostFailed)?;
 
-        let signed_cost = match self.network.sign(&cost.to_bytes()) {
-            Ok(signed_cost) => signed_cost,
-            Err(_) => return Err(Error::SignStoreCostFailed),
-        };
-
-        Ok((cost, signed_cost))
+        Ok(cost)
     }
 
     pub(crate) async fn get_spend_from_network(

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -471,7 +471,7 @@ impl Node {
                 }
 
                 // If this is a storage payment, then verify FeeOutput's id is the expected.
-                verify_fee_output_id(&signed_spend.spent_tx(), false)?;
+                verify_fee_output_id(&signed_spend.spent_tx(), true)?;
 
                 // Get parents
                 let mut parent_spends = BTreeSet::new();
@@ -528,7 +528,7 @@ impl Node {
 // If 'required' was set to 'true' then the fee output must be non-zero and valid.
 fn verify_fee_output_id(spent_tx: &DbcTransaction, required: bool) -> Result<(), ProtocolError> {
     let fee = &spent_tx.fee;
-    info!(">>>> FEE: {fee:?}");
+    debug!("Verification fee: {fee:?}");
     if fee.is_free() {
         if required {
             return Err(ProtocolError::PaymentProofInvalidFeeOutput(fee.id));

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -471,7 +471,7 @@ impl Node {
                 }
 
                 // If this is a storage payment, then verify FeeOutput's id is the expected.
-                verify_fee_output_id(&signed_spend.spent_tx(), true)?;
+                verify_fee_output_id(&signed_spend.spent_tx(), false)?;
 
                 // Get parents
                 let mut parent_spends = BTreeSet::new();

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -361,7 +361,7 @@ fn store_chunks_task(
                 bytes.len()
             );
             sleep(delay).await;
-            let proofs = wallet_client
+            let (proofs, _cost) = wallet_client
                 .pay_for_storage(chunks.iter().map(|c| c.name()), false)
                 .await
                 .expect("Failed to pay for storage for new file at {addr:?}");

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -62,8 +62,8 @@ const MAX_NUM_OF_QUERY_ATTEMPTS: u8 = 5;
 // It can be overriden by setting the 'TEST_DURATION_MINS' env var.
 const TEST_DURATION: Duration = Duration::from_secs(60 * 60); // 1hr
 
-const PAYING_WALLET_INITIAL_BALANCE: u64 = 10_000_000;
-const TRANSFERS_WALLET_INITIAL_BALANCE: u64 = 2_000_000;
+const PAYING_WALLET_INITIAL_BALANCE: u64 = 100_000_000_000_000;
+const TRANSFERS_WALLET_INITIAL_BALANCE: u64 = 200_000_000_000;
 
 type ContentList = Arc<RwLock<VecDeque<NetworkAddress>>>;
 type DbcMap = Arc<RwLock<BTreeMap<DbcAddress, Dbc>>>;

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 pub enum QueryResponse {
     /// The store cost in nanos for storing the next record, and the node's singature over that cost.
-    GetStoreCost(Result<(Token, Vec<u8>)>),
+    GetStoreCost(Result<Token>),
     // ===== ReplicatedData =====
     //
     /// Response to [`GetReplicatedData`]

--- a/sn_transfers/src/client_transfers/error.rs
+++ b/sn_transfers/src/client_transfers/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_dbc::Error as DbcError;
+use sn_dbc::{Error as DbcError, Token};
 
 use thiserror::Error;
 
@@ -18,8 +18,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// Not enough balance to perform a transaction
-    #[error("Not enough balance: {0}")]
-    NotEnoughBalance(String),
+    #[error("Not enough balance, {0} available, {1} required")]
+    NotEnoughBalance(Token, Token),
     /// An error from the `sn_dbc` crate.
     #[error("Dbc error: {0}")]
     Dbcs(#[from] Box<DbcError>),

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -137,7 +137,10 @@ fn select_inputs(
 
     // Make sure total input amount gathered with input DBCs are enough for the output amount
     if total_output_amount > total_input_amount {
-        return Err(Error::NotEnoughBalance(total_input_amount.to_string()));
+        return Err(Error::NotEnoughBalance(
+            total_input_amount,
+            total_output_amount,
+        ));
     }
 
     Ok((dbcs_to_spend, change_amount))

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -61,12 +61,12 @@ pub fn create_transfer(
 pub fn create_storage_payment_transfer(
     available_dbcs: Vec<(Dbc, DerivedKey)>,
     change_to: PublicAddress,
-    storage_cost: Token,
+    storage_payment: Token,
     root_hash: Hash,
     reason_hash: Hash,
 ) -> Result<TransferOutputs> {
     // We need to select the necessary number of dbcs from those that we were passed.
-    let (dbcs_to_spend, change_amount) = select_inputs(available_dbcs, storage_cost)?;
+    let (dbcs_to_spend, change_amount) = select_inputs(available_dbcs, storage_payment)?;
 
     // We build the recipients to contain just a single output which is for the network owned output.
     // This is a special output that spendbook peers validating the signed spends (inputs) will be
@@ -77,7 +77,11 @@ pub fn create_storage_payment_transfer(
         .iter()
         .for_each(|(dbc, _)| fee_id_bytes.extend(&dbc.id().to_bytes()));
 
-    let fee = FeeOutput::new(Hash::hash(&fee_id_bytes), storage_cost.as_nano(), root_hash);
+    let fee = FeeOutput::new(
+        Hash::hash(&fee_id_bytes),
+        storage_payment.as_nano(),
+        root_hash,
+    );
 
     let selected_inputs = Inputs {
         dbcs_to_spend,

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -14,6 +14,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Transfer errors.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// No DBCs available for spend
+    #[error("No DBCs available for spend")]
+    NoDbcsAvailable,
     /// Failed to create transfer.
     #[error("Transfer error {0}")]
     CreateTransfer(#[from] crate::client_transfers::Error),
@@ -23,6 +26,9 @@ pub enum Error {
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),
+    /// A general error when a retrieving a store cost fails
+    #[error("Failed to get store cost due to {0}")]
+    CouldNotGetStoreCost(String),
     /// A general error when verifying a transfer validity in the network.
     #[error("Failed to verify transfer validity in the network {0}")]
     CouldNotVerifyTransfer(String),
@@ -37,7 +43,10 @@ pub enum Error {
     FailedToHexEncodeKey(String),
     /// Dbc error.
     #[error("Dbc error: {0}")]
-    Dbc(#[from] Box<sn_dbc::Error>),
+    BoxedDbc(#[from] Box<sn_dbc::Error>),
+    /// Dbc error.
+    #[error("Dbc error: {0}")]
+    Dbc(#[from] sn_dbc::Error),
     /// Bls error.
     #[error("Bls error: {0}")]
     Bls(#[from] bls::error::Error),

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -43,9 +43,6 @@ pub enum Error {
     FailedToHexEncodeKey(String),
     /// Dbc error.
     #[error("Dbc error: {0}")]
-    BoxedDbc(#[from] Box<sn_dbc::Error>),
-    /// Dbc error.
-    #[error("Dbc error: {0}")]
     Dbc(#[from] sn_dbc::Error),
     /// Bls error.
     #[error("Bls error: {0}")]

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -169,7 +169,7 @@ impl LocalWallet {
 
     pub async fn local_send_storage_payment(
         &mut self,
-        storage_cost: Token,
+        storage_payment: Token,
         root_hash: Hash,
         reason_hash: Option<Hash>,
     ) -> Result<TransferOutputs> {
@@ -179,7 +179,7 @@ impl LocalWallet {
         let transfer = create_storage_payment_transfer(
             available_dbcs,
             self.address(),
-            storage_cost,
+            storage_payment,
             root_hash,
             reason_hash.unwrap_or_default(),
         )?;

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -65,7 +65,7 @@ pub(super) async fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path
 
         let dbc_file_path = public_address_dir_path.join(dbc_id_file_name);
 
-        let hex = dbc.to_hex().map_err(|e| Error::BoxedDbc(Box::new(e)))?;
+        let hex = dbc.to_hex().map_err(Error::Dbc)?;
         fs::write(dbc_file_path, &hex).await?;
     }
     Ok(())

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -65,7 +65,7 @@ pub(super) async fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path
 
         let dbc_file_path = public_address_dir_path.join(dbc_id_file_name);
 
-        let hex = dbc.to_hex().map_err(|e| Error::Dbc(Box::new(e)))?;
+        let hex = dbc.to_hex().map_err(|e| Error::BoxedDbc(Box::new(e)))?;
         fs::write(dbc_file_path, &hex).await?;
     }
     Ok(())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Aug 23 16:15 UTC
This pull request includes several changes across multiple files. Here is a brief summary of the changes:

- In `sn_client/src/api.rs`, a new import statement has been added for the `Token` type from the `sn_dbc` module.
- In the same file, a new method `get_store_cost_for_dbc_id` has been added to the `Client` struct, which retrieves the store cost for a given DbcId.
- In `sn_client/src/error.rs`, a new variant `CouldNotSendTokens` has been added to the `Error` enum, which represents a general error when sending tokens fails.
- In `sn_client/src/wallet.rs`, a new method `get_store_cost` has been added to the `WalletClient` struct, which retrieves the store cost from the network.
- In the same file, the `pay_for_storage` method has been modified to use the `get_store_cost` method to retrieve the storage cost.
- In `sn_networking/src/cmd.rs`, a comment has been updated to reflect the purpose of the `GetLocalStoreCost` command.
- In `sn_networking/src/error.rs`, a new variant `NoStoreCostReturned` has been added to the `Error` enum, which represents an error when no store cost is returned from the network.
- In `sn_networking/src/lib.rs`, a new method `get_store_cost_from_network` has been added to the `Network` struct, which retrieves the store cost from the network for a given DbcId.
- In `sn_transfers/src/wallet/error.rs`, a new variant `NoDbcsAvailable` has been added to the `Error` enum, which represents an error when no DBCs are available for spend.
- In the same file, a new variant `CouldNotGetStoreCost` has been added to the `Error` enum, which represents a general error when retrieving a store cost fails.
- In `sn_transfers/src/wallet/local_store.rs`, a new method `largest_dbc` has been added to the `LocalWallet` struct, which retrieves the largest DBC available in the wallet.
- In the same file, a new method `add_payment_proofs` has been added to the `LocalWallet` struct, which adds storage payment proofs to the wallet's cache.
- In `sn_transfers/src/wallet/wallet_file.rs`, an error handling statement has been updated to use the `BoxedDbc` variant of the `Error` enum instead of the `Dbc` variant when handling a DBC conversion error.

These are the main changes made in this pull request.
<!-- reviewpad:summarize:end --> 
