### PR TITLE
feat: rework register addresses to include pk

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -196,13 +196,13 @@ jobs:
         timeout-minutes: 10
 
       - name: Start a client to get a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to edit a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit baobao wood
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao wood
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,13 +72,13 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to get a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
       - name: Start a client to edit a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit baobao wood
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao wood
         env:
           SN_LOG: "all"
         timeout-minutes: 2

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Assuming you have `SAFE_PEERS` set as above:
 `cargo run --release --bin safe -- register create myregister`
 
 - Get Register using its name from the previous cmd:
-`cargo run --release --bin safe -- register get myregister`
+`cargo run --release --bin safe -- register get -n myregister`
 
 - Edit Register using its name from the previous cmd:
-`cargo run --release --bin safe -- register edit myregister somename`
+`cargo run --release --bin safe -- register edit -n myregister somename`
 
 - Upload files
 `cargo run --release --bin safe -- files upload ~/dir/with/files`

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -26,7 +26,8 @@ pub enum RegisterCmds {
         /// The address of the register to edit.
         #[clap(name = "address")]
         address: String,
-        /// If you are the owner, the name of the register can be used as a shorthand to the address, as we can derive the address from the public key + name
+        /// If you are the owner, the name of the register can be used as a shorthand to the address,
+        /// as we can derive the address from the public key + name
         /// Use this flag if you are providing the register name instead of the address
         #[clap(name = "name", short = 'n')]
         use_name: bool,
@@ -38,7 +39,8 @@ pub enum RegisterCmds {
         /// The register addresses to get.
         #[clap(name = "addresses")]
         addresses: Vec<String>,
-        /// If you are the owner, the name of the register can be used as a shorthand to the address, as we can derive the address from the public key + name
+        /// If you are the owner, the name of the register can be used as a shorthand to the address,
+        /// as we can derive the address from the public key + name
         /// Use this flag if you are providing the register names instead of the addresses
         #[clap(name = "name", short = 'n')]
         use_name: bool,
@@ -76,13 +78,13 @@ async fn create_register(name: String, client: &Client, verify_store: bool) -> R
 }
 
 async fn edit_register(
-    address: String,
+    address_str: String,
     use_name: bool,
     entry: String,
     client: &Client,
     verify_store: bool,
 ) -> Result<()> {
-    let (address, printing_name) = parse_addr(&address, use_name, client.signer_pk())?;
+    let (address, printing_name) = parse_addr(&address_str, use_name, client.signer_pk())?;
 
     println!("Trying to retrieve Register from {address}");
 
@@ -147,13 +149,17 @@ async fn get_registers(addresses: Vec<String>, use_name: bool, client: &Client) 
 }
 
 /// Parse str and return the address and the register info for printing
-fn parse_addr(str: &str, use_name: bool, pk: PublicKey) -> Result<(RegisterAddress, String)> {
+fn parse_addr(
+    address_str: &str,
+    use_name: bool,
+    pk: PublicKey,
+) -> Result<(RegisterAddress, String)> {
     if use_name {
-        let user_metadata = XorName::from_content(str.as_bytes());
+        let user_metadata = XorName::from_content(address_str.as_bytes());
         let addr = RegisterAddress::new(user_metadata, pk);
-        Ok((addr, format!("'{str}' at {addr}")))
+        Ok((addr, format!("'{address_str}' at {addr}")))
     } else {
-        let addr = RegisterAddress::from_hex(str)?;
-        Ok((addr, format!("at {str}")))
+        let addr = RegisterAddress::from_hex(address_str)?;
+        Ok((addr, format!("at {address_str}")))
     }
 }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -252,17 +252,17 @@ impl Client {
             .network
             .get_record_from_network(key, None, false)
             .await
-            .map_err(|_| ProtocolError::RegisterNotFound(address))?;
+            .map_err(|_| ProtocolError::RegisterNotFound(Box::new(address)))?;
         debug!(
             "Got record from the network, {:?}",
             PrettyPrintRecordKey::from(record.key.clone())
         );
         let header = RecordHeader::from_record(&record)
-            .map_err(|_| ProtocolError::RegisterNotFound(address))?;
+            .map_err(|_| ProtocolError::RegisterNotFound(Box::new(address)))?;
 
         if let RecordKind::Register = header.kind {
             let register = try_deserialize_record::<SignedRegister>(&record)
-                .map_err(|_| ProtocolError::RegisterNotFound(address))?;
+                .map_err(|_| ProtocolError::RegisterNotFound(Box::new(address)))?;
             Ok(register)
         } else {
             error!("RecordKind mismatch while trying to retrieve a signed register");
@@ -273,20 +273,19 @@ impl Client {
     }
 
     /// Retrieve a Register from the network.
-    pub async fn get_register(&self, xorname: XorName, tag: u64) -> Result<ClientRegister> {
-        info!("Retrieving a Register replica with name {xorname} and tag {tag}");
-        ClientRegister::retrieve(self.clone(), xorname, tag).await
+    pub async fn get_register(&self, address: RegisterAddress) -> Result<ClientRegister> {
+        info!("Retrieving a Register replica at {address}");
+        ClientRegister::retrieve(self.clone(), address).await
     }
 
     /// Create a new Register on the Network.
     pub async fn create_register(
         &self,
-        xorname: XorName,
-        tag: u64,
+        meta: XorName,
         verify_store: bool,
     ) -> Result<ClientRegister> {
-        info!("Instantiating a new Register replica with name {xorname} and tag {tag}");
-        ClientRegister::create_online(self.clone(), xorname, tag, verify_store).await
+        info!("Instantiating a new Register replica with meta {meta:?}");
+        ClientRegister::create_online(self.clone(), meta, verify_store).await
     }
 
     /// Store `Chunk` as a record.

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -152,7 +152,7 @@ impl Files {
             let client = self.client.clone();
             let chunk_addr = *chunk.address();
             let payment = payment_proofs
-                .get(chunk_addr.name())
+                .get(chunk_addr.xorname())
                 .cloned()
                 .ok_or(super::Error::MissingPaymentProof(chunk_addr))?;
 
@@ -212,7 +212,7 @@ impl Files {
         let chunk = package_small(small)?;
         let address = *chunk.address();
         let payment = payment_proofs
-            .get(address.name())
+            .get(address.xorname())
             .cloned()
             .ok_or(super::Error::MissingPaymentProof(address))?;
 

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -258,7 +258,7 @@ impl Node {
                 match replicated_data {
                     ReplicatedData::Chunk(chunk_with_payment) => {
                         let chunk_addr = *chunk_with_payment.chunk.address();
-                        debug!("Chunk received for replication: {:?}", chunk_addr.name());
+                        debug!("Chunk received for replication: {:?}", chunk_addr.xorname());
 
                         let success = self.validate_and_store_chunk(chunk_with_payment).await?;
                         trace!("ReplicatedData::Chunk with {chunk_addr:?} has been validated and stored. {success:?}");
@@ -266,7 +266,10 @@ impl Node {
                     ReplicatedData::DbcSpend(signed_spend) => {
                         if let Some(spend) = signed_spend.first() {
                             let dbc_addr = DbcAddress::from_dbc_id(spend.dbc_id());
-                            debug!("DbcSpend received for replication: {:?}", dbc_addr.name());
+                            debug!(
+                                "DbcSpend received for replication: {:?}",
+                                dbc_addr.xorname()
+                            );
                             let addr = NetworkAddress::from_dbc_address(dbc_addr);
 
                             let success = self.validate_and_store_spends(signed_spend).await?;
@@ -282,7 +285,7 @@ impl Node {
                         let register_addr = *register.address();
                         debug!(
                             "Register received for replication: {:?}",
-                            register_addr.name()
+                            register_addr.xorname()
                         );
 
                         let success = self.validate_and_store_register(register).await?;

--- a/sn_node/src/get_validation.rs
+++ b/sn_node/src/get_validation.rs
@@ -84,8 +84,8 @@ impl Node {
         address: NetworkAddress,
     ) -> Result<ReplicatedData> {
         let error = Error::ReplicatedDataNotFound {
-            holder: NetworkAddress::from_peer(self.network.peer_id),
-            address: address.clone(),
+            holder: Box::new(NetworkAddress::from_peer(self.network.peer_id)),
+            address: Box::new(address.clone()),
         };
 
         let record_key = address.as_record_key().ok_or(error.clone())?;

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -150,7 +150,7 @@ impl Node {
             .await
             .map_err(|err| {
                 warn!("Error while checking if register's key is present locally {err}");
-                ProtocolError::RegisterNotStored(*reg_addr.name())
+                ProtocolError::RegisterNotStored(Box::new(*reg_addr))
             })?;
 
         // check register and merge if needed
@@ -171,7 +171,7 @@ impl Node {
         debug!("Storing register {reg_addr:?} as Record locally");
         self.network.put_local_record(record).map_err(|err| {
             warn!("Error while locally storing register as a Record {err}");
-            ProtocolError::RegisterNotStored(*reg_addr.name())
+            ProtocolError::RegisterNotStored(Box::new(*reg_addr))
         })?;
 
         Ok(CmdOk::StoredSuccessfully)
@@ -328,7 +328,7 @@ impl Node {
         let reg_addr = register.address();
         if let Err(e) = register.verify() {
             error!("Register with addr {reg_addr:?} is invalid: {e:?}");
-            return Err(ProtocolError::RegisterInvalid(*reg_addr));
+            return Err(ProtocolError::RegisterInvalid(Box::new(*reg_addr)));
         }
 
         // if we don't have it locally return it
@@ -343,13 +343,13 @@ impl Node {
         // get local register
         let maybe_record = self.network.get_local_record(&key).await.map_err(|err| {
             warn!("Error while fetching local record {err}");
-            ProtocolError::RegisterNotStored(*reg_addr.name())
+            ProtocolError::RegisterNotStored(Box::new(*reg_addr))
         })?;
         let record = match maybe_record {
             Some(r) => r,
             None => {
                 error!("Register with addr {reg_addr:?} already exists locally, but not found in local storage");
-                return Err(ProtocolError::RegisterNotStored(*reg_addr.name()));
+                return Err(ProtocolError::RegisterNotStored(Box::new(*reg_addr)));
             }
         };
         let local_register: SignedRegister = try_deserialize_record(&record)?;

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -209,7 +209,7 @@ impl Node {
         let key = NetworkAddress::from_dbc_address(dbc_addr).to_record_key();
         debug!(
             "validating and storing spends {:?} - {:?}",
-            dbc_addr.name(),
+            dbc_addr.xorname(),
             PrettyPrintRecordKey::from(key.clone())
         );
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -312,14 +312,14 @@ fn create_registers_task(client: Client, content: ContentList, churn_period: Dur
         let delay = churn_period / REGISTER_CREATION_RATIO_TO_CHURN;
 
         loop {
-            let xorname = XorName(rand::random());
-            let tag = rand::random();
+            let meta = XorName(rand::random());
+            let owner = client.signer_pk();
 
-            let addr = RegisterAddress { name: xorname, tag };
+            let addr = RegisterAddress::new(meta, owner);
             println!("Creating Register at {addr:?} in {delay:?}");
             sleep(delay).await;
 
-            match client.create_register(xorname, tag, false).await {
+            match client.create_register(meta, false).await {
                 Ok(_) => content
                     .write()
                     .await
@@ -599,7 +599,7 @@ async fn query_content(
             }
         }
         NetworkAddress::RegisterAddress(addr) => {
-            let _ = client.get_register(*addr.name(), addr.tag()).await?;
+            let _ = client.get_register(*addr).await?;
             Ok(())
         }
         NetworkAddress::ChunkAddress(addr) => {

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -29,12 +29,12 @@ pub enum Error {
     ChunkNotStored(XorName),
 
     // ---------- register errors
-    #[error("Register was not stored, xorname: {0:?}")]
-    RegisterNotStored(XorName),
-    #[error("Register not found: {0:?}")]
-    RegisterNotFound(RegisterAddress),
-    #[error("Register is Invalid: {0:?}")]
-    RegisterInvalid(RegisterAddress),
+    #[error("Register was not stored: {0}")]
+    RegisterNotStored(Box<RegisterAddress>),
+    #[error("Register not found: {0}")]
+    RegisterNotFound(Box<RegisterAddress>),
+    #[error("Register is Invalid: {0}")]
+    RegisterInvalid(Box<RegisterAddress>),
     #[error("Register is Invalid: {0}")]
     RegisterError(#[from] sn_registers::Error),
     #[error("The Register was already created by another owner: {0:?}")]
@@ -86,9 +86,9 @@ pub enum Error {
     #[error("Peer {holder:?} cannot find ReplicatedData {address:?}")]
     ReplicatedDataNotFound {
         /// Holder that being contacted
-        holder: NetworkAddress,
+        holder: Box<NetworkAddress>,
         /// Address of the missing data
-        address: NetworkAddress,
+        address: Box<NetworkAddress>,
     },
 
     // ---------- record errors

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -21,7 +21,6 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
-use xor_name::XorName;
 
 /// This is the address in the network by which proximity/distance
 /// to other items (whether nodes or data chunks) are calculated.
@@ -77,7 +76,7 @@ impl NetworkAddress {
             NetworkAddress::PeerId(bytes) | NetworkAddress::RecordKey(bytes) => bytes.to_vec(),
             NetworkAddress::ChunkAddress(chunk_address) => chunk_address.name().0.to_vec(),
             NetworkAddress::DbcAddress(dbc_address) => dbc_address.name().0.to_vec(),
-            NetworkAddress::RegisterAddress(register_address) => register_address.id().0.to_vec(),
+            NetworkAddress::RegisterAddress(register_address) => register_address.name().0.to_vec(),
         }
     }
 
@@ -106,9 +105,7 @@ impl NetworkAddress {
             NetworkAddress::RecordKey(bytes) => RecordKey::new(bytes),
             NetworkAddress::ChunkAddress(chunk_address) => RecordKey::new(chunk_address.name()),
             NetworkAddress::RegisterAddress(register_address) => {
-                let mut reg_name: Vec<u8> = register_address.name().to_vec();
-                reg_name.extend(register_address.tag.to_be_bytes());
-                RecordKey::new(&XorName::from_content(&reg_name))
+                RecordKey::new(&register_address.name())
             }
             NetworkAddress::DbcAddress(dbc_address) => RecordKey::new(dbc_address.name()),
             NetworkAddress::PeerId(bytes) => RecordKey::new(bytes),
@@ -153,7 +150,7 @@ impl Debug for NetworkAddress {
             }
             NetworkAddress::RegisterAddress(register_address) => format!(
                 "NetworkAddress::RegisterAddress({:?} - ",
-                register_address.id()
+                register_address.name()
             ),
             NetworkAddress::RecordKey(_) => "NetworkAddress::RecordKey(".to_string(),
         };

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -74,9 +74,11 @@ impl NetworkAddress {
     pub fn as_bytes(&self) -> Vec<u8> {
         match self {
             NetworkAddress::PeerId(bytes) | NetworkAddress::RecordKey(bytes) => bytes.to_vec(),
-            NetworkAddress::ChunkAddress(chunk_address) => chunk_address.name().0.to_vec(),
-            NetworkAddress::DbcAddress(dbc_address) => dbc_address.name().0.to_vec(),
-            NetworkAddress::RegisterAddress(register_address) => register_address.name().0.to_vec(),
+            NetworkAddress::ChunkAddress(chunk_address) => chunk_address.xorname().0.to_vec(),
+            NetworkAddress::DbcAddress(dbc_address) => dbc_address.xorname().0.to_vec(),
+            NetworkAddress::RegisterAddress(register_address) => {
+                register_address.xorname().0.to_vec()
+            }
         }
     }
 
@@ -103,11 +105,11 @@ impl NetworkAddress {
     pub fn to_record_key(&self) -> RecordKey {
         match self {
             NetworkAddress::RecordKey(bytes) => RecordKey::new(bytes),
-            NetworkAddress::ChunkAddress(chunk_address) => RecordKey::new(chunk_address.name()),
+            NetworkAddress::ChunkAddress(chunk_address) => RecordKey::new(chunk_address.xorname()),
             NetworkAddress::RegisterAddress(register_address) => {
-                RecordKey::new(&register_address.name())
+                RecordKey::new(&register_address.xorname())
             }
-            NetworkAddress::DbcAddress(dbc_address) => RecordKey::new(dbc_address.name()),
+            NetworkAddress::DbcAddress(dbc_address) => RecordKey::new(dbc_address.xorname()),
             NetworkAddress::PeerId(bytes) => RecordKey::new(bytes),
         }
     }
@@ -143,14 +145,17 @@ impl Debug for NetworkAddress {
         let name_str = match self {
             NetworkAddress::PeerId(_) => "NetworkAddress::PeerId(".to_string(),
             NetworkAddress::ChunkAddress(chunk_address) => {
-                format!("NetworkAddress::ChunkAddress({:?} - ", chunk_address.name())
+                format!(
+                    "NetworkAddress::ChunkAddress({:?} - ",
+                    chunk_address.xorname()
+                )
             }
             NetworkAddress::DbcAddress(dbc_address) => {
-                format!("NetworkAddress::DbcAddress({:?} - ", dbc_address.name())
+                format!("NetworkAddress::DbcAddress({:?} - ", dbc_address.xorname())
             }
             NetworkAddress::RegisterAddress(register_address) => format!(
                 "NetworkAddress::RegisterAddress({:?} - ",
-                register_address.name()
+                register_address.xorname()
             ),
             NetworkAddress::RecordKey(_) => "NetworkAddress::RecordKey(".to_string(),
         };

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -77,12 +77,12 @@ impl ReplicatedData {
             Self::Chunk(chunk) => *chunk.chunk.name(),
             Self::DbcSpend(spends) => {
                 if let Some(spend) = spends.first() {
-                    *DbcAddress::from_dbc_id(spend.dbc_id()).name()
+                    *DbcAddress::from_dbc_id(spend.dbc_id()).xorname()
                 } else {
                     return Err(Error::SpendIsEmpty);
                 }
             }
-            Self::Register(register) => register.address().name(),
+            Self::Register(register) => register.address().xorname(),
         };
         Ok(name)
     }

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -82,7 +82,7 @@ impl ReplicatedData {
                     return Err(Error::SpendIsEmpty);
                 }
             }
-            Self::Register(register) => *register.address().name(),
+            Self::Register(register) => register.address().name(),
         };
         Ok(name)
     }

--- a/sn_protocol/src/messages/register.rs
+++ b/sn_protocol/src/messages/register.rs
@@ -9,7 +9,6 @@
 use sn_registers::{Register, RegisterAddress, RegisterOp};
 
 use serde::{Deserialize, Serialize};
-use xor_name::XorName;
 
 /// A register cmd that is sent over to the Network
 #[allow(clippy::large_enum_variant)]
@@ -27,12 +26,6 @@ pub enum RegisterCmd {
 }
 
 impl RegisterCmd {
-    /// Returns the name of the register.
-    /// This is not a unique identifier.
-    pub fn name(&self) -> XorName {
-        *self.dst().name()
-    }
-
     /// Returns the dst address of the register.
     pub fn dst(&self) -> RegisterAddress {
         match self {

--- a/sn_protocol/src/storage/address/chunk.rs
+++ b/sn_protocol/src/storage/address/chunk.rs
@@ -21,7 +21,7 @@ impl ChunkAddress {
     }
 
     /// Returns the name.
-    pub fn name(&self) -> &XorName {
+    pub fn xorname(&self) -> &XorName {
         &self.0
     }
 }

--- a/sn_protocol/src/storage/address/dbc.rs
+++ b/sn_protocol/src/storage/address/dbc.rs
@@ -29,7 +29,7 @@ impl DbcAddress {
     }
 
     /// Return the name, which is the hash of `DbcId`.
-    pub fn name(&self) -> &XorName {
+    pub fn xorname(&self) -> &XorName {
         &self.0
     }
 }

--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -44,7 +44,7 @@ impl Chunk {
 
     /// Returns the name.
     pub fn name(&self) -> &XorName {
-        self.address.name()
+        self.address.xorname()
     }
 
     /// Returns size of contained value.

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_register_address_tofro_hex() {
+    fn test_register_hex_conversion() {
         let mut rng = rand::thread_rng();
         let owner = SecretKey::random().public_key();
         let meta = XorName::random(&mut rng);

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -6,42 +6,95 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::error::{Error, Result};
+
+use bls::{PublicKey, PK_SIZE};
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
-use xor_name::XorName;
+use std::{fmt::Display, hash::Hash};
+use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Address of a Register on the SAFE Network
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct RegisterAddress {
-    /// Name.
-    pub name: XorName,
-    /// Tag.
-    pub tag: u64,
+    /// User chosen meta, can be anything, the register's name on the network will be the hash of this meta and the owner
+    pub(crate) meta: XorName,
+    /// Owner of the register
+    pub(crate) owner: PublicKey,
+}
+
+impl Display for RegisterAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
 }
 
 impl RegisterAddress {
-    /// Construct a new `RegisterAddress` given `name` and `tag`.
-    pub fn new(name: XorName, tag: u64) -> Self {
-        Self { name, tag }
+    /// Construct a new `RegisterAddress` given `meta` and `owner`.
+    pub fn new(meta: XorName, owner: PublicKey) -> Self {
+        Self { meta, owner }
     }
 
-    /// Return the identifier of the register.
+    /// Return the network name of the register.
     /// This is used to locate the register on the network.
-    pub fn id(&self) -> XorName {
+    pub fn name(&self) -> XorName {
         let mut bytes = vec![];
-        bytes.extend_from_slice(&self.name.0);
-        bytes.extend_from_slice(&self.tag.to_be_bytes());
+        bytes.extend_from_slice(&self.meta.0);
+        bytes.extend_from_slice(&self.owner.to_bytes());
         XorName::from_content(&bytes)
     }
 
-    /// Return the name.
-    /// This is not a unique identifier.
-    pub fn name(&self) -> &XorName {
-        &self.name
+    /// Serialize this `RegisterAddress` instance to a hex-encoded `String`.
+    pub fn to_hex(&self) -> String {
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&self.meta.0);
+        bytes.extend_from_slice(&self.owner.to_bytes());
+        hex::encode(bytes)
     }
 
-    /// Return the tag.
-    pub fn tag(&self) -> u64 {
-        self.tag
+    /// Deserialize a hex-encoded representation of a `RegisterAddress` to a `RegisterAddress` instance.
+    pub fn from_hex(hex: &str) -> Result<Self> {
+        let bytes = hex::decode(hex).map_err(|_| Error::HexDeserializeFailed)?;
+        let meta_bytes: [u8; XOR_NAME_LEN] = bytes[..XOR_NAME_LEN]
+            .try_into()
+            .map_err(|_| Error::HexDeserializeFailed)?;
+        let meta = XorName(meta_bytes);
+        let owner_bytes: [u8; PK_SIZE] = bytes[XOR_NAME_LEN..]
+            .try_into()
+            .map_err(|_| Error::HexDeserializeFailed)?;
+        let owner = PublicKey::from_bytes(owner_bytes).map_err(|_| Error::HexDeserializeFailed)?;
+        Ok(Self { meta, owner })
+    }
+
+    /// Return the user chosen meta.
+    pub fn meta(&self) -> XorName {
+        self.meta
+    }
+
+    /// Return the owner.
+    pub fn owner(&self) -> PublicKey {
+        self.owner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bls::SecretKey;
+
+    use super::*;
+
+    #[test]
+    fn test_register_address_tofro_hex() {
+        let mut rng = rand::thread_rng();
+        let owner = SecretKey::random().public_key();
+        let meta = XorName::random(&mut rng);
+        let addr = RegisterAddress::new(meta, owner);
+        let hex = &addr.to_hex();
+        let addr2 = RegisterAddress::from_hex(hex).unwrap();
+
+        assert_eq!(addr, addr2);
+
+        let bad_hex = format!("{}0", hex);
+        let err = RegisterAddress::from_hex(&bad_hex);
+        assert_eq!(err, Err(Error::HexDeserializeFailed));
     }
 }

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -36,7 +36,7 @@ impl RegisterAddress {
 
     /// Return the network name of the register.
     /// This is used to locate the register on the network.
-    pub fn name(&self) -> XorName {
+    pub fn xorname(&self) -> XorName {
         let mut bytes = vec![];
         bytes.extend_from_slice(&self.meta.0);
         bytes.extend_from_slice(&self.owner.to_bytes());

--- a/sn_registers/src/error.rs
+++ b/sn_registers/src/error.rs
@@ -62,7 +62,7 @@ pub enum Error {
         requested: Box<RegisterAddress>,
         got: Box<RegisterAddress>,
     },
-    /// The provided RegisterAddress is invalid
+    /// The provided String can't be deserialized as a RegisterAddress
     #[error("Failed to deserialize hex RegisterAddress")]
     HexDeserializeFailed,
 }

--- a/sn_registers/src/error.rs
+++ b/sn_registers/src/error.rs
@@ -15,14 +15,14 @@ use crate::{EntryHash, RegisterAddress, User};
 pub enum Error {
     /// Register operation destination address mismatch
     #[error(
-        "The CRDT operation cannot be applied since the Register operation destination address ({dst_addr:?}) \
-         doesn't match the targeted Register's address: {reg_addr:?}"
+        "The CRDT operation cannot be applied since the Register operation destination address ({dst_addr}) \
+         doesn't match the targeted Register's address: {reg_addr}"
     )]
     RegisterAddrMismatch {
         /// Register operation destination address
-        dst_addr: RegisterAddress,
+        dst_addr: Box<RegisterAddress>,
         /// Targeted Register's address
-        reg_addr: RegisterAddress,
+        reg_addr: Box<RegisterAddress>,
     },
     /// Entry is too big to fit inside a register
     #[error("Entry is too big to fit inside a register: {size}, max: {max}")]
@@ -57,13 +57,14 @@ pub enum Error {
     #[error("Invalid SecretKey provided, signer is not the owner of the Register")]
     InvalidSecretKey,
     /// The register obtained was not the one requested
-    #[error(
-        "Got Register with an invalid register address, requested: {requested:?}, got: {got:?}"
-    )]
+    #[error("Got Register with an invalid register address, requested: {requested}, got: {got}")]
     InvalidRegisterAddress {
-        requested: RegisterAddress,
-        got: RegisterAddress,
+        requested: Box<RegisterAddress>,
+        got: Box<RegisterAddress>,
     },
+    /// The provided RegisterAddress is invalid
+    #[error("Failed to deserialize hex RegisterAddress")]
+    HexDeserializeFailed,
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -91,8 +91,8 @@ impl RegisterCrdt {
         // Check the targetting address is correct
         if self.address != op.address {
             return Err(Error::RegisterAddrMismatch {
-                dst_addr: op.address,
-                reg_addr: self.address,
+                dst_addr: Box::new(op.address),
+                reg_addr: Box::new(self.address),
             });
         }
 
@@ -121,18 +121,19 @@ impl RegisterCrdt {
 mod tests {
     use super::*;
 
+    use bls::SecretKey;
     use xor_name::XorName;
 
     #[test]
     fn creating_entry_hash() -> Result<()> {
         let mut rng = rand::thread_rng();
         let address_1 = RegisterAddress {
-            name: XorName::random(&mut rng),
-            tag: 0,
+            meta: XorName::random(&mut rng),
+            owner: SecretKey::random().public_key(),
         };
         let address_2 = RegisterAddress {
-            name: XorName::random(&mut rng),
-            tag: 0,
+            meta: XorName::random(&mut rng),
+            owner: SecretKey::random().public_key(),
         };
 
         let mut crdt_1 = RegisterCrdt::new(address_1);

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -26,8 +26,6 @@ const MAX_REG_NUM_ENTRIES: u16 = 1024;
 /// A Register on the SAFE Network
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct Register {
-    /// Owner of the Register
-    owner: PublicKey,
     /// CRDT data of the Register
     crdt: RegisterCrdt,
     /// Permissions of the Register
@@ -79,8 +77,8 @@ impl SignedRegister {
     pub fn verify_with_address(&self, address: RegisterAddress) -> Result<()> {
         if self.base_register.address() != &address {
             return Err(Error::InvalidRegisterAddress {
-                requested: address,
-                got: *self.address(),
+                requested: Box::new(address),
+                got: Box::new(*self.address()),
             });
         }
         self.verify()
@@ -122,7 +120,7 @@ impl SignedRegister {
 
     /// Return the owner of the data.
     pub fn owner(&self) -> PublicKey {
-        self.base_register.owner
+        self.base_register.owner()
     }
 
     /// Check and add an Op to the SignedRegister
@@ -135,11 +133,10 @@ impl SignedRegister {
 
 impl Register {
     /// Create a new Register
-    pub fn new(owner: PublicKey, name: XorName, tag: u64, mut permissions: Permissions) -> Self {
-        let address = RegisterAddress { name, tag };
+    pub fn new(owner: PublicKey, meta: XorName, mut permissions: Permissions) -> Self {
+        let address = RegisterAddress { meta, owner };
         permissions.writers.insert(User::Key(owner));
         Self {
-            owner,
             crdt: RegisterCrdt::new(address),
             permissions,
         }
@@ -147,7 +144,7 @@ impl Register {
 
     /// Sign a Register and return the signature, makes sure the signer is the owner in the process
     pub fn sign(&self, secret_key: &SecretKey) -> Result<Signature> {
-        if self.owner != secret_key.public_key() {
+        if self.owner() != secret_key.public_key() {
             return Err(Error::InvalidSecretKey);
         }
         let bytes = self.bytes()?;
@@ -168,9 +165,9 @@ impl Register {
     }
 
     #[cfg(test)]
-    pub fn new_owned(owner: PublicKey, name: XorName, tag: u64) -> Self {
+    pub fn new_owned(owner: PublicKey, meta: XorName) -> Self {
         let permissions = Default::default();
-        Self::new(owner, name, tag, permissions)
+        Self::new(owner, meta, permissions)
     }
 
     /// Return the address.
@@ -178,19 +175,9 @@ impl Register {
         self.crdt.address()
     }
 
-    /// Return the name.
-    pub fn name(&self) -> &XorName {
-        self.address().name()
-    }
-
-    /// Return the tag.
-    pub fn tag(&self) -> u64 {
-        self.address().tag()
-    }
-
     /// Return the owner of the data.
     pub fn owner(&self) -> PublicKey {
-        self.owner
+        self.address().owner()
     }
 
     /// Return the number of items held in the register
@@ -227,7 +214,7 @@ impl Register {
         children: BTreeSet<EntryHash>,
     ) -> Result<(EntryHash, RegisterOp)> {
         self.check_entry_and_reg_sizes(&entry)?;
-        self.crdt.write(entry, children, User::Key(self.owner))
+        self.crdt.write(entry, children, User::Key(self.owner()))
     }
 
     /// Apply a signed data CRDT operation.
@@ -261,7 +248,7 @@ impl Register {
     /// `Ok(())` if the user can write to this register
     /// `Err::AccessDenied` if the user cannot write to this register
     pub fn check_user_permissions(&self, requester: User) -> Result<()> {
-        if requester == User::Key(self.owner) || self.permissions.can_write(&requester) {
+        if requester == User::Key(self.owner()) || self.permissions.can_write(&requester) {
             Ok(())
         } else {
             Err(Error::AccessDenied(requester))
@@ -303,18 +290,14 @@ mod tests {
 
     #[test]
     fn register_create() {
-        let name = xor_name::rand::random();
-        let tag = 43_000;
-        let (authority_sk, register) = &gen_reg_replicas(None, name, tag, None, 1)[0];
-
-        assert_eq!(*register.name(), name);
-        assert_eq!(register.tag(), tag);
+        let meta = xor_name::rand::random();
+        let (authority_sk, register) = &gen_reg_replicas(None, meta, None, 1)[0];
 
         let authority = authority_sk.public_key();
         assert_eq!(register.owner(), authority);
         assert_eq!(register.owner(), authority);
 
-        let address = RegisterAddress::new(name, tag);
+        let address = RegisterAddress::new(meta, authority);
         assert_eq!(*register.address(), address);
     }
 
@@ -323,11 +306,10 @@ mod tests {
         let authority_sk = SecretKey::random();
         let authority = authority_sk.public_key();
 
-        let name: XorName = xor_name::rand::random();
-        let tag = 43_000u64;
+        let meta: XorName = xor_name::rand::random();
 
-        let mut replica1 = Register::new_owned(authority, name, tag);
-        let mut replica2 = Register::new_owned(authority, name, tag);
+        let mut replica1 = Register::new_owned(authority, meta);
+        let mut replica2 = Register::new_owned(authority, meta);
 
         // Different item from same replica's root shall having different entry_hash
         let item1 = random_register_entry();
@@ -359,16 +341,15 @@ mod tests {
         let authority_sk2 = SecretKey::random();
         let authority2 = User::Key(authority_sk2.public_key());
 
-        let name: XorName = xor_name::rand::random();
-        let tag = 43_000u64;
+        let meta: XorName = xor_name::rand::random();
 
         // We'll have 'authority1' as the owner in both replicas and
         // grant permissions for Write to 'authority2' in both replicas too
         let perms = Permissions::new_with([authority1, authority2]);
 
         // Instantiate the same Register on two replicas with the two diff authorities
-        let mut replica1 = Register::new(authority_sk1.public_key(), name, tag, perms.clone());
-        let mut replica2 = Register::new(authority_sk2.public_key(), name, tag, perms);
+        let mut replica1 = Register::new(authority_sk1.public_key(), meta, perms.clone());
+        let mut replica2 = Register::new(authority_sk2.public_key(), meta, perms);
 
         // And let's write an item to replica1 with autority1
         let item1 = random_register_entry();
@@ -438,22 +419,21 @@ mod tests {
 
     #[test]
     fn register_query_public_perms() -> eyre::Result<()> {
-        let name = xor_name::rand::random();
-        let tag = 43_666;
+        let meta = xor_name::rand::random();
 
         // one replica will allow write ops to anyone
         let authority_sk1 = SecretKey::random();
         let authority_pk1 = authority_sk1.public_key();
         let owner1 = User::Key(authority_pk1);
         let perms1 = Permissions::new_anyone_can_write();
-        let replica1 = create_reg_replica_with(name, tag, Some(authority_sk1), Some(perms1));
+        let replica1 = create_reg_replica_with(meta, Some(authority_sk1), Some(perms1));
 
         // the other replica will allow write ops to 'owner1' and 'owner2' only
         let authority_sk2 = SecretKey::random();
         let authority_pk2 = authority_sk2.public_key();
         let owner2 = User::Key(authority_pk2);
         let perms2 = Permissions::new_with([owner1]);
-        let replica2 = create_reg_replica_with(name, tag, Some(authority_sk2), Some(perms2));
+        let replica2 = create_reg_replica_with(meta, Some(authority_sk2), Some(perms2));
 
         // dummy owner
         let sk_rand = SecretKey::random();
@@ -484,14 +464,13 @@ mod tests {
 
     #[test]
     fn exceeding_max_reg_entries_errors() -> eyre::Result<()> {
-        let name = xor_name::rand::random();
-        let tag = 43_666;
+        let meta = xor_name::rand::random();
 
         // one replica will allow write ops to anyone
         let authority_sk1 = SecretKey::random();
         let perms1 = Permissions::new_anyone_can_write();
 
-        let mut replica = create_reg_replica_with(name, tag, Some(authority_sk1), Some(perms1));
+        let mut replica = create_reg_replica_with(meta, Some(authority_sk1), Some(perms1));
 
         for _ in 0..MAX_REG_NUM_ENTRIES {
             let (_hash, _op) = replica
@@ -517,8 +496,7 @@ mod tests {
     // Helpers for tests
     fn gen_reg_replicas(
         authority_sk: Option<SecretKey>,
-        name: XorName,
-        tag: u64,
+        meta: XorName,
         perms: Option<Permissions>,
         count: usize,
     ) -> Vec<(SecretKey, Register)> {
@@ -527,7 +505,7 @@ mod tests {
                 let authority_sk = authority_sk.clone().unwrap_or_else(SecretKey::random);
                 let authority = authority_sk.public_key();
                 let perms = perms.clone().unwrap_or_default();
-                let register = Register::new(authority, name, tag, perms);
+                let register = Register::new(authority, meta, perms);
                 (authority_sk, register)
             })
             .collect();
@@ -537,19 +515,17 @@ mod tests {
     }
 
     fn create_reg_replicas(count: usize) -> Vec<(SecretKey, Register)> {
-        let name = xor_name::rand::random();
-        let tag = 43_000;
+        let meta = xor_name::rand::random();
 
-        gen_reg_replicas(None, name, tag, None, count)
+        gen_reg_replicas(None, meta, None, count)
     }
 
     fn create_reg_replica_with(
-        name: XorName,
-        tag: u64,
+        meta: XorName,
         authority_sk: Option<SecretKey>,
         perms: Option<Permissions>,
     ) -> Register {
-        let replicas = gen_reg_replicas(authority_sk, name, tag, perms, 1);
+        let replicas = gen_reg_replicas(authority_sk, meta, perms, 1);
         replicas[0].1.clone()
     }
 
@@ -574,7 +550,6 @@ mod tests {
         max_quantity: usize,
     ) -> impl Strategy<Value = Result<(Vec<Register>, Arc<SecretKey>)>> {
         let xorname = xor_name::rand::random();
-        let tag = 45_000u64;
 
         let owner_sk = Arc::new(SecretKey::random());
         let owner = owner_sk.public_key();
@@ -583,7 +558,7 @@ mod tests {
         (1..max_quantity + 1).prop_map(move |quantity| {
             let mut replicas = Vec::with_capacity(quantity);
             for _ in 0..quantity {
-                let replica = Register::new(owner, xorname, tag, perms.clone());
+                let replica = Register::new(owner, xorname, perms.clone());
 
                 replicas.push(replica);
             }
@@ -616,15 +591,13 @@ mod tests {
             _data in generate_reg_entry()
         ) {
             // Instantiate the same Register on two replicas
-            let name = xor_name::rand::random();
-            let tag = 45_000u64;
+            let meta = xor_name::rand::random();
             let owner_sk = SecretKey::random();
             let perms = Default::default();
 
             let mut replicas = gen_reg_replicas(
                 Some(owner_sk.clone()),
-                name,
-                tag,
+                meta,
                 Some(perms),
                 2);
             let (_, mut replica1) = replicas.remove(0);
@@ -644,16 +617,14 @@ mod tests {
             dataset in generate_dataset(1000)
         ) {
             // Instantiate the same Register on two replicas
-            let name = xor_name::rand::random();
-            let tag = 43_000u64;
+            let meta = xor_name::rand::random();
             let owner_sk = SecretKey::random();
             let perms = Default::default();
 
             // Instantiate the same Register on two replicas
             let mut replicas = gen_reg_replicas(
                 Some(owner_sk.clone()),
-                name,
-                tag,
+                meta,
                 Some(perms),
                 2);
             let (_, mut replica1) = replicas.remove(0);
@@ -681,16 +652,14 @@ mod tests {
             dataset in generate_dataset(1000)
         ) {
             // Instantiate the same Register on two replicas
-            let name = xor_name::rand::random();
-            let tag = 43_000u64;
+            let meta = xor_name::rand::random();
             let owner_sk = SecretKey::random();
             let perms = Default::default();
 
             // Instantiate the same Register on two replicas
             let mut replicas = gen_reg_replicas(
                 Some(owner_sk.clone()),
-                name,
-                tag,
+                meta,
                 Some(perms),
                 2);
             let (_, mut replica1) = replicas.remove(0);
@@ -822,16 +791,14 @@ mod tests {
             dataset in generate_dataset_and_probability(1000),
         ) {
             // Instantiate the same Register on two replicas
-            let name = xor_name::rand::random();
-            let tag = 43_000u64;
+            let meta = xor_name::rand::random();
             let owner_sk = SecretKey::random();
             let perms = Default::default();
 
             // Instantiate the same Register on two replicas
             let mut replicas = gen_reg_replicas(
                 Some(owner_sk.clone()),
-                name,
-                tag,
+                meta,
                 Some(perms),
                 2);
             let (_, mut replica1) = replicas.remove(0);
@@ -944,9 +911,8 @@ mod tests {
 
             // set up a replica that has nothing to do with the rest, random xor... different owner...
             let xorname = xor_name::rand::random();
-            let tag = 45_000u64;
             let random_owner_sk = SecretKey::random();
-            let mut bogus_replica = Register::new_owned(random_owner_sk.public_key(), xorname, tag);
+            let mut bogus_replica = Register::new_owned(random_owner_sk.public_key(), xorname);
 
             // add bogus ops from bogus replica + bogus data
             let mut children = BTreeSet::new();

--- a/sn_registers/src/register_op.rs
+++ b/sn_registers/src/register_op.rs
@@ -65,10 +65,11 @@ impl RegisterOp {
 
     /// Add signature to register Op using provided secret key
     pub fn sign_with(&mut self, sk: &bls::SecretKey) {
-        let bytes = self.bytes_for_signing();
-        let signature = sk.sign(bytes);
         self.source = User::Key(sk.public_key());
+        let bytes = self.bytes_for_signing();
+        let signature = sk.sign(bytes.clone());
         self.signature = Some(signature);
+        debug_assert!(self.verify_signature(&sk.public_key()).is_ok());
     }
 
     /// Manually add signature to register Op

--- a/sn_registers/src/register_op.rs
+++ b/sn_registers/src/register_op.rs
@@ -24,7 +24,7 @@ pub struct RegisterOp {
     pub(crate) crdt_op: MerkleDagEntry<Entry>,
     /// The PublicKey of the entity that generated the operation
     pub(crate) source: User,
-    /// The signature of source on the crdt_op, required to apply the op
+    /// The signature of source on hash(address, crdt_op, source) required to apply the op
     pub(crate) signature: Option<bls::Signature>,
 }
 

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -589,7 +589,7 @@ mod tests {
 
         let public_address_name = public_address_name(&recipient_public_address);
         let public_address_dir = format!("public_address_{}", hex::encode(public_address_name));
-        let dbc_id_name = *DbcAddress::from_dbc_id(&dbc_id).name();
+        let dbc_id_name = *DbcAddress::from_dbc_id(&dbc_id).xorname();
         let dbc_id_file_name = format!("{}.dbc", hex::encode(dbc_id_name));
 
         let created_dbcs_dir = sender_root_dir.join(WALLET_DIR_NAME).join("created_dbcs");

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -57,7 +57,7 @@ pub(super) async fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path
         // One dir per recipient public address.
         let public_address_name = public_address_name(dbc.public_address());
         let public_address_dir = format!("public_address_{}", hex::encode(public_address_name));
-        let dbc_id_name = *DbcAddress::from_dbc_id(&dbc.id()).name();
+        let dbc_id_name = *DbcAddress::from_dbc_id(&dbc.id()).xorname();
         let dbc_id_file_name = format!("{}.dbc", hex::encode(dbc_id_name));
 
         let public_address_dir_path = created_dbcs_path.join(&public_address_dir);


### PR DESCRIPTION
## Description

- Fixes the register replacement attack
- Removes unpopular/confusing register tag
- Make register related logs actionable by printing hex encoded `RegisterAddress` everywhere throughout the code so users can directly paste it in the cli
- Fixes a signature bug that was revealed by this PR!

Now register addresses are:
```rust
pub struct RegisterAddress {
    /// User chosen meta, can be anything, the register's name on the network will be the hash of this meta and the owner
    pub(crate) meta: XorName,
    /// Owner of the register
    pub(crate) owner: PublicKey,
}
```
I used `XorName` for `meta` to limit the changes for this PR, but virtually anything is possible here, we could allow users to choose a string, or bytes metadata, anything really. 

This makes `RegisterAddress` bigger so I had to Box a lot of `Error` contents to keep enum sizes in check. 

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Aug 23 10:25 UTC
This pull request includes the following changes:

- The `RegisterOp` struct in `register_op.rs` now has an updated `signature` field with a more detailed comment explaining its requirement.
- The `get_validation.rs` file has changes related to improving memory management and reducing memory usage.
- The `error.rs` file in the `sn_protocol` module has modifications to the error handling logic, using boxes for specific types in the error variants.
- Various changes have been made in the usage of `RegisterAddress` and `XorName` in different files related to interacting with registers.
- The `address.rs` file has undergone multiple changes, including adding and removing dependencies, modifying the `RegisterAddress` struct, implementing new functions, and adding tests.
- The `put_validation.rs` file in the `sn_node/src` directory has updates to the error handling logic, including passing boxed register addresses instead of just register names.
- The `register.rs` file has changes such as removing imports, modifying functions to use `RegisterAddress` instead of `XorName` and `tag`, and updating log messages.
- The `api.rs` file has changes related to error handling and the usage of `RegisterAddress` instead of `address`.
- The implementation of the `ReplicatedData` struct in the `mod.rs` file has been modified, removing the dereference operator of `register.address().name()`.
- The `reg_crdt.rs` file has changes to the error handling related to address mismatch and modifications to the `RegisterAddress` struct in the tests module.
- The `register.rs` file has updates to the register functionality, including changes in function parameters, the removal of certain functions, and updates to log messages.
- The implementation of the `RegisterCrdt` struct in the `reg_crdt.rs` file has changes related to error handling and modifications to the `RegisterAddress` struct in the tests module.
- The `register.rs` file has changes such as adding imports, updating variants, modifying function parameters, and adding print statements.
- The `register.rs` file has modifications such as removing an import, updating method implementations, and simplifying the code.
- The `RegisterAddress` struct in the `network_address.rs` file has changes in the error variants of the `Error` enum.
- The `network_address.rs` file has changes such as removing an import, updating method implementations, and implementing `Debug` for `NetworkAddress`.
- The `register.rs` file has changes such as updating imports, modifying variants, and adding a new variant to the `Error` enum.
- The `register.rs` file has changes such as removing an import, updating method implementations, and simplifying the code.

Overall, these changes involve various updates and modifications in different files related to register operations, error handling, address handling, and function parameters.
<!-- reviewpad:summarize:end --> 
