### PR TITLE
chore(ci): do not upload benchmark logs

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -117,12 +117,11 @@ jobs:
       ### Mem Analysis      ###
       #########################
       
-      - name: Stop the local network and upload logs
+      - name: Stop the local network
         if: always()
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_benchmark_prs
           platform: ubuntu-latest
 
       # The large file uploaded will increase node's peak mem usage a lot

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -112,12 +112,11 @@ jobs:
       ### Mem Analysis      ###
       #########################
 
-      - name: Stop the local network and upload logs
+      - name: Stop the local network
         if: always()
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_benchmark_charts
           platform: ubuntu-latest
 
       - name: Check node memory usage


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Aug 23 19:00 UTC
This pull request makes a chore improvement in the CI workflow by removing the step that uploads benchmark logs. The patch modifies two files: ".github/workflows/benchmark-prs.yml" and ".github/workflows/generate-benchmark-charts.yml". The changes involve stopping the local network without uploading logs, which helps reduce the node's peak memory usage.
<!-- reviewpad:summarize:end --> 
