### PR TITLE
chore(ci): revert benchmark name change

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -139,7 +139,7 @@ jobs:
           # Write the node memory usage to a file
           echo '[
               {
-                  "name": "node-memory-usage-through-safe-benchmark",
+                  "name": "Peak memory w/ `safe` benchmarks",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               }
@@ -198,12 +198,12 @@ jobs:
           # Write the client memory usage to a file
           echo '[
               {
-                  "name": "client-peak-memory-usage-during-upload",
+                  "name": "Peak memory usage w/ upload",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               },
               {
-                  "name": "client-average-memory-usage-during-upload",
+                  "name": "Average memory usage w/ upload",
                   "value": '$average_mem',
                   "unit": "MB"
               }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Aug 23 06:42 UTC
This pull request reverts the name change of benchmarks in the ci workflow. Specifically, it changes the name "Peak memory w/ `safe` benchmarks" back to "node-memory-usage-through-safe-benchmark", and changes "Peak memory usage w/ upload" back to "client-peak-memory-usage-during-upload", and "Average memory usage w/ upload" back to "client-average-memory-usage-during-upload".
<!-- reviewpad:summarize:end --> 
