### PR TITLE
chore(node): dont verify during benchmarks

### DIFF
--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -18,6 +18,7 @@ fn safe_files_upload(dir: &str) {
         .arg("files")
         .arg("upload")
         .arg(dir)
+        .arg("-n")
         .output()
         .expect("Failed to execute command");
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Aug 23 10:41 UTC
This pull request updates the `files.rs` file in the `sn_cli/benches` directory. It adds a new command line argument `--no_verify` to the `safe_files_upload` function. This change prevents verification during benchmarks.
<!-- reviewpad:summarize:end --> 
