### PR TITLE
nonense change to test ci

### DIFF
--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -118,7 +118,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // The download will download all uploaded files during bench.
     // If the previous bench executed with the default 100 sample size,
     // there will then be around 1.1GB in total, and may take around 40s for each iteratioin.
-    // Hence we have to reduce the number of iterations from the default 100 to 10,
+    // Hence the number of iterations from the default 100 to 10,
     // To avoid the benchmark test taking over one hour to complete.
     let total_size: u64 = sizes.iter().map(|size| SAMPLE_SIZE as u64 * size).sum();
     group.sample_size(SAMPLE_SIZE / 5);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Aug 23 11:24 UTC
This pull request includes a nonsensical change to the test CI. The number of iterations in the benchmark test has been reduced from 100 to 10 to avoid the test taking too long to complete.
<!-- reviewpad:summarize:end --> 
