### PR TITLE
fix(cli): remove manual faucet claim from benchmarking.

### DIFF
--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -1,9 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use std::process::{exit, Command};
-use std::time::Duration;
+use std::{
+    fs::File,
+    io::Write,
+    path::Path,
+    process::{exit, Command},
+    time::Duration,
+};
 use tempfile::tempdir;
 
 const SAMPLE_SIZE: usize = 50;
@@ -51,37 +53,12 @@ fn create_file(size_mb: u64) -> tempfile::TempDir {
 }
 
 fn fund_cli_wallet() {
-    let output = Command::new("./target/release/safe")
-        .arg("wallet")
-        .arg("address")
-        .output()
-        .expect("Failed to execute 'safe wallet address' command");
-
-    let str = String::from_utf8(output.stdout).unwrap();
-    let addr = str.lines().last().unwrap();
-
-    let _ = Command::new("./target/release/faucet")
-        .arg("claim-genesis")
-        .output()
-        .expect("Failed to execute 'faucet claim-genesis");
-
-    let output = Command::new("./target/release/faucet")
-        .arg("send")
-        .arg("10000")
-        .arg(addr)
-        .output()
-        .expect("Failed to execute 'faucet send 10000' command");
-
-    let str = String::from_utf8(output.stdout).unwrap();
-    let dbc_hex = str.lines().last().unwrap();
-
     let _ = Command::new("./target/release/safe")
         .arg("wallet")
-        .arg("deposit")
-        .arg("--dbc")
-        .arg(dbc_hex)
+        .arg("get-faucet")
+        .arg("127.0.0.1:8000")
         .output()
-        .expect("Failed to execute 'safe wallet deposit' command");
+        .expect("Failed to execute 'safe wallet get-faucet' command");
 }
 
 fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
local testnets already start a faucet and make that claim

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Aug 23 21:05 UTC
This pull request fixes an issue in the CLI code. It removes the manual faucet claim from benchmarking because local testnets already start a faucet and make that claim. The changes include 11 insertions and 33 deletions in the `files.rs` file of the `sn_cli/benches` directory.
<!-- reviewpad:summarize:end --> 
