### PR TITLE
Reduce initial peers req for client

### DIFF
--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -55,8 +55,6 @@ fn create_file(size_mb: u64) -> tempfile::TempDir {
 }
 
 fn fund_cli_wallet() {
-    println!("Setting up CLI wallet");
-
     let _ = Command::new("./target/release/safe")
         .arg("wallet")
         .arg("get-faucet")


### PR DESCRIPTION
local testnets already start a faucet and make that claim## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Aug 23 21:08 UTC
This pull request includes two patches. 

The first patch removes the manual claim of a faucet from the benchmarking process, as local testnets already handle this.

The second patch updates the minimum connection count on startup to use CLOSE_GROUP_SIZE from the sn_networking module. This change improves the startup performance of the client.
<!-- reviewpad:summarize:end --> 
