### PR TITLE
chore(node): increase faucet default send

### DIFF
--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -48,7 +48,7 @@ pub async fn run_faucet_server(client: &Client) -> Result<()> {
         );
         let key = request.url().trim_matches(path::is_separator);
 
-        match send_tokens(client, "1000000", key).await {
+        match send_tokens(client, "1000000000", key).await {
             Ok(dbc) => {
                 println!("Sent tokens to {}", key);
                 let response = Response::from_string(dbc);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Aug 23 05:43 UTC
This pull request updates the `faucet_server.rs` file in the `sn_node/src/bin/faucet` directory. The change increases the default send value in the `run_faucet_server` function from "1000000" to "10000000000000000" when calling the `send_tokens` function.
<!-- reviewpad:summarize:end --> 
