### PR TITLE
chore: tweak the storage cost curve

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -245,7 +245,8 @@ impl DiskBackedRecordStore {
     /// Calculate the cost to store data for our current store state
     pub fn store_cost(&self) -> Token {
         // Calculate the factor to increase the cost for every PUTS_PER_PRICE_STEP records
-        let factor = 2.0f64.powf(MAX_RECORDS_COUNT as f64 / PUTS_PER_PRICE_STEP as f64) as u64;
+        let factor =
+            10.0f64.powf(MAX_RECORDS_COUNT as f64 / PUTS_PER_PRICE_STEP as f64 - 2.0_f64) as u64;
 
         // Calculate the starting cost
         let mut cost = TOTAL_SUPPLY / factor;


### PR DESCRIPTION
Make the curve more exponentially. Reduce the starting cost from trillion to around 8 tokens, then more exponentially stepping increased according to the stored records.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Aug 23 08:25 UTC
This pull request tweaks the storage cost curve by making it more exponentially increasing. The starting cost is reduced from trillion to around 8 tokens, and the cost increases exponentially according to the number of stored records.
<!-- reviewpad:summarize:end --> 
