### PR TITLE
feat(test): enable location verification for churn test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -465,6 +465,7 @@ jobs:
             # new output folder to avoid linker issues w/ windows
             CARGO_TARGET_DIR: "./data-location-target"
             CHURN_COUNT: 4
+            CHUNK_COUNT: 100
             SN_LOG: "all"
           timeout-minutes: 30
 

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -7,22 +7,37 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 #![allow(dead_code)]
+#![allow(clippy::mutable_key_type)]
 
 #[allow(unused_qualifications, unreachable_pub, clippy::unwrap_used)]
 pub mod safenode_proto {
     tonic::include_proto!("safenode_proto");
 }
 
-use safenode_proto::{safe_node_client::SafeNodeClient, NodeInfoRequest, RestartRequest};
-use sn_client::{load_faucet_wallet_from_genesis_wallet, send, Client};
-use sn_peers_acquisition::parse_peer_addr;
-use sn_transfers::wallet::LocalWallet;
-
 use eyre::{eyre, Result};
 use lazy_static::lazy_static;
+use libp2p::{
+    kad::{KBucketKey, RecordKey},
+    PeerId,
+};
+use safenode_proto::{
+    safe_node_client::SafeNodeClient, NodeInfoRequest, RecordAddressesRequest, RestartRequest,
+};
+use sn_client::{load_faucet_wallet_from_genesis_wallet, send, Client};
 use sn_dbc::Token;
 use sn_logging::{LogFormat, LogOutputDest};
-use std::{net::SocketAddr, path::Path, sync::Once};
+use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
+use sn_peers_acquisition::parse_peer_addr;
+use sn_protocol::PrettyPrintRecordKey;
+use sn_transfers::wallet::LocalWallet;
+
+use std::{
+    collections::{HashMap, HashSet},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
+    sync::Once,
+    time::Duration,
+};
 use tokio::{fs::remove_dir_all, sync::Mutex};
 use tonic::Request;
 use tracing_core::Level;
@@ -146,4 +161,184 @@ pub async fn node_restart(addr: SocketAddr) -> Result<()> {
     );
 
     Ok(())
+}
+
+// DATA_LOCATION_VERIFICATION_DELAY is set based on the dead peer detection interval
+// Once a node has been restarted, it takes VERIFICATION_DELAY time
+// for the old peer to be removed from the routing table.
+// Replication is then kicked off to distribute the data to the new closest
+// nodes, hence verification has to be performed after this.
+pub const DATA_LOCATION_VERIFICATION_DELAY: Duration = Duration::from_secs(300);
+// Number of times to retry verification if it fails
+const DATA_LOCATION_VERIFICATION_ATTEMPTS: usize = 3;
+
+type NodeIndex = usize;
+pub struct DataLocationVerification {
+    node_count: usize,
+    pub all_peers: Vec<PeerId>,
+    record_holders: HashMap<RecordKey, HashSet<NodeIndex>>,
+}
+
+impl DataLocationVerification {
+    pub async fn new(node_count: usize) -> Result<Self> {
+        let mut ver = Self {
+            node_count,
+            all_peers: Default::default(),
+            record_holders: Default::default(),
+        };
+        ver.collect_all_peer_ids().await?;
+        ver.collect_initial_record_keys().await?;
+        Ok(ver)
+    }
+
+    pub fn update_peer_index(&mut self, node_index: NodeIndex, peer_id: PeerId) {
+        self.all_peers[node_index - 1] = peer_id;
+    }
+
+    // Verifies that the chunk is stored by the actual closest peers to the RecordKey
+    pub async fn verify(&mut self) -> Result<()> {
+        self.get_record_holder_list().await?;
+
+        let mut failed = HashMap::new();
+        let mut verification_attempts = 0;
+        while verification_attempts < DATA_LOCATION_VERIFICATION_ATTEMPTS {
+            failed.clear();
+            for (key, actual_closest_idx) in self.record_holders.iter() {
+                println!("Verifying {:?}", PrettyPrintRecordKey::from(key.clone()));
+                let record_key = KBucketKey::from(key.to_vec());
+                let expected_closest_peers =
+                    sort_peers_by_key(self.all_peers.clone(), &record_key, CLOSE_GROUP_SIZE)?
+                        .into_iter()
+                        .collect::<HashSet<_>>();
+
+                let actual_closest = actual_closest_idx
+                    .iter()
+                    .map(|idx| self.all_peers[*idx - 1])
+                    .collect::<HashSet<_>>();
+
+                let mut failed_peers = Vec::new();
+                expected_closest_peers
+                    .iter()
+                    .filter(|expected| !actual_closest.contains(expected))
+                    .for_each(|expected| failed_peers.push(*expected));
+
+                if !failed_peers.is_empty() {
+                    failed.insert(key.clone(), failed_peers);
+                }
+            }
+
+            if !failed.is_empty() {
+                println!("Verification failed");
+
+                failed.iter().for_each(|(key, failed_peers)| {
+                    failed_peers.iter().for_each(|peer| {
+                        println!(
+                            "Record {:?} is not stored inside {peer:?}",
+                            PrettyPrintRecordKey::from(key.clone()),
+                        )
+                    });
+                });
+                println!("State of each node:");
+                self.record_holders.iter().for_each(|(key, node_index)| {
+                    println!(
+                        "Record {:?} is currently held by node indexes {node_index:?}",
+                        PrettyPrintRecordKey::from(key.clone())
+                    );
+                });
+                println!("Node index map:");
+                self.all_peers
+                    .iter()
+                    .enumerate()
+                    .for_each(|(idx, peer)| println!("{} : {peer:?}", idx + 1));
+                verification_attempts += 1;
+                println!("Sleeping before retrying verification");
+                tokio::time::sleep(Duration::from_secs(20)).await;
+            } else {
+                // if successful, break out of the loop
+                break;
+            }
+        }
+
+        if !failed.is_empty() {
+            println!("Verification failed after {DATA_LOCATION_VERIFICATION_ATTEMPTS} times");
+            Err(eyre!("Verification failed for: {failed:?}"))
+        } else {
+            println!("All the Records have been verified!");
+            Ok(())
+        }
+    }
+
+    // Collect all the PeerId for all the locally running nodes
+    async fn collect_all_peer_ids(&mut self) -> Result<()> {
+        let mut all_peers = Vec::new();
+
+        let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+        for node_index in 1..self.node_count + 1 {
+            addr.set_port(12000 + node_index as u16);
+            let endpoint = format!("https://{addr}");
+            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+
+            // get the peer_id
+            let response = rpc_client
+                .node_info(Request::new(NodeInfoRequest {}))
+                .await?;
+            let peer_id = PeerId::from_bytes(&response.get_ref().peer_id)?;
+            all_peers.push(peer_id);
+        }
+        println!(
+            "Obtained the PeerId list for the locally running network with a node count of {}",
+            self.node_count
+        );
+
+        self.all_peers = all_peers;
+        Ok(())
+    }
+
+    // Collect the initial set of records keys after put
+    async fn collect_initial_record_keys(&mut self) -> Result<()> {
+        for node_index in 1..self.node_count + 1 {
+            let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+            addr.set_port(12000 + node_index as u16);
+            let endpoint = format!("https://{addr}");
+            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+
+            let response = rpc_client
+                .record_addresses(Request::new(RecordAddressesRequest {}))
+                .await?;
+
+            for bytes in response.get_ref().addresses.iter() {
+                let key = RecordKey::from(bytes.clone());
+                self.record_holders.insert(key, Default::default());
+            }
+        }
+        Ok(())
+    }
+
+    // get all the current set of holders for pre filled Record keys
+    async fn get_record_holder_list(&mut self) -> Result<()> {
+        // Clear the set of NodeIndex before updating with the new set
+        for (_, v) in self.record_holders.iter_mut() {
+            *v = HashSet::new();
+        }
+        for node_index in 1..self.node_count + 1 {
+            let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+            addr.set_port(12000 + node_index as u16);
+            let endpoint = format!("https://{addr}");
+            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+
+            let response = rpc_client
+                .record_addresses(Request::new(RecordAddressesRequest {}))
+                .await?;
+
+            for bytes in response.get_ref().addresses.iter() {
+                let key = RecordKey::from(bytes.clone());
+                self.record_holders
+                .get_mut(&key)
+                .ok_or_else(|| eyre!("Key {key:?} has not been PUT to the network by the test. Please restart the local testnet"))?
+                .insert(node_index);
+            }
+        }
+        println!("Obtained the current set of Record Key holders");
+        Ok(())
+    }
 }

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -13,14 +13,11 @@ use assert_fs::TempDir;
 use bytes::Bytes;
 use common::{
     get_client_and_wallet, node_restart,
-    safenode_proto::{safe_node_client::SafeNodeClient, NodeInfoRequest, RecordAddressesRequest},
-    PAYING_WALLET_INITIAL_BALANCE,
+    safenode_proto::{safe_node_client::SafeNodeClient, NodeInfoRequest},
+    DataLocationVerification, DATA_LOCATION_VERIFICATION_DELAY, PAYING_WALLET_INITIAL_BALANCE,
 };
-use eyre::{eyre, Result};
-use libp2p::{
-    kad::{KBucketKey, RecordKey},
-    PeerId,
-};
+use eyre::Result;
+use libp2p::{kad::RecordKey, PeerId};
 use rand::{rngs::OsRng, Rng};
 use sn_client::{Client, Files, WalletClient};
 use sn_logging::{init_logging, LogFormat, LogOutputDest};
@@ -28,7 +25,7 @@ use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{storage::ChunkAddress, NetworkAddress, PrettyPrintRecordKey};
 use sn_transfers::wallet::LocalWallet;
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
@@ -38,27 +35,17 @@ use tracing_core::Level;
 const NODE_COUNT: u8 = 25;
 const CHUNK_SIZE: usize = 1024;
 
-// VERIFICATION_DELAY is set based on the dead peer detection interval
-// Once a node has been restarted, it takes VERIFICATION_DELAY time
-// for the old peer to be removed from the routing table.
-// Replication is then kicked off to distribute the data to the new closest
-// nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(300);
-
-// Number of times to retry verification if it fails
-const VERIFICATION_ATTEMPTS: usize = 3;
-
 // Default number of churns that should be performed. After each churn, we
 // wait for VERIFICATION_DELAY time before verifying the data location.
 // It can be overridden by setting the 'CHURN_COUNT' env var.
 const CHURN_COUNT: u8 = 4;
 
-/// Default number of chunks that should be PUT to the netowrk.
+/// Default number of chunks that should be PUT to the network.
 // It can be overridden by setting the 'CHUNK_COUNT' env var.
 const CHUNK_COUNT: usize = 5;
 
 type NodeIndex = u8;
-type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
+pub type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
@@ -87,12 +74,8 @@ async fn verify_data_location() -> Result<()> {
     };
     println!(
         "Performing data location verification with a churn count of {churn_count} and n_chunks {chunk_count}\nIt will take approx {:?}",
-        VERIFICATION_DELAY*churn_count as u32
+        DATA_LOCATION_VERIFICATION_DELAY*churn_count as u32
     );
-
-    // set of all the node indexes that stores a record key
-    let mut record_holders = RecordHolders::default();
-    let mut all_peers = get_all_peer_ids().await?;
 
     // Store chunks
     println!("Creating a client and paying wallet...");
@@ -102,11 +85,11 @@ async fn verify_data_location() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), PAYING_WALLET_INITIAL_BALANCE).await?;
 
     store_chunk(client, paying_wallet, chunk_count).await?;
-    get_initial_record_keys(&mut record_holders).await?;
+
+    let mut data_verification = DataLocationVerification::new(NODE_COUNT as usize).await?;
 
     // Verify data location initially
-    get_record_holder_list(&mut record_holders).await?;
-    verify_location(&record_holders, &all_peers).await?;
+    data_verification.verify().await?;
 
     // Churn nodes and verify the location of the data after VERIFICATION_DELAY
     let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
@@ -124,8 +107,8 @@ async fn verify_data_location() -> Result<()> {
         node_restart(addr).await?;
 
         // wait for the dead peer to be removed from the RT and the replication flow to finish
-        println!("\nNode {node_index} has been restarted, waiting for {VERIFICATION_DELAY:?} before verification");
-        tokio::time::sleep(VERIFICATION_DELAY).await;
+        println!("\nNode {node_index} has been restarted, waiting for {DATA_LOCATION_VERIFICATION_DELAY:?} before verification");
+        tokio::time::sleep(DATA_LOCATION_VERIFICATION_DELAY).await;
 
         // get the new PeerId for the current NodeIndex
         let endpoint = format!("https://{addr}");
@@ -134,14 +117,12 @@ async fn verify_data_location() -> Result<()> {
             .node_info(Request::new(NodeInfoRequest {}))
             .await?;
         let peer_id = PeerId::from_bytes(&response.get_ref().peer_id)?;
-        all_peers[node_index as usize - 1] = peer_id;
+        data_verification.update_peer_index(node_index as usize, peer_id);
 
-        // get the new set of holders
-        get_record_holder_list(&mut record_holders).await?;
+        print_node_close_groups(&data_verification.all_peers);
 
-        print_node_close_groups(&all_peers);
-
-        verify_location(&record_holders, &all_peers).await?;
+        // get the new set of holders and verify
+        data_verification.verify().await?;
 
         node_index += 1;
         if node_index > NODE_COUNT as u16 {
@@ -164,145 +145,6 @@ fn print_node_close_groups(all_peers: &[PeerId]) {
             .collect::<Vec<_>>();
         println!("Close for {node_index}: {peer:?} are {closest_peers_idx:?}");
     }
-}
-
-// Get initial set of records keys after put
-async fn get_initial_record_keys(record_holders: &mut RecordHolders) -> Result<()> {
-    for node_index in 1..NODE_COUNT + 1 {
-        let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
-        addr.set_port(12000 + node_index as u16);
-        let endpoint = format!("https://{addr}");
-        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
-
-        let response = rpc_client
-            .record_addresses(Request::new(RecordAddressesRequest {}))
-            .await?;
-
-        for bytes in response.get_ref().addresses.iter() {
-            let key = RecordKey::from(bytes.clone());
-            record_holders.insert(key, Default::default());
-        }
-    }
-    Ok(())
-}
-
-async fn get_record_holder_list(record_holders: &mut RecordHolders) -> Result<()> {
-    // Clear the set of NodeIndex before updating with the new set
-    for (_, v) in record_holders.iter_mut() {
-        *v = HashSet::new();
-    }
-    for node_index in 1..NODE_COUNT + 1 {
-        let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
-        addr.set_port(12000 + node_index as u16);
-        let endpoint = format!("https://{addr}");
-        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
-
-        let response = rpc_client
-            .record_addresses(Request::new(RecordAddressesRequest {}))
-            .await?;
-
-        for bytes in response.get_ref().addresses.iter() {
-            let key = RecordKey::from(bytes.clone());
-            record_holders
-                .get_mut(&key)
-                .ok_or_else(|| eyre!("Key {key:?} has not been PUT to the network by the test. Please restart the local testnet"))?
-                .insert(node_index);
-        }
-    }
-    println!("Obtained the current set of Record Key holders");
-    Ok(())
-}
-
-// Verifies that the chunk is stored by the actual closest peers to the RecordKey
-async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -> Result<()> {
-    let mut failed = HashMap::new();
-    let mut verification_attempts = 0;
-    while verification_attempts < VERIFICATION_ATTEMPTS {
-        failed.clear();
-        for (key, actual_closest_idx) in record_holders.iter() {
-            println!("Verifying {:?}", PrettyPrintRecordKey::from(key.clone()));
-            let record_key = KBucketKey::from(key.to_vec());
-            let expected_closest_peers =
-                sort_peers_by_key(all_peers.to_vec(), &record_key, CLOSE_GROUP_SIZE)?
-                    .into_iter()
-                    .collect::<BTreeSet<_>>();
-
-            let actual_closest = actual_closest_idx
-                .iter()
-                .map(|idx| all_peers[*idx as usize - 1])
-                .collect::<BTreeSet<_>>();
-
-            let mut failed_peers = Vec::new();
-            expected_closest_peers
-                .iter()
-                .filter(|expected| !actual_closest.contains(expected))
-                .for_each(|expected| failed_peers.push(*expected));
-
-            if !failed_peers.is_empty() {
-                failed.insert(key.clone(), failed_peers);
-            }
-        }
-
-        if !failed.is_empty() {
-            println!("Verification failed");
-
-            failed.iter().for_each(|(key, failed_peers)| {
-                failed_peers.iter().for_each(|peer| {
-                    println!(
-                        "Record {:?} is not stored inside {peer:?}",
-                        PrettyPrintRecordKey::from(key.clone()),
-                    )
-                });
-            });
-            println!("State of each node:");
-            record_holders.iter().for_each(|(key, node_index)| {
-                println!(
-                    "Record {:?} is currently held by node indexes {node_index:?}",
-                    PrettyPrintRecordKey::from(key.clone())
-                );
-            });
-            println!("Node index map:");
-            all_peers
-                .iter()
-                .enumerate()
-                .for_each(|(idx, peer)| println!("{} : {peer:?}", idx + 1));
-            verification_attempts += 1;
-            println!("Sleeping before retrying verification");
-            tokio::time::sleep(Duration::from_secs(20)).await;
-        } else {
-            // if successful, break out of the loop
-            break;
-        }
-    }
-
-    if !failed.is_empty() {
-        println!("Verification failed after {VERIFICATION_ATTEMPTS} times");
-        Err(eyre!("Verification failed for: {failed:?}"))
-    } else {
-        println!("All the Records have been verified!");
-        Ok(())
-    }
-}
-
-// Returns all the PeerId for all the locally running nodes
-async fn get_all_peer_ids() -> Result<Vec<PeerId>> {
-    let mut all_peers = Vec::new();
-
-    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
-    for node_index in 1..NODE_COUNT + 1 {
-        addr.set_port(12000 + node_index as u16);
-        let endpoint = format!("https://{addr}");
-        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
-
-        // get the peer_id
-        let response = rpc_client
-            .node_info(Request::new(NodeInfoRequest {}))
-            .await?;
-        let peer_id = PeerId::from_bytes(&response.get_ref().peer_id)?;
-        all_peers.push(peer_id);
-    }
-    println!("Obtained the PeerId list for the locally running network with a node count of {NODE_COUNT}");
-    Ok(all_peers)
 }
 
 // Generate a random Chunk and store it to the Network


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Aug 23 10:14 UTC
This pull request includes several changes across multiple files:

1. In the `verify_data_location.rs` file:
   - Added an `allow(clippy::mutable_key_type)` attribute.
   - Imported additional modules and structs from various crates.
   - Added constants `DATA_LOCATION_VERIFICATION_DELAY` and `DATA_LOCATION_VERIFICATION_ATTEMPTS`.
   - Defined the `DataLocationVerification` struct and implemented its methods.
   - Added a function `node_restart`.
   - Added comments for better code understanding.
   - Made other minor code improvements and adjustments.

2. In another file:
   - Removed unused imports and variables.
   - Removed the constants `VERIFICATION_DELAY` and `VERIFICATION_ATTEMPTS`.
   - Added the constant `DATA_LOCATION_VERIFICATION_DELAY`.
   - Renamed the function `get_initial_record_keys` to `get_record_holder_list`.
   - Moved the verification logic into a new struct called `DataLocationVerification`.
   - Replaced the function `verify_location` with the method `verify` of the `DataLocationVerification` struct.
   - Updated the code to utilize the `DataLocationVerification` struct and its methods.
   - Removed the functions `get_all_peer_ids` and `print_node_close_groups`.
   - Removed unused local variables and unnecessary log statements.

3. In another file:
   - Modified imports: The import statements for `get_client_and_wallet`, `get_funded_wallet`, `get_wallet`, and `node_restart` have been modified to include `DataLocationVerification` and `DATA_LOCATION_VERIFICATION_DELAY`.
   - Modified test output: The `println!()` statement that prints the test duration now includes `test_duration + DATA_LOCATION_VERIFICATION_DELAY`.
   - New verification step: After the retry querying task, there is a new step to perform data location verification after a delay.
   - New instance of `DataLocationVerification`: The `data_verification` variable is declared and initialized with a new instance of `DataLocationVerification`.
   - Verification of data location: The `verify()` method of the `data_verification` instance is called to verify the data location.
   - Log appender guard: The log appender guard is dropped at the end of the test.
   - Test completion message: The final message includes the duration the test ran for.
<!-- reviewpad:summarize:end --> 
