### PR TITLE
fix(CI): upload proper logs for the benchmark CI

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -114,7 +114,7 @@ jobs:
           SN_LOG: "all"
 
       #########################
-      ### Mem Analysis      ###
+      ### Stop Network      ###
       #########################
       
       - name: Stop the local network
@@ -122,7 +122,20 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
+          log_file_prefix: safe_test_logs_benchmark
           platform: ubuntu-latest
+
+      - name: Upload Faucet folder
+        uses: actions/upload-artifact@main
+        with:
+          name: faucet_folder
+          path: /home/runner/.local/share/safe/test_faucet
+        continue-on-error: true
+        if: always()
+
+      #########################
+      ### Mem Analysis      ###
+      #########################
 
       # The large file uploaded will increase node's peak mem usage a lot
       - name: Check node memory usage

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -149,10 +149,6 @@ impl DiskBackedRecordStore {
         }
     }
 
-    pub fn distance_range(&self) -> Option<Distance> {
-        self.distance_range
-    }
-
     pub fn put_verified(&mut self, r: Record) -> Result<()> {
         let content_hash = XorName::from_content(&r.value);
         trace!(


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Aug 23 11:46 UTC
This pull request fixes the issue with uploading proper logs for the benchmark CI. The changes include adding the ability to stop the local network and uploading the faucet folder. Additionally, it includes a check for node memory usage.
<!-- reviewpad:summarize:end --> 
