### PR TITLE
chore(faucet): reduce token handout

### DIFF
--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -48,7 +48,7 @@ pub async fn run_faucet_server(client: &Client) -> Result<()> {
         );
         let key = request.url().trim_matches(path::is_separator);
 
-        match send_tokens(client, "1000000000", key).await {
+        match send_tokens(client, "100", key).await {
             Ok(dbc) => {
                 println!("Sent tokens to {}", key);
                 let response = Response::from_string(dbc);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Aug 23 12:55 UTC
This pull request reduces the number of tokens handed out by the faucet server. Instead of sending 1,000,000,000 tokens, it now sends only 100 tokens.
<!-- reviewpad:summarize:end --> 
