### PR TITLE
feat(client): use network contacts file to speed up the bootstrap process

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -46,7 +46,7 @@ use tokio::sync::oneshot;
 use tracing::{info, warn};
 use xor_name::XorName;
 
-// Usig XorName to differentiate different record content under the same key.
+// Using XorName to differentiate different record content under the same key.
 pub(super) type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
 
 #[derive(NetworkBehaviour)]


### PR DESCRIPTION
- Store the multi addresses of our connected peers locally. 
- When the client is restarted, we try connecting to these peers directly. This speeds up the client bootstrap process

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Aug 23 10:49 UTC
This pull request introduces a new feature to the client code. It adds the ability to use a network contacts file to speed up the bootstrap process. The patch modifies several files in the codebase, including `main.rs`, `api.rs`, `cmd.rs`, `event.rs`, and `lib.rs`. 

In `main.rs`, the patch adds code to read network contacts from the client data directory and use them in the `Client` initialization if no peers are provided as command line arguments. It also stores network contacts in the client data directory after the client has connected to the network.

In `api.rs`, the patch adds functions to store and read network contacts from the client data directory. These functions use the `Network` struct to access the local peer addresses and write/read them to/from the network contacts file.

In `cmd.rs`, the patch adds a new command `GetAllLocalPeerAddresses` to retrieve the multiaddresses of all peers in the local routing table.

In `event.rs`, the patch fixes a typo in a comment.

In `lib.rs`, the patch adds a function `get_all_local_peer_addresses` to the `Network` struct to retrieve the multiaddresses of all peers in the local routing table.

These changes aim to improve the bootstrap process by storing and reusing network contacts, reducing the time required to connect to the network.
<!-- reviewpad:summarize:end --> 
