### PR TITLE
feat(client): do not use cached proofs

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -110,21 +110,25 @@ impl WalletClient {
         // Let's filter the content addresses we hold payment proofs for, i.e. avoid
         // paying for those chunks we've already paid for with this wallet.
         let mut proofs = PaymentProofsMap::default();
-        let addrs_to_pay: Vec<&XorName> = content_addrs
-            .filter(|name| {
-                if let Some(proof) = self.wallet.get_payment_proof(name) {
-                    proofs.insert(**name, proof.clone());
-                    false
-                } else {
-                    true
-                }
-            })
-            .collect();
+
+        let addrs_to_pay: Vec<&XorName> = content_addrs.collect();
+        // TODO: reenable this when we have a way to get the store cost from the network
+        // per chunk, and can readily check what we've paid here.
+        // .filter(|name| {
+        //     if let Some(proof) = self.wallet.get_payment_proof(name) {
+        //         proofs.insert(**name, proof.clone());
+        //         false
+        //     } else {
+        //         true
+        //     }
+        // })
+        // .collect();
 
         let number_of_records_to_pay = addrs_to_pay.len() as u64;
+
         // If no addresses need to be paid for, we don't have to go further
         if addrs_to_pay.is_empty() {
-            trace!("We already hold payment proofs for all the Chunks.");
+            trace!("We already hold payment proofs for all the records.");
             return Ok((proofs, None));
         }
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -115,6 +115,8 @@ async fn storage_payment_fails() -> Result<()> {
     Ok(())
 }
 
+// TODO: reenable
+#[ignore = "Currently we do not cache the proofs in the wallet"]
 #[tokio::test(flavor = "multi_thread")]
 async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
     let wallet_original_balance = 100_000_000_000_000_000;


### PR DESCRIPTION
Payments may well be out of date. We can check this again once we have DBCs paying per chunk and readily know the price we've paid previously

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Aug 23 14:06 UTC
This pull request updates the `WalletClient` implementation in the `sn_client/src/wallet.rs` file. It introduces a change to not use cached proofs for payments, as they may be out of date. The code filters the content addresses and collects the ones that need to be paid for. However, the current implementation is commented out as it requires a way to get the store cost from the network per chunk and check what has been paid. If no addresses need to be paid for, the code returns early.
<!-- reviewpad:summarize:end --> 
