### PR TITLE
feat!(protocol): starting to simplify payments to a per chunk basis

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use color_eyre::Result;
 use sn_client::{Client, Files};
 use sn_protocol::storage::{Chunk, ChunkAddress};
-use sn_transfers::wallet::PaymentProofsMap;
+use sn_transfers::wallet::PaymentTransactionsMap;
 
 use std::{
     fs,
@@ -139,7 +139,7 @@ async fn upload_chunks(
     file_api: &Files,
     file_name: &str,
     chunks_paths: Vec<(XorName, PathBuf)>,
-    payment_proofs: &PaymentProofsMap,
+    payment_proofs: &PaymentTransactionsMap,
     verify_store: bool,
 ) -> Result<()> {
     let chunks_reader = chunks_paths

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -8,7 +8,7 @@
 
 use sn_client::{Client, Files, WalletClient};
 use sn_dbc::Token;
-use sn_transfers::wallet::{parse_public_address, LocalWallet, PaymentProofsMap};
+use sn_transfers::wallet::{parse_public_address, LocalWallet, PaymentTransactionsMap};
 
 use bytes::Bytes;
 use clap::Parser;
@@ -236,7 +236,7 @@ pub(super) async fn chunk_and_pay_for_storage(
     root_dir: &Path,
     files_path: &Path,
     verify_store: bool,
-) -> Result<(BTreeMap<XorName, ChunkedFile>, PaymentProofsMap)> {
+) -> Result<(BTreeMap<XorName, ChunkedFile>, PaymentTransactionsMap)> {
     let wallet = LocalWallet::load_from(root_dir)
         .await
         .wrap_err("Unable to read wallet file in {path:?}")

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -18,7 +18,7 @@ use sn_dbc::{DbcId, SignedSpend, Token};
 use sn_networking::{multiaddr_is_global, NetworkEvent, SwarmDriver, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     error::Error as ProtocolError,
-    messages::PaymentProof,
+    messages::PaymentTransactions,
     storage::{
         try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, ChunkWithPayment,
         DbcAddress, RecordHeader, RecordKind, RegisterAddress,
@@ -292,7 +292,7 @@ impl Client {
     pub(super) async fn store_chunk(
         &self,
         chunk: Chunk,
-        payment: PaymentProof,
+        payment: PaymentTransactions,
         verify_store: bool,
     ) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -13,7 +13,7 @@ use super::{
 };
 
 use sn_protocol::storage::{Chunk, ChunkAddress};
-use sn_transfers::wallet::PaymentProofsMap;
+use sn_transfers::wallet::PaymentTransactionsMap;
 
 use bincode::deserialize;
 use bytes::Bytes;
@@ -96,7 +96,7 @@ impl Files {
     pub async fn upload_with_proof(
         &self,
         bytes: Bytes,
-        payment_proofs: &PaymentProofsMap,
+        payment_proofs: &PaymentTransactionsMap,
         verify_store: bool,
     ) -> Result<ChunkAddress> {
         self.upload_bytes(bytes, payment_proofs, verify_store).await
@@ -110,7 +110,7 @@ impl Files {
     pub async fn upload_and_verify(
         &self,
         bytes: Bytes,
-        payment_proofs: &PaymentProofsMap,
+        payment_proofs: &PaymentTransactionsMap,
     ) -> Result<ChunkAddress> {
         self.upload_bytes(bytes, payment_proofs, true).await
     }
@@ -141,7 +141,7 @@ impl Files {
     pub async fn upload_chunks_in_batches(
         &self,
         chunks: impl Iterator<Item = Chunk>,
-        payment_proofs: &PaymentProofsMap,
+        payment_proofs: &PaymentTransactionsMap,
         verify_store: bool,
     ) -> Result<()> {
         trace!("Client upload in batches started");
@@ -186,7 +186,7 @@ impl Files {
     async fn upload_bytes(
         &self,
         bytes: Bytes,
-        payment_proofs: &PaymentProofsMap,
+        payment_proofs: &PaymentTransactionsMap,
         verify: bool,
     ) -> Result<ChunkAddress> {
         if bytes.len() < MIN_ENCRYPTABLE_BYTES {
@@ -206,7 +206,7 @@ impl Files {
     async fn upload_small(
         &self,
         small: SmallFile,
-        payment_proofs: &PaymentProofsMap,
+        payment_proofs: &PaymentTransactionsMap,
         verify_store: bool,
     ) -> Result<ChunkAddress> {
         let chunk = package_small(small)?;

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -10,11 +10,10 @@ use super::Client;
 
 use rand::rngs::OsRng;
 use sn_dbc::{Dbc, PublicAddress, Token};
-use sn_protocol::{messages::PaymentProof, storage::ChunkAddress, NetworkAddress};
+use sn_protocol::{messages::PaymentTransactions, storage::ChunkAddress, NetworkAddress};
 use sn_transfers::{
     client_transfers::TransferOutputs,
-    payment_proof::build_payment_proofs,
-    wallet::{Error, LocalWallet, PaymentProofsMap, Result},
+    wallet::{Error, LocalWallet, PaymentTransactionsMap, Result},
 };
 
 use futures::future::join_all;
@@ -106,10 +105,10 @@ impl WalletClient {
         &mut self,
         content_addrs: impl Iterator<Item = &XorName>,
         verify_store: bool,
-    ) -> Result<(PaymentProofsMap, Option<Token>)> {
+    ) -> Result<(PaymentTransactionsMap, Option<Token>)> {
         // Let's filter the content addresses we hold payment proofs for, i.e. avoid
         // paying for those chunks we've already paid for with this wallet.
-        let mut proofs = PaymentProofsMap::default();
+        let mut proofs = PaymentTransactionsMap::default();
         let addrs_to_pay: Vec<&XorName> = content_addrs
             .filter(|name| {
                 if let Some(proof) = self.wallet.get_payment_proof(name) {
@@ -129,8 +128,10 @@ impl WalletClient {
         }
 
         // Let's build the payment proofs for list of content addresses
-        let (root_hash, audit_trail_info) = build_payment_proofs(addrs_to_pay.into_iter())?;
-        let num_of_addrs = audit_trail_info.len() as u64;
+        // let (root_hash, audit_trail_info) = build_payment_proofs(addrs_to_pay.into_iter())?;
+        // let num_of_addrs = audit_trail_info.len() as u64;
+
+        let num_of_addrs = addrs_to_pay.len();
 
         // Always check storage cost, and overpay to allow margin when validation.
         self.set_store_cost_from_random_address().await?;
@@ -141,12 +142,12 @@ impl WalletClient {
         info!("Storage cost per record: {}", storage_cost);
 
         let amount_to_pay = number_of_records_to_pay * storage_cost.as_nano();
-
         trace!("Making payment for {num_of_addrs} addresses of {amount_to_pay:?} nano tokens.");
 
+        // TODO: This needs to go out to each CLOSEGROUP of addresses
         let transfer = self
             .wallet
-            .local_send_storage_payment(Token::from_nano(amount_to_pay), root_hash, None)
+            .local_send_storage_payment(Token::from_nano(amount_to_pay), None)
             .await?;
 
         // send to network
@@ -159,25 +160,17 @@ impl WalletClient {
 
         let spent_ids: Vec<_> = transfer.tx.inputs.iter().map(|i| i.dbc_id()).collect();
 
-        let new_payment_proofs: PaymentProofsMap = audit_trail_info
-            .into_iter()
-            .map(|(addr, (audit_trail, path))| {
-                (
-                    addr,
-                    PaymentProof {
-                        spent_ids: spent_ids.clone(),
-                        audit_trail,
-                        path,
-                    },
-                )
-            })
-            .collect();
+        for addr in addrs_to_pay.into_iter() {
+            proofs.insert(
+                *addr,
+                PaymentTransactions {
+                    spent_ids: spent_ids.clone(),
+                },
+            );
+        }
 
         // cache the new set of payment proofs
-        self.wallet.add_payment_proofs(new_payment_proofs.clone());
-
-        // return the set of payment proofs, including new ones, and the ones we had in cache
-        proofs.extend(new_payment_proofs);
+        self.wallet.add_payment_proofs(proofs.clone());
 
         Ok((proofs, Some(storage_cost)))
     }

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -12,7 +12,7 @@ use common::{get_client_and_wallet, init_logging};
 
 use self_encryption::MIN_ENCRYPTABLE_BYTES;
 use sn_client::{Client, Error as ClientError, Files, WalletClient};
-use sn_dbc::{Hash, Token};
+use sn_dbc::Token;
 use sn_networking::Error as NetworkError;
 use sn_protocol::storage::{Chunk, ChunkAddress};
 
@@ -97,7 +97,7 @@ async fn storage_payment_fails() -> Result<()> {
     let storage_cost = Token::from_nano(random_num_of_addrs);
 
     let mut transfer = wallet_client
-        .local_send_storage_payment(storage_cost, Hash::default(), None)
+        .local_send_storage_payment(storage_cost, None)
         .await?;
     assert!(transfer.created_dbcs.is_empty());
 
@@ -241,48 +241,12 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
         Err(ClientError::Network(NetworkError::RecordNotFound))
     ));
 
-    // let's corrupt the proofs' audit trail
-    let invalid_proofs: std::collections::BTreeMap<_, _> = proofs
-        .clone()
-        .into_iter()
-        .map(|(a, mut p)| {
-            p.audit_trail = vec![];
-            (a, p)
-        })
-        .collect();
-
-    files_api
-        .upload_with_proof(content_bytes.clone(), &invalid_proofs, false)
-        .await?;
-    assert!(matches!(
-        files_api.read_bytes(content_addr).await,
-        Err(ClientError::Network(NetworkError::RecordNotFound))
-    ));
-
-    // let's corrupt the proofs' audit trail path
-    let invalid_proofs: std::collections::BTreeMap<_, _> = proofs
-        .clone()
-        .into_iter()
-        .map(|(a, mut p)| {
-            p.path = vec![];
-            (a, p)
-        })
-        .collect();
-
-    files_api
-        .upload_with_proof(content_bytes.clone(), &invalid_proofs, false)
-        .await?;
-    assert!(matches!(
-        files_api.read_bytes(content_addr).await,
-        Err(ClientError::Network(NetworkError::RecordNotFound))
-    ));
-
     // let's make a payment but only for one chunk/address,
-    let (root_hash, _) =
+    let (_root_hash, _) =
         sn_transfers::payment_proof::build_payment_proofs(chunks.iter().map(|c| c.name()))?;
     let transfer = wallet_client
         .into_wallet()
-        .local_send_storage_payment(Token::from_nano(1), root_hash, None)
+        .local_send_storage_payment(Token::from_nano(1), None)
         .await?;
     client.send(transfer.clone(), false).await?;
     let spent_ids: Vec<_> = transfer.tx.inputs.iter().map(|i| i.dbc_id()).collect();

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -60,13 +60,8 @@ impl std::fmt::Display for Cmd {
 pub type MerkleTreeNodesType = [u8; 32];
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
-pub struct PaymentProof {
+pub struct PaymentTransactions {
     // Ids of the DBCs spent, for nodes to check the storage payment is valid and inputs have
     // been effectivelly spent on the network.
     pub spent_ids: Vec<DbcId>,
-    // Merkletree audit trail to prove the content storage has been paid by the
-    // given DBC (using DBC's parent/s 'reason' field)
-    pub audit_trail: Vec<MerkleTreeNodesType>,
-    // Path of the audit trail
-    pub path: Vec<usize>,
 }

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -14,7 +14,7 @@ mod register;
 mod response;
 
 pub use self::{
-    cmd::{Cmd, Hash, MerkleTreeNodesType, PaymentProof},
+    cmd::{Cmd, Hash, MerkleTreeNodesType, PaymentTransactions},
     node_id::NodeId,
     query::Query,
     register::RegisterCmd,

--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::ChunkAddress;
-use crate::messages::PaymentProof;
+use crate::messages::PaymentTransactions;
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use xor_name::XorName;
@@ -76,5 +76,5 @@ impl<'de> Deserialize<'de> for Chunk {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ChunkWithPayment {
     pub chunk: Chunk,
-    pub payment: PaymentProof,
+    pub payment: PaymentTransactions,
 }

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -62,12 +62,13 @@ pub fn create_storage_payment_transfer(
     available_dbcs: Vec<(Dbc, DerivedKey)>,
     change_to: PublicAddress,
     storage_payment: Token,
-    root_hash: Hash,
     reason_hash: Hash,
 ) -> Result<TransferOutputs> {
     // We need to select the necessary number of dbcs from those that we were passed.
     let (dbcs_to_spend, change_amount) = select_inputs(available_dbcs, storage_payment)?;
 
+    // TODO: Clear all this up when we've removed this
+    let root_hash = sn_dbc::Hash::hash(b"nonsense");
     // We build the recipients to contain just a single output which is for the network owned output.
     // This is a special output that spendbook peers validating the signed spends (inputs) will be
     // verifying before accepting them as valid spends for a storage payment. This special output is

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -11,11 +11,11 @@ use super::{
     wallet_file::{
         create_received_dbcs_dir, get_wallet, load_received_dbcs, store_created_dbcs, store_wallet,
     },
-    Error, KeyLessWallet, PaymentProofsMap, Result,
+    Error, KeyLessWallet, PaymentTransactionsMap, Result,
 };
 use crate::client_transfers::{create_storage_payment_transfer, create_transfer, TransferOutputs};
 use sn_dbc::{random_derivation_index, Dbc, DerivedKey, Hash, MainKey, PublicAddress, Token};
-use sn_protocol::messages::PaymentProof;
+use sn_protocol::messages::PaymentTransactions;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -132,12 +132,12 @@ impl LocalWallet {
 
     /// Add given storage payment proofs to the wallet's cache,
     /// so they can be used when uploading the paid content.
-    pub fn add_payment_proofs(&mut self, proofs: PaymentProofsMap) {
+    pub fn add_payment_proofs(&mut self, proofs: PaymentTransactionsMap) {
         self.wallet.paymet_proofs.extend(proofs);
     }
 
     /// Return the payment proof for the given content address name if cached.
-    pub fn get_payment_proof(&self, name: &XorName) -> Option<&PaymentProof> {
+    pub fn get_payment_proof(&self, name: &XorName) -> Option<&PaymentTransactions> {
         self.wallet.paymet_proofs.get(name)
     }
 
@@ -170,7 +170,6 @@ impl LocalWallet {
     pub async fn local_send_storage_payment(
         &mut self,
         storage_payment: Token,
-        root_hash: Hash,
         reason_hash: Option<Hash>,
     ) -> Result<TransferOutputs> {
         let available_dbcs = self.available_dbcs();
@@ -180,7 +179,6 @@ impl LocalWallet {
             available_dbcs,
             self.address(),
             storage_payment,
-            root_hash,
             reason_hash.unwrap_or_default(),
         )?;
 
@@ -249,7 +247,7 @@ impl KeyLessWallet {
             spent_dbcs: BTreeMap::new(),
             available_dbcs: BTreeMap::new(),
             dbcs_created_for_others: vec![],
-            paymet_proofs: PaymentProofsMap::default(),
+            paymet_proofs: PaymentTransactionsMap::default(),
         }
     }
 

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -64,13 +64,13 @@ pub use self::{
 };
 
 use sn_dbc::{Dbc, DbcId, PublicAddress, Token};
-use sn_protocol::messages::PaymentProof;
+use sn_protocol::messages::PaymentTransactions;
 
 use std::collections::BTreeMap;
 use xor_name::XorName;
 
 /// Map from content address name to its corresponding PaymentProof.
-pub type PaymentProofsMap = BTreeMap<XorName, PaymentProof>;
+pub type PaymentTransactionsMap = BTreeMap<XorName, PaymentTransactions>;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(super) struct KeyLessWallet {
@@ -88,7 +88,7 @@ pub(super) struct KeyLessWallet {
     /// transfer history.
     dbcs_created_for_others: Vec<Dbc>,
     /// Cached proofs of storage payments made to be used for uploading the paid content.
-    paymet_proofs: PaymentProofsMap,
+    paymet_proofs: PaymentTransactionsMap,
 }
 
 /// Return the name of a PublicAddress.


### PR DESCRIPTION
A first step in #638

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Aug 23 07:59 UTC
This pull request includes several file diffs. Here is a summary of the changes:

1. In the file `cmd.rs`:
   - The struct `PaymentProof` was renamed to `PaymentTransactions`.
   - The fields `audit_trail` and `path` were removed from the `PaymentTransactions` struct.
   - The field `spent_ids` of type `Vec<DbcId>` was added to the `PaymentTransactions` struct.

2. In the file `mod.rs`:
   - Changes in the import statements, specifically the replacement of `PaymentProof` with `PaymentTransactions`.

3. In the file `sn_cli/src/subcommands/files.rs`:
   - Changes in import statements, including the removal of `PaymentProofsMap` and the addition of `PaymentTransactionsMap`.
   - Change in the parameter `payment_proofs` type from `PaymentProofsMap` to `PaymentTransactionsMap` in the function `upload_chunks`.

4. In the file `wallet.rs`:
   - Changes in import statements, swapping `PaymentProofsMap` for `PaymentTransactionsMap`.
   - The return type of the function `chunk_and_pay_for_storage` is now a tuple with `PaymentTransactionsMap`.
   - Updated error message in the function `chunk_and_pay_for_storage`.

5. In the file `put_validation.rs`:
   - Inclusion of the import statement for `PaymentTransactions`.
   - Removal of import statements for `validate_payment_proof` and `XorName`.
   - Modification of the function `verify_fee_output_and_proof` to remove the arguments `addr_name`, `audit_trail`, and `path`.
   - Modification of the parameter `chunk_with_payment` in the function `store_record` to extract the `spent_ids` from `payment`.
   - Modification of the function `verify_fee_output_and_proof` to remove the parameter `audit_trail` and `path`.
   - Modification of the unit test cases to match the changes in the `verify_fee_output_and_proof` function.

6. In the file `wallet.rs` within the `sn_client` module:
   - Replacement of the import `PaymentProof` with `PaymentTransactions`.
   - Renaming of the type `PaymentProofsMap` to `PaymentTransactionsMap`.
   - Commenting out of the function `build_payment_proofs` and the addition of some placeholder code.
   - The variable `num_of_addrs` is now assigned the length of `addrs_to_pay` instead of the length of `audit_trail_info`.
   - The argument `root_hash` has been removed from the function `local_send_storage_payment`.
   - Initialization of the variable `new_payment_proofs` as an empty `PaymentTransactionsMap` and population with payment transactions for each address in `addrs_to_pay`.

7. In the file `sn_transfers/src/wallet/mod.rs`:
   - Replacing the import statement for `PaymentProof` with `PaymentTransactions`.
   - Renaming the type `PaymentProofsMap` to `PaymentTransactionsMap`, which is a BTreeMap from `XorName` to `PaymentTransactions`.

8. In the file `api.rs`:
   - Changing the import statement from `PaymentProof` to `PaymentTransactions`.
   - Modifying the `store_chunk` method in the `impl Client` block, changing the parameter `payment` from `PaymentProof` to `PaymentTransactions`.

9. In the file `sn_protocol/src/storage/chunks.rs`:
   - Changing the import statement from `PaymentProof` to `PaymentTransactions`.
   - Modifying the `Chunk` struct, replacing the `PaymentProof` field with `PaymentTransactions`.
   - Introducing a new struct `ChunkWithPayment`, which contains a `Chunk` field and a `PaymentTransactions` field.

These changes indicate a restructuring of the code related to payment transactions in the protocol, including renaming types, modifying import statements, and updating function parameters and return types. Please review the diff thoroughly and let me know if you need further assistance or clarification.
<!-- reviewpad:summarize:end --> 
