### PR TITLE
fix: avoid download bench result polluted

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Cleanup uploaded_files folder to avoid pollute download benchmark
         shell: bash
-        run: rm -rf /home/runner/.local/share/safe/client/uploaded_files
+        run: rm -rf $CLIENT_DATA_PATH/uploaded_files
 
       ###########################
       ### Client Mem Analysis ###
@@ -172,6 +172,13 @@ jobs:
           unit: "MiB/s",
           value: ((if .throughput[0].unit == "KiB/s" then (.throughput[0].per_iteration / (1024*1024*1024)) else (.throughput[0].per_iteration / (1024*1024)) end) / (.mean.estimate / 1e9))
           })' > files-benchmark.json
+
+      - name: Confirming the number of files got uploaded and downloaded during the benchmark test
+        shell: bash
+        run: |
+          ls -l $CLIENT_DATA_PATH/uploaded_files
+          ls -l $CLIENT_DATA_PATH/downloaded_files
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -77,6 +77,10 @@ jobs:
         env:
           SN_LOG: "all"
 
+      - name: Cleanup uploaded_files folder to avoid pollute download benchmark
+        shell: bash
+        run: rm -rf /home/runner/.local/share/safe/client/uploaded_files
+
       ###########################
       ### Client Mem Analysis ###
       ###########################

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -201,8 +201,10 @@ async fn download_file(
         "Downloading file {file_name:?} with address {:64x}",
         xorname
     );
+    debug!("Downloading file {file_name:?}");
     match file_api.read_bytes(ChunkAddress::new(*xorname)).await {
         Ok(bytes) => {
+            debug!("Successfully got file {file_name}!");
             println!("Successfully got file {file_name}!");
             let file_name_path = download_path.join(file_name);
             println!("Writing {} bytes to {file_name_path:?}", bytes.len());
@@ -211,6 +213,7 @@ async fn download_file(
             }
         }
         Err(error) => {
+            error!("Did not get file {file_name:?} from the network! {error}");
             println!("Did not get file {file_name:?} from the network! {error}")
         }
     }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -360,7 +360,10 @@ impl SwarmDriver {
         let distance = NetworkAddress::from_peer(self.self_peer_id).distance(target);
 
         match (distance.ilog2(), close_range) {
-            (Some(target_ilog2), Some(range_ilog2)) => target_ilog2 <= range_ilog2,
+            (Some(target_ilog2), Some(range_ilog2)) => {
+                trace!("Record {target:?} is {target_ilog2:?} distance to us, while our close range is {range_ilog2:?}");
+                target_ilog2 <= range_ilog2
+            }
             _ => {
                 // This shall never happen.
                 error!("Cannot get ilog2 from one of {distance:?} or {close_range:?} ???!!!");
@@ -375,8 +378,7 @@ impl SwarmDriver {
         for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
             total_peers += kbucket.num_entries();
             if total_peers > CLOSE_GROUP_SIZE + 1 {
-                let range = kbucket.range();
-                return range.0.ilog2();
+                return kbucket.range().0.ilog2();
             }
         }
         None


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Aug 23 11:52 UTC
This pull request fixes an issue where the download benchmark results were being polluted. The patch includes modifications to the benchmark-prs.yml file and the files.rs file. In benchmark-prs.yml, a cleanup step is added to remove the uploaded_files folder to prevent pollution. In files.rs, an argument is added to the Command to specify the log output destination.
<!-- reviewpad:summarize:end --> 
