### PR TITLE
fix(client): use boostrap and fire Connecting event

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -88,7 +88,7 @@ jobs:
           client_avg_mem_limit_mb="700" # mb
 
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename |
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |
             awk -F':' '/"memory_used_mb":/{print $2}' |
             sort -n |
             tail -n 1
@@ -100,11 +100,11 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename |
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safenode.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -165,7 +165,7 @@ jobs:
           client_avg_mem_limit_mb="700" # mb
           
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/{print $2}' | 
             sort -n | 
             tail -n 1
@@ -177,11 +177,11 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safenode.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -229,7 +229,7 @@ jobs:
           client_avg_mem_limit_mb="700" # mb
           
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/{print $2}' | 
             sort -n | 
             tail -n 1
@@ -241,11 +241,11 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safenode.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safenode.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -39,6 +39,8 @@ impl ClientEventsChannel {
 pub enum ClientEvent {
     /// The client has been connected to the network
     ConnectedToNetwork,
+    /// ConnectingToNetwork
+    ConnectingToNetwork,
     /// No network activity has been received for a given duration
     /// we should error out
     InactiveClient(std::time::Duration),

--- a/sn_logging/src/appender.rs
+++ b/sn_logging/src/appender.rs
@@ -12,6 +12,8 @@ use file_rotate::{
     ContentLimit, FileRotate,
 };
 use std::{
+    env,
+    ffi::OsStr,
     fmt::Debug,
     io,
     io::Write,
@@ -35,9 +37,18 @@ pub(super) fn file_rotater(
     uncompressed_files: usize,
     max_files: usize,
 ) -> (NonBlocking, WorkerGuard) {
+    let binary_name = env::current_exe()
+        .map(|path| {
+            path.file_stem()
+                .unwrap_or(OsStr::new("safe"))
+                .to_string_lossy()
+                .into_owned()
+        })
+        .unwrap_or_else(|_| "safe".to_string());
+
     let file_appender = FileRotateAppender::make_rotate_appender(
         dir,
-        "safenode.log",
+        format!("{binary_name}.log"),
         AppendTimestamp::default(FileLimit::MaxFiles(max_files)),
         ContentLimit::Lines(max_lines),
         Compression::OnRotate(uncompressed_files),

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -28,6 +28,7 @@ use tokio::sync::oneshot;
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SwarmCmd {
+    Bootstrap,
     StartListening {
         addr: Multiaddr,
         sender: oneshot::Sender<Result<()>>,
@@ -149,6 +150,9 @@ impl SwarmDriver {
                 if !keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }
+            }
+            SwarmCmd::Bootstrap => {
+                let _res = self.swarm.behaviour_mut().kademlia.bootstrap();
             }
             SwarmCmd::SetRecordDistanceRange { distance } => {
                 self.swarm

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -505,6 +505,13 @@ impl Network {
         receiver.await?
     }
 
+    /// Bootstrap us onto the network via an address
+    pub fn bootstrap(&self) -> Result<()> {
+        info!("Bootstrapping onto the network");
+        self.send_swarm_cmd(SwarmCmd::Bootstrap)?;
+        Ok(())
+    }
+
     /// Dial the given peer at the given address.
     pub async fn dial(&self, addr: Multiaddr) -> Result<()> {
         let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
Previously we were hangining waiting on inactivity before we continued, now we
push the loop forward and can us bootstrap to get us going## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Aug 23 06:56 UTC
This pull request includes two patches:

1. The first patch titled "fix(client): use bootstrap and fire Connecting event" addresses an issue where the client was hanging while waiting for inactivity before continuing. With this patch, the loop is pushed forward and the bootstrap function is used to start the client. Additionally, a new event "ConnectingToNetwork" is introduced to indicate that the client is connecting to the network.

2. The second patch titled "fix(logging): get log name per bin" fixes a logging issue by getting the log name based on the binary name. Previously, a static name "safenode.log" was used for logging. With this patch, the binary name is obtained dynamically and used as the log name.

Overall, these patches improve the client's connection process and enhance the logging functionality.
<!-- reviewpad:summarize:end --> 
