### PR TITLE
fix: fixes to allow upload file works properly

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -176,6 +176,7 @@ jobs:
       - name: Confirming the number of files got uploaded and downloaded during the benchmark test
         shell: bash
         run: |
+          ls -l $CLIENT_DATA_PATH
           ls -l $CLIENT_DATA_PATH/uploaded_files
           ls -l $CLIENT_DATA_PATH/downloaded_files
 
@@ -197,6 +198,16 @@ jobs:
           alert-threshold: '200%'
           # Enable Job Summary for PRs
           summary-always: true
+
+      - name: Start a client to carry out download to output the logs
+        shell: bash
+        run: target/release/safe --log-output-dest=data-dir files download
+
+      - name: Start a client to simulate criterion upload
+        shell: bash
+        run: |
+          ls -l target/release
+          target/release/safe --log-output-dest=data-dir files upload target/release/faucet -n
 
       #########################
       ### Stop Network      ###

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -1,3 +1,11 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::{
     fs::File,
@@ -33,7 +41,6 @@ fn safe_files_upload(dir: &str) {
 
 fn safe_files_download() {
     let output = Command::new("./target/release/safe")
-        .arg("--log-output-dest=data-dir")
         .arg("files")
         .arg("download")
         .output()
@@ -48,7 +55,9 @@ fn safe_files_download() {
 
 fn create_file(size_mb: u64) -> tempfile::TempDir {
     let dir = tempdir().expect("Failed to create temporary directory");
-    let file_path = dir.path().join("tempfile");
+
+    let time_stamp = chrono::Local::now().format("%H-%M-%S_%6f").to_string();
+    let file_path = dir.path().join(format!("tempfile_{time_stamp}"));
 
     let mut file = File::create(file_path).expect("Failed to create file");
     let data = vec![0u8; (size_mb * 1024 * 1024) as usize]; // Create a vector with size_mb MB of data
@@ -79,6 +88,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let dir = create_file(*size);
         let dir_path = dir.path().to_str().unwrap();
         fund_cli_wallet();
+
+        // Wait little bit for the fund to be settled.
+        std::thread::sleep(Duration::from_secs(10));
 
         let mut group = c.benchmark_group(format!("Upload Benchmark {}MB", size));
         group.sampling_mode(criterion::SamplingMode::Flat);

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -78,7 +78,7 @@ pub(crate) async fn files_cmds(
     Ok(())
 }
 
-/// Givena directory, upload all files contained
+/// Given a directory, upload all files contained
 /// Optionally verifies data was stored successfully
 async fn upload_files(
     files_path: PathBuf,
@@ -95,8 +95,9 @@ async fn upload_files(
     // The input files_path has to be a dir
     let file_names_path = root_dir.join("uploaded_files");
 
+    // Payment shall always be verified.
     let (chunks_to_upload, payment_proofs) =
-        chunk_and_pay_for_storage(&client, root_dir, &files_path, verify_store).await?;
+        chunk_and_pay_for_storage(&client, root_dir, &files_path, true).await?;
 
     let mut chunks_to_fetch = Vec::new();
     for (

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -723,11 +723,14 @@ impl Network {
                     }
                 }
                 Err(error) => {
+                    error!("{error:?}");
+                    if verification_attempts >= total_attempts {
+                        break;
+                    }
                     warn!(
                         "Did not retrieve Record '{:?}' from network!. Retrying...",
                         PrettyPrintRecordKey::from(key.clone()),
                     );
-                    error!("{error:?}");
                 }
             }
 


### PR DESCRIPTION
This commit contains couple of fixes to make upload file without verification works as expected.
1, Avoid extra wait on spend existence check via get_record 2, Pause between batch uploads to allow network settle down 3, Avoid out of index panic when try parse RecordHead

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Aug 23 15:28 UTC
This pull request contains several fixes that improve the functionality of uploading files without verification. The fixes include avoiding extra wait on the spend existence check, adding pauses between batch uploads to allow the network to settle down, and preventing out of index panics when trying to parse the RecordHead. Overall, these changes aim to make the upload file feature work properly.
<!-- reviewpad:summarize:end --> 
