### PR TITLE
fix(client): start bootstrap when we are connected to one peer

### DIFF
--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -39,8 +39,6 @@ impl ClientEventsChannel {
 pub enum ClientEvent {
     /// The client has been connected to the network
     ConnectedToNetwork,
-    /// ConnectingToNetwork
-    ConnectingToNetwork,
     /// No network activity has been received for a given duration
     /// we should error out
     InactiveClient(std::time::Duration),


### PR DESCRIPTION
- The `kad bootstrap process` requires atleast 1 peer to be in the RT.
- Thus the first call to `bootstrap` doesn't actually do anything. We perform the second call only after receiving an event (`ConnectingToNetwork` or `InactiveClient`), which would actually trigger the bootstrap process.
- So moving things around, we can actually remove the `ConnectingToNetwork` event but achieve the same results.
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Aug 23 17:55 UTC
This pull request fixes the issue where the bootstrap process was not started when the client is connected to at least one peer. It spawns a task to dial to the given peers and starts the bootstrap process if there is at least one peer available. It also removes unused code related to connecting to the network.
<!-- reviewpad:summarize:end --> 
