### PR TITLE
feat(network): perform kad bootstrap from the network layer

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -176,11 +176,6 @@ impl Client {
             self.peers_added += 1;
             debug!("PeerAdded: {peer_id}");
 
-            // we need at least 1 peer to be able to start the bootstrap process
-            if self.peers_added == 1 {
-                let _ = self.network.bootstrap();
-            }
-
             // In case client running in non-local-discovery mode,
             // it may take some time to fill up the RT.
             // To avoid such delay may fail the query with RecordNotFound,

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -28,7 +28,6 @@ use tokio::sync::oneshot;
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SwarmCmd {
-    Bootstrap,
     StartListening {
         addr: Multiaddr,
         sender: oneshot::Sender<Result<()>>,
@@ -150,9 +149,6 @@ impl SwarmDriver {
                 if !keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }
-            }
-            SwarmCmd::Bootstrap => {
-                let _res = self.swarm.behaviour_mut().kademlia.bootstrap();
             }
             SwarmCmd::SetRecordDistanceRange { distance } => {
                 self.swarm

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -505,7 +505,6 @@ impl SwarmDriver {
             KademliaEvent::OutboundQueryProgressed {
                 id,
                 result: QueryResult::Bootstrap(bootstrap_result),
-
                 step,
                 ..
             } => {
@@ -527,7 +526,8 @@ impl SwarmDriver {
                     info!("Connected peers: {connected_peers}");
                     // kad bootstrap process needs at least one peer in the RT be carried out.
                     if !self.bootstrap_done {
-                        let _res = self.swarm.behaviour_mut().kademlia.bootstrap();
+                        let res = self.swarm.behaviour_mut().kademlia.bootstrap();
+                        debug!("Initiated kad bootstrap process {res:?}");
                         self.bootstrap_done = true;
                     }
                 }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -508,13 +508,6 @@ impl Network {
         receiver.await?
     }
 
-    /// Bootstrap us onto the network via an address
-    pub fn bootstrap(&self) -> Result<()> {
-        info!("Bootstrapping onto the network");
-        self.send_swarm_cmd(SwarmCmd::Bootstrap)?;
-        Ok(())
-    }
-
     /// Dial the given peer at the given address.
     pub async fn dial(&self, addr: Multiaddr) -> Result<()> {
         let (sender, receiver) = oneshot::channel();

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -125,6 +125,8 @@ pub struct SwarmDriver {
     dialed_peers: CircularVec<PeerId>,
     /// The peers that are closer to our PeerId. Includes self.
     close_group: Vec<PeerId>,
+    /// Perform initial kad bootstrap process on adding the first peer
+    bootstrap_done: bool,
     is_client: bool,
 }
 
@@ -405,6 +407,7 @@ impl SwarmDriver {
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
             close_group: Default::default(),
+            bootstrap_done: false,
             is_client,
         };
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Aug 23 12:54 UTC
This pull request contains two changes. 

The first patch adds a new feature to the network layer. It implements the ability to perform `kad bootstrap` from the network layer. This is done by handling the `KademliaEvent::OutboundQueryProgressed` event and initiating the bootstrap process if it has not been done already. Additionally, some logging statements are added for debugging purposes.

The second patch removes the initial join flow for both clients and nodes. Instead, it relies on the lower layer kad bootstrap process to handle the initial join. Some code related to the initial join flow is removed from sn_client/src/api.rs, sn_networking/src/cmd.rs, sn_node/src/api.rs and sn_networking/src/event.rs.

Overall, these changes enhance the network layer by allowing the bootstrap process to be initiated from the network layer itself and removing the redundant initial join flow.
<!-- reviewpad:summarize:end --> 
