### PR TITLE
chore: update circular vec to handle errors.

### DIFF
--- a/sn_networking/src/circular_vec.rs
+++ b/sn_networking/src/circular_vec.rs
@@ -6,31 +6,59 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::error::Error;
+
 /// Based on https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/7
 
+/// A circular buffer implemented with a VecDeque.
 #[derive(Debug)]
 pub struct CircularVec<T> {
     inner: std::collections::VecDeque<T>,
 }
 
 impl<T> CircularVec<T> {
+    /// Creates a new CircularVec with the given capacity.
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: std::collections::VecDeque::with_capacity(capacity),
         }
     }
 
-    pub fn push(&mut self, item: T) {
+    /// Pushes an item into the CircularVec. If the CircularVec is full, the oldest item is removed.
+    pub fn push(&mut self, item: T) -> Result<(), Error> {
         if self.inner.len() == self.inner.capacity() {
-            let _ = self.inner.pop_front();
+            self.inner
+                .pop_front()
+                .ok_or(Error::CircularVecPopFrontError)?;
         }
         self.inner.push_back(item);
+        Ok(())
     }
 
+    /// Checks if the CircularVec contains the given item.
     pub fn contains(&self, item: &T) -> bool
     where
         T: PartialEq,
     {
         self.inner.contains(item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_and_contains() {
+        let mut cv = CircularVec::new(2);
+        assert!(cv.push(1).is_ok());
+        assert!(cv.push(2).is_ok());
+        assert!(cv.contains(&1));
+        assert!(cv.contains(&2));
+
+        assert!(cv.push(3).is_ok());
+        assert!(!cv.contains(&1));
+        assert!(cv.contains(&2));
+        assert!(cv.contains(&3));
     }
 }

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -103,6 +103,9 @@ pub enum Error {
 
     #[error("Failed to sign the message with the PeerId keypair")]
     SigningFailed(#[from] libp2p::identity::SigningError),
+
+    #[error("Failed to pop from front of CircularVec")]
+    CircularVecPopFrontError,
 }
 
 #[cfg(test)]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -47,9 +47,10 @@ use tokio::sync::oneshot;
 use tracing::{info, warn};
 use xor_name::XorName;
 
-// Usig XorName to differentiate different record content under the same key.
+/// Using XorName to differentiate different record content under the same key.
 pub(super) type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
 
+/// NodeBehaviour struct
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "NodeEvent")]
 pub(super) struct NodeBehaviour {
@@ -61,6 +62,7 @@ pub(super) struct NodeBehaviour {
     pub(super) autonat: Toggle<autonat::Behaviour>,
 }
 
+/// NodeEvent enum
 #[derive(CustomDebug)]
 pub(super) enum NodeEvent {
     MsgReceived(request_response::Event<Request, Response>),
@@ -306,7 +308,9 @@ impl SwarmDriver {
                 debug!(%peer_id, num_established, "ConnectionEstablished: {}", endpoint_str(&endpoint));
 
                 if endpoint.is_dialer() {
-                    self.dialed_peers.push(peer_id);
+                    self.dialed_peers
+                        .push(peer_id)
+                        .map_err(|_| Error::CircularVecPopFrontError)?;
                 }
             }
             SwarmEvent::ConnectionClosed {

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -128,6 +128,8 @@ impl ReplicationFetcher {
             {
                 match holder_status {
                     HolderStatus::Pending => {
+                        // Check if the fetch for the key is ongoing and the FETCH_TIMEOUT is not hit
+                        let fetch_will_end_now = fetch_for_key_is_ongoing.unwrap_or(false);
                         if no_more_fetches_left
                             || key_added_to_list
                             || keys_to_fetch.len() >= fetches_left
@@ -136,7 +138,7 @@ impl ReplicationFetcher {
                             // continue. This is to make sure that we queue up that key as soon as
                             // the FETCH_TIMEOUT is hit, else we might have to wait till the next
                             // call to `next_keys_to_fetch` 
-                            || fetch_for_key_is_ongoing.is_some_and(|fetch_will_end_now| !fetch_will_end_now)
+                            || (fetch_for_key_is_ongoing.is_some() && !fetch_will_end_now)
                         {
                             continue;
                         }


### PR DESCRIPTION
Also update replication fetchers to not use is_some_and (unstable)

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Aug 23 15:34 UTC
This pull request updates the circular_vec.rs file to handle errors. It also updates the replication_fetchers.rs file to remove the usage of the unstable is_some_and method.
<!-- reviewpad:summarize:end --> 
