### PR TITLE
refactor: set distance range on close group change

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -9,7 +9,7 @@
 use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
 use crate::{error::Result, multiaddr_pop_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE};
 use libp2p::{
-    kad::{store::RecordStore, KBucketDistance as Distance, Quorum, Record, RecordKey},
+    kad::{store::RecordStore, Quorum, Record, RecordKey},
     swarm::{
         dial_opts::{DialOpts, PeerCondition},
         DialError,
@@ -110,10 +110,6 @@ pub enum SwarmCmd {
         peer: PeerId,
         keys: Vec<NetworkAddress>,
     },
-    // Set the acceptable range of `Record` entry. Records outside this range are pruned.
-    SetRecordDistanceRange {
-        distance: Distance,
-    },
 }
 
 /// Snapshot of information kept in the Swarm's local state
@@ -149,13 +145,6 @@ impl SwarmDriver {
                 if !keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }
-            }
-            SwarmCmd::SetRecordDistanceRange { distance } => {
-                self.swarm
-                    .behaviour_mut()
-                    .kademlia
-                    .store_mut()
-                    .set_distance_range(distance);
             }
             SwarmCmd::GetNetworkRecord { key, sender } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -600,10 +600,30 @@ impl SwarmDriver {
             debug!("The close group has been updated. The new members are {new_members:?}");
             debug!("New close group: {new_closest_peers:?}");
             self.close_group = new_closest_peers;
+            let _ = self.update_record_distance_range();
             Some(new_members)
         } else {
             None
         }
+    }
+
+    /// Set the acceptable range of record entry. A record is removed from the storage if the
+    /// distance between the record and the node is greater than the `distance_range`
+    fn update_record_distance_range(&mut self) -> Option<()> {
+        debug!("setting record distance range on close group change");
+        let our_address = NetworkAddress::from_peer(self.self_peer_id);
+        let distance_range = self
+            .close_group
+            .last()
+            .map(|peer| NetworkAddress::from_peer(*peer).distance(&our_address))?;
+
+        self.swarm
+            .behaviour_mut()
+            .kademlia
+            .store_mut()
+            .set_distance_range(distance_range);
+        trace!("set distance_range successfully");
+        Some(())
     }
 
     fn log_kbuckets(&mut self, peer: &PeerId) {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -130,8 +130,6 @@ pub enum NetworkEvent {
     PeerAdded(PeerId),
     // Peer has been removed from the Routing Table
     PeerRemoved(PeerId),
-    /// The following members have been newly included in our close group
-    CloseGroupUpdated(Vec<PeerId>),
     /// The Records for the these keys are to be fetched from the provided Peer or from the network
     KeysForReplication(Vec<(RecordKey, Option<PeerId>)>),
     /// Started listening on a new address
@@ -157,9 +155,6 @@ impl Debug for NetworkEvent {
             }
             NetworkEvent::PeerRemoved(peer_id) => {
                 write!(f, "NetworkEvent::PeerRemoved({peer_id:?})")
-            }
-            NetworkEvent::CloseGroupUpdated(peer_ids) => {
-                write!(f, "NetworkEvent::CloseGroupUpdated({peer_ids:?})")
             }
             NetworkEvent::KeysForReplication(list) => {
                 let pretty_list: Vec<_> = list
@@ -332,9 +327,7 @@ impl SwarmDriver {
                 {
                     self.send_event(NetworkEvent::PeerRemoved(*dead_peer.node.key.preimage()));
                     self.log_kbuckets(&failed_peer_id);
-                    if let Some(new_members) = self.check_for_change_in_our_close_group() {
-                        self.send_event(NetworkEvent::CloseGroupUpdated(new_members));
-                    }
+                    let _ = self.check_for_change_in_our_close_group();
                 }
             }
             SwarmEvent::IncomingConnectionError { .. } => {}
@@ -537,9 +530,7 @@ impl SwarmDriver {
                     self.send_event(NetworkEvent::PeerRemoved(peer));
                     self.log_kbuckets(&peer);
                 }
-                if let Some(new_members) = self.check_for_change_in_our_close_group() {
-                    self.send_event(NetworkEvent::CloseGroupUpdated(new_members));
-                }
+                let _ = self.check_for_change_in_our_close_group();
             }
             KademliaEvent::InboundRequest {
                 request: InboundRequest::PutRecord { .. },

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -40,10 +40,7 @@ use itertools::Itertools;
 use libp2p::mdns;
 use libp2p::{
     identity::Keypair,
-    kad::{
-        KBucketDistance as Distance, KBucketKey, Kademlia, KademliaConfig, QueryId, Record,
-        RecordKey,
-    },
+    kad::{KBucketKey, Kademlia, KademliaConfig, QueryId, Record, RecordKey},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{behaviour::toggle::Toggle, StreamProtocol, Swarm, SwarmBuilder},
@@ -862,12 +859,6 @@ impl Network {
         keys: Vec<NetworkAddress>,
     ) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { peer, keys })
-    }
-
-    /// Set the acceptable range of record entry. A record is removed from the storage if the
-    /// distance between the record and the node is greater than the provided `distance`.
-    pub fn set_record_distance_range(&self, distance: Distance) -> Result<()> {
-        self.send_swarm_cmd(SwarmCmd::SetRecordDistanceRange { distance })
     }
 
     /// Send `Request` to the given `PeerId` and await for the response. If `self` is the recipient,

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -182,9 +182,6 @@ impl Node {
                     error!("During PeerRemoved, error while triggering replication {err:?}");
                 }
             }
-            NetworkEvent::CloseGroupUpdated(new_members) => {
-                Marker::CloseGroupUpdated(&new_members).log();
-            }
             NetworkEvent::KeysForReplication(keys) => {
                 Marker::fetching_keys_for_replication(&keys).log();
 

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -44,9 +44,6 @@ pub enum Marker<'a> {
     /// Replication trigger was fired
     ReplicationTriggered,
 
-    /// The new members added to our close group
-    CloseGroupUpdated(&'a Vec<PeerId>),
-
     /// Keys of Records we are fetching to replicate locally
     FetchingKeysForReplication {
         /// fetching_keys_len: number of keys we are fetching

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -104,18 +104,6 @@ impl Node {
             self.send_replicate_cmd_without_wait(&our_address, &peer_id, remaining_keys.to_vec())?;
         }
 
-        // set the distance range used for pruning
-        // our_close_group only has CLOSE_GROUP_SIZE entries, so we just grab the last one
-        let our_close_group = self.network.get_our_close_group().await?;
-        let distance_range = match our_close_group.last() {
-            Some(peer) => NetworkAddress::from_peer(*peer).distance(&our_address),
-            None => {
-                warn!("Could not obtain distance_range");
-                return Ok(());
-            }
-        };
-        self.network.set_record_distance_range(distance_range)?;
-        debug!("Set record distance range");
         Ok(())
     }
 


### PR DESCRIPTION
- move the `set distance range` process to the network layer. Else, the process is triggered on every replication (on peer add/removal).
- removes a `SwarmCmd` and a `NetworkEvent`
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Aug 23 11:38 UTC
This pull request includes two patches. 

The first patch fixes a replication issue by setting the acceptable range of record entries on a close group change. It updates the `sn_networking/src/event.rs` file to include a new function `update_record_distance_range()` that sets the distance range used for pruning records. It also modifies the `sn_networking/src/cmd.rs` and `sn_networking/src/lib.rs` files to remove the `SetRecordDistanceRange` command and function, which are no longer needed.

The second patch is a chore to remove an unused `NetworkEvent::CloseGroupUpdated` variant. It removes the unused code from the `sn_networking/src/event.rs`, `sn_node/src/api.rs`, and `sn_node/src/log_markers.rs` files.

The changes in total include 22 insertions and 34 deletions.
<!-- reviewpad:summarize:end --> 
