### PR TITLE
feat(node): add relay functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-relay",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -2140,6 +2141,7 @@ dependencies = [
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
+ "libp2p-relay",
  "libp2p-swarm",
  "once_cell",
  "prometheus-client",
@@ -2168,6 +2170,30 @@ dependencies = [
  "thiserror",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb07202cdf103486709fda5d9d10a0297a8ba01c212b1e19b7943c45c1bd7d6"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "static_assertions",
+ "thiserror",
+ "void",
 ]
 
 [[package]]

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -20,7 +20,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 futures = "~0.3.13"
 itertools = "~0.10.1"
 custom_debug = "~0.5.0"
-libp2p = { version="0.52", features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux"] }
+libp2p = { version="0.52", features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux", "relay" ] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -32,6 +32,7 @@ use libp2p::{
     request_response::{self, ResponseChannel as PeerResponseChannel},
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour, SwarmEvent},
     Multiaddr, PeerId,
+    relay,
 };
 use sn_protocol::{
     messages::{Request, Response},
@@ -60,6 +61,7 @@ pub(super) struct NodeBehaviour {
     pub(super) mdns: mdns::tokio::Behaviour,
     pub(super) identify: libp2p::identify::Behaviour,
     pub(super) autonat: Toggle<autonat::Behaviour>,
+    pub(super) relay: Toggle<relay::Behaviour>,
 }
 
 /// NodeEvent enum
@@ -71,6 +73,7 @@ pub(super) enum NodeEvent {
     Mdns(Box<mdns::Event>),
     Identify(Box<libp2p::identify::Event>),
     Autonat(autonat::Event),
+    Relay(relay::Event),
 }
 
 impl From<request_response::Event<Request, Response>> for NodeEvent {
@@ -101,6 +104,12 @@ impl From<libp2p::identify::Event> for NodeEvent {
 impl From<autonat::Event> for NodeEvent {
     fn from(event: autonat::Event) -> Self {
         NodeEvent::Autonat(event)
+    }
+}
+
+impl From<relay::Event> for NodeEvent {
+    fn from(event: relay::Event) -> Self {
+        NodeEvent::Relay(event)
     }
 }
 
@@ -360,7 +369,10 @@ impl SwarmDriver {
                         NatStatus::Unknown => {}
                     };
                 }
-            },
+            }
+            SwarmEvent::Behaviour(NodeEvent::Relay(event)) => {
+                info!("{:?}", event)
+            }
             other => debug!("SwarmEvent has been ignored: {other:?}"),
         }
         Ok(())

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -45,6 +45,7 @@ use libp2p::{
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{behaviour::toggle::Toggle, StreamProtocol, Swarm, SwarmBuilder},
     Multiaddr, PeerId, Transport,
+    relay,
 };
 use rand::Rng;
 use sn_dbc::Token;
@@ -382,6 +383,13 @@ impl SwarmDriver {
         };
         let autonat = Toggle::from(autonat);
 
+        let relay = if !local && !is_client {
+            Some(relay::Behaviour::new(peer_id, Default::default()))
+        } else {
+            None
+        };
+        let relay = Toggle::from(relay);
+
         let behaviour = NodeBehaviour {
             request_response,
             kademlia,
@@ -389,6 +397,7 @@ impl SwarmDriver {
             #[cfg(feature = "local-discovery")]
             mdns,
             autonat,
+            relay,
         };
         let swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, peer_id).build();
 

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -312,18 +312,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                     }
                 }
                 Ok(NodeEvent::BehindNat) => {
-                    if let Err(err) = ctrl_tx
-                        .send(NodeCtrl::Stop {
-                            delay: Duration::from_secs(1),
-                            cause: eyre!("We have been determined to be behind a NAT. This means we are not reachable externally by other nodes. In the future, the network will implement relays that allow us to still join the network."),
-                        })
-                        .await
-                    {
-                        error!(
-                            "Failed to send node control msg to safenode bin main thread: {err}"
-                        );
-                        break;
-                    }
+                    info!("NodeEvent: Determined to be behind NAT");
                 }
                 Ok(event) => {
                     /* we ignore other events */


### PR DESCRIPTION
Adds relay server and client behaviour and transport method. Currently limited to TCP due to AutoNAT with QUIC reporting private NAT statuses as public. There is a fix for this being worked on in libp2p's AutoNATv2 updates.

At the moment, it works as follows: If a node is determined to have a private or public AutoNAT status it acts as a relay client or server respectively. A client automatically requests reservation slots with servers and if accepted adds new relayed listen addresses which use the /p2p-circuit/ protocol and combine the relay server multiaddr and client peer id. Relayed connections are then attempted to be established by any nodes that receive an Identify event containing a relayed listen address as that signifies the remote is a relay client. If successful, the next step is a direct-connection upgrade (hole-punch) using the DCUtR protocol. This feature will be added in an additional PR.

The relay servers are rate-limited by data amounts and time periods.