### PR TITLE
feat(node): node to store rewards in a local wallet

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -36,8 +36,8 @@ pub enum WalletCmds {
     /// Print the wallet balance.
     Balance {
         /// Instead of checking CLI local wallet balance, the PeerId of a node can be used
-        /// to check the balance of its rewards local wallet. Multiple ids can be provided, e.g.:
-        /// --peer-id <PeerId-1> --peer-id <PeerId-2> ...
+        /// to check the balance of its rewards local wallet. Multiple ids can be provided
+        /// in order to read the balance of multiple nodes at once.
         #[clap(long)]
         peer_id: Vec<String>,
     },
@@ -128,7 +128,7 @@ async fn address(root_dir: &Path) -> Result<()> {
 }
 
 async fn balance(root_dir: &Path) -> Result<Token> {
-    let wallet = LocalWallet::load_from(root_dir)?;
+    let wallet = LocalWallet::try_load_from(root_dir)?;
     let balance = wallet.balance();
     Ok(balance)
 }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -15,6 +15,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
+use sn_transfers::wallet::LocalWallet;
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -93,6 +94,10 @@ impl Node {
     ) -> Result<RunningNode> {
         // TODO: Make this key settable, and accessible via API
         let reward_key = MainKey::random();
+        let reward_address = reward_key.public_address();
+
+        let wallet = LocalWallet::load_from_main_key(&root_dir, reward_key)?;
+        wallet.store()?;
 
         let (network, mut network_event_receiver, swarm_driver) =
             SwarmDriver::new(keypair, addr, local, root_dir)?;
@@ -102,7 +107,7 @@ impl Node {
             network: network.clone(),
             events_channel: node_events_channel.clone(),
             initial_peers,
-            reward_address: reward_key.public_address(),
+            reward_address,
         };
 
         let network_clone = network.clone();

--- a/sn_node/src/error.rs
+++ b/sn_node/src/error.rs
@@ -8,7 +8,7 @@
 
 use sn_networking::Error as NetworkError;
 use sn_protocol::error::Error as ProtocolError;
-use sn_transfers::dbc_genesis::Error as GenesisError;
+use sn_transfers::{dbc_genesis::Error as GenesisError, wallet::Error as RewardsWalletError};
 use thiserror::Error;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
@@ -28,4 +28,7 @@ pub enum Error {
 
     #[error("Failed to parse NodeEvent")]
     NodeEventParsingFailed,
+
+    #[error("Node's rewards wallet error {0}")]
+    RewardsWallet(#[from] RewardsWalletError),
 }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -77,6 +77,9 @@ pub enum Error {
         /// Reason why the payment proof was deemed invalid
         reason: String,
     },
+    /// Payments received could not be stored on node's local wallet
+    #[error("Payments received could not be stored on node's local wallet: {0}")]
+    FailedToStorePaymentIntoNodeWallet(String),
     #[error("UTXO serialisation failed")]
     UtxoSerialisationFailed,
     #[error("UTXO decryption failed")]

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -109,6 +109,18 @@ impl LocalWallet {
         })
     }
 
+    /// Tries to loads a serialized wallet from a path, bailing out if it doesn't exist.
+    pub fn try_load_from(root_dir: &Path) -> Result<Self> {
+        let wallet_dir = root_dir.join(WALLET_DIR_NAME);
+        let (key, wallet, unconfirmed_txs) = load_from_path(&wallet_dir, None)?;
+        Ok(Self {
+            key,
+            wallet,
+            wallet_dir: wallet_dir.to_path_buf(),
+            unconfirmed_txs,
+        })
+    }
+
     pub fn address(&self) -> PublicAddress {
         self.key.public_address()
     }


### PR DESCRIPTION
Example of usage of CLI new wallet flag:
```
$ safe wallet balance --peer-id 12D3KooW9qD52azpRWxbZxU8M93aaTXJPcjcSntAf6KaotTo77La
Instantiating a SAFE client...
🔗 Connected to the Network
Node's rewards wallet balance (PeerId: 12D3KooW9qD52azpRWxbZxU8M93aaTXJPcjcSntAf6KaotTo77La): 0.000000064

$ safe wallet balance --peer-id 12D3KooW9qD52azpRWxbZxU8M93aaTXJPcjcSntAf6KaotTo77La --peer-id 12D3KooWT1XiiLADtVF4UuFctDfVfn7xL7tgEQMVDn6HKPJ4Q3od
Instantiating a SAFE client...
🔗 Connected to the Network
Node's rewards wallet balance (PeerId: 12D3KooW9qD52azpRWxbZxU8M93aaTXJPcjcSntAf6KaotTo77La): 0.000000064
Node's rewards wallet balance (PeerId: 12D3KooWT1XiiLADtVF4UuFctDfVfn7xL7tgEQMVDn6HKPJ4Q3od): 0.000000012
```

## Description

reviewpad:summary 
