### PR TITLE
feat(store): implement client and node record store

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -128,10 +128,7 @@ pub struct SwarmLocalState {
     pub listeners: Vec<Multiaddr>,
 }
 
-impl<TRecordStore> SwarmDriver<TRecordStore>
-where
-    TRecordStore: RecordStore + RecordStoreAPI + Send + 'static,
-{
+impl SwarmDriver {
     #[allow(clippy::result_large_err)]
     pub(crate) fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
         let drives_forward_replication = matches!(

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -6,8 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
-use crate::{error::Result, multiaddr_pop_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE};
+use crate::{
+    error::{Error, Result},
+    multiaddr_pop_p2p,
+    record_store_api::RecordStoreAPI,
+    sort_peers_by_address, MsgResponder, NetworkEvent, SwarmDriver, CLOSE_GROUP_SIZE,
+};
 use libp2p::{
     kad::{store::RecordStore, Quorum, Record, RecordKey},
     swarm::{
@@ -124,7 +128,10 @@ pub struct SwarmLocalState {
     pub listeners: Vec<Multiaddr>,
 }
 
-impl SwarmDriver {
+impl<TRecordStore> SwarmDriver<TRecordStore>
+where
+    TRecordStore: RecordStore + RecordStoreAPI + Send + 'static,
+{
     #[allow(clippy::result_large_err)]
     pub(crate) fn handle_cmd(&mut self, cmd: SwarmCmd) -> Result<(), Error> {
         let drives_forward_replication = matches!(

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -6,20 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    error::Error, record_store_api::RecordStoreAPI, MsgResponder, NetworkEvent, SwarmDriver,
-};
-use libp2p::{
-    kad::store::RecordStore,
-    request_response::{self, Message},
-};
+use crate::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
+use libp2p::request_response::{self, Message};
 use sn_protocol::messages::{Request, Response};
-use tracing::{trace, warn};
 
-impl<TRecordStore> SwarmDriver<TRecordStore>
-where
-    TRecordStore: RecordStore + RecordStoreAPI + Send + 'static,
-{
+impl SwarmDriver {
     /// Forwards `Request` to the upper layers using `Sender<NetworkEvent>`. Sends `Response` to the peers
     #[allow(clippy::result_large_err)]
     pub fn handle_msg(

--- a/sn_networking/src/msg/mod.rs
+++ b/sn_networking/src/msg/mod.rs
@@ -6,13 +6,20 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{error::Error, MsgResponder, NetworkEvent, SwarmDriver};
-
-use libp2p::request_response::{self, Message};
+use crate::{
+    error::Error, record_store_api::RecordStoreAPI, MsgResponder, NetworkEvent, SwarmDriver,
+};
+use libp2p::{
+    kad::store::RecordStore,
+    request_response::{self, Message},
+};
 use sn_protocol::messages::{Request, Response};
 use tracing::{trace, warn};
 
-impl SwarmDriver {
+impl<TRecordStore> SwarmDriver<TRecordStore>
+where
+    TRecordStore: RecordStore + RecordStoreAPI + Send + 'static,
+{
     /// Forwards `Request` to the upper layers using `Sender<NetworkEvent>`. Sends `Response` to the peers
     #[allow(clippy::result_large_err)]
     pub fn handle_msg(

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -20,7 +20,7 @@ use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
 use sn_transfers::dbc_genesis::TOTAL_SUPPLY;
 use std::{
     borrow::Cow,
-    collections::{hash_set, HashSet},
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     time::Duration,
@@ -281,7 +281,7 @@ impl DiskBackedRecordStore {
 }
 
 impl RecordStore for DiskBackedRecordStore {
-    type RecordsIter<'a> = RecordsIterator<'a>;
+    type RecordsIter<'a> = vec::IntoIter<Cow<'a, Record>>;
     type ProvidedIter<'a> = vec::IntoIter<Cow<'a, ProviderRecord>>;
 
     fn get(&self, k: &Key) -> Option<Cow<'_, Record>> {
@@ -356,12 +356,9 @@ impl RecordStore for DiskBackedRecordStore {
         });
     }
 
-    // A backstop replication shall only trigger within pre-defined interval
     fn records(&self) -> Self::RecordsIter<'_> {
-        RecordsIterator {
-            keys: self.records.iter(),
-            storage_dir: self.config.storage_dir.clone(),
-        }
+        // the records iter is used only during kad replication which is turned off
+        vec![].into_iter()
     }
 
     fn add_provider(&mut self, _record: ProviderRecord) -> Result<()> {
@@ -381,28 +378,6 @@ impl RecordStore for DiskBackedRecordStore {
 
     fn remove_provider(&mut self, _key: &Key, _provider: &PeerId) {
         // ProviderRecords are not used currently
-    }
-}
-
-// Since 'Record's need to be read from disk for each individual 'Key', we need this iterator
-// which does that operation at the very moment the consumer/user is iterating each item.
-pub struct RecordsIterator<'a> {
-    keys: hash_set::Iter<'a, Key>,
-    storage_dir: PathBuf,
-}
-
-impl<'a> Iterator for RecordsIterator<'a> {
-    type Item = Cow<'a, Record>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        for key in self.keys.by_ref() {
-            let record = DiskBackedRecordStore::read_from_disk(key, &self.storage_dir);
-            if record.is_some() {
-                return record;
-            }
-        }
-
-        None
     }
 }
 

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -1,0 +1,35 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::kad::{store::Result, KBucketDistance as Distance, Record, RecordKey};
+use sn_dbc::Token;
+use sn_protocol::NetworkAddress;
+use std::collections::HashSet;
+
+pub trait RecordStoreAPI {
+    /// Returns `true` if the `Key` is present locally
+    fn contains(&self, key: &RecordKey) -> bool;
+
+    /// Returns the set of `NetworkAddress::RecordKey` held by the store
+    /// Use `record_addresses_ref` to get a borrowed type
+    fn record_addresses(&self) -> HashSet<NetworkAddress>;
+
+    /// Returns the reference to the set of `NetworkAddress::RecordKey` held by the store
+    #[allow(clippy::mutable_key_type)]
+    fn record_addresses_ref(&self) -> &HashSet<RecordKey>;
+
+    /// Warning: PUTs a `Record` to the store without validation
+    /// Should be used in context where the `Record` is trusted
+    fn put_verified(&mut self, r: Record) -> Result<()>;
+
+    /// Calculate the cost to store data for our current store state
+    fn store_cost(&self) -> Token;
+
+    /// Setup the distance range.
+    fn set_distance_range(&mut self, distance_range: Distance);
+}

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -6,11 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use libp2p::kad::{store::Result, KBucketDistance as Distance, Record, RecordKey};
+use crate::record_store::{ClientRecordStore, NodeRecordStore};
+use libp2p::kad::{
+    store::{RecordStore, Result},
+    KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
+};
 use sn_dbc::Token;
 use sn_protocol::NetworkAddress;
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 
+/// Methods used from inside the `SwarmDriver` after calling `store_mut()` should are placed here
 pub trait RecordStoreAPI {
     /// Returns `true` if the `Key` is present locally
     fn contains(&self, key: &RecordKey) -> bool;
@@ -32,4 +37,114 @@ pub trait RecordStoreAPI {
 
     /// Setup the distance range.
     fn set_distance_range(&mut self, distance_range: Distance);
+}
+
+pub enum UnifiedRecordStore {
+    Client(ClientRecordStore),
+    Node(NodeRecordStore),
+}
+
+impl RecordStore for UnifiedRecordStore {
+    type RecordsIter<'a> = std::vec::IntoIter<Cow<'a, Record>>;
+    type ProvidedIter<'a> = std::vec::IntoIter<Cow<'a, ProviderRecord>>;
+
+    fn get(&self, k: &RecordKey) -> Option<std::borrow::Cow<'_, Record>> {
+        match self {
+            Self::Client(store) => store.get(k),
+            Self::Node(store) => store.get(k),
+        }
+    }
+
+    fn put(&mut self, r: Record) -> Result<()> {
+        match self {
+            Self::Client(store) => store.put(r),
+            Self::Node(store) => store.put(r),
+        }
+    }
+
+    fn remove(&mut self, k: &RecordKey) {
+        match self {
+            Self::Client(store) => store.remove(k),
+            Self::Node(store) => store.remove(k),
+        }
+    }
+
+    fn records(&self) -> Self::RecordsIter<'_> {
+        match self {
+            Self::Client(store) => store.records(),
+            Self::Node(store) => store.records(),
+        }
+    }
+
+    fn add_provider(&mut self, record: ProviderRecord) -> Result<()> {
+        match self {
+            Self::Client(store) => store.add_provider(record),
+            Self::Node(store) => store.add_provider(record),
+        }
+    }
+
+    fn providers(&self, key: &RecordKey) -> Vec<ProviderRecord> {
+        match self {
+            Self::Client(store) => store.providers(key),
+            Self::Node(store) => store.providers(key),
+        }
+    }
+
+    fn provided(&self) -> Self::ProvidedIter<'_> {
+        match self {
+            Self::Client(store) => store.provided(),
+            Self::Node(store) => store.provided(),
+        }
+    }
+
+    fn remove_provider(&mut self, k: &RecordKey, p: &libp2p::PeerId) {
+        match self {
+            Self::Client(store) => store.remove_provider(k, p),
+            Self::Node(store) => store.remove_provider(k, p),
+        }
+    }
+}
+
+impl RecordStoreAPI for UnifiedRecordStore {
+    fn contains(&self, key: &RecordKey) -> bool {
+        match self {
+            Self::Client(store) => store.contains(key),
+            Self::Node(store) => store.contains(key),
+        }
+    }
+
+    fn record_addresses(&self) -> HashSet<NetworkAddress> {
+        match self {
+            Self::Client(store) => store.record_addresses(),
+            Self::Node(store) => store.record_addresses(),
+        }
+    }
+
+    fn record_addresses_ref(&self) -> &HashSet<RecordKey> {
+        match self {
+            Self::Client(store) => store.record_addresses_ref(),
+            Self::Node(store) => store.record_addresses_ref(),
+        }
+    }
+
+    fn put_verified(&mut self, r: Record) -> Result<()> {
+        match self {
+            Self::Client(store) => store.put_verified(r),
+            Self::Node(store) => store.put_verified(r),
+        }
+    }
+
+    fn store_cost(&self) -> Token {
+        match self {
+            Self::Client(store) => store.store_cost(),
+            Self::Node(store) => store.store_cost(),
+        }
+    }
+
+    fn set_distance_range(&mut self, distance_range: Distance) {
+        match self {
+            Self::Client(store) => store.set_distance_range(distance_range),
+            Self::Node(store) => store.set_distance_range(distance_range),
+        }
+    }
 }


### PR DESCRIPTION
- They are placed inside an enum called `UnifiedRecordStore`. 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 07:03 UTC
This pull request includes the following changes:

1. In `sn_networking/src/msg/mod.rs`, unused imports for `error::Error`, `trace`, and `warn` are removed. The unused trait implementation for `MsgResponder` is also removed.

2. In `sn_networking/src/cmd.rs`, changes are made to import organization. Import statements for `RecordStoreAPI` are added, import statements are reorganized by grouping them together, `RecordStoreAPI` is added to the list of struct imports, import statements are reordered alphabetically, and the formatting of the imports is updated. These changes focus on import organization and adding a new import for `RecordStoreAPI`.

3. In `sn_networking/src/event.rs`, changes include removal of imports for `error::{Error, Result}` and `record_store::DiskBackedRecordStore` from the `super` module, addition of import for `record_store_api::{RecordStoreAPI, UnifiedRecordStore}`, and replacing the `kademlia` field in the `NodeBehaviour` struct with the `Kademlia<UnifiedRecordStore>` type.

4. The file `record_store_api.rs` is added to the project, containing the implementation of the `RecordStoreAPI` trait and the `UnifiedRecordStore` enum. The `RecordStoreAPI` trait defines methods for interacting with a record store, and the `UnifiedRecordStore` enum represents either a client record store or a node record store.

5. In `lib.rs`, changes include adding the `record_store_api` module, replacing `DiskBackedRecordStore` with `ClientRecordStore`, `NodeRecordStore`, and `NodeRecordStoreConfig`, moving the `storage_dir_path` variable inside the `store_cfg` block, changing `store_cfg` to an `Option<NodeRecordStoreConfig>` parameter for the `Self::with` function, passing `network_event_sender` as an argument to the `NodeRecordStore` constructor, replacing `DiskBackedRecordStore` with `UnifiedRecordStore::Node` or `UnifiedRecordStore::Client` based on `record_store_cfg`, and replacing the `sleep` function with `tokio::time::sleep`.

Please review the diff for more details. Let me know if you need further assistance!
<!-- reviewpad:summarize:end --> 


copilot:summary