### PR TITLE
fix: correct bench download calculation

### DIFF
--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -117,7 +117,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     // there will then be around 1.1GB in total, and may take around 40s for each iteratioin.
     // Hence we have to reduce the number of iterations from the default 100 to 10,
     // To avoid the benchmark test taking over one hour to complete.
-    let total_size: u64 = sizes.iter().map(|size| SAMPLE_SIZE as u64 * size).sum();
+    //
+    // During `measurement_time` and `warm_up_time`, there will be one upload run for each.
+    // Which means two additional `uploaded_files` created and for downloading.
+    let total_size: u64 = sizes
+        .iter()
+        .map(|size| (SAMPLE_SIZE as u64 + 2) * size)
+        .sum();
     group.sample_size(SAMPLE_SIZE / 2);
 
     // Set the throughput to be reported in terms of bytes


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 10:37 UTC
This pull request fixes the calculation of the bench download in the `files.rs` file. The total size now takes into account the additional `uploaded_files` created for downloading during `measurement_time` and `warm_up_time`. This ensures accurate benchmark results.
<!-- reviewpad:summarize:end --> 
