### PR TITLE
chore: some logging updates

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -345,7 +345,10 @@ impl Client {
         let address = DbcAddress::from_dbc_id(dbc_id);
         let key = NetworkAddress::from_dbc_address(address).to_record_key();
 
-        trace!("Getting spend {dbc_id:?} with record_key {key:?}");
+        trace!(
+            "Getting spend {dbc_id:?} with record_key {:?}",
+            PrettyPrintRecordKey::from(key.clone())
+        );
         let record = self
             .network
             .get_record_from_network(key.clone(), None, true)

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -91,7 +91,15 @@ impl ReplicationFetcher {
             }
         }
 
-        trace!("Sending out {} keys to fetch", data_to_fetch.len());
+        let pretty_keys: Vec<_> = data_to_fetch
+            .iter()
+            .map(|key| PrettyPrintRecordKey::from(key.clone()))
+            .collect();
+        trace!(
+            "Sending out replication fetching {} keys {:?}",
+            data_to_fetch.len(),
+            pretty_keys
+        );
         self.on_going_fetches += data_to_fetch.len();
         data_to_fetch
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 14:05 UTC
This pull request includes some logging updates in the code. In the `sn_client/src/api.rs` file, a trace message has been updated to include the `PrettyPrintRecordKey` when getting spend information. In the `sn_networking/src/replication_fetcher.rs` file, a trace message has been modified to include the number of keys and the `PrettyPrintRecordKey` when sending out replication fetching. Overall, this patch adds 13 insertions and modifies 2 deletions.
<!-- reviewpad:summarize:end --> 
