### PR TITLE
refactor: optimise getting furthest record

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -191,15 +191,18 @@ impl DiskBackedRecordStore {
         }
 
         // sort records by distance to our local key
-        let mut records = self.records.iter().cloned().collect::<Vec<_>>();
-        records.sort_unstable_by_key(|k| {
-            let kbucket_key = KBucketKey::from(k.to_vec());
-            self.local_key.distance(&kbucket_key)
-        });
+        let furthest = self
+            .records
+            .iter()
+            .max_by_key(|k| {
+                let kbucket_key = KBucketKey::from(k.to_vec());
+                self.local_key.distance(&kbucket_key)
+            })
+            .cloned();
 
         // now check if the incoming record is closer than our furthest
         // if it is, we can prune
-        if let Some(furthest_record) = records.last() {
+        if let Some(furthest_record) = furthest {
             let furthest_record_key = KBucketKey::from(furthest_record.to_vec());
             let incoming_record_key = KBucketKey::from(r.to_vec());
 
@@ -212,7 +215,7 @@ impl DiskBackedRecordStore {
                     PrettyPrintRecordKey::from(r.clone())
                 );
                 // we should prune and make space
-                self.remove(furthest_record);
+                self.remove(&furthest_record);
 
                 // Warn if the furthest record was within our distance range
                 if let Some(distance_range) = self.distance_range {


### PR DESCRIPTION
Instead of cloning and sorting an entire vec of record keys, compare
with an iterator and clone only the resulting key.

Tested by asserting the old and new method are equal and running the `pruning_on_full` test.