### PR TITLE
Client mem improvments

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="2000" # mb
-          client_avg_mem_limit_mb="1500" # mb
+          client_peak_mem_limit_mb="1000" # mb
+          client_avg_mem_limit_mb="850" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,4 +1,4 @@
-name: build release artifacts
+mename: build release artifacts
 
 on:
   workflow_dispatch:

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -161,8 +161,8 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="2000" # mb
-          client_avg_mem_limit_mb="1500" # mb
+          client_peak_mem_limit_mb="1000" # mb
+          client_avg_mem_limit_mb="850" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -213,9 +213,10 @@ jobs:
 
       - name: Check client memory usage
         shell: bash
+        # limits here are lower that benchmark tests as there is less going on.
         run: |
-          client_peak_mem_limit_mb="2000" # mb
-          client_avg_mem_limit_mb="1500" # mb
+          client_peak_mem_limit_mb="350" # mb
+          client_avg_mem_limit_mb="250" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ settings.json
 *.log
 
 bump_version_output
+
+heaptrack.*.gz

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -184,8 +184,8 @@ async fn upload_chunks(
             let _permit = semaphore.acquire_owned().await?;
 
             println!(
-                "Starting to upload chunk #{i} from {file_name:?}. (after {:.2}mins elapsed)",
-                start_time.elapsed().as_secs_f64() / 60.0
+                "Starting to upload chunk #{i} from {file_name:?}. (after {} elapsed)",
+                format_elapsed_time(start_time.elapsed())
             );
 
             let upload_start_time = std::time::Instant::now();
@@ -198,8 +198,8 @@ async fn upload_chunks(
                 .await?;
 
             println!(
-                "Uploaded chunk #{i} from {file_name:?} in {:.2} seconds)",
-                upload_start_time.elapsed().as_secs_f64()
+                "Uploaded chunk #{i} from {file_name:?} in {})",
+                format_elapsed_time(upload_start_time.elapsed())
             );
             Ok::<(), Error>(())
         });
@@ -212,8 +212,8 @@ async fn upload_chunks(
     }
 
     println!(
-        "Uploaded {file_name:?} in {:.2} minutes",
-        start_time.elapsed().as_secs_f64() / 60.0
+        "Uploaded {file_name:?} in {}",
+        format_elapsed_time(start_time.elapsed())
     );
     Ok(())
 }
@@ -244,6 +244,17 @@ async fn download_files(file_api: &Files, root_dir: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Function to format elapsed time into a string
+fn format_elapsed_time(elapsed_time: std::time::Duration) -> String {
+    let elapsed_minutes = elapsed_time.as_secs() / 60;
+    let elapsed_seconds = elapsed_time.as_secs() % 60;
+    if elapsed_minutes > 0 {
+        format!("{} minutes {} seconds", elapsed_minutes, elapsed_seconds)
+    } else {
+        format!("{} seconds", elapsed_seconds)
+    }
 }
 
 async fn download_file(

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -210,7 +210,7 @@ fn deposit_from_dbc_hex(root_dir: &Path, input: String) -> Result<()> {
     let dbc = sn_dbc::Dbc::from_hex(input.trim())?;
 
     let old_balance = wallet.balance();
-    wallet.deposit(vec![dbc])?;
+    wallet.deposit(&vec![dbc])?;
     let new_balance = wallet.balance();
     wallet.store()?;
 
@@ -250,7 +250,7 @@ async fn send(
                 println!("Successfully stored wallet with new balance {new_balance}.");
             }
 
-            wallet.store_dbc(new_dbc)?;
+            wallet.store_dbc(&new_dbc)?;
             println!("Successfully stored new dbc to wallet dir. It can now be sent to the recipient, using any channel of choice.");
         }
         Err(err) => {

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -52,7 +52,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
     )
     .await?;
 
-    faucet_wallet.deposit(vec![dbc.clone()])?;
+    faucet_wallet.deposit(&vec![dbc.clone()])?;
     faucet_wallet
         .store()
         .expect("Faucet wallet shall be stored successfully.");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -337,7 +337,7 @@ pub async fn send(
         .store()
         .expect("Wallet shall be successfully stored.");
     wallet
-        .store_dbc(new_dbc.clone())
+        .store_dbc(&new_dbc)
         .expect("Created dbc shall be successfully stored.");
 
     if did_error {

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -19,7 +19,7 @@ use sn_transfers::{
 
 use futures::future::join_all;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     iter::Iterator,
     time::{Duration, Instant},
 };
@@ -53,7 +53,7 @@ impl WalletClient {
         self.wallet.unconfirmed_txs_exist()
     }
     /// Get unconfirmed txs
-    pub fn unconfirmed_txs(&self) -> &Vec<SpendRequest> {
+    pub fn unconfirmed_txs(&self) -> &BTreeSet<SpendRequest> {
         self.wallet.unconfirmed_txs()
     }
 
@@ -70,9 +70,7 @@ impl WalletClient {
         to: PublicAddress,
         verify_store: bool,
     ) -> Result<Dbc> {
-        let transfer = self.wallet.local_send(vec![(amount, to)], None)?;
-
-        let created_dbcs = transfer.created_dbcs.clone();
+        let created_dbcs = self.wallet.local_send(vec![(amount, to)], None)?;
 
         // send to network
         if let Err(error) = self
@@ -229,7 +227,11 @@ impl WalletClient {
 impl Client {
     /// Send a spend request to the network.
     /// This can optionally verify the spend has been correctly stored before returning
-    pub async fn send(&self, spend_requests: &Vec<SpendRequest>, verify_store: bool) -> Result<()> {
+    pub async fn send(
+        &self,
+        spend_requests: &BTreeSet<SpendRequest>,
+        verify_store: bool,
+    ) -> Result<()> {
         let mut tasks = Vec::new();
 
         for spend_request in spend_requests {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -339,7 +339,7 @@ impl Node {
                     });
                 }
 
-                wallet.deposit(vec![dbc.clone()]).map_err(|err| {
+                wallet.deposit(&vec![dbc.clone()]).map_err(|err| {
                     ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string())
                 })?;
             }

--- a/sn_node/src/spends.rs
+++ b/sn_node/src/spends.rs
@@ -31,6 +31,7 @@ where
         "aggregating spends for {:?}",
         DbcAddress::from_dbc_id(&valid_dbc_id)
     );
+
     let spends = spends.into_iter().collect::<HashSet<_>>();
     // on the unique set of SignedSpends, perform the below filter + sort
     spends
@@ -39,6 +40,14 @@ where
         .filter(|signed_spend| {
             // make sure the dbc_ids are the same
             let is_valid_dbc_id = signed_spend.dbc_id() == &valid_dbc_id;
+
+            // don't verify if we already failed this check
+            if !is_valid_dbc_id {
+                trace!("Aggregating spend, is not valid dbc id, this dbc {:?}, expected {:?}", signed_spend.dbc_id(), &valid_dbc_id);
+
+                return false
+            }
+
             // make sure the spent_tx hash matches
             let spent_tx_hash_matches = signed_spend
             .verify(signed_spend.spent_tx_hash())

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -90,7 +90,7 @@ pub async fn get_funded_wallet(
 
     println!("Verifying the transfer from faucet...");
     client.verify(&tokens).await?;
-    local_wallet.deposit(vec![tokens])?;
+    local_wallet.deposit(&vec![tokens])?;
     assert_eq!(local_wallet.balance(), wallet_balance);
     println!("Tokens deposited to the wallet that'll pay for storage: {wallet_balance}.");
 

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -45,7 +45,7 @@ async fn dbc_transfer_multiple_sequential_succeed() -> Result<()> {
     .await?;
     println!("Verifying the transfer from first wallet...");
     client.verify(&tokens).await?;
-    second_wallet.deposit(vec![tokens])?;
+    second_wallet.deposit(&vec![tokens])?;
     assert_eq!(second_wallet.balance(), second_wallet_balance);
     println!("Tokens deposited to second wallet: {second_wallet_balance}.");
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -288,11 +288,15 @@ async fn storage_payment_chunk_nodes_rewarded() -> Result<()> {
         .upload_with_payments(content_bytes, &wallet_client, true)
         .await?;
 
+    // sleep for 1 second to allow nodes to process and store the payment
+    sleep(Duration::from_secs(1)).await;
+
     let new_rewards_balance = current_rewards_balance()?;
 
     let expected_rewards_balance = prev_rewards_balance
         .checked_add(cost)
         .ok_or_else(|| eyre!("Failed to sum up rewards balance"))?;
+
     assert_eq!(expected_rewards_balance, new_rewards_balance);
 
     Ok(())

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -75,7 +75,9 @@ pub struct TransferOutputs {
 }
 
 /// The parameters necessary to send a spend request to the network.
-#[derive(custom_debug::Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(
+    custom_debug::Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub struct SpendRequest {
     /// The dbc to register in the network as spent.
     pub signed_spend: SignedSpend,

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -124,15 +124,13 @@ fn create_transfer_with(
     fee: Option<FeeOutput>,
 ) -> Result<TransferOutputs> {
     let Inputs {
-        dbcs_to_spend,
-        recipients,
         change: (change, change_to),
         ..
     } = selected_inputs;
 
     let mut inputs = vec![];
     let mut src_txs = BTreeMap::new();
-    for (dbc, derived_key) in dbcs_to_spend {
+    for (dbc, derived_key) in selected_inputs.dbcs_to_spend {
         let token = match dbc.token() {
             Ok(token) => token,
             Err(err) => {
@@ -150,7 +148,7 @@ fn create_transfer_with(
 
     let mut tx_builder = TransactionBuilder::default()
         .add_inputs(inputs)
-        .add_outputs(recipients);
+        .add_outputs(selected_inputs.recipients);
 
     if let Some(fee_output) = fee {
         tx_builder = tx_builder.set_fee_output(fee_output);

--- a/sn_transfers/src/dbc_genesis.rs
+++ b/sn_transfers/src/dbc_genesis.rs
@@ -80,7 +80,7 @@ pub fn load_genesis_wallet() -> Result<LocalWallet, Error> {
 
     info!("Depositing genesis DBC: {:#?}", GENESIS_DBC.id());
     genesis_wallet
-        .deposit(vec![GENESIS_DBC.clone()])
+        .deposit(&vec![GENESIS_DBC.clone()])
         .map_err(|err| Error::WalletError(err.to_string()))?;
     genesis_wallet
         .store()

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -298,11 +298,11 @@ impl LocalWallet {
             self.deposit(&vec![dbc])?;
         }
 
-        // Store created DBCs in a batch, improving IO performance
-        for dbc in transfer.created_dbcs {
+        for dbc in &transfer.created_dbcs {
             self.wallet.dbcs_created_for_others.insert(dbc.id());
-            self.store_dbcs(vec![&dbc])?;
         }
+        // Store created DBCs in a batch, improving IO performance
+        self.store_dbcs(transfer.created_dbcs.iter().collect())?;
 
         for request in transfer.all_spend_requests {
             self.unconfirmed_txs.insert(request);

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -16,6 +16,7 @@ use super::{
 use sn_dbc::{Dbc, DbcId};
 use sn_protocol::storage::DbcAddress;
 use std::{
+    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
 };
@@ -55,7 +56,7 @@ pub(super) fn get_wallet(wallet_dir: &Path) -> Result<Option<KeyLessWallet>> {
 /// Writes the `unconfirmed_txs` to the specified path.
 pub(super) fn store_unconfirmed_txs(
     wallet_dir: &Path,
-    unconfirmed_txs: &Vec<SpendRequest>,
+    unconfirmed_txs: &BTreeSet<SpendRequest>,
 ) -> Result<()> {
     let unconfirmed_txs_path = wallet_dir.join(UNCONFRIMED_TX_NAME);
     let bytes = bincode::serialize(&unconfirmed_txs)?;
@@ -64,7 +65,7 @@ pub(super) fn store_unconfirmed_txs(
 }
 
 /// Returns `Some(Vec<SpendRequest>)` or None if file doesn't exist.
-pub(super) fn get_unconfirmed_txs(wallet_dir: &Path) -> Result<Option<Vec<SpendRequest>>> {
+pub(super) fn get_unconfirmed_txs(wallet_dir: &Path) -> Result<Option<BTreeSet<SpendRequest>>> {
     let path = wallet_dir.join(UNCONFRIMED_TX_NAME);
     if !path.is_file() {
         return Ok(None);

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -79,10 +79,10 @@ pub(super) fn get_unconfirmed_txs(wallet_dir: &Path) -> Result<Option<BTreeSet<S
 
 /// Hex encode and write each `Dbc` to a separate file in respective
 /// recipient public address dir in the created dbcs dir. Each file is named after the dbc id.
-pub(super) fn store_created_dbcs(created_dbcs: Vec<Dbc>, wallet_dir: &Path) -> Result<()> {
+pub(super) fn store_created_dbcs(created_dbcs: Vec<&Dbc>, wallet_dir: &Path) -> Result<()> {
     // The create dbcs dir within the wallet dir.
     let created_dbcs_path = wallet_dir.join(CREATED_DBCS_DIR_NAME);
-    for dbc in created_dbcs.into_iter() {
+    for dbc in created_dbcs.iter() {
         let dbc_id_name = *DbcAddress::from_dbc_id(&dbc.id()).xorname();
         let dbc_id_file_name = format!("{}.dbc", hex::encode(dbc_id_name));
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 15:39 UTC
This pull request includes various changes in multiple files:

1. The file "sn_client/src/faucet/mod.rs" has a small change on line 57, where the code now uses a reference to a vector instead of passing it by value.

2. In the file "dbc_genesis.rs", the change in the "deposit" function call replaces the argument from "vec![GENESIS_DBC.clone()]" to "&vec![GENESIS_DBC.clone()]". This change might be related to performance improvements or preventing unnecessary cloning of the "GENESIS_DBC" object.

3. The file "transfer.rs" implements changes in the "create_transfer_with" function:
   - The variables "dbcs_to_spend" and "recipients" have been removed from the "Inputs" struct, and their values are directly accessed from the "selected_inputs" struct.
   - The "for" loop now iterates over "selected_inputs.dbcs_to_spend" instead of "dbcs_to_spend".
   - The "tx_builder.add_outputs" method now takes "selected_inputs.recipients" as the input parameter instead of "recipients". These changes simplify the code and improve readability.

4. The file "wallet.rs" includes various changes:
   - In the "WalletClient" implementation:
     - The "collections::BTreeMap" import is replaced with "collections::{BTreeMap, BTreeSet}".
     - The return type of the "unconfirmed_txs" function changed from "&Vec<SpendRequest>" to "&BTreeSet<SpendRequest>".
     - The implementation of the "send" function now takes a tuple as an argument and removes the cloning of the "transfer.created_dbcs".

   - In the "Client" implementation, the "send" function now takes a "BTreeSet<SpendRequest>" as an argument instead of a "Vec<SpendRequest>".

   - In the "send" function outside the implementations, the "store_dbc" function now takes a reference to "new_dbc" instead of cloning it.

5. The file "api.rs" includes changes:
   - A check is added starting at line 365 to handle a specific "RecordKind".
   - Deserialization of a record is attempted, and error handling is implemented if deserialization fails.
   - The length of the deserialized record is checked, and different actions are taken based on the length.
   - If the length is 0, a trace log is added indicating that no spend was found for the given address, and an error is returned with a corresponding message.
   - If the length is 1, a signed spend is extracted from the deserialized record, and validation and verification checks are performed. Appropriate logs and error messages are added based on the outcome.
   - If the length is anything other than 0 or 1, two elements are removed from the deserialized record, and an error is returned indicating a double spend, along with the relevant information. These changes provide additional handling for specific cases when verifying transfers and address spends.

6. The ".gitignore" file's changes include:
   - Three new entries: "bump_version_output", "heaptrack.*.gz".
   - A newline is added at the end of the file. No existing entries are removed or modified.

7. The "SpendRequest" struct in the "client_transfers/mod.rs" file now implements the traits "Eq", "PartialOrd", and "Ord".

8. In the "wallet.rs" file, the changes include:
   - Line 178: The "wallet.deposit" function now passes a reference to the vector "[dbc]" instead of passing the vector directly.
   - Line 222: The "wallet.store_dbc" function now passes a reference to the "new_dbc" variable instead of passing the variable directly. These changes enhance function execution and improve code readability.

9. The changes in another file include:
   - An import statement for the "BTreeSet" collection is added.
   - The "store_unconfirmed_txs" function now accepts a "BTreeSet<SpendRequest>" instead of a "Vec<SpendRequest>".
   - The return type of the "get_unconfirmed_txs" function is now "Option<BTreeSet<SpendRequest>>" instead of "Option<Vec<SpendRequest>>".
   - The "store_created_dbcs" function now accepts "Vec<&Dbc>" instead of "Vec<Dbc>". Additionally, the "for" loop now iterates over "created_dbcs.iter()" instead of "created_dbcs.into_iter()".


Please review these changes and ensure they meet the requirements and expectations of the codebase. Let me know if you need further assistance with this code review.
<!-- reviewpad:summarize:end --> 
