### PR TITLE
Revert "add llvm path"

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -222,9 +222,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include: 
-          - os: windows-latest
-            shell: msys2 {0}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -239,22 +239,19 @@ jobs:
       # - name: Change default linker on windows
       #   if: matrix.os == 'windows-latest'
       #   run: rustup toolchain install stable-x86_64-pc-windows-gnu && rustup default stable-x86_64-pc-windows-gnu && rustup component add rustfmt
-      # - name: Setup msys2
-      #   if: matrix.os == 'windows-latest'
-      #   uses: msys2/setup-msys2@v2
-      #   with:
-      #     msystem: UCRT64
-      #     update: true
-      #     install: >-
-      #       make
-      #       git
-      #     pacboy: >-
-      #       toolchain:p
-      #       cmake:p
-      #       ninja:p
-      - name: Add llvm path on Windows
+      - name: Setup msys2
         if: matrix.os == 'windows-latest'
-        run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            make
+            git
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
 
       - name: Build safe bins
         run: cargo build --release --features local-discovery --bin safenode --bin faucet

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -239,6 +239,8 @@ jobs:
       - name: Build testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
+        env:
+          CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -263,12 +265,14 @@ jobs:
         run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
           SN_LOG: "all"
+          CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 25
 
       - name: execute the storage payment tests
         run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
+          CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 25
 
       - name: Stop the local network and upload logs
@@ -308,6 +312,9 @@ jobs:
       - name: Build churn tests
         run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
+        # new output folder to avoid linker issues w/ windows
+        env:
+          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -332,6 +339,8 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 10
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
@@ -341,6 +350,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 10
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
@@ -425,6 +436,9 @@ jobs:
         - name: Build data location test
           run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run  
           timeout-minutes: 30
+          # new output folder to avoid linker issues w/ windows
+          env:
+            CARGO_TARGET_DIR: "./data-location-target"
 
         - name: Start a local network
           uses: maidsafe/sn-local-testnet-action@main
@@ -448,6 +462,8 @@ jobs:
         - name: Verify the location of the data on the network (4 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture 
           env:
+            # new output folder to avoid linker issues w/ windows
+            CARGO_TARGET_DIR: "./data-location-target"
             CHURN_COUNT: 4
             SN_LOG: "all"
           timeout-minutes: 30

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -232,23 +232,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # # fixes the linker issue on windows
-      # - name: Change default linker on windows
-      #   if: matrix.os == 'windows-latest'
-      #   run: rustup toolchain install stable-x86_64-pc-windows-gnu && rustup default stable-x86_64-pc-windows-gnu && rustup component add rustfmt
-      - name: Setup msys2
+      # fixes the linker issue on windows
+      - name: Change default linker on windows
         if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          install: >-
-            make
-            git
-          pacboy: >-
-            toolchain:p
-            cmake:p
-            ninja:p
+        run: rustup toolchain install stable-x86_64-pc-windows-gnu && rustup default stable-x86_64-pc-windows-gnu && rustup component add rustfmt
 
       - name: Build safe bins
         run: cargo build --release --features local-discovery --bin safenode --bin faucet

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -232,11 +232,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # fixes the linker issue on windows
-      - name: Change default linker on windows
-        if: matrix.os == 'windows-latest'
-        run: rustup toolchain install stable-x86_64-pc-windows-gnu && rustup default stable-x86_64-pc-windows-gnu && rustup component add rustfmt
-
       - name: Build safe bins
         run: cargo build --release --features local-discovery --bin safenode --bin faucet
         timeout-minutes: 30

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,6 +175,8 @@ jobs:
       - name: Build testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
+        env:
+          CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -188,12 +190,14 @@ jobs:
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
+          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the storage payment tests
         run: cargo test --release --features="local-discovery" --test storage_payments -- --nocapture
         env:
+          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
       
@@ -243,6 +247,9 @@ jobs:
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
+        # new output folder to avoid linker issues w/ windows
+        env:
+          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -256,6 +263,8 @@ jobs:
       - name: Chunks data integrity during nodes churn (during 10min) (in theory)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
         env:
+          # new output folder to avoid linker issues w/ windows
+          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6
           SN_LOG: "all"
@@ -349,6 +358,9 @@ jobs:
         - name: Build data location test
           run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run
           timeout-minutes: 30
+          # new output folder to avoid linker issues w/ windows
+          env:
+            CARGO_TARGET_DIR: "./data-location-target"        
 
         - name: Start a local network
           uses: maidsafe/sn-local-testnet-action@main
@@ -362,6 +374,8 @@ jobs:
         - name: Verify the location of the data on the network (approx 12 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
           env:
+            # new output folder to avoid linker issues w/ windows
+            CARGO_TARGET_DIR: "./data-location-target"
             CHURN_COUNT: 12
             SN_LOG: "all"
           timeout-minutes: 70


### PR DESCRIPTION
This reverts commit 3a87d97.## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 15:58 UTC
This pull request includes several changes to the workflows files. 

In `.github/workflows/merge.yml`, the following changes have been made:
- Removed the `include` section under `strategy.matrix.os`
- Commented out a section related to changing the default linker on Windows
- Commented out a section related to setting up msys2 on Windows
- Modified the `CARGO_TARGET_DIR` environment variable for the `Build testing executable` and `execute the storage payment tests` steps
- Modified the `CARGO_TARGET_DIR` environment variable for the `Build churn tests`, `Churn data integrity tests`, and `Verify the location of the data on the network` steps

In `.github/workflows/nightly.yml`, the following changes have been made:
- Modified the `CARGO_TARGET_DIR` environment variable for the `Build testing executable` and `execute the storage payment tests` steps
- Modified the `CARGO_TARGET_DIR` environment variable for the `Build churn tests`, `Chunks data integrity during nodes churn`, and `Verify the location of the data on the network` steps

These changes seem to be related to folder paths and environment variables to avoid linker issues on Windows and improve test output organization.
<!-- reviewpad:summarize:end --> 
This reverts commit 3a87d97.