### PR TITLE
feat(ci): CI should fail on DoNotMerge lable

### DIFF
--- a/.github/workflows/merge-queue-checks.yml
+++ b/.github/workflows/merge-queue-checks.yml
@@ -1,0 +1,16 @@
+name: Merge Queue Checks
+
+on:
+  merge_group:
+    branches: [main]
+
+jobs:
+  # fail if PR is labeled as `DoNotMerge`
+  fail-by-label:
+    if: contains(github.event.pull_request.labels.*.name, 'DoNotMerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is labeled "DoNotMerge"
+        run: |
+          echo "This PR is labeled as DoNotMerge!"
+          exit 1


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 16:16 UTC
This pull request adds a new feature to the continuous integration (CI) workflow. Specifically, it ensures that the CI fails when a pull request is labeled as "DoNotMerge". This helps prevent merging of certain PRs that should not be merged. The update includes changes to the `.github/workflows/merge.yml` file by adding a step to fail the CI if the DoNotMerge label is present in the pull request.
<!-- reviewpad:summarize:end --> 
