### PR TITLE
feat(ci): perform certain wallet actions without network connection

### DIFF
--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -6,14 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::subcommands::SubCmd;
 use clap::Parser;
 use color_eyre::{eyre::eyre, Result};
-use std::path::PathBuf;
-use std::time::Duration;
-
-use crate::subcommands::SubCmd;
 use sn_logging::{parse_log_format, LogFormat, LogOutputDest};
 use sn_peers_acquisition::PeersArgs;
+use std::{path::PathBuf, time::Duration};
 
 pub fn parse_log_output(val: &str) -> Result<LogOutputDest> {
     match val {

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -192,7 +192,7 @@ async fn upload_chunks(
 
             let upload_start_time = std::time::Instant::now();
 
-            let wallet_client = file_api.wallet(wallet_dir).await?;
+            let wallet_client = file_api.wallet(wallet_dir)?;
             let chunk = Chunk::new(Bytes::from(fs::read(path)?));
 
             file_api

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -13,14 +13,12 @@ use color_eyre::{eyre::Error, Result};
 use libp2p::futures::future::join_all;
 use sn_client::{Client, Files};
 use sn_protocol::storage::{Chunk, ChunkAddress};
-use std::fs;
-use tokio::sync::Semaphore;
-
 use std::{
-    // fs,
+    fs,
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tokio::sync::Semaphore;
 use walkdir::WalkDir;
 use xor_name::XorName;
 

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -44,7 +44,7 @@ impl Files {
     }
 
     /// Create a new WalletClient for a given root directory.
-    pub async fn wallet(&self, root_dir: PathBuf) -> Result<WalletClient> {
+    pub fn wallet(&self, root_dir: PathBuf) -> Result<WalletClient> {
         let wallet = LocalWallet::load_from(root_dir.as_path())?;
         Ok(WalletClient::new(self.client.clone(), wallet))
     }
@@ -148,7 +148,7 @@ impl Files {
         let chunk_addr = chunk.network_address();
         trace!("Client upload started for chunk: {chunk_addr:?}");
 
-        let payment = wallet_client.get_payment_dbcs(&chunk_addr).await;
+        let payment = wallet_client.get_payment_dbcs(&chunk_addr);
 
         if payment.is_empty() {
             warn!(
@@ -210,7 +210,7 @@ impl Files {
     ) -> Result<NetworkAddress> {
         let chunk = package_small(small)?;
         let address = chunk.network_address();
-        let payment = wallet_client.get_payment_dbcs(&address).await;
+        let payment = wallet_client.get_payment_dbcs(&address);
 
         if payment.is_empty() {
             return Err(super::Error::MissingPaymentProof(format!("{address}")));

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -39,7 +39,7 @@ impl WalletClient {
     }
 
     /// Stores the wallet to disk.
-    pub async fn store_local_wallet(&self) -> Result<()> {
+    pub fn store_local_wallet(&self) -> Result<()> {
         self.wallet.store()
     }
 
@@ -58,7 +58,7 @@ impl WalletClient {
     }
 
     /// Get the payment dbc for a given network address
-    pub async fn get_payment_dbcs(&self, address: &NetworkAddress) -> Vec<Dbc> {
+    pub fn get_payment_dbcs(&self, address: &NetworkAddress) -> Vec<Dbc> {
         self.wallet.get_payment_dbcs(address)
     }
 

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
 
     if args.flame {
         #[cfg(not(target_os = "windows"))]
-        check_flamegraph_prerequisites().await?;
+        check_flamegraph_prerequisites()?;
         #[cfg(target_os = "windows")]
         return Err(eyre!("Flamegraph cannot be used on Windows"));
     }
@@ -166,7 +166,7 @@ async fn main() -> Result<()> {
     if let Some(node_path) = args.node_path {
         node_bin_path.push(node_path);
     } else if args.build_node {
-        build_binaries(vec![SAFENODE_BIN_NAME.to_owned()]).await?;
+        build_binaries(vec![SAFENODE_BIN_NAME.to_owned()])?;
         node_bin_path.push("target");
         node_bin_path.push("release");
         node_bin_path.push(SAFENODE_BIN_NAME);
@@ -185,8 +185,7 @@ async fn main() -> Result<()> {
                 .unwrap_or(DEFAULT_NODE_LAUNCH_INTERVAL),
             node_count,
             args.node_args,
-        )
-        .await?;
+        )?;
         return Ok(());
     }
 
@@ -205,7 +204,7 @@ async fn main() -> Result<()> {
     if let Some(faucet_path) = args.faucet_path {
         faucet_bin_path.push(faucet_path);
     } else if args.build_faucet {
-        build_binaries(vec![FAUCET_BIN_NAME.to_owned()]).await?;
+        build_binaries(vec![FAUCET_BIN_NAME.to_owned()])?;
         faucet_bin_path.push("target");
         faucet_bin_path.push("release");
         faucet_bin_path.push(FAUCET_BIN_NAME);
@@ -214,14 +213,14 @@ async fn main() -> Result<()> {
     }
 
     info!("Launching DBC faucet server");
-    run_faucet(gen_multi_addr, faucet_bin_path).await?;
+    run_faucet(gen_multi_addr, faucet_bin_path)?;
 
     println!("Testnet and faucet launched successfully");
     Ok(())
 }
 
 #[cfg(not(target_os = "windows"))]
-async fn check_flamegraph_prerequisites() -> Result<()> {
+fn check_flamegraph_prerequisites() -> Result<()> {
     let output = Command::new("cargo")
         .arg("install")
         .arg("--list")
@@ -250,7 +249,7 @@ async fn check_flamegraph_prerequisites() -> Result<()> {
 }
 
 // Calls cargo build on the given binaries.
-async fn build_binaries(binaries_to_build: Vec<String>) -> Result<()> {
+fn build_binaries(binaries_to_build: Vec<String>) -> Result<()> {
     let mut args = vec!["build", "--release"];
     for bin in &binaries_to_build {
         args.push("--bin");
@@ -301,7 +300,7 @@ async fn build_binaries(binaries_to_build: Vec<String>) -> Result<()> {
 }
 
 /// Start the faucet from the provided bin_path and with the given bootstrap peer
-async fn run_faucet(gen_multi_addr: String, bin_path: PathBuf) -> Result<()> {
+fn run_faucet(gen_multi_addr: String, bin_path: PathBuf) -> Result<()> {
     let testnet = Testnet::configure().node_bin_path(bin_path).build()?;
     let launch_bin = testnet.node_bin_path;
 
@@ -352,7 +351,7 @@ async fn run_network(
     Ok(gen_multi_addr)
 }
 
-async fn join_network(
+fn join_network(
     node_bin_path: PathBuf,
     node_launch_interval: u64,
     node_count: u32,

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -394,29 +394,14 @@ impl KeyLessWallet {
 #[cfg(test)]
 mod tests {
     use super::{get_wallet, store_wallet, LocalWallet};
-
     use crate::{
-        client_transfers::TransferOutputs,
         dbc_genesis::{create_first_dbc_from_key, GENESIS_DBC_AMOUNT},
         wallet::{local_store::WALLET_DIR_NAME, KeyLessWallet},
     };
-
-    use sn_dbc::{MainKey, Token};
-    use sn_protocol::storage::DbcAddress;
-
     use assert_fs::TempDir;
     use eyre::Result;
-
-    #[derive(Clone)]
-    struct MockSendClient;
-
-    impl MockSendClient {
-        async fn send(&self, _transfer: TransferOutputs) -> super::Result<()> {
-            // Here we just return Ok(()), without network calls,
-            // and without sending it to the network.
-            Ok(())
-        }
-    }
+    use sn_dbc::{MainKey, Token};
+    use sn_protocol::storage::DbcAddress;
 
     #[tokio::test]
     async fn keyless_wallet_to_and_from_file() -> Result<()> {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 17:31 UTC
This pull request includes the following changes:

1. The file `files.rs`:
   - The import `std::fs` has been removed, while the import `tokio::sync::Semaphore` has been added.
   - The code block starting from line 192 to line 194 has been modified. The function `wallet` is now called synchronously instead of using an async/await pattern.

2. The file `main.rs` in the `sn_cli` module:
   - Some imports have been rearranged and reorganized.
   - The `sn_logging` crate is now using the `metrics` module for initializing metrics.
   - The `wallet_cmds_without_client` function is invoked for specific wallet commands, such as `Address`, `Balance`, `Deposit`, and `GetFaucet`.
   - The message for instantiating a SAFE client has been moved after the above check.

3. The file `local_store.rs`:
   - The `KeyLessWallet` struct has been modified.
   - A new module named `tests` has been introduced.
   - The `MockSendClient` struct and its implementation have been removed.
   - The `sn_dbc`, `sn_protocol`, and `eyre` crates have been imported.
   - The `keyless_wallet_to_and_from_file` async function has been added.

4. The file `cli.rs`:
   - The import statement `use crate::subcommands::SubCmd;` is added.
   - The imports `std::path::PathBuf` and `std::time::Duration` are reordered and combined in a single `std` import.
   - The imports `clap::Parser` and `color_eyre::{eyre::eyre, Result}` remain unchanged.
   - The import statement `use sn_logging::{parse_log_format, LogFormat, LogOutputDest};` is modified to remove the unused imports `parse_log_format` and `LogFormat`.
   - The import statement `use sn_peers_acquisition::PeersArgs;` is unchanged.

5. The file `main.rs`:
   - The function `check_flamegraph_prerequisites` was modified. It no longer returns a `Result` asynchronously but synchronously.
   - The function `build_binaries` was modified. It no longer returns a `Result` asynchronously but synchronously.
   - The function `run_faucet` was modified. It no longer returns a `Result` asynchronously but synchronously.
   - The function `join_network` was modified. It no longer returns a `Result` asynchronously but synchronously.

6. The file `wallet.rs`:
   - Added imports for `bytes::Bytes`, `clap::Parser`, `color_eyre::eyre`, `color_eyre::{eyre::bail, eyre::WrapErr, Result, Section}`.
   - Reordered imports alphabetically within the same `use` block.
   - Added a new `pub(crate) async fn wallet_cmds_without_client` function.
   - Added a match arm in `wallet_cmds_without_client` for `WalletCmds::Deposit` variant.
   - Replaced the `address`, `balance`, `deposit`, and `get_faucet` functions in `wallet_cmds` with non-async versions.
   - Removed the unused async modifier on `address`, `balance`, `get_faucet`, `deposit`, and `deposit_from_dbc_hex` functions.
   - Replaced the `Logic::Local` variant in `store_local_wallet` function call with a closure.
   - Removed the unused async modifier on `chunk_and_pay_for_storage` function.
   - Replaced `store_local_wallet().await` with `store_local_wallet` in the file.

7. The file `wallet.rs`:
   - In the `WalletClient` struct, the `store_local_wallet` method was changed from an asynchronous function (`async`) to a synchronous function.
   - In the `WalletClient` struct, the `get_payment_dbcs` method was changed from an asynchronous function (`async`) to a synchronous function.

Please review these changes and let me know if you need further assistance.
<!-- reviewpad:summarize:end --> 
