### PR TITLE
disable `CARGO_TARGET_DIR` to speedup build time

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -239,8 +239,6 @@ jobs:
       - name: Build testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -265,14 +263,12 @@ jobs:
         run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
           SN_LOG: "all"
-          CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 25
 
       - name: execute the storage payment tests
         run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
-          CARGO_TARGET_DIR: "./transfer-target"
         timeout-minutes: 25
 
       - name: Stop the local network and upload logs
@@ -312,9 +308,6 @@ jobs:
       - name: Build churn tests
         run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
-        # new output folder to avoid linker issues w/ windows
-        env:
-          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -339,8 +332,6 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
-          # new output folder to avoid linker issues w/ windows
-          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 10
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
@@ -350,8 +341,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
-          # new output folder to avoid linker issues w/ windows
-          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 10
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
@@ -436,9 +425,6 @@ jobs:
         - name: Build data location test
           run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run  
           timeout-minutes: 30
-          # new output folder to avoid linker issues w/ windows
-          env:
-            CARGO_TARGET_DIR: "./data-location-target"
 
         - name: Start a local network
           uses: maidsafe/sn-local-testnet-action@main
@@ -462,8 +448,6 @@ jobs:
         - name: Verify the location of the data on the network (4 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture 
           env:
-            # new output folder to avoid linker issues w/ windows
-            CARGO_TARGET_DIR: "./data-location-target"
             CHURN_COUNT: 4
             SN_LOG: "all"
           timeout-minutes: 30

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,8 +175,6 @@ jobs:
       - name: Build testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
         timeout-minutes: 30
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -190,14 +188,12 @@ jobs:
       - name: execute the dbc spend test
         run: cargo test --release --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the storage payment tests
         run: cargo test --release --features="local-discovery" --test storage_payments -- --nocapture
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
       
@@ -247,9 +243,6 @@ jobs:
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
         timeout-minutes: 30
-        # new output folder to avoid linker issues w/ windows
-        env:
-          CARGO_TARGET_DIR: "./churn-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -263,8 +256,6 @@ jobs:
       - name: Chunks data integrity during nodes churn (during 10min) (in theory)
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
         env:
-          # new output folder to avoid linker issues w/ windows
-          CARGO_TARGET_DIR: "./churn-target"
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6
           SN_LOG: "all"
@@ -358,9 +349,6 @@ jobs:
         - name: Build data location test
           run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run
           timeout-minutes: 30
-          # new output folder to avoid linker issues w/ windows
-          env:
-            CARGO_TARGET_DIR: "./data-location-target"        
 
         - name: Start a local network
           uses: maidsafe/sn-local-testnet-action@main
@@ -374,8 +362,6 @@ jobs:
         - name: Verify the location of the data on the network (approx 12 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
           env:
-            # new output folder to avoid linker issues w/ windows
-            CARGO_TARGET_DIR: "./data-location-target"
             CHURN_COUNT: 12
             SN_LOG: "all"
           timeout-minutes: 70


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Aug 23 17:33 UTC
This pull request includes a patch that disables the `CARGO_TARGET_DIR` environment variable in the `.github/workflows/merge.yml` and `.github/workflows/nightly.yml` files. This change aims to speed up the build time. The patch removes the `CARGO_TARGET_DIR` variable from multiple `run` commands in the workflow files. Additionally, it removes the corresponding `env` sections that specify the target directories for different tests. Overall, this patch aims to improve the efficiency of the build process by eliminating the use of the `CARGO_TARGET_DIR` variable.
<!-- reviewpad:summarize:end --> 
