### PR TITLE
feat(networking): change storage cost formula

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,6 @@ dependencies = [
  "serde",
  "sn_dbc",
  "sn_protocol",
- "sn_transfers",
  "thiserror",
  "tokio",
  "tracing",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -28,7 +28,6 @@ rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.6.5" }
 sn_dbc = { version = "19.1.1", features = ["serdes"] }
-sn_transfers = { path = "../sn_transfers", version = "0.11.7" }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -227,15 +227,6 @@ impl RecordStoreAPI for NodeRecordStore {
 
     /// Calculate the cost to store data for our current store state
     fn store_cost(&self) -> Token {
-        // Calculate the factor to increase the cost for every PUTS_PER_PRICE_STEP records
-        let factor =
-            10.0f64.powf(MAX_RECORDS_COUNT as f64 / PUTS_PER_PRICE_STEP as f64 - 2.0_f64) as u64;
-
-        // Calculate the starting cost
-        let mut cost = TOTAL_SUPPLY / factor;
-
-        trace!("Starting cost is {:?}", cost);
-
         trace!("Record count is {:?}", self.records.len());
         let relevant_records_len = if let Some(distance_range) = self.distance_range {
             self.records
@@ -254,17 +245,9 @@ impl RecordStoreAPI for NodeRecordStore {
 
         trace!("Relevant records len is {:?}", relevant_records_len);
 
-        // Find where we are on the scale
-        let current_step = relevant_records_len / PUTS_PER_PRICE_STEP + 1;
+        let cost = calculate_cost_at_step(relevant_records_len);
 
-        trace!("Current step is {:?}", current_step);
-
-        // Double the cost for each step up to the current step
-        for _i in 0..current_step {
-            cost = cost.saturating_add(cost);
-        }
-
-        trace!("Cost is now {:?}", cost);
+        trace!("Cost is now {cost:?}");
         Token::from_nano(cost)
     }
 
@@ -438,6 +421,32 @@ impl RecordStore for ClientRecordStore {
     }
 
     fn remove_provider(&mut self, _key: &Key, _provider: &PeerId) {}
+}
+
+/// Cost calculator that increases cost nearing the maximum (2048).
+/// Table:
+///    1 =          0.000000010
+///    2 =          0.000000010
+///    4 =          0.000000011
+///    8 =          0.000000012
+///   16 =          0.000000014
+///   32 =          0.000000019
+///   64 =          0.000000036
+///  128 =          0.000000126
+///  256 =          0.000001591
+///  512 =          0.000253098
+/// 1024 =          6.405837009
+/// 2048 = 4103474778.282772064
+fn calculate_cost_at_step(step: usize) -> u64 {
+    assert!(step <= 2048, "step must be <= 2048");
+
+    // Using an exponential growth function: y = ab^x. Here, a is the starting cost and b is the growth factor.
+    // We want a function that starts with a low cost and only ramps up once we get closer to the maximum.
+    let a = 0.000_000_010_f64;
+    let b = 1.02_f64;
+    let y = a * b.powf(step as f64);
+
+    (y * 1_000_000_000_f64) as u64
 }
 
 #[allow(trivial_casts)]

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -432,6 +432,9 @@ impl RecordStore for ClientRecordStore {
 ///  256 =         0.000001238
 ///  512 =         0.000153173
 /// 1024 =         2.346196716
+/// 1280 =       290.372529764
+/// 1536 =     35937.398370712
+/// 1792 =   4447723.077333529
 /// 2048 = 550463903.051128626 (about 13% of TOTAL_SUPPLY at moment of writing)
 fn calculate_cost_at_step(step: usize) -> u64 {
     assert!(
@@ -441,8 +444,8 @@ fn calculate_cost_at_step(step: usize) -> u64 {
 
     // Using an exponential growth function: y = ab^x. Here, a is the starting cost and b is the growth factor.
     // We want a function that starts with a low cost and only ramps up once we get closer to the maximum.
-    let a = 0.000_000_010_f64;
-    let b = 1.019_f64;
+    let a = 0.000_000_010_f64; // This is the starting cost, starting at 10 nanos.
+    let b = 1.019_f64; // This is a hand-picked number; a low growth factor keeping the cost low for long.
     let y = a * b.powf(step as f64);
 
     (y * 1_000_000_000_f64) as u64

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -423,27 +423,30 @@ impl RecordStore for ClientRecordStore {
     fn remove_provider(&mut self, _key: &Key, _provider: &PeerId) {}
 }
 
-/// Cost calculator that increases cost nearing the maximum (2048).
+/// Cost calculator that increases cost nearing the maximum (MAX_RECORDS_COUNT (2048 at moment of writing)).
 /// Table:
-///    1 =          0.000000010
-///    2 =          0.000000010
-///    4 =          0.000000011
-///    8 =          0.000000012
-///   16 =          0.000000014
-///   32 =          0.000000019
-///   64 =          0.000000036
-///  128 =          0.000000126
-///  256 =          0.000001591
-///  512 =          0.000253098
-/// 1024 =          6.405837009
-/// 2048 = 4103474778.282772064
+///    1 =         0.000000010
+///    2 =         0.000000010
+///    4 =         0.000000011
+///    8 =         0.000000012
+///   16 =         0.000000014
+///   32 =         0.000000018
+///   64 =         0.000000033
+///  128 =         0.000000111
+///  256 =         0.000001238
+///  512 =         0.000153173
+/// 1024 =         2.346196716
+/// 2048 = 550463903.051128626 (about 13% of TOTAL_SUPPLY at moment of writing)
 fn calculate_cost_at_step(step: usize) -> u64 {
-    assert!(step <= 2048, "step must be <= 2048");
+    assert!(
+        step <= MAX_RECORDS_COUNT,
+        "step must be <= MAX_RECORDS_COUNT"
+    );
 
     // Using an exponential growth function: y = ab^x. Here, a is the starting cost and b is the growth factor.
     // We want a function that starts with a low cost and only ramps up once we get closer to the maximum.
     let a = 0.000_000_010_f64;
-    let b = 1.02_f64;
+    let b = 1.019_f64;
     let y = a * b.powf(step as f64);
 
     (y * 1_000_000_000_f64) as u64

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -16,7 +16,6 @@ use libp2p::{
 };
 use sn_dbc::Token;
 use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
-use sn_transfers::dbc_genesis::TOTAL_SUPPLY;
 use std::{
     borrow::Cow,
     collections::HashSet,
@@ -29,9 +28,6 @@ use xor_name::XorName;
 
 /// Max number of records a node can store
 const MAX_RECORDS_COUNT: usize = 2048;
-
-/// ~Number of puts per price step
-const PUTS_PER_PRICE_STEP: usize = 100;
 
 /// A `RecordStore` that stores records on disk.
 pub struct NodeRecordStore {


### PR DESCRIPTION
The storage cost is an exponential calculation, but was adjusted for
readability and so that the store cost stays lower for longer. The cost
only starts ramping up when we're nearing 50% of capacity.

Here are the costs associated with steps:
```
///    1 =         0.000000010
///    2 =         0.000000010
///    4 =         0.000000011
///    8 =         0.000000012
///   16 =         0.000000014
///   32 =         0.000000018
///   64 =         0.000000033
///  128 =         0.000000111
///  256 =         0.000001238
///  512 =         0.000153173
/// 1024 =         2.346196716
/// 1280 =       290.372529764
/// 1536 =     35937.398370712
/// 1792 =   4447723.077333529
/// 2048 = 550463903.051128626 (about 13% of TOTAL_SUPPLY at moment of writing)
```
