### PR TITLE
chore(node): add valid put log markers

### DIFF
--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -7,7 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use libp2p::{kad::RecordKey, PeerId};
-use sn_protocol::messages::{Cmd, CmdResponse};
+use sn_protocol::{
+    messages::{Cmd, CmdResponse},
+    PrettyPrintRecordKey,
+};
 use std::time::Duration;
 // this gets us to_string easily enough
 use strum::Display;
@@ -49,6 +52,12 @@ pub enum Marker<'a> {
         /// fetching_keys_len: number of keys we are fetching from network
         fetching_keys_len: usize,
     },
+
+    /// Valid non-existing record PUT from the network received and stored
+    ValidRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+
+    /// Record rejected
+    RecordRejected(&'a PrettyPrintRecordKey),
 }
 
 impl<'a> Marker<'a> {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Sep 23 16:04 UTC
This pull request adds valid put log markers to the sn_node codebase. It introduces new markers for valid non-existing record PUTs from the network received and stored, as well as for record rejections. The patch modifies the `log_markers.rs` and `put_validation.rs` files, adding 29 lines of code and removing 3 lines.
<!-- reviewpad:summarize:end --> 
