### PR TITLE
feat!(protocol): make payments for all record types

### DIFF
--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -265,7 +265,7 @@ impl Node {
             }
             NetworkEvent::UnverifiedRecord(record) => {
                 let key = PrettyPrintRecordKey::from(record.key.clone());
-                match self.validate_and_store_record(record, true).await {
+                match self.validate_and_store_record(record).await {
                     Ok(cmdok) => trace!("UnverifiedRecord {key:?} stored with {cmdok:?}."),
                     Err(err) => {
                         trace!("UnverifiedRecord {key:?} failed to be stored with error {err:?}.")

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -53,8 +53,12 @@ pub enum Marker<'a> {
         fetching_keys_len: usize,
     },
 
-    /// Valid non-existing record PUT from the network received and stored
-    ValidRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    /// Valid non-existing Chunk record PUT from the network received and stored
+    ValidChunkRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    /// Valid non-existing Register record PUT from the network received and stored
+    ValidRegisterRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    /// Valid non-existing Spend record PUT from the network received and stored
+    ValidSpendRecordPutFromNetwork(&'a PrettyPrintRecordKey),
 
     /// Record rejected
     RecordRejected(&'a PrettyPrintRecordKey),

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -134,7 +134,7 @@ impl Node {
                     "Got Replication Record {:?} from network, validating and storing it",
                     PrettyPrintRecordKey::from(key)
                 );
-                let _ = node.validate_and_store_record(record, false).await?;
+                let _ = node.validate_and_store_record(record).await?;
                 Ok(())
             });
         }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -134,7 +134,7 @@ impl Node {
                     "Got Replication Record {:?} from network, validating and storing it",
                     PrettyPrintRecordKey::from(key)
                 );
-                let _ = node.validate_and_store_record(record).await?;
+                let _ = node.store_prepaid_record(record).await?;
                 Ok(())
             });
         }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -25,8 +25,8 @@ pub enum Error {
     // ---------- chunk errors
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(ChunkAddress),
-    #[error("Chunk was not stored, xorname: {0:?}")]
-    ChunkNotStored(XorName),
+    #[error("Record was not stored: {0:?}")]
+    RecordNotStored(XorName),
 
     // ---------- register errors
     #[error("Register was not stored: {0}")]

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -24,6 +24,7 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
+use xor_name::XorName;
 
 /// This is the address in the network by which proximity/distance
 /// to other items (whether nodes or data chunks) are calculated.
@@ -94,6 +95,16 @@ impl NetworkAddress {
         }
 
         None
+    }
+
+    /// Try to return the represented `XorName`.
+    pub fn as_xorname(&self) -> Option<XorName> {
+        match self {
+            NetworkAddress::DbcAddress(dbc_address) => Some(*dbc_address.xorname()),
+            NetworkAddress::ChunkAddress(chunk_address) => Some(*chunk_address.xorname()),
+            NetworkAddress::RegisterAddress(register_address) => Some(register_address.xorname()),
+            _ => None,
+        }
     }
 
     /// Try to return the represented `RecordKey`.

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
 use super::NetworkAddress;
 use crate::{
     error::{Error, Result},
-    storage::{ChunkWithPayment, DbcAddress},
+    storage::{Chunk, DbcAddress},
 };
 use serde::{Deserialize, Serialize};
 use sn_dbc::SignedSpend;
@@ -55,7 +55,7 @@ pub enum Response {
 #[derive(custom_debug::Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum ReplicatedData {
     /// A chunk of data.
-    Chunk(ChunkWithPayment),
+    Chunk(Chunk),
     /// A set of SignedSpends
     DbcSpend(Vec<SignedSpend>),
     /// A signed register
@@ -76,7 +76,7 @@ impl ReplicatedData {
     /// Return the name.
     pub fn name(&self) -> Result<XorName> {
         let name = match self {
-            Self::Chunk(chunk) => *chunk.chunk.name(),
+            Self::Chunk(chunk) => *chunk.name(),
             Self::DbcSpend(spends) => {
                 if let Some(spend) = spends.first() {
                     *DbcAddress::from_dbc_id(spend.dbc_id()).xorname()
@@ -92,7 +92,7 @@ impl ReplicatedData {
     /// Return the dst.
     pub fn dst(&self) -> Result<NetworkAddress> {
         let dst = match self {
-            Self::Chunk(chunk) => NetworkAddress::from_chunk_address(*chunk.chunk.address()),
+            Self::Chunk(chunk) => NetworkAddress::from_chunk_address(*chunk.address()),
             Self::DbcSpend(spends) => {
                 if let Some(spend) = spends.first() {
                     NetworkAddress::from_dbc_address(DbcAddress::from_dbc_id(spend.dbc_id()))

--- a/sn_protocol/src/storage/chunks.rs
+++ b/sn_protocol/src/storage/chunks.rs
@@ -10,7 +10,6 @@ use super::ChunkAddress;
 use crate::NetworkAddress;
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use sn_dbc::Dbc;
 
 use xor_name::XorName;
 
@@ -77,12 +76,4 @@ impl<'de> Deserialize<'de> for Chunk {
         let value = Deserialize::deserialize(deserializer)?;
         Ok(Self::new(value))
     }
-}
-
-/// The Chunk along with the Payment is written as Record to kademlia
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ChunkWithPayment {
-    pub chunk: Chunk,
-    /// TODO: encrypt this or supply only encrypted derivation index
-    pub payment: Vec<Dbc>,
 }

--- a/sn_protocol/src/storage/header.rs
+++ b/sn_protocol/src/storage/header.rs
@@ -130,11 +130,18 @@ mod tests {
 
     #[test]
     fn verify_record_header_encoded_size() -> Result<()> {
-        let record_with_payment = RecordHeader {
+        let chunk_with_payment = RecordHeader {
             kind: RecordKind::ChunkWithPayment,
         }
         .try_serialize()?;
-        assert_eq!(record_with_payment.len(), RecordHeader::SIZE);
+        assert_eq!(chunk_with_payment.len(), RecordHeader::SIZE);
+
+        let reg_with_payment = RecordHeader {
+            kind: RecordKind::RegisterWithPayment,
+        }
+        .try_serialize()?;
+        assert_eq!(reg_with_payment.len(), RecordHeader::SIZE);
+
         let chunk = RecordHeader {
             kind: RecordKind::Chunk,
         }

--- a/sn_protocol/src/storage/mod.rs
+++ b/sn_protocol/src/storage/mod.rs
@@ -12,6 +12,6 @@ mod header;
 
 pub use self::{
     address::{ChunkAddress, DbcAddress, RegisterAddress},
-    chunks::{Chunk, ChunkWithPayment},
+    chunks::Chunk,
     header::{try_deserialize_record, try_serialize_record, RecordHeader, RecordKind},
 };


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Sep 23 04:58 UTC
This pull request includes multiple file diffs with various changes. Here is a summary of the changes:

- In the `api.rs` file, the `validate_and_store_record` function call was modified to remove the boolean argument.
- The `sn_protocol/src/messages/mod.rs` file has changes related to the `ChunkWithPayment`, `Chunk`, and `ReplicatedData` structs.
- The `log_markers.rs` file has changes related to the `Marker` enum, where new variants were added.
- The `error.rs` file has changes related to the renaming of the `ChunkNotStored` error variant and updating the associated error message.
- The `sn_protocol/src/storage/mod.rs` file has changes related to import modifications and removals.
- The `sn_protocol/src/storage/chunks.rs` file has changes related to import removals and the removal of the `ChunkWithPayment` struct.
- The `lib.rs` file has changes related to import additions and improvements to existing methods.
- The `Client` implementation in the `lib.rs` file has changes related to the `Store chunk` method, including the removal of the `ChunkWithPayment` struct.
- The `header.rs` file has changes related to the `RecordKind` enum and the `RecordHeader` struct, including new variants, serialize and deserialize trait implementations, and additional methods and test cases.
- The `replication.rs` file has changes related to the modification of the `validate_and_store_record` function call by removing the `false` argument.

These changes indicate modifications to various parts of the codebase, including function calls, imports, enums, structs, error messages, and test cases. Let me know if you need further assistance.
<!-- reviewpad:summarize:end --> 
