### PR TITLE
fix permissions for public register creation

### DIFF
--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -59,7 +59,7 @@ impl ClientRegister {
         meta: XorName,
         verify_store: bool,
     ) -> Result<Self> {
-        let mut reg = Self::create_register(client, meta, Permissions::new_owner_only())?;
+        let mut reg = Self::create_register(client, meta, Permissions::new_anyone_can_write())?;
         reg.sync(verify_store).await?;
         Ok(reg)
     }


### PR DESCRIPTION
I've noticed `::create_online()` and `::create_public_online()` were exactly the same :-)