### PR TITLE
chore: utilize encrypt_from_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010ea71bdf29522bd1940b645c79b805d83f1f9f07f194ed1132348fe448043"
+checksum = "48b4a2e4e28ad3f5406727cdab4bb03a25d6fa9563bae0fd522184d5256e02e8"
 dependencies = [
  "aes 0.8.3",
  "bincode",

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -25,7 +25,7 @@ itertools = "~0.10.1"
 libp2p = { version="0.52", features = ["identify"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
-self_encryption = "~0.28.0"
+self_encryption = "~0.28.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_dbc = { version = "19.1.1", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.5.8" }

--- a/sn_client/src/chunks/pac_man.rs
+++ b/sn_client/src/chunks/pac_man.rs
@@ -103,8 +103,7 @@ fn pack_data_map(data_map: DataMapLevel) -> Result<Bytes> {
 }
 
 fn encrypt_file(file: &Path) -> Result<(DataMap, Vec<EncryptedChunk>)> {
-    let bytes = Bytes::from(std::fs::read(file)?);
-    let encrypted_chunk = self_encryption::encrypt(bytes)?;
+    let encrypted_chunk = self_encryption::encrypt_from_file(file)?;
     Ok(encrypted_chunk)
 }
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -45,7 +45,7 @@ prost = { version = "0.9" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "~1.5.1"
-self_encryption = "~0.28.0"
+self_encryption = "~0.28.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
-self_encryption = "~0.28.0"
+self_encryption = "~0.28.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Sep 23 12:04 UTC
This pull request updates the version of the `self_encryption` crate to 0.28.1. It also modifies the `encrypt_file` function in `pac_man.rs` to utilize the `encrypt_from_file` function from the `self_encryption` crate. There are some other minor changes in the `Cargo.toml` files related to the updated version of `self_encryption`.
<!-- reviewpad:summarize:end --> 
