### PR TITLE
setup color eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap 4.3.21",
+ "color-eyre",
  "crdts",
  "custom_debug",
  "dirs-next",

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -35,6 +35,7 @@ const CLIENT_KEY: &str = "clientkey";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    color_eyre::install()?;
     let opt = Opt::parse();
     let _log_appender_guard = if let Some(log_output_dest) = opt.log_output_dest {
         let logging_targets = vec![

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -8,7 +8,7 @@
 
 use bls::PublicKey;
 use clap::Subcommand;
-use color_eyre::Result;
+use color_eyre::{eyre::WrapErr, Result, Section};
 use sn_client::{Client, ClientRegister, Error as ClientError};
 use sn_protocol::storage::RegisterAddress;
 use xor_name::XorName;
@@ -155,11 +155,18 @@ fn parse_addr(
     pk: PublicKey,
 ) -> Result<(RegisterAddress, String)> {
     if use_name {
+        debug!("Parsing address as name");
         let user_metadata = XorName::from_content(address_str.as_bytes());
         let addr = RegisterAddress::new(user_metadata, pk);
         Ok((addr, format!("'{address_str}' at {addr}")))
     } else {
-        let addr = RegisterAddress::from_hex(address_str)?;
+        debug!("Parsing address as hex");
+        let addr = RegisterAddress::from_hex(address_str)
+            .wrap_err("Could not parse hex string")
+            .suggestion(
+                "If getting a register by name, use the `-n` flag eg:\n
+        safe register get -n <register-name>",
+            )?;
         Ok((addr, format!("at {address_str}")))
     }
 }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -70,6 +70,7 @@ xor_name = "5.0.0"
 tracing-log = { version = "0.1.3", features = ["env_logger"] }
 strum = { version = "0.25.0", features = ["derive"] }
 tiny_http = { version="0.11", features = ["ssl-rustls"] }
+color-eyre = "0.6.2"
 
 [dev-dependencies]
 assert_fs = "1.0.0"

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -138,6 +138,7 @@ enum NodeCtrl {
 }
 
 fn main() -> Result<()> {
+    color_eyre::install()?;
     let mut opt = Opt::parse();
 
     let node_socket_addr = SocketAddr::new(opt.ip, opt.port);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Sep 23 09:47 UTC
This pull request adds a new feature to the CLI. It properly initializes color_eyre and provides advice when the hex parse fails in the register subcommand. The patch includes modifications to the `main.rs` and `register.rs` files.
<!-- reviewpad:summarize:end --> 
