### PR TITLE
ci: increase nightly churn run time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -265,7 +265,7 @@ jobs:
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6
           SN_LOG: "all"
-        timeout-minutes: 70
+        timeout-minutes: 90
       
       - name: Verify restart of nodes using rg
         shell: bash
@@ -370,7 +370,7 @@ jobs:
           env:
             CHURN_COUNT: 12
             SN_LOG: "all"
-          timeout-minutes: 70
+          timeout-minutes: 90
         
         - name: Verify restart of nodes using rg
           shell: bash


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Sep 23 10:55 UTC
This pull request increases the timeout for the nightly churn run in the CI workflow. It changes the timeout from 70 minutes to 90 minutes for both the test and verification stages. Additionally, it updates the code to reflect the increased timeout.
<!-- reviewpad:summarize:end --> 
