### PR TITLE
refactor and repay chunks

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -84,6 +84,7 @@ async fn upload_files(
     root_dir: &Path,
     verify_store: bool,
 ) -> Result<()> {
+    let start_time = std::time::Instant::now();
     debug!(
         "Uploading files from {:?}, will verify?: {verify_store}",
         files_path
@@ -97,46 +98,54 @@ async fn upload_files(
     let mut uploads = Vec::new();
 
     // Iterate over each file to be uploaded
-    for (
-        file_addr,
-        ChunkedFile {
-            file_name,
-            size,
-            chunks,
-        },
-    ) in chunks_to_upload
-    {
-        println!(
-            "Preparing to store file '{file_name}' of {size} bytes ({} chunk/s)..",
-            chunks.len()
-        );
-
+    for (file_addr, ChunkedFile { file_name, chunks }) in chunks_to_upload {
         // Clone necessary variables for each file upload
         let file_api: Files = Files::new(client.clone(), root_dir.to_path_buf());
 
-        // Spawn a new task for each file upload
-        let upload = tokio::spawn(async move {
-            match upload_chunks(&file_api, &file_name, chunks, verify_store).await {
-                Err(error) => {
-                    println!("Failed to store all chunks of file '{file_name}' to all nodes in the close group: {error}");
-                    None
-                }
-                _ => {
-                    println!("Successfully stored '{file_name}' to {file_addr:64x}");
-                    Some((file_addr, file_name))
-                }
-            }
-        });
+        // dont verify this first batch
+        let upload = async move {
+            let res = upload_chunks(file_api, chunks.clone(), false).await;
+
+            (file_addr, file_name, res)
+        };
 
         // Add the upload task to the list of uploads
         uploads.push(upload);
     }
 
-    let results = join_all(uploads).await;
+    let upload_results = join_all(uploads).await;
+    let mut uploaded_data = vec![];
+    for (file_addr, filename, result) in upload_results {
+        uploaded_data.push((file_addr, filename, result?));
+    }
 
-    let chunks_to_fetch: Vec<_> = results.into_iter().flatten().flatten().collect();
+    // If we are not verifying, we can skip this
+    let file_api: Files = Files::new(client.clone(), root_dir.to_path_buf());
+    let mut data_to_verify = Vec::new();
+    let mut data_stored = Vec::new();
 
-    let content = bincode::serialize(&chunks_to_fetch)?;
+    for (addr, filename, chunks) in uploaded_data {
+        data_to_verify.extend(chunks);
+        data_stored.push((addr, filename));
+    }
+
+    if verify_store {
+        while !data_to_verify.is_empty() {
+            trace!(
+                "verifying and repaying data of len: {:?}",
+                data_to_verify.len()
+            );
+            data_to_verify = verify_and_repay_if_needed(file_api.clone(), data_to_verify).await?;
+        }
+    }
+
+    println!(
+        "Uploaded all chunks in {}",
+        format_elapsed_time(start_time.elapsed())
+    );
+
+    // Write the chunks locally to be able to verify them later
+    let content = bincode::serialize(&data_stored)?;
     fs::create_dir_all(file_names_path.as_path())?;
     let date_time = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
     let file_names_path = file_names_path.join(format!("file_names_{date_time}"));
@@ -146,60 +155,127 @@ async fn upload_files(
     Ok(())
 }
 
-/// Upload chunks of an individual file to the network.
+/// Store all chunks from chunk_paths (assuming payments have already been made and are in our local wallet).
+/// If verify_store is true, we will attempt to fetch all chunks from the network and check they are stored.
+///
 async fn upload_chunks(
-    file_api: &Files,
-    file_name: &str,
+    file_api: Files,
     chunks_paths: Vec<(XorName, PathBuf)>,
-    verify_store: bool,
-) -> Result<()> {
-    let start_time = std::time::Instant::now();
-    let mut handles = Vec::new();
-    for (i, (_name, path)) in chunks_paths.into_iter().enumerate() {
-        let file_name = file_name.to_string();
+    _verify_store: bool,
+) -> Result<Vec<(XorName, PathBuf)>> {
+    let mut upload_handles = Vec::new();
+    let mut uploaded_chunks = Vec::new();
+    for (name, path) in chunks_paths.into_iter() {
+        uploaded_chunks.push((name, path.clone()));
         let file_api = file_api.clone();
         let semaphore = file_api.concurrency_limiter();
 
-        // At this level, we need to
-        // upload
-        // verify
-        // repay
-        // retry
-
+        // first we upload all chunks in parallel
         let handle = tokio::spawn(async move {
             let _permit = semaphore.acquire_owned().await?;
-
-            println!(
-                "Starting to upload chunk #{i} from {file_name:?}. (after {} elapsed)",
-                format_elapsed_time(start_time.elapsed())
-            );
 
             let upload_start_time = std::time::Instant::now();
             let chunk = Chunk::new(Bytes::from(fs::read(path)?));
 
-            file_api
-                .upload_chunk_in_parallel(chunk, verify_store)
-                .await?;
+            file_api.upload_chunk_in_parallel(chunk, false).await?;
 
             println!(
-                "Uploaded chunk #{i} from {file_name:?} in {})",
+                "Uploaded chunk #{name} in {})",
                 format_elapsed_time(upload_start_time.elapsed())
             );
             Ok::<(), Error>(())
         });
-        handles.push(handle);
+        upload_handles.push(handle);
     }
-    let results = join_all(handles).await;
 
-    for result in results {
+    let upload_results = join_all(upload_handles).await;
+
+    // lets check there were no wild errors during upload
+    for result in upload_results {
         result??;
     }
 
-    println!(
-        "Uploaded {file_name:?} in {}",
-        format_elapsed_time(start_time.elapsed())
-    );
-    Ok(())
+    Ok(uploaded_chunks)
+}
+
+/// Verify if chunks exist on the network.
+/// Repay if they don't.
+/// Return a list of files which had to be repaid, but not yet reverified.
+async fn verify_and_repay_if_needed(
+    file_api: Files,
+    chunks_paths: Vec<(XorName, PathBuf)>,
+) -> Result<Vec<(XorName, PathBuf)>> {
+    let _start_time = std::time::Instant::now();
+
+    let mut verify_handles = Vec::new();
+
+    // now we try and get all chunks, keep track of any that fail
+    // Iterate over each uploaded chunk
+    for (name, path) in chunks_paths.into_iter() {
+        let file_api = file_api.clone();
+        let semaphore = file_api.concurrency_limiter();
+
+        // Spawn a new task to fetch each chunk concurrently
+        let handle = tokio::spawn(async move {
+            let _permit = semaphore.acquire_owned().await?;
+
+            let chunk_address: ChunkAddress = ChunkAddress::new(name);
+            // Attempt to fetch the chunk
+            let res = file_api.client().get_chunk(chunk_address).await;
+
+            Ok::<_, Error>(((chunk_address, path), res.is_err()))
+        });
+        verify_handles.push(handle);
+    }
+
+    // Await all fetch tasks and collect the results
+    let verify_results = join_all(verify_handles).await;
+
+    let mut failed_chunks = Vec::new();
+    // Check for any errors during fetch
+    for result in verify_results {
+        if let ((chunk_addr, path), true) = result?? {
+            println!("Failed to fetch a chunk {chunk_addr:?}");
+            // This needs to be NetAddr to allow for repayment
+            failed_chunks.push((chunk_addr, path));
+        }
+    }
+
+    // If there were any failed chunks, we need to repay them
+    if !failed_chunks.is_empty() {
+        println!(
+            "Failed to fetch {} chunks, attempting to repay them",
+            failed_chunks.len()
+        );
+
+        let mut wallet = file_api.wallet()?;
+
+        // Now we pay again or top up, depending on the new current store cost is
+        wallet
+            .pay_for_storage(
+                failed_chunks
+                    .iter()
+                    .map(|(addr, _path)| sn_protocol::NetworkAddress::ChunkAddress(*addr)),
+                true,
+            )
+            .await?;
+
+        println!("=======re uploading failed chunks =============");
+
+        upload_chunks(
+            file_api,
+            failed_chunks
+                .iter()
+                .cloned()
+                .map(|(addr, path)| (*addr.xorname(), path))
+                .collect(),
+            false,
+        )
+        .await
+    } else {
+        // No more failed chunks, we are done
+        Ok(vec![])
+    }
 }
 
 async fn download_files(file_api: &Files, root_dir: &Path) -> Result<()> {

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -274,15 +274,14 @@ pub(super) async fn chunk_and_pay_for_storage(
     verify_store: bool,
 ) -> Result<BTreeMap<XorName, ChunkedFile>> {
     trace!("Starting to chunk_and_pay_for_storage");
-    let wallet = LocalWallet::load_from(root_dir)
-        .wrap_err("Unable to read wallet file in {path:?}")
+
+    let file_api: Files = Files::new(client.clone(), root_dir.to_path_buf());
+    let mut wallet_client = file_api
+        .wallet()
+        .wrap_err("Unable to read wallet file in {root_dir:?}")
         .suggestion(
             "If you have an old wallet file, it may no longer be compatible. Try removing it",
         )?;
-
-    debug!("Wallet readdddd!!!!!");
-    let mut wallet_client = WalletClient::new(client.clone(), wallet);
-    let file_api: Files = Files::new(client.clone());
 
     // Get the list of Chunks addresses from the files found at 'files_path'
     println!(

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -263,7 +263,6 @@ async fn send(
 
 pub(super) struct ChunkedFile {
     pub file_name: String,
-    pub size: usize,
     pub chunks: Vec<(XorName, PathBuf)>,
 }
 
@@ -284,10 +283,6 @@ pub(super) async fn chunk_and_pay_for_storage(
         )?;
 
     // Get the list of Chunks addresses from the files found at 'files_path'
-    println!(
-        "Preparing (chunking) files at '{}'...",
-        files_path.display()
-    );
     let chunks_dir = std::env::temp_dir();
     let mut num_of_chunks = 0;
     let mut chunked_files = BTreeMap::new();
@@ -323,7 +318,6 @@ pub(super) async fn chunk_and_pay_for_storage(
                 file_addr,
                 ChunkedFile {
                     file_name,
-                    size: bytes.len(),
                     chunks: chunks_paths,
                 },
             );

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -346,7 +346,7 @@ pub(super) async fn chunk_and_pay_for_storage(
         .await?;
 
     println!(
-        "Successfully made payment of {cost} for {} records. (At a cost per record of {cost:?}.)",
+        "Successfully made payment of {cost} for {} files.)",
         chunked_files.len(),
     );
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -33,7 +33,7 @@ use xor_name::XorName;
 
 // Maximum number of concurrency to be allowed at any time
 // eg, concurrent uploads/downloads of chunks, managed by a semaphore
-pub const DEFAULT_CLIENT_CONCURRENCY: usize = 5;
+pub const DEFAULT_CLIENT_CONCURRENCY: usize = 10;
 
 /// The timeout duration for the client to receive any response from the network.
 const INACTIVITY_TIMEOUT: std::time::Duration = tokio::time::Duration::from_secs(30);
@@ -303,7 +303,7 @@ impl Client {
     }
 
     /// Retrieve a `Chunk` from the kad network.
-    pub(super) async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
+    pub async fn get_chunk(&self, address: ChunkAddress) -> Result<Chunk> {
         info!("Getting chunk: {address:?}");
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -21,9 +21,14 @@ use thiserror::Error;
 pub enum Error {
     #[error("Genesis error {0}")]
     GenesisError(#[from] sn_transfers::dbc_genesis::Error),
+
     /// Could not acquire a Semaphore permit.
     #[error("Could not acquire a Semaphore permit.")]
     CouldNotAcquireSemaphorePermit(#[from] tokio::sync::AcquireError),
+
+    /// Could not acquire a netowrk semaphore
+    #[error("Network layer does not have the expected concurrency limiter.")]
+    NoNetworkConcurrencyLimiterFound,
 
     #[error("Transfer Error {0}.")]
     Transfers(#[from] sn_transfers::wallet::Error),

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -44,6 +44,11 @@ impl Files {
         Self { client, wallet_dir }
     }
 
+    /// Return the client instance
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
     /// Get the client semaphore
     pub fn concurrency_limiter(&self) -> Arc<Semaphore> {
         self.client.concurrency_limiter()

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::WalletClient;
 
@@ -27,7 +27,7 @@ use bytes::Bytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use self_encryption::{self, ChunkInfo, DataMap, EncryptedChunk, MIN_ENCRYPTABLE_BYTES};
-use tokio::task;
+use tokio::{sync::Semaphore, task};
 use tracing::trace;
 use xor_name::XorName;
 
@@ -41,6 +41,11 @@ impl Files {
     /// Create file apis instance.
     pub fn new(client: Client) -> Self {
         Self { client }
+    }
+
+    /// Get the client semaphore
+    pub fn concurrency_limiter(&self) -> Arc<Semaphore> {
+        self.client.concurrency_limiter()
     }
 
     /// Create a new WalletClient for a given root directory.

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -18,10 +18,7 @@ mod file_apis;
 mod register;
 mod wallet;
 
-use std::sync::Arc;
-
 pub(crate) use error::Result;
-use tokio::sync::Semaphore;
 
 pub use self::{
     error::Error,
@@ -44,5 +41,4 @@ pub struct Client {
     signer: bls::SecretKey,
     peers_added: usize,
     progress: Option<ProgressBar>,
-    concurrency_limiter: Arc<Semaphore>,
 }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -292,7 +292,11 @@ impl ClientRegister {
         };
 
         // Register edits might exist so we cannot be sure that jsut because we get a record back that this should fail
-        Ok(self.client.network.put_record(record, verify_store).await?)
+        Ok(self
+            .client
+            .network
+            .put_record(record, verify_store, None)
+            .await?)
     }
 
     // Retrieve a `Register` from the Network.

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -160,6 +160,9 @@ impl WalletClient {
         all_data_payments: BTreeMap<NetworkAddress, Vec<(PublicAddress, Token)>>,
         verify_store: bool,
     ) -> Result<Token> {
+        // TODO:
+        // Check for any existing payment DBCs, and use them if they exist, only topping up if needs be
+
         let now = Instant::now();
         let mut total_cost = Token::zero();
         for (_data, costs) in all_data_payments.iter() {

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -26,6 +26,10 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    /// Could not acquire a Semaphore permit.
+    #[error("Could not acquire a Semaphore permit.")]
+    CouldNotAcquireSemaphorePermit(#[from] tokio::sync::AcquireError),
+
     #[error(
         "Not enough store cost quotes returned from the network to ensure a valid fee is paid"
     )]

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -322,11 +322,11 @@ impl Network {
     /// Put `Record` to network
     /// optionally verify the record is stored after putting it to network
     pub async fn put_record(&self, record: Record, verify_store: bool) -> Result<()> {
-        // if verify_store {
-        self.put_record_with_retries(record, verify_store).await
-        // } else {
-        //     self.put_record_once(record, false).await
-        // }
+        if verify_store {
+            self.put_record_with_retries(record, verify_store).await
+        } else {
+            self.put_record_once(record, false).await
+        }
     }
 
     /// Put `Record` to network

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -29,7 +29,11 @@ use rand::{
 };
 use sn_dbc::Token;
 use sn_logging::{LogFormat, LogOutputDest};
-use std::{net::SocketAddr, path::Path, sync::Once};
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Once,
+};
 use tokio::sync::Mutex;
 use tonic::Request;
 use tracing_core::Level;
@@ -114,7 +118,10 @@ pub async fn get_client_and_wallet(root_dir: &Path, amount: u64) -> Result<(Clie
     Ok((client, local_wallet))
 }
 
-pub fn random_content(client: &Client) -> Result<(Files, Bytes, ChunkAddress, Vec<Chunk>)> {
+pub fn random_content(
+    client: &Client,
+    wallet_dir: PathBuf,
+) -> Result<(Files, Bytes, ChunkAddress, Vec<Chunk>)> {
     let mut rng = rand::thread_rng();
 
     let random_len = rng.gen_range(MIN_ENCRYPTABLE_BYTES..1024 * MIN_ENCRYPTABLE_BYTES);
@@ -123,7 +130,7 @@ pub fn random_content(client: &Client) -> Result<(Files, Bytes, ChunkAddress, Ve
             .take(random_len)
             .collect();
 
-    let files_api = Files::new(client.clone());
+    let files_api = Files::new(client.clone(), wallet_dir);
     let content_bytes = Bytes::from(random_length_content);
     let (file_addr, chunks) = files_api.chunk_bytes(content_bytes.clone())?;
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -401,7 +401,10 @@ fn store_chunks_task(
             sleep(delay).await;
 
             for chunk in chunks {
-                match file_api.upload_chunk_in_parallel(chunk, true).await {
+                match file_api
+                    .get_local_payment_and_upload_chunk(chunk, true, None)
+                    .await
+                {
                     Ok(()) => content
                         .write()
                         .await

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -27,7 +27,8 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
-    let (files_api, content_bytes, _content_addr, chunks) = random_content(&client)?;
+    let (files_api, content_bytes, _content_addr, chunks) =
+        random_content(&client, paying_wallet_dir.to_path_buf())?;
 
     println!("Paying for {} random addresses...", chunks.len());
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -72,7 +72,8 @@ async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
 
     let (client, paying_wallet) =
         get_client_and_wallet(paying_wallet_dir.path(), wallet_original_balance).await?;
-    let (files_api, content_bytes, _random_content_addrs, chunks) = random_content(&client)?;
+    let (files_api, content_bytes, _random_content_addrs, chunks) =
+        random_content(&client, paying_wallet_dir.to_path_buf())?;
 
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
     let subset_len = chunks.len() / 3;
@@ -171,7 +172,8 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
-    let (files_api, content_bytes, content_addr, chunks) = random_content(&client)?;
+    let (files_api, content_bytes, content_addr, chunks) =
+        random_content(&client, paying_wallet_dir.to_path_buf())?;
 
     println!("Paying for {} random addresses...", chunks.len());
 
@@ -197,7 +199,8 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
-    let (files_api, content_bytes, content_addr, chunks) = random_content(&client)?;
+    let (files_api, content_bytes, content_addr, chunks) =
+        random_content(&client, paying_wallet_dir.to_path_buf())?;
 
     println!("Paying for {} random addresses...", chunks.len());
 

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -274,6 +274,9 @@ impl LocalWallet {
             .payment_transactions
             .extend(all_transfers_per_address);
 
+        // get the content payment map stored
+        store_wallet(&self.wallet_dir, &self.wallet)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Sep 23 16:04 UTC
This pull request introduces several changes across multiple files:

1. In `lib.rs`, the `put_record` function in the `Network` implementation has been modified. Previously commented code has been uncommented, which adds logic to check if `verify_store` is true and call the `put_record_with_retries` function. Otherwise, it calls the `put_record_once` function.

2. In `wallet.rs`, the changes include:
   - Lines 278-282: Creating a new `file_api` instance of `Files` using the `root_dir` and assigning it to `wallet_client`.
   - Lines 285-287: Removing the debug print statement "Wallet readdddd!!!!!"
   - Lines 290-291: Removing the `println!` statement for "Preparing (chunking) files at '{}'..."

3. In `sn_client/src/file_apis.rs`, the main changes are:
   - Adding `sync::Arc` to the import of `std::path::PathBuf` and renaming the import to `std::{path::PathBuf, sync::Arc}` (line 7).
   - Adding a new field `wallet_dir: PathBuf` to the `Files` struct and updating the `new` method to accept it as a parameter (lines 33-36).
   - Adding a new method `client` to the `Files` struct that returns a reference to the `Client` instance (lines 39-41).
   - Adding a new method `concurrency_limiter` to the `Files` struct that returns a reference to the `concurrency_limiter` field of the `Client` instance (lines 44-46).
   - Updating the `wallet` method to remove the `root_dir` parameter and use the `wallet_dir` field instead (lines 49-53).
   - Updating the `upload_chunk_in_parallel` method to remove the `wallet_client` parameter and obtain the `WalletClient` instance from the `wallet` method (lines 57-64).

4. In `sn_cli/files.rs`, changes include:
   - Removing imports for `Arc` and `Semaphore`.
   - Adding an additional argument, `root_dir`, to the `new` function in the `Files` struct.
   - Refactoring the `upload_files` function to use a new `upload_chunks` function for handling chunk uploading in parallel.
   - Numerous changes within the `upload_chunks` function, including the extraction of chunk uploading logic from `upload_files`, removal of unused `file_name` argument, and accessing `wallet_dir` through `file_api.wallet()`.
   - Addition of a new function, `verify_and_repay_if_needed`, to handle chunk verification and repayment logic.

5. In `sn_client/src/api.rs`, there is a single diff, where the `get_chunk` function has been modified to remove the `super` visibility specifier and marked as `pub async` instead of `pub(super) async`.

6. In `wallet.rs`, a TODO comment at line 162 suggests checking for existing payment DBCs and using them if they exist. It also suggests topping up only if necessary.

Overall, this pull request implements various modifications that range from uncommenting code to refactorings and additions in different files across the project.
<!-- reviewpad:summarize:end --> 
