### PR TITLE
fix(ci): enable cargo dir env variable for nightly run

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -237,7 +237,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
         timeout-minutes: 30
 
       - name: Start a local network

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -173,8 +173,10 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
         timeout-minutes: 30
+        env:
+          CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -186,20 +188,23 @@ jobs:
           platform: ${{ matrix.os }}
 
       - name: execute the dbc spend test
-        run: cargo test --release --features="local-discovery" --test sequential_transfers -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
+          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the storage payment tests
-        run: cargo test --release --features="local-discovery" --test storage_payments -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1          
         env:
+          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the nodes rewards tests
         run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture
         env:
+          CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 25
       


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Sep 23 16:53 UTC
This pull request fixes an issue with the CI pipeline by enabling the `CARGO_TARGET_DIR` environment variable for the nightly run. It modifies the `merge.yml` and `nightly.yml` files by adding the `CARGO_TARGET_DIR` variable with the value "./transfer-target" to the "Build testing executable" step. This change ensures that the target directory is set correctly during the execution of the cargo test commands for the `sn_node` crate with various feature flags and test cases. Overall, this patch enhances the CI workflow and improves the reliability of the test runs.
<!-- reviewpad:summarize:end --> 
