### PR TITLE
chore: rotate logs after exceeding 20mb

### DIFF
--- a/sn_logging/src/appender.rs
+++ b/sn_logging/src/appender.rs
@@ -21,8 +21,8 @@ use std::{
 };
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 
-/// max_lines:
-/// - maximum number of lines per file
+/// max_bytes:
+/// - the maximum size a log can grow to until it is rotated.
 ///
 /// uncompressed_files:
 /// - number of files to keep uncompressed.
@@ -33,7 +33,7 @@ use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 /// - older files are deleted.
 pub(super) fn file_rotater(
     dir: &PathBuf,
-    max_lines: usize,
+    max_bytes: usize,
     uncompressed_files: usize,
     max_files: usize,
 ) -> (NonBlocking, WorkerGuard) {
@@ -50,7 +50,7 @@ pub(super) fn file_rotater(
         dir,
         format!("{binary_name}.log"),
         AppendTimestamp::default(FileLimit::MaxFiles(max_files)),
-        ContentLimit::Lines(max_lines),
+        ContentLimit::BytesSurpassed(max_bytes),
         Compression::OnRotate(uncompressed_files),
     );
 

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -30,6 +30,10 @@ use tracing_subscriber::{
     Layer, Registry,
 };
 
+const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
+const MAX_UNCOMPRESSED_LOG_FILES: usize = 100;
+const MAX_LOG_FILES: usize = 1000;
+
 #[derive(Debug, Clone)]
 pub enum LogOutputDest {
     Stdout,
@@ -123,12 +127,12 @@ impl TracingLayers {
                 std::fs::create_dir_all(path)?;
                 println!("Logging to directory: {path:?}");
 
-                let logs_max_lines = 5000;
-                let logs_uncompressed = 100;
-                let logs_max_files = 1000;
-
-                let (file_rotation, worker_guard) =
-                    appender::file_rotater(path, logs_max_lines, logs_uncompressed, logs_max_files);
+                let (file_rotation, worker_guard) = appender::file_rotater(
+                    path,
+                    MAX_LOG_SIZE,
+                    MAX_UNCOMPRESSED_LOG_FILES,
+                    MAX_LOG_FILES,
+                );
                 self.guard = Some(worker_guard);
 
                 match format {


### PR DESCRIPTION
The previous rotation strategy was using the number of lines, which was set to 5000.

Users recently noticed this limitation was producing lots of logs, so we've changed the strategy to be based on the size of the log in bytes.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Sep 23 19:14 UTC
This pull request updates the log rotation strategy in the `sn_logging` library. Previously, logs were rotated based on the number of lines, but this caused an excessive number of logs. The new strategy rotates logs based on the size of the log in bytes. This change is implemented in the `appender.rs` and `lib.rs` files. The maximum log size is set to 20mb, the maximum number of uncompressed log files is set to 100, and the maximum number of log files is set to 1000.
<!-- reviewpad:summarize:end --> 
