### PR TITLE
chore: remove some unused code

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -215,8 +215,8 @@ jobs:
         shell: bash
         # limits here are lower that benchmark tests as there is less going on.
         run: |
-          client_peak_mem_limit_mb="350" # mb
-          client_avg_mem_limit_mb="250" # mb
+          client_peak_mem_limit_mb="1000" # mb
+          client_avg_mem_limit_mb="850" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Sep 23 11:17 UTC
This pull request removes some unused code in the `sn_networking` module. Specifically, it deletes the `start_listening`, `get_our_close_group`, `node_send_to_closest`, `client_send_to_closest` functions, and their respective implementations. The patch also includes some other deletions in the code.
<!-- reviewpad:summarize:end --> 
