### PR TITLE
feat: chunk payments using UTXOs instead of DBCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "19.1.1"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8faf6b32cd0442a7aa030db665c0e6dc6f20428c5629751a3e5353685a5250"
 dependencies = [
  "bincode",
  "blsttc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,8 +3966,6 @@ dependencies = [
 [[package]]
 name = "sn_dbc"
 version = "19.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46704477d95233cf8daefb6e1601eebdf755a9fd6cd35e6d4d4dc3f6e0dc946"
 dependencies = [
  "bincode",
  "blsttc",
@@ -4165,6 +4163,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "rand 0.8.5",
+ "rmp-serde",
  "serde",
  "sn_dbc",
  "sn_protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,7 +4046,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libp2p",
- "proptest",
  "prost",
  "rand 0.8.5",
  "rayon",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -36,8 +36,7 @@ libp2p = { version="0.52", features = ["identify", "kad"] }
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.89.0" }
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.11.9" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -36,7 +36,7 @@ libp2p = { version="0.52", features = ["identify", "kad"] }
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.89.0" }
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.11.9" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -36,7 +36,8 @@ libp2p = { version="0.52", features = ["identify", "kad"] }
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.89.0" }
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_transfers = { path = "../sn_transfers", version = "0.11.9" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,8 +28,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.6.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
 sn_registers = { path = "../sn_registers", version = "0.2.6" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,7 +28,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.6.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,7 +28,8 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "~1.5.1"
 self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_networking = { path = "../sn_networking", version = "0.6.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
 sn_registers = { path = "../sn_registers", version = "0.2.6" }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -14,7 +14,7 @@ use super::{
 use bls::{PublicKey, SecretKey, Signature};
 use indicatif::ProgressBar;
 use libp2p::{kad::Record, Multiaddr};
-use sn_dbc::{Dbc, DbcId, PublicAddress, SignedSpend, Token};
+use sn_dbc::{DbcId, PublicAddress, SignedSpend, Token};
 use sn_networking::{multiaddr_is_global, NetworkEvent, SwarmDriver, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     error::Error as ProtocolError,
@@ -25,7 +25,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_registers::SignedRegister;
-use sn_transfers::client_transfers::SpendRequest;
+use sn_transfers::{client_transfers::SpendRequest, wallet::Transfer};
 use std::time::Duration;
 use tokio::{sync::OwnedSemaphorePermit, task::spawn};
 use tracing::trace;
@@ -291,7 +291,7 @@ impl Client {
     pub(super) async fn store_chunk(
         &self,
         chunk: Chunk,
-        payment: Vec<Dbc>,
+        payment: Vec<Transfer>,
         verify_store: bool,
         optional_permit: Option<OwnedSemaphorePermit>,
     ) -> Result<()> {

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -169,12 +169,10 @@ impl Files {
         trace!("Client upload started for chunk: {chunk_addr:?}");
 
         let wallet_client = self.wallet()?;
-        let payment = wallet_client.get_payment_dbcs(&chunk_addr);
+        let payment = wallet_client.get_payment_transfers(&chunk_addr)?;
 
         if payment.is_empty() {
-            warn!(
-                    "Failed to get payment proof for chunk: {chunk_addr:?} it was not found in the local wallet",
-                );
+            warn!("Failed to get payment proof for chunk: {chunk_addr:?} it was not found in the local wallet");
             return Err(Error::NoPaymentForRecord(PrettyPrintRecordKey::from(
                 chunk_addr.to_record_key(),
             )))?;

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_transfers::client_transfers::SpendRequest;
+use sn_transfers::{client_transfers::SpendRequest, wallet::Transfer};
 
 use super::Client;
 
@@ -57,9 +57,10 @@ impl WalletClient {
         self.wallet.unconfirmed_txs()
     }
 
-    /// Get the payment dbc for a given network address
-    pub fn get_payment_dbcs(&self, address: &NetworkAddress) -> Vec<Dbc> {
-        self.wallet.get_payment_dbcs(address)
+    /// Get the payment transfers for a given network address
+    pub fn get_payment_transfers(&self, address: &NetworkAddress) -> Result<Vec<Transfer>> {
+        let dbcs = self.wallet.get_payment_dbcs(address);
+        self.wallet.create_transfers(dbcs)
     }
 
     /// Send tokens to another wallet.

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -27,8 +27,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -27,7 +27,8 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -74,7 +74,6 @@ color-eyre = "0.6.2"
 
 [dev-dependencies]
 assert_fs = "1.0.0"
-proptest = { version = "1.0.0" }
 tempfile = "3.6.0"
 
 [build-dependencies]

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -49,8 +49,7 @@ self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.89.0" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }
 sn_networking = { path = "../sn_networking", version = "0.6.0" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -49,7 +49,7 @@ self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.89.0" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -49,7 +49,8 @@ self_encryption = "~0.28.4"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.6" }
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_client = { path = "../sn_client", version = "0.89.0" }
 sn_logging = { path = "../sn_logging", version = "0.2.6" }
 sn_networking = { path = "../sn_networking", version = "0.6.0" }

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -49,7 +49,6 @@ mod event;
 mod get_validation;
 mod log_markers;
 mod put_validation;
-mod receive_transfer;
 mod replication;
 mod spends;
 

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -49,6 +49,7 @@ mod event;
 mod get_validation;
 mod log_markers;
 mod put_validation;
+mod receive_transfer;
 mod replication;
 mod spends;
 

--- a/sn_node/src/receive_transfer.rs
+++ b/sn_node/src/receive_transfer.rs
@@ -1,0 +1,7 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.

--- a/sn_node/src/receive_transfer.rs
+++ b/sn_node/src/receive_transfer.rs
@@ -1,7 +1,0 @@
-// Copyright 2023 MaidSafe.net limited.
-//
-// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
-// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
-// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. Please review the Licences for the specific language governing
-// permissions and limitations relating to use of the SAFE Network Software.

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -13,7 +13,7 @@ use common::{get_client_and_wallet, get_wallet, init_logging};
 use sn_client::send;
 
 use sn_dbc::{random_derivation_index, rng, Hash, Token};
-use sn_transfers::client_transfers::create_transfer;
+use sn_transfers::client_transfers::create_offline_transfer;
 
 use assert_fs::TempDir;
 use eyre::Result;
@@ -89,8 +89,10 @@ async fn dbc_transfer_double_spend_fail() -> Result<()> {
     let to3_unique_key = (amount, to3, random_derivation_index(&mut rng));
     let reason_hash = Hash::default();
 
-    let transfer_to_2 = create_transfer(some_dbcs, vec![to2_unique_key], to1, reason_hash).unwrap();
-    let transfer_to_3 = create_transfer(same_dbcs, vec![to3_unique_key], to1, reason_hash).unwrap();
+    let transfer_to_2 =
+        create_offline_transfer(some_dbcs, vec![to2_unique_key], to1, reason_hash).unwrap();
+    let transfer_to_3 =
+        create_offline_transfer(same_dbcs, vec![to3_unique_key], to1, reason_hash).unwrap();
 
     // send both transfers to the network
     // upload won't error out, only error out during verification.

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -18,8 +18,7 @@ hex = "~0.4.3"
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_registers = { path = "../sn_registers", version = "0.2.6" }
 thiserror = "1.0.23"
 tracing = { version = "~0.1.26" }

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -18,7 +18,7 @@ hex = "~0.4.3"
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_registers = { path = "../sn_registers", version = "0.2.6" }
 thiserror = "1.0.23"

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -18,7 +18,8 @@ hex = "~0.4.3"
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_registers = { path = "../sn_registers", version = "0.2.6" }
 thiserror = "1.0.23"
 tracing = { version = "~0.1.26" }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -33,8 +33,8 @@ pub enum Error {
     // ---------- chunk errors
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(ChunkAddress),
-    #[error("Record was not stored: {0:?}")]
-    RecordNotStored(PrettyPrintRecordKey),
+    #[error("Record was not stored: {0:?}: {1:?}")]
+    RecordNotStored(PrettyPrintRecordKey, String),
 
     // ---------- register errors
     #[error("Register was not stored: {0}")]
@@ -90,10 +90,6 @@ pub enum Error {
     /// Payments received could not be stored on node's local wallet
     #[error("Payments received could not be stored on node's local wallet: {0}")]
     FailedToStorePaymentIntoNodeWallet(String),
-    #[error("UTXO serialisation failed")]
-    UtxoSerialisationFailed,
-    #[error("UTXO decryption failed")]
-    UtxoDecryptionFailed,
 
     // ---------- replication errors
     /// Replication not found.

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -12,7 +12,6 @@ mod node_id;
 mod query;
 mod register;
 mod response;
-mod utxo;
 
 pub use self::{
     cmd::{Cmd, Hash, MerkleTreeNodesType, PaymentTransactions},
@@ -20,7 +19,6 @@ pub use self::{
     query::Query,
     register::RegisterCmd,
     response::{CmdOk, CmdResponse, QueryResponse},
-    utxo::{Transfer, Utxo},
 };
 
 use super::NetworkAddress;

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "~1.4.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
 tokio = { version = "1.32.0", features = ["macros", "rt"] }

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -22,8 +22,7 @@ lazy_static = "~1.4.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-# sn_dbc = { version = "20.0.0", features = ["serdes"] }
-sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
+sn_dbc = { version = "20.0.0", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
 tokio = { version = "1.32.0", features = ["macros", "rt"] }
 thiserror = "1.0.23"

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -20,8 +20,10 @@ hex = "~0.4.3"
 itertools = "~0.10.1"
 lazy_static = "~1.4.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
+rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-sn_dbc = { version = "19.1.1", features = ["serdes"] }
+# sn_dbc = { version = "19.1.1", features = ["serdes"] }
+sn_dbc = { path = "../../sn_dbc", features = ["serdes"] }
 sn_protocol = { path = "../sn_protocol", version = "0.6.6" }
 tokio = { version = "1.32.0", features = ["macros", "rt"] }
 thiserror = "1.0.23"

--- a/sn_transfers/src/client_transfers/mod.rs
+++ b/sn_transfers/src/client_transfers/mod.rs
@@ -33,7 +33,7 @@ mod transfer;
 use std::collections::BTreeMap;
 
 pub(crate) use self::error::{Error, Result};
-pub use self::transfer::create_transfer;
+pub use self::transfer::create_offline_transfer;
 
 use sn_dbc::{
     Dbc, DbcId, DbcTransaction, DerivationIndex, DerivedKey, PublicAddress, SignedSpend, Token,

--- a/sn_transfers/src/client_transfers/transfer.rs
+++ b/sn_transfers/src/client_transfers/transfer.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 /// The peers will validate each signed spend they receive, before accepting it.
 /// Once enough peers have accepted all the spends of the transaction, and serve
 /// them upon request, the transaction will be completed.
-pub fn create_transfer(
+pub fn create_offline_transfer(
     available_dbcs: Vec<(Dbc, DerivedKey)>,
     recipients: Vec<(Token, PublicAddress, DerivationIndex)>,
     change_to: PublicAddress,

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -20,9 +20,9 @@ pub enum Error {
     /// Dbc add would overflow
     #[error("Total price exceed possible token amount")]
     TotalPriceTooHigh,
-    /// Failed to create transfer.
-    #[error("Transfer error {0}")]
-    CreateTransfer(#[from] crate::client_transfers::Error),
+    /// Failed to create offline transfer.
+    #[error("Offline transfer creation error {0}")]
+    CreateOfflineTransfer(#[from] crate::client_transfers::Error),
     /// A general error when a transfer fails.
     #[error("Failed to send tokens due to {0}")]
     CouldNotSendTokens(String),
@@ -44,6 +44,16 @@ pub enum Error {
     /// Failed to serialize a main key to hex.
     #[error("Could not serialize main key to hex: {0}")]
     FailedToHexEncodeKey(String),
+
+    #[error("UTXO serialisation failed")]
+    UtxoSerialisationFailed,
+    #[error("UTXO decryption failed")]
+    UtxoDecryptionFailed,
+    #[error("UTXO encryption failed")]
+    UtxoEncryptionFailed,
+    #[error("We are not a recipient of this Transfer")]
+    NotRecipient,
+
     /// Dbc error.
     #[error("Dbc error: {0}")]
     Dbc(#[from] sn_dbc::Error),

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -377,13 +377,17 @@ impl LocalWallet {
         Ok(transfers)
     }
 
-    pub fn decipher_transfer(&self, transfer: Transfer) -> Result<Vec<Utxo>> {
+    pub fn unwrap_transfer(&self, transfer: Transfer) -> Result<Vec<Utxo>> {
         transfer.utxos(self.key.secret_key())
     }
 
-    pub fn decipher_transfer_for_us(&self, payment: Vec<Transfer>) -> Result<Vec<Utxo>> {
+    /// Takes in a list of transfers and tries to decipher them one by one until
+    /// we find one that is for us.
+    /// Return the UTXOs if we find one.
+    /// Return an error if we find none.
+    pub fn unwrap_transfer_for_us(&self, payment: Vec<Transfer>) -> Result<Vec<Utxo>> {
         for tr in payment {
-            match self.decipher_transfer(tr) {
+            match self.unwrap_transfer(tr) {
                 Ok(utxos) => return Ok(utxos),
                 Err(_) => continue, // cannot decipher, not ours
             }

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -55,6 +55,7 @@
 mod error;
 mod keys;
 mod local_store;
+mod utxo;
 mod wallet_file;
 
 use crate::client_transfers::ContentPaymentsIdMap;
@@ -64,6 +65,7 @@ pub use self::{
     keys::{bls_secret_from_hex, parse_public_address},
     local_store::LocalWallet,
 };
+pub use utxo::{Transfer, Utxo};
 
 use sn_dbc::{DbcId, PublicAddress, Token};
 use std::collections::{BTreeMap, BTreeSet};

--- a/sn_transfers/src/wallet/utxo.rs
+++ b/sn_transfers/src/wallet/utxo.rs
@@ -9,11 +9,9 @@
 use bls::{Ciphertext, PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};
 use sn_dbc::DerivationIndex;
+use sn_protocol::storage::DbcAddress;
 
-use crate::{
-    error::{Error, Result},
-    storage::DbcAddress,
-};
+use super::error::{Error, Result};
 
 /// Transfer sent to a recipient
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
@@ -59,10 +57,10 @@ pub struct Utxo {
     /// derivation index of the UTXO
     /// with this derivation index the owner can derive
     /// the secret key from their main key needed to spend this UTXO
-    derivation_index: DerivationIndex,
+    pub derivation_index: DerivationIndex,
     /// spentbook entry of one of one of the inputs (parent spends)
     /// using data found at this address the owner can check that the output is valid money
-    parent_spend: DbcAddress,
+    pub parent_spend: DbcAddress,
 }
 
 impl Utxo {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Sep 23 04:49 UTC
This pull request includes the following changes:

1. In the file `sn_protocol/src/messages/mod.rs`:
   - The `utxo` module was removed from the module imports.
   - The `Utxo` struct was removed from the public exports.
   - The `Transfer` struct was removed from the public exports.

2. In the file `api.rs`:
   - Line 17: Import statement for `sn_dbc::Token` has been removed.
   - Line 27: Import statement for `sn_transfers::client_transfers::SpendRequest` has been added.
   - Line 29: Import statement for `sn_transfers::wallet::Transfer` has been added.
   - Line 50: The type of the `payment` parameter in the `store_chunk` method has been changed from `Vec<Dbc>` to `Vec<Transfer>`.

3. In the file `Cargo.toml`:
   - Added the dependency `rmp-serde` with version `1.1.1`.
   - Modified the `sn_dbc` dependency by commenting out the version `19.1.1` and adding a new line that specifies a path to the `sn_dbc` crate with the `serdes` feature.
   - Updated the `sn_protocol` dependency to version `0.6.4`.
   - Updated the `tokio` dependency to version `1.32.0` with the features `macros` and `rt`.
   - Added the dependency `thiserror` with version `1.0.23`.

4. In the file `error.rs`:
   - In the `Error` enum, the `RecordNotStored` variant has been modified to include an additional String parameter.
     - Before: `RecordNotStored(PrettyPrintRecordKey)`
     - After: `RecordNotStored(PrettyPrintRecordKey, String)`
   - The `UtxoSerialisationFailed` and `UtxoDecryptionFailed` variants have been removed from the `Error` enum.

5. In the file `mod.rs`:
   - Added a new module called `utxo`.
   - Exported the `Transfer` and `Utxo` types from the module `utxo`.
   - No other changes were made to the existing code.

6. A new file named `receive_transfer.rs` has been added in the `sn_node/src` directory. This file contains a license header, which states that the SAFE Network Software is licensed under the General Public License (GPL), version 3. The license grants permissions and limitations for using the software.

7. In the file `sequential_transfers.rs`:
   - Line 15: The import statement for `create_transfer` from `sn_transfers::client_transfers` has been changed to import `create_offline_transfer`.
   - Lines 34-37: The function `create_transfer` is replaced with `create_offline_transfer` in the code.

8. In the file `local_store.rs` in the `sn_transfers/src/wallet` directory:
   - Imported `Error`, `Transfer`, and `Utxo` types from the current module.
   - Renamed `create_transfer` function to `create_offline_transfer`.
   - Updated function calls to `create_offline_transfer`.
   - Added new function `create_transfers` that creates transfers from the given DBCs.
   - Added new function `decipher_transfer` that deciphers a transfer using the secret key.
   - Added new function `decipher_transfer_for_us` that deciphers a transfer for us.
   - Added new function `derive_key` that derives a key using the derivation index.

9. In the file `sn_client/src/wallet.rs`:
   - Imported `wallet::Transfer` from `sn_transfers` module.
   - Changed the function name `get_payment_dbcs` to `get_payment_transfers`.
   - Updated the return type of `get_payment_transfers` to `Result<Vec<Transfer>>`.
   - Added code to create transfers from DBCs.

10. The file `transfer.rs` shows a change in the function name `create_transfer` to `create_offline_transfer`. Additionally, there are changes in the function parameters and their types. The `available_dbcs` parameter is now of type `Vec<(Dbc, DerivedKey)>`, the `recipients` parameter is of type `Vec<(Token, PublicAddress, DerivationIndex)>`, and the `change_to` parameter is of type `PublicAddress`.

11. In the `Cargo.toml` file:
    - The dependency `sn_dbc` has been modified. It was previously version `19.1.1` with the feature `"serdes"`, but now it is commented out and a new dependency with a path to `../../sn_dbc` and the feature `"serdes"` has been added.
    - The version of the `sn_client` dependency has been updated to `0.88.9`.
    - The version of the `sn_logging` dependency has been updated to `0.2.5`.
    - The version of the `sn_networking` dependency has been updated to `0.5.9`.

Please let me know if you have any questions or need further clarification.
<!-- reviewpad:summarize:end --> 
