### PR TITLE
chore(networking): refactor record_store to have relevant records cal…

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="4000" # mb
-          client_avg_mem_limit_mb="3850" # mb
+          client_peak_mem_limit_mb="1500" # mb
+          client_avg_mem_limit_mb="1000" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -215,8 +215,8 @@ jobs:
         shell: bash
         # limits here are lower that benchmark tests as there is less going on.
         run: |
-          client_peak_mem_limit_mb="1000" # mb
-          client_avg_mem_limit_mb="850" # mb
+          client_peak_mem_limit_mb="300" # mb
+          client_avg_mem_limit_mb="120" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -271,6 +271,10 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 25
 
+      - name: Small wait to allow reward receipt
+        run: sleep 30
+        timeout-minutes: 1
+
       - name: execute the nodes rewards tests
         run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -201,6 +201,10 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 10
 
+      - name: Small wait to allow reward receipt
+        run: sleep 30
+        timeout-minutes: 1
+
       - name: execute the nodes rewards tests
         run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture
         env:

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -9,7 +9,6 @@
 use crate::{
     driver::SwarmDriver,
     error::{Error, Result},
-    record_store_api::RecordStoreAPI,
     sort_peers_by_address, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
 };
 use libp2p::{

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -10,9 +10,7 @@ use crate::{
     close_group_majority,
     driver::SwarmDriver,
     error::{Error, Result},
-    multiaddr_is_global, multiaddr_strip_p2p,
-    record_store_api::RecordStoreAPI,
-    sort_peers_by_address, CLOSE_GROUP_SIZE,
+    multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE,
 };
 use core::fmt;
 use custom_debug::Debug as CustomDebug;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -25,6 +25,7 @@ pub use self::{
     driver::SwarmDriver,
     error::Error,
     event::{MsgResponder, NetworkEvent},
+    record_store::NodeRecordStore,
 };
 
 use self::{cmd::SwarmCmd, error::Result};


### PR DESCRIPTION
…culation separately## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Sep 23 09:38 UTC
This pull request contains multiple file diffs with various changes.

Here is a summary of the changes:

1. In the file `cmd.rs`:
   - The import `record_store_api::RecordStoreAPI` has been removed.

2. In the file `sn_networking/src/lib.rs`:
   - A new import `record_store::NodeRecordStore` was added to the list of used items.

3. In the file `event.rs`:
   - The imported module `record_store_api::RecordStoreAPI` has been removed.
   - The import statements have been reorganized.

4. In the file `record_store_api.rs`:
   - The `RecordStoreAPI` trait has been removed.
   - The methods from the `RecordStoreAPI` trait have been moved into the `UnifiedRecordStore` implementation.
   - The visibility of some methods has been changed to `pub(crate)`.
   - The `store_cost()` method now returns a `Token` instead of `u64`.
   - A warning has been added when calling `store_cost()` on the `Client` variant of `UnifiedRecordStore`.

5. In the file `record_store.rs`:
   - The import statement for `RecordStoreAPI` has been removed.
   - The trait `RecordStoreAPI` has been replaced with the struct `NodeRecordStore`.
   - The visibility of several methods in `NodeRecordStore` has been changed to `pub(crate)`.
   - The method `set_distance_range` in `NodeRecordStore` now takes a `Distance` parameter.
   - A new method `get_records_within_distance_range` has been added to `NodeRecordStore` to calculate the number of records stored within a given distance range.
   - The trait `RecordStoreAPI` has been removed from the `ClientRecordStore` struct.
   - The method `get_records_within_distance_range` has been added to the test module to test the calculation of records within a distance range.

Please review these changes and ensure they are in line with the desired functionality and design of the code.
<!-- reviewpad:summarize:end --> 
