### PR TITLE
feat: utilize stream decryptor

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -340,15 +340,18 @@ async fn download_file(
         xorname
     );
     debug!("Downloading file {file_name:?}");
-    match file_api.read_bytes(ChunkAddress::new(*xorname)).await {
-        Ok(bytes) => {
+    let downloaded_file_path = download_path.join(file_name);
+    // The downloaded file will be writen to the folder directly.
+    match file_api
+        .read_bytes(
+            ChunkAddress::new(*xorname),
+            Some(downloaded_file_path.clone()),
+        )
+        .await
+    {
+        Ok(_) => {
             debug!("Successfully got file {file_name}!");
-            println!("Successfully got file {file_name}!");
-            let file_name_path = download_path.join(file_name);
-            println!("Writing {} bytes to {file_name_path:?}", bytes.len());
-            if let Err(err) = fs::write(file_name_path, bytes) {
-                println!("Failed to create file {file_name:?} with error {err:?}");
-            }
+            println!("Successfully got file {file_name}, stored at {downloaded_file_path:?}!");
         }
         Err(error) => {
             error!("Did not get file {file_name:?} from the network! {error}");

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -648,7 +648,7 @@ async fn query_content(
         }
         NetworkAddress::ChunkAddress(addr) => {
             let file_api = Files::new(client.clone(), wallet_dir.to_path_buf());
-            let _ = file_api.read_bytes(*addr).await?;
+            let _ = file_api.read_bytes(*addr, None).await?;
             Ok(())
         }
         _other => Ok(()), // we don't create/store any other type of content in this test yet

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -199,7 +199,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         .upload_with_payments(content_bytes, &wallet_client, true)
         .await?;
 
-    files_api.read_bytes(content_addr).await?;
+    files_api.read_bytes(content_addr, None).await?;
 
     Ok(())
 }
@@ -257,7 +257,7 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
         .await?;
 
     assert!(matches!(
-        files_api.read_bytes(content_addr).await,
+        files_api.read_bytes(content_addr, None).await,
         Err(ClientError::Network(NetworkError::RecordNotFound))
     ));
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Sep 23 11:57 UTC
This pull request introduces a new feature that utilizes the stream decryptor. It includes changes to multiple files, such as `sn_cli/src/subcommands/files.rs`, `sn_client/src/file_apis.rs`, `sn_node/tests/data_with_churn.rs`, and `sn_node/tests/storage_payments.rs`. The changes involve adding a new parameter to the `read_bytes` function in the `Files` struct, which allows the downloaded file to be stored directly in a given folder. Additionally, the `read_all` function has been modified to support writing the decrypted file to a given path or returning the decrypted content as bytes. Overall, these changes enhance the functionality related to file downloading and decryption.
<!-- reviewpad:summarize:end --> 
