### PR TITLE
chore(client): remove unused wallet_client

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -129,15 +129,14 @@ impl Files {
 
     /// Directly writes [`Bytes`] to the network in the
     /// form of immutable chunks, without any batching.
-    #[instrument(skip(self, bytes, wallet_client), level = "debug")]
+    #[instrument(skip(self, bytes), level = "debug")]
     pub async fn upload_with_payments(
         &self,
         bytes: Bytes,
-        wallet_client: &WalletClient,
         // content_payments_map: ContentPaymentsMap,
         verify_store: bool,
     ) -> Result<NetworkAddress> {
-        self.upload_bytes(bytes, wallet_client, verify_store).await
+        self.upload_bytes(bytes, verify_store).await
     }
 
     /// Tries to chunk the file, returning `(head_address, file_size, chunk_names)`
@@ -205,13 +204,8 @@ impl Files {
     // --------------------------------------------
 
     /// Used for testing
-    #[instrument(skip(self, bytes, _wallet_client), level = "trace")]
-    async fn upload_bytes(
-        &self,
-        bytes: Bytes,
-        _wallet_client: &WalletClient,
-        verify: bool,
-    ) -> Result<NetworkAddress> {
+    #[instrument(skip(self, bytes), level = "trace")]
+    async fn upload_bytes(&self, bytes: Bytes, verify: bool) -> Result<NetworkAddress> {
         let temp_dir = tempdir()?;
         let file_path = temp_dir.path().join("tempfile");
         let mut file = File::create(&file_path)?;

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -48,9 +48,7 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
 
     let prev_rewards_balance = current_rewards_balance()?;
 
-    files_api
-        .upload_with_payments(content_bytes, &wallet_client, true)
-        .await?;
+    files_api.upload_with_payments(content_bytes, true).await?;
 
     // sleep for 1 second to allow nodes to process and store the payment
     sleep(Duration::from_secs(1)).await;

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -96,7 +96,7 @@ async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
     // now let's request to upload all addresses, even that we've already paid for a subset of them
     let verify_store = false;
     let res = files_api
-        .upload_with_payments(content_bytes, &wallet_client, verify_store)
+        .upload_with_payments(content_bytes, verify_store)
         .await;
     assert!(
         res.is_err(),
@@ -195,9 +195,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         )
         .await?;
 
-    files_api
-        .upload_with_payments(content_bytes, &wallet_client, true)
-        .await?;
+    files_api.upload_with_payments(content_bytes, true).await?;
 
     files_api.read_bytes(content_addr, None).await?;
 
@@ -253,7 +251,7 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
 
     // this should fail to store as the amount paid is not enough
     files_api
-        .upload_with_payments(content_bytes.clone(), &wallet_client, false)
+        .upload_with_payments(content_bytes.clone(), false)
         .await?;
 
     assert!(matches!(

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -369,7 +369,7 @@ async fn store_chunks(
 
         let key = PrettyPrintRecordKey::from(RecordKey::new(&file_addr));
         file_api
-            .upload_with_payments(random_bytes.into(), &wallet_client, true)
+            .upload_with_payments(random_bytes.into(), true)
             .await?;
         uploaded_chunks_count += 1;
 


### PR DESCRIPTION
Seems these parameters are no longer used, and they make API more complex. Perhaps they can be removed? 

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Sep 23 19:52 UTC
This pull request removes the unused `wallet_client` parameter from the `upload_with_payments` function in the `Files` struct in the `file_apis.rs` file. It also removes the usage of this parameter in the `upload_bytes` function. Additionally, the `upload_with_payments` function calls in the `nodes_rewards.rs`, `storage_payments.rs`, and `verify_data_location.rs` test files have been updated to remove the `wallet_client` parameter. These changes simplify the code by removing unnecessary dependencies.
<!-- reviewpad:summarize:end --> 
