### PR TITLE
feat: split upload procedure into batches

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -163,6 +163,7 @@ impl WalletClient {
     ) -> Result<Token> {
         // TODO:
         // Check for any existing payment DBCs, and use them if they exist, only topping up if needs be
+        let num_of_payments = all_data_payments.len();
 
         let now = Instant::now();
         let mut total_cost = Token::zero();
@@ -195,7 +196,7 @@ impl WalletClient {
         }
 
         let elapsed = now.elapsed();
-        println!("After {elapsed:?}, All transfers made for total payment of {total_cost:?} nano tokens. ");
+        println!("After {elapsed:?}, All transfers made for total payment of {total_cost:?} nano tokens for {num_of_payments:?} chunks. ");
 
         Ok(total_cost)
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Sep 23 13:18 UTC
This pull request introduces a new feature that splits the upload procedure into batches. It modifies the `files.rs` and `wallet.rs` files to implement this feature. The `upload_files` function in `files.rs` now splits the files into batches and uploads them in parallel. The `chunk_and_pay_for_storage` function in `wallet.rs` is also updated to handle batch processing of chunks and payments. Additionally, the `BATCH_SIZE` constant is introduced in `wallet.rs` to define the size of each batch. Overall, this patch improves the efficiency of file uploads by splitting them into smaller batches.
<!-- reviewpad:summarize:end --> 
