### PR TITLE
feat(register): client to pay for Register only if local wallet has not payment for it yet

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -276,7 +276,7 @@ jobs:
         timeout-minutes: 1
 
       - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,7 +206,7 @@ jobs:
         timeout-minutes: 1
 
       - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -105,8 +105,8 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
             .await?;
     }
 
-    // sleep for 1 second to allow nodes to process and store the payment
-    sleep(Duration::from_secs(5)).await;
+    // sleep for 15 second to allow nodes to process and store the payment
+    sleep(Duration::from_secs(15)).await;
 
     let new_rewards_balance = current_rewards_balance()?;
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -12,8 +12,12 @@ use common::{get_client_and_wallet, random_content};
 
 use sn_client::WalletClient;
 use sn_dbc::Token;
-use sn_protocol::{storage::ChunkAddress, NetworkAddress};
+use sn_protocol::{
+    storage::{ChunkAddress, RegisterAddress},
+    NetworkAddress,
+};
 use sn_transfers::wallet::LocalWallet;
+use xor_name::XorName;
 
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
@@ -40,8 +44,8 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
     let cost = wallet_client
         .pay_for_storage(
             chunks
-                .iter()
-                .map(|(name, _)| NetworkAddress::ChunkAddress(ChunkAddress::new(*name))),
+                .into_iter()
+                .map(|(name, _)| NetworkAddress::ChunkAddress(ChunkAddress::new(name))),
             true,
         )
         .await?;
@@ -54,6 +58,55 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
 
     // sleep for 1 second to allow nodes to process and store the payment
     sleep(Duration::from_secs(1)).await;
+
+    let new_rewards_balance = current_rewards_balance()?;
+
+    let expected_rewards_balance = prev_rewards_balance
+        .checked_add(cost)
+        .ok_or_else(|| eyre!("Failed to sum up rewards balance"))?;
+
+    assert_eq!(expected_rewards_balance, new_rewards_balance);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn nodes_rewards_for_storing_registers() -> Result<()> {
+    let paying_wallet_balance = 10_000_000_000_444;
+    let paying_wallet_dir = TempDir::new()?;
+
+    let (client, paying_wallet) =
+        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+    let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
+
+    let num_of_regs = 20;
+    println!("Paying for {num_of_regs} random Register address...");
+    let mut rng = rand::thread_rng();
+    let mut register_addrs = vec![];
+    let owner_pk = client.signer_pk();
+    for _ in 0..num_of_regs {
+        register_addrs.push(XorName::random(&mut rng));
+    }
+
+    let cost = wallet_client
+        .pay_for_storage(
+            register_addrs
+                .iter()
+                .map(|name| NetworkAddress::RegisterAddress(RegisterAddress::new(*name, owner_pk))),
+            true,
+        )
+        .await?;
+
+    let prev_rewards_balance = current_rewards_balance()?;
+
+    for xor_name in register_addrs.into_iter() {
+        let _register = client
+            .create_register(xor_name, &mut wallet_client, false)
+            .await?;
+    }
+
+    // sleep for 1 second to allow nodes to process and store the payment
+    sleep(Duration::from_secs(5)).await;
 
     let new_rewards_balance = current_rewards_balance()?;
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -79,34 +79,29 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
-    let num_of_regs = 20;
-    println!("Paying for {num_of_regs} random Register address...");
+    println!("Paying for random Register address...");
     let mut rng = rand::thread_rng();
-    let mut register_addrs = vec![];
     let owner_pk = client.signer_pk();
-    for _ in 0..num_of_regs {
-        register_addrs.push(XorName::random(&mut rng));
-    }
+    let register_addr = XorName::random(&mut rng);
 
     let cost = wallet_client
         .pay_for_storage(
-            register_addrs
-                .iter()
-                .map(|name| NetworkAddress::RegisterAddress(RegisterAddress::new(*name, owner_pk))),
+            std::iter::once(NetworkAddress::RegisterAddress(RegisterAddress::new(
+                register_addr,
+                owner_pk,
+            ))),
             true,
         )
         .await?;
 
     let prev_rewards_balance = current_rewards_balance()?;
 
-    for xor_name in register_addrs.into_iter() {
-        let _register = client
-            .create_register(xor_name, &mut wallet_client, false)
-            .await?;
-    }
+    let _register = client
+        .create_register(register_addr, &mut wallet_client, false)
+        .await?;
 
-    // sleep for 15 second to allow nodes to process and store the payment
-    sleep(Duration::from_secs(15)).await;
+    // sleep for 10 second to allow nodes to process and store the payment
+    sleep(Duration::from_secs(10)).await;
 
     let new_rewards_balance = current_rewards_balance()?;
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -335,9 +335,6 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
         .mut_wallet()
         .local_send_storage_payment(no_data_payments, None)?;
 
-    // invalid spends
-    client.send(wallet_client.unconfirmed_txs(), true).await?;
-
     // this should fail to store as the amount paid is not enough
     let mut register = client
         .create_register(xor_name, &mut wallet_client, false)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Sep 23 15:05 UTC
This pull request includes two patches. 

The first patch introduces a new feature that allows the client to pay for registering an address only if the local wallet has not already made the payment for it. It includes changes in the `sn_client/src/register.rs` file. The patch modifies the logic to check if the user has already paid for the address before making the storage payment. If the user has not paid, the payment is made and the wallet is stored with the payment proofs.

The second patch adds a new test in the `sn_node/tests/storage_payments.rs` file. The test verifies that the creation and mutation of an unpaid Register fails. It tests the scenario where the storage payment has not been sent or the amount paid is not enough. The test checks that the creation of the register fails in both cases.
<!-- reviewpad:summarize:end --> 
