### PR TITLE
feat(client): pay for chunks in batches

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -320,5 +320,7 @@ pub(super) async fn chunk_path(
         bail!("The provided path does not contain any file. Please check your path!\nExiting...");
     }
 
+    println!("Total number of chunks to be stored: {}", num_of_chunks);
+
     Ok(chunked_files)
 }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -17,7 +17,6 @@ use super::{
 };
 
 use self_encryption::{decrypt_full_set, StreamSelfDecryptor};
-use sn_dbc::Token;
 use sn_protocol::{
     storage::{Chunk, ChunkAddress},
     NetworkAddress, PrettyPrintRecordKey,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Sep 23 08:47 UTC
This pull request includes the following changes:

- In the `Files` struct, a new method called `pay_for_chunks` has been added. This method interacts with the `wallet` module to pay for a given set of chunks and upload them. It takes a vector of XOR names representing the chunks and a boolean flag to verify the store. After making the payment, it prints the cost and stores the wallet. There are also some private helper methods in this file.

- In the `color_eyre` import statement, `eyre::WrapErr` and `Section` are no longer imported.

- In the function `wallet_cmds`, the `use sn_protocol::storage::ChunkAddress;` import statement is removed.

- The `WalletCmds::Pay` branch in the `match` statement is modified.

- The function `chunk_and_pay_for_storage` is renamed to `chunk_path`.

- The variable `batch_size` is no longer used in the `chunk_path` function.

- The code for making payment and storing the wallet in the `chunk_path` function is removed.

- A new print statement is added to display the total number of chunks to be stored.

Please review these changes for any potential issues.
<!-- reviewpad:summarize:end --> 
