### PR TITLE
ci: do reward tests _first_

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -258,6 +258,13 @@ jobs:
           else
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
+        
+      # This should be first to avoid slow reward acceptance etc
+      - name: execute the nodes rewards tests
+        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 25
 
       - name: execute the dbc spend tests
         run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
@@ -271,15 +278,6 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 25
 
-      - name: Small wait to allow reward receipt
-        run: sleep 30
-        timeout-minutes: 1
-
-      - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 25
 
       - name: Stop the local network and upload logs
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -187,6 +187,14 @@ jobs:
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
 
+      # This should be first to avoid slow reward acceptance etc
+      - name: execute the nodes rewards tests
+        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
+        env:
+          CARGO_TARGET_DIR: "./transfer-target"
+          SN_LOG: "all"
+        timeout-minutes: 25
+
       - name: execute the dbc spend test
         run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
@@ -205,12 +213,6 @@ jobs:
         run: sleep 30
         timeout-minutes: 1
 
-      - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
-          SN_LOG: "all"
-        timeout-minutes: 25
       
       - name: Stop the local network and upload logs
         if: always()


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Sep 23 09:24 UTC
This pull request updates the CI workflow to prioritize the execution of reward tests. It moves the execution of reward tests to the beginning of the workflow to avoid slow reward acceptance. The patch makes changes to both the `merge.yml` and `nightly.yml` files in the `.github/workflows` directory.
<!-- reviewpad:summarize:end --> 
