### PR TITLE
fix(cli): repay and upload after verifying all the chunks

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -213,7 +213,7 @@ impl Files {
             )
             .await?;
         println!(
-            "Successfully made payment of {cost} for {} chunks.)",
+            "Successfully made payment of {cost} for {} chunks.",
             chunks.len(),
         );
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Sep 23 13:49 UTC
This pull request fixes an issue in the CLI where repayment and uploading of chunks were not being done after verifying all the chunks. The patch modifies the `verify_and_repay_if_needed` function in the `files.rs` file. It introduces a loop to handle batch processing of chunks and keeps track of failed chunks. The failed chunks are then repaid and uploaded in batches using parallel upload. Overall, this patch improves the chunk verification and repayment process in the CLI.
<!-- reviewpad:summarize:end --> 
