### PR TITLE
chore: output address of uploaded file

### DIFF
--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -62,16 +62,18 @@ pub(crate) struct Opt {
     #[clap(subcommand)]
     pub cmd: SubCmd,
 
-    /// Timeout in seconds for the CLI to wait for a data response from the network.
+    /// Timeout in seconds to wait for a data response from the network.
     #[clap(long = "timeout", global = true, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_secs)?) })]
     pub timeout: Option<Duration>,
 
-    /// Number of concurrent uploads/downloads to allow at any one time.
+    /// Maximum concurrent uploads/downloads.
+    ///
     /// Defaults to 5.
     #[clap(long = "concurrency", short = 'c', global = true)]
     pub concurrency: Option<usize>,
 
-    /// Prevent verification of data storage on the network
+    /// Prevent verification of data storage on the network.
+    ///
     /// This may increase operation speed, but offers no guarantees that operations were successful.
     #[clap(global = true, short = 'n')]
     pub no_verify: bool,

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -15,7 +15,7 @@ mod subcommands;
 use crate::{
     cli::Opt,
     subcommands::{
-        files::{files_cmds, offline_files_cmds, FilesCmds},
+        files::files_cmds,
         register::register_cmds,
         wallet::{wallet_cmds, wallet_cmds_without_client, WalletCmds},
         SubCmd,
@@ -66,11 +66,6 @@ async fn main() -> Result<()> {
         | WalletCmds::GetFaucet { .. } = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
-            return Ok(());
-        }
-    } else if let SubCmd::Files(cmd) = &opt.cmd {
-        if let FilesCmds::Ls {} = cmd {
-            offline_files_cmds(cmd, &client_data_dir_path).await?;
             return Ok(());
         }
     }

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -15,7 +15,7 @@ mod subcommands;
 use crate::{
     cli::Opt,
     subcommands::{
-        files::files_cmds,
+        files::{files_cmds, offline_files_cmds, FilesCmds},
         register::register_cmds,
         wallet::{wallet_cmds, wallet_cmds_without_client, WalletCmds},
         SubCmd,
@@ -66,6 +66,11 @@ async fn main() -> Result<()> {
         | WalletCmds::GetFaucet { .. } = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
+            return Ok(());
+        }
+    } else if let SubCmd::Files(cmd) = &opt.cmd {
+        if let FilesCmds::Ls {} = cmd {
+            offline_files_cmds(cmd, &client_data_dir_path).await?;
             return Ok(());
         }
     }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -22,6 +22,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_transfers::wallet::LocalWallet;
+
 use std::{
     fs::{self, create_dir_all, File},
     io::{Read, Write},
@@ -204,16 +205,13 @@ impl Files {
                 verify_store,
             )
             .await?;
-        println!(
-            "Successfully made payment of {cost} for {} chunks.",
-            chunks.len(),
-        );
+        println!("Made payment of {cost} for {} chunks", chunks.len(),);
 
         if let Err(err) = wallet_client.store_local_wallet() {
             println!("Failed to store wallet: {err:?}");
         } else {
             println!(
-                "Successfully stored wallet with cached payment proofs, and new balance {}.",
+                "Stored wallet with cached payment proofs. New balance: {}",
                 wallet_client.balance()
             );
         }
@@ -377,7 +375,7 @@ impl Files {
                     }),
                     Err(err) => {
                         warn!(
-                            "Reading chunk {} from network, resulted in error {err:?}.",
+                            "Error reading chunk {} from network: {err:?}.",
                             chunk_info.dst_hash
                         );
                         Err(err)

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -213,7 +213,9 @@ impl WalletClient {
         }
 
         let elapsed = now.elapsed();
-        println!("After {elapsed:?}, All transfers made for total payment of {total_cost:?} nano tokens for {num_of_payments:?} chunks. ");
+        println!(
+            "All transfers made for total payment of {total_cost:?} nano tokens in {elapsed:?} "
+        );
 
         Ok(total_cost)
     }

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -213,9 +213,8 @@ impl WalletClient {
         }
 
         let elapsed = now.elapsed();
-        println!(
-            "All transfers made for total payment of {total_cost:?} nano tokens in {elapsed:?} "
-        );
+        println!("All transfers completed in {elapsed:?}");
+        println!("Total payment: {total_cost:?} nano tokens for {num_of_payments:?} chunks");
 
         Ok(total_cost)
     }


### PR DESCRIPTION
- b8487f4f **chore: output address of uploaded file**

  Other minor adjustments for more compact text output.

- b5666cef **feat: provide a `files ls` command**

  Gives the user to list the files they have uploaded, along with their addresses. We were storing
  this data anyway, but it's serialized to binary, so it's not human readable. A little interface on
  the client could be useful for users.

- bdfd4f75 **chore: clarify `files download` usage**

  The documentation for the arguments for the command are clarified, and we introduce a failure if
  only one of the name/address pair is used, as both are necessary.

  Also fix up some code from a complicated rebase.

- ba4809ed **chore: store uploaded files list as text**

  For the uploaded files list, rather than serialize to binary, we use a simple text format. The user
  can now see the addresses of all the files they've uploaded, and use this information to retrieve
  them, if need be. We are also now just using one file, appending to it for each upload.

  Now that this file is human readable, the `files ls` command was deemed unnecessary and was
  therefore removed.

  With respect to the `files` commands, I've also taken the opportunity to make the language in the
  text output more concise and matter of fact. For example, we don't really need to use things like
  exclamation marks in the text.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Sep 23 21:01 UTC
This pull request includes the following changes:

- In `cli.rs`:
  - Added a clarification comment for the `timeout` field.
  - Added a clarification comment for the `concurrency` field.
  - Added a clarification comment for the `no_verify` field.

- In `main.rs`:
  - Added a new `FilesCmds` variant, `Ls`, which lists all files uploaded by the current user.
  - Added handling for the `Ls` variant in the `files_cmds` function.

- In `files.rs`:
  - Added a new `FilesCmds` variant, `Ls`, which lists all files uploaded by the current user.
  - Added a new function, `offline_files_cmds`, which handles the `Ls` variant when offline.
  - Added handling for the `Ls` variant in the `files_cmds` function.
  - Added a new function, `list_files`, which lists all files uploaded by the current user.
  - Various changes, including clarifying comments and error handling improvements.

- In `file_apis.rs`:
  - Clarified print statements.

- In `wallet.rs`:
  - Adjusted print statement for completed transfers.
<!-- reviewpad:summarize:end --> 
