### PR TITLE
chore(client): simplify API

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -103,10 +103,7 @@ impl Files {
         address: ChunkAddress,
         position: usize,
         length: usize,
-    ) -> Result<Bytes>
-    where
-        Self: Sized,
-    {
+    ) -> Result<Bytes> {
         trace!("Reading {length} bytes at: {address:?}, starting from position: {position}");
         let chunk = self.client.get_chunk(address).await?;
 


### PR DESCRIPTION
Could it be removed? It compiles and passes `cargo test` without this.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Sep 23 23:47 UTC
This pull request simplifies the client API by removing unnecessary code in the file_apis.rs file. The `read_chunk` method now takes in the required parameters and returns the result directly, without the need for the `Self: Sized` constraint.
<!-- reviewpad:summarize:end --> 
