### PR TITLE
chore(networking): remove the quote from names as it's misleading

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -27,9 +27,9 @@ pub enum Error {
     CouldNotAcquireSemaphorePermit(#[from] tokio::sync::AcquireError),
 
     #[error(
-        "Not enough store cost quotes returned from the network to ensure a valid fee is paid"
+        "Not enough store cost prices returned from the network to ensure a valid fee is paid"
     )]
-    NotEnoughCostQuotes,
+    NotEnoughCostPricesReturned,
 
     #[error("Close group size must be a non-zero usize")]
     InvalidCloseGroupSize,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -212,6 +212,7 @@ impl Network {
         // loop over responses, generating an average fee and storing all responses along side
         let mut all_costs = vec![];
         for response in responses.into_iter().flatten() {
+            debug!("StoreCostReq received response: {:?}", response);
             if let Response::Query(QueryResponse::GetStoreCost {
                 store_cost: Ok(cost),
                 payment_address,
@@ -223,7 +224,7 @@ impl Network {
             }
         }
 
-        get_fees_from_store_cost_quotes(all_costs)
+        get_fees_from_store_cost_responses(all_costs)
     }
 
     /// Get the Record from the network
@@ -603,7 +604,7 @@ impl Network {
 
 /// Given `all_costs` it will return the CLOSE_GROUP majority cost.
 #[allow(clippy::result_large_err)]
-fn get_fees_from_store_cost_quotes(
+fn get_fees_from_store_cost_responses(
     mut all_costs: Vec<(PublicAddress, Token)>,
 ) -> Result<Vec<(PublicAddress, Token)>> {
     // TODO: we should make this configurable based upon data type
@@ -621,7 +622,7 @@ fn get_fees_from_store_cost_quotes(
     all_costs.truncate(desired_quote_count);
 
     if all_costs.len() < desired_quote_count {
-        return Err(Error::NotEnoughCostQuotes);
+        return Err(Error::NotEnoughCostPricesReturned);
     }
 
     info!(
@@ -676,7 +677,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_fee_from_store_cost_quotes() -> Result<()> {
+    fn test_get_fee_from_store_cost_responses() -> Result<()> {
         // for a vec of different costs of CLOSE_GROUP size
         // ensure we return the CLOSE_GROUP / 2 indexed price
         let mut costs = vec![];
@@ -684,7 +685,7 @@ mod tests {
             let addr = PublicAddress::new(bls::SecretKey::random().public_key());
             costs.push((addr, Token::from_nano(i as u64)));
         }
-        let prices = get_fees_from_store_cost_quotes(costs)?;
+        let prices = get_fees_from_store_cost_responses(costs)?;
         let total_price: u64 = prices
             .iter()
             .fold(0, |acc, (_, price)| acc + price.as_nano());
@@ -702,7 +703,8 @@ mod tests {
     }
     #[test]
     #[ignore = "we want to pay the entire CLOSE_GROUP for now"]
-    fn test_get_any_fee_from_store_cost_quotes_errs_if_insufficient_quotes() -> eyre::Result<()> {
+    fn test_get_any_fee_from_store_cost_responses_errs_if_insufficient_responses(
+    ) -> eyre::Result<()> {
         // for a vec of different costs of CLOSE_GROUP size
         // ensure we return the CLOSE_GROUP / 2 indexed price
         let mut costs = vec![];
@@ -711,27 +713,27 @@ mod tests {
             costs.push((addr, Token::from_nano(i as u64)));
         }
 
-        if get_fees_from_store_cost_quotes(costs).is_ok() {
-            bail!("Should have errored as we have too few quotes")
+        if get_fees_from_store_cost_responses(costs).is_ok() {
+            bail!("Should have errored as we have too few responses")
         }
 
         Ok(())
     }
     #[test]
     #[ignore = "we want to pay the entire CLOSE_GROUP for now"]
-    fn test_get_some_fee_from_store_cost_quotes_errs_if_sufficient() -> eyre::Result<()> {
+    fn test_get_some_fee_from_store_cost_responses_errs_if_sufficient() -> eyre::Result<()> {
         // for a vec of different costs of CLOSE_GROUP size
-        let quotes_count = CLOSE_GROUP_SIZE as u64 - 1;
+        let responses_count = CLOSE_GROUP_SIZE as u64 - 1;
         let mut costs = vec![];
-        for i in 0..quotes_count {
+        for i in 0..responses_count {
             // push random PublicAddress and Token
             let addr = PublicAddress::new(bls::SecretKey::random().public_key());
             costs.push((addr, Token::from_nano(i)));
             println!("price added {}", i);
         }
 
-        let prices = match get_fees_from_store_cost_quotes(costs) {
-            Err(_) => bail!("Should not have errored as we have enough quotes"),
+        let prices = match get_fees_from_store_cost_responses(costs) {
+            Err(_) => bail!("Should not have errored as we have enough responses"),
             Ok(cost) => cost,
         };
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 12:38 UTC
This pull request removes the quote from names in the `sn_networking` crate as it is misleading. It modifies the `error.rs` and `lib.rs` files, changing the error message to indicate that there are not enough store cost prices returned from the network to ensure a valid fee is paid. It also renames the function `get_fees_from_store_cost_quotes` to `get_fees_from_store_cost_responses` and updates its implementation to handle store cost responses instead of quotes. Additionally, it updates the corresponding test names accordingly.
<!-- reviewpad:summarize:end --> 
