### PR TITLE
fix: avoid verification too close to put; remove un-necessary wait fo…

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -215,6 +215,7 @@ async fn upload_files(
 
         let mut data_to_verify_or_repay = chunks_to_upload;
         while !data_to_verify_or_repay.is_empty() {
+            tokio::time::sleep(Duration::from_secs(3)).await;
             trace!(
                 "Verifying and potential topping up payment of {:?} chunks",
                 data_to_verify_or_repay.len()
@@ -222,7 +223,6 @@ async fn upload_files(
             data_to_verify_or_repay =
                 verify_and_repay_if_needed(file_api.clone(), data_to_verify_or_repay, batch_size)
                     .await?;
-            tokio::time::sleep(Duration::from_secs(3)).await;
         }
     }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -322,7 +322,9 @@ impl Network {
             _permit = None;
 
             // wait for a bit before re-trying
-            tokio::time::sleep(REVERIFICATION_WAIT_TIME_S).await;
+            if re_attempt {
+                tokio::time::sleep(REVERIFICATION_WAIT_TIME_S).await;
+            }
         }
 
         Err(Error::RecordNotFound)


### PR DESCRIPTION
…r put

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 13:09 UTC
This pull request fixes an issue where verification was being performed too close to uploading data in the `upload_files` function. It also removes an unnecessary wait for put.
<!-- reviewpad:summarize:end --> 
