### PR TITLE
Shorter wait on verfication

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -424,8 +424,12 @@ impl Network {
         drop(_permit);
 
         if verify_store.is_some() {
-            // small wait before we attempt to verify
-            tokio::time::sleep(REVERIFICATION_WAIT_TIME_S).await;
+            // Small wait before we attempt to verify.
+            // There will be `re-attempts` to be carried out within the later step anyway.
+            tokio::time::sleep(std::time::Duration::from_millis(
+                REVERIFICATION_WAIT_TIME_S.as_millis() as u64 / 6,
+            ))
+            .await;
             trace!("attempting to verify {pretty_key:?}");
 
             // Verify the record is stored, requiring re-attempts


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 14:12 UTC
This pull request includes two patches. 

Patch 1/2 fixes an issue in the sn_cli project. It avoids performing verification too close to the put operation and removes an unnecessary sleep before the put operation.

Patch 2/2 addresses a bug in the sn_networking project. It reduces the wait time for verification by using a smaller duration.

Overall, these patches improve the efficiency and performance of the code.
<!-- reviewpad:summarize:end --> 
