### PR TITLE
chore: error handling when failed fetch store cost

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -189,7 +189,7 @@ async fn upload_files(
         ))
         .await
         {
-            result??;
+            let _ = result?;
         }
 
         let elapsed = now.elapsed();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 16:25 UTC
This pull request includes a chore to handle error when failed to fetch store cost. It updates the error handling in the `files.rs` and `wallet.rs` files by using a `let _ = result?;` statement instead of `result??;` and adding additional error handling code. It also adds logging and printing of error messages when store costs cannot be fetched from the network.
<!-- reviewpad:summarize:end --> 
