### PR TITLE
feat(network): adding support for gossipsub behaviour/messaging

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -215,6 +215,51 @@ jobs:
           log_file_prefix: safe_test_logs_e2e
           platform: ${{ matrix.os }}
 
+  gossipsub:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    name: Gossipsub E2E tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build node
+        run: cargo build --release --bin safenode
+        timeout-minutes: 30
+
+      - name: Build gossipsub testing executable
+        run: cargo test --release -p sn_node --features=local-discovery --test msgs_over_gossipsub --no-run
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ${{ matrix.os }}
+
+      - name: Gossipsub - nodes to subscribe to topics, and publish messages 
+        run: cargo test --release -p sn_node --features local-discovery msgs_over_gossipsub -- --nocapture
+        timeout-minutes: 20
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_e2e
+          platform: ${{ matrix.os }}
+
   spend_test:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
     name: spend tests against network
@@ -337,17 +382,7 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
-      - name: Chunks data integrity during nodes churn - Linux/MacOS
-        if: matrix.os != 'windows-latest'
-        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
-        env:
-          TEST_DURATION_MINS: 5
-          TEST_TOTAL_CHURN_CYCLES: 15
-          SN_LOG: "all"
-        timeout-minutes: 30
-
-      - name: Chunks data integrity during nodes churn - Windows
-        if: matrix.os == 'windows-latest'
+      - name: Chunks data integrity during nodes churn
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
           TEST_DURATION_MINS: 5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -151,6 +151,51 @@ jobs:
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Nightly Unit Test Run Failed"
 
+  gossipsub:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    name: Gossipsub E2E tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build node
+        run: cargo build --release --bin safenode
+        timeout-minutes: 30
+
+      - name: Build gossipsub testing executable
+        run: cargo test --release -p sn_node --features=local-discovery --test msgs_over_gossipsub --no-run
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ${{ matrix.os }}
+
+      - name: Gossipsub - nodes to subscribe to topics, and publish messages 
+        run: cargo test --release -p sn_node --features local-discovery msgs_over_gossipsub -- --nocapture
+        timeout-minutes: 20
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_e2e
+          platform: ${{ matrix.os }}
+
   spend_test:
     name: spend tests against network
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2210,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
@@ -2301,6 +2313,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.21.2",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-ticker",
+ "getrandom 0.2.10",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "regex",
+ "sha2 0.10.7",
+ "smallvec",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2440,7 @@ checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
  "instant",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
 dependencies = [
  "asynchronous-codec",
- "base64 0.21.2",
+ "base64 0.21.4",
  "byteorder",
  "bytes",
  "either",
@@ -2336,9 +2336,9 @@ dependencies = [
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand",
  "regex",
- "sha2 0.10.7",
+ "sha2",
  "smallvec",
  "unsigned-varint",
  "void",

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -16,6 +16,7 @@ use crate::{
     cli::Opt,
     subcommands::{
         files::files_cmds,
+        gossipsub::gossipsub_cmds,
         register::register_cmds,
         wallet::{wallet_cmds, wallet_cmds_without_client, WalletCmds},
         SubCmd,
@@ -109,6 +110,7 @@ async fn main() -> Result<()> {
         SubCmd::Register(cmds) => {
             register_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
         }
+        SubCmd::Gossipsub(cmds) => gossipsub_cmds(cmds, &client).await?,
     };
 
     Ok(())

--- a/sn_cli/src/subcommands/gossipsub.rs
+++ b/sn_cli/src/subcommands/gossipsub.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use clap::Subcommand;
+use color_eyre::Result;
+use sn_client::{Client, ClientEvent};
+
+#[derive(Subcommand, Debug)]
+pub enum GossipsubCmds {
+    /// Subscribe to a topic and listen for messages published on it
+    Subscribe {
+        /// The name of the topic.
+        #[clap(name = "topic")]
+        topic: String,
+    },
+    /// Publish a message on a given topic
+    Publish {
+        /// The name of the topic.
+        #[clap(name = "topic")]
+        topic: String,
+        /// The message to publish.
+        #[clap(name = "msg")]
+        msg: String,
+    },
+}
+
+pub(crate) async fn gossipsub_cmds(cmds: GossipsubCmds, client: &Client) -> Result<()> {
+    match cmds {
+        GossipsubCmds::Subscribe { topic } => {
+            client.subscribe_to_topic(topic.clone())?;
+            println!("Subscribed to topic '{topic}'. Listening for messages published on it...");
+            let mut events_channel = client.events_channel();
+            while let Ok(event) = events_channel.recv().await {
+                if let ClientEvent::GossipsubMsg { msg, .. } = event {
+                    let msg = String::from_utf8(msg)?;
+                    println!("New message published: {msg}");
+                }
+            }
+        }
+        GossipsubCmds::Publish { topic, msg } => {
+            client.publish_on_topic(topic.clone(), msg.into())?;
+            println!("Message published on topic '{topic}'.");
+        }
+    }
+    Ok(())
+}

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 pub(crate) mod files;
+pub(crate) mod gossipsub;
 pub(crate) mod register;
 pub(crate) mod wallet;
 
@@ -22,4 +23,7 @@ pub(super) enum SubCmd {
     #[clap(name = "register", subcommand)]
     /// Commands for register management
     Register(register::RegisterCmds),
+    #[clap(name = "gossipsub", subcommand)]
+    /// Commands for gossipsub management
+    Gossipsub(gossipsub::GossipsubCmds),
 }

--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -42,6 +42,13 @@ pub enum ClientEvent {
     /// No network activity has been received for a given duration
     /// we should error out
     InactiveClient(std::time::Duration),
+    /// Gossipsub message received on a topic the client has subscribed to
+    GossipsubMsg {
+        /// Topic the message was published on
+        topic: String,
+        /// The raw bytes of the received message
+        msg: Vec<u8>,
+    },
 }
 
 /// Receiver Channel where users of the public API can listen to events broadcasted by the client.

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -23,7 +23,7 @@ futures = "~0.3.13"
 hyper = { version = "0.14", features = ["server", "tcp", "http1"], optional = true}
 itertools = "~0.11.0"
 custom_debug = "~0.5.0"
-libp2p = { version="0.52", features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux"] }
+libp2p = { version="0.52", features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux", "gossipsub"] }
 libp2p-metrics = { version = "0.13.1", features = ["identify", "kad", ], optional = true }
 libp2p-quic = { version = "0.9.2", features = ["tokio"], optional = true }
 prometheus-client = { version = "0.21.2", optional = true }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -114,6 +114,13 @@ pub enum SwarmCmd {
     AddKeysToReplicationFetcher {
         keys: Vec<NetworkAddress>,
     },
+    /// Publish a message through Gossipsub protocol
+    GossipMsg {
+        /// Topic to publish on
+        topic_id: libp2p::gossipsub::IdentTopic,
+        /// Raw bytes of the message to publish
+        msg: Vec<u8>,
+    },
 }
 
 /// Snapshot of information kept in the Swarm's local state
@@ -351,6 +358,13 @@ impl SwarmDriver {
                 sender
                     .send(current_state)
                     .map_err(|_| Error::InternalMsgChannelDropped)?;
+            }
+            SwarmCmd::GossipMsg { topic_id, msg } => {
+                self.swarm
+                    .behaviour_mut()
+                    .gossipsub
+                    .publish(topic_id, msg)
+                    .unwrap();
             }
         }
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -370,13 +370,9 @@ impl NetworkBuilder {
             libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
 
         // build a gossipsub network behaviour
-        let mut gossipsub: libp2p::gossipsub::Behaviour =
-            libp2p::gossipsub::Behaviour::new(message_authenticity, gossipsub_config).unwrap();
-
-        // Create a Gossipsub topic
-        let topic = libp2p::gossipsub::IdentTopic::new("example-topic");
-        // subscribe to the topic
-        gossipsub.subscribe(&topic).unwrap();
+        let gossipsub: libp2p::gossipsub::Behaviour =
+            libp2p::gossipsub::Behaviour::new(message_authenticity, gossipsub_config)
+                .expect("Failed to instantiate Gossipsub behaviour.");
 
         if !self.local {
             debug!("Preventing non-global dials");

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use libp2p::{
+    gossipsub::{PublishError, SubscriptionError},
     kad::{self, Record},
     request_response::{OutboundFailure, RequestId},
     swarm::DialError,
@@ -103,6 +104,12 @@ pub enum Error {
     #[cfg(feature = "open-metrics")]
     #[error("Network Metric error")]
     NetworkMetricError,
+
+    #[error("Gossipsub publish Error: {0}")]
+    GossipsubPublishError(#[from] PublishError),
+
+    #[error("Gossipsub subscribe Error: {0}")]
+    GossipsubSubscriptionError(#[from] SubscriptionError),
 }
 
 #[cfg(test)]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -135,7 +135,7 @@ pub enum NetworkEvent {
     /// Report unverified record
     UnverifiedRecord(Record),
     /// Gossipsub message received
-    Gossipsub {
+    GossipsubMsg {
         /// Topic the message was published on
         topic: String,
         /// The raw bytes of the received message
@@ -176,8 +176,8 @@ impl Debug for NetworkEvent {
                 let pretty_key = PrettyPrintRecordKey::from(record.key.clone());
                 write!(f, "NetworkEvent::UnverifiedRecord({pretty_key:?})")
             }
-            NetworkEvent::Gossipsub { topic, .. } => {
-                write!(f, "NetworkEvent::Gossipsub({topic})")
+            NetworkEvent::GossipsubMsg { topic, .. } => {
+                write!(f, "NetworkEvent::GossipsubMsg({topic})")
             }
         }
     }
@@ -335,7 +335,7 @@ impl SwarmDriver {
                 libp2p::gossipsub::Event::Message { message, .. } => {
                     let topic = message.topic.into_string();
                     let msg = message.data;
-                    self.send_event(NetworkEvent::Gossipsub { topic, msg });
+                    self.send_event(NetworkEvent::GossipsubMsg { topic, msg });
                 }
                 other => trace!("Gossipsub Event has been ignored: {other:?}"),
             },

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -227,9 +227,15 @@ impl Network {
         get_fees_from_store_cost_responses(all_costs)
     }
 
-    pub fn publish_on_topic(&self, msg: Vec<u8>) -> Result<()> {
-        let topic_id = libp2p::gossipsub::IdentTopic::new("example-topic");
-        self.send_swarm_cmd(SwarmCmd::GossipMsg { topic_id, msg })?;
+    /// Subscribe to given gossipsub topic
+    pub fn subscribe_to_topic(&self, topic_id: String) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::GossipsubSubscribe(topic_id))?;
+        Ok(())
+    }
+
+    /// Publish a msg on a given topic
+    pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::GossipsubPublish { topic_id, msg })?;
         Ok(())
     }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -227,6 +227,12 @@ impl Network {
         get_fees_from_store_cost_responses(all_costs)
     }
 
+    pub fn publish_on_topic(&self, msg: Vec<u8>) -> Result<()> {
+        let topic_id = libp2p::gossipsub::IdentTopic::new("example-topic");
+        self.send_swarm_cmd(SwarmCmd::GossipMsg { topic_id, msg })?;
+        Ok(())
+    }
+
     /// Get the Record from the network
     /// Carry out re-attempts if required
     /// In case a target_record is provided, only return when fetched target.

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -76,6 +76,18 @@ impl RunningNode {
         let addresses = self.network.get_all_local_record_addresses().await?;
         Ok(addresses)
     }
+
+    /// Subscribe to given gossipsub topic
+    pub fn subscribe_to_topic(&self, topic_id: String) -> Result<()> {
+        self.network.subscribe_to_topic(topic_id)?;
+        Ok(())
+    }
+
+    /// Publish a message on a given gossipsub topic
+    pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
+        self.network.publish_on_topic(topic_id, msg)?;
+        Ok(())
+    }
 }
 
 impl Node {
@@ -225,7 +237,7 @@ impl Node {
                 | NetworkEvent::PeerRemoved(_)
                 | NetworkEvent::NewListenAddr(_)
                 | NetworkEvent::NatStatusChanged(_)
-                | NetworkEvent::Gossipsub { .. } => break,
+                | NetworkEvent::GossipsubMsg { .. } => break,
             }
         }
         trace!("Handling NetworkEvent {event:?}");
@@ -300,9 +312,9 @@ impl Node {
                     }
                 }
             }
-            NetworkEvent::Gossipsub { topic, msg } => {
+            NetworkEvent::GossipsubMsg { topic, msg } => {
                 self.events_channel
-                    .broadcast(NodeEvent::Gossipsub { topic, msg });
+                    .broadcast(NodeEvent::GossipsubMsg { topic, msg });
             }
         }
     }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -81,12 +81,12 @@ impl RunningNode {
 impl Node {
     /// Asynchronously runs a new node instance, setting up the swarm driver,
     /// creating a data storage, and handling network events. Returns the
-    /// created node and a `NodeEventsChannel` for listening to node-related
-    /// events.
+    /// created `RunningNode` which contians a `NodeEventsChannel` for listening
+    /// to node-related events.
     ///
     /// # Returns
     ///
-    /// A tuple containing a `Node` instance and a `NodeEventsChannel`.
+    /// A `RunningNode` instance.
     ///
     /// # Errors
     ///
@@ -224,7 +224,8 @@ impl Node {
                 NetworkEvent::PeerAdded(_)
                 | NetworkEvent::PeerRemoved(_)
                 | NetworkEvent::NewListenAddr(_)
-                | NetworkEvent::NatStatusChanged(_) => break,
+                | NetworkEvent::NatStatusChanged(_)
+                | NetworkEvent::Gossipsub { .. } => break,
             }
         }
         trace!("Handling NetworkEvent {event:?}");
@@ -298,6 +299,10 @@ impl Node {
                         trace!("UnverifiedRecord {key} failed to be stored with error {err:?}.")
                     }
                 }
+            }
+            NetworkEvent::Gossipsub { topic, msg } => {
+                self.events_channel
+                    .broadcast(NodeEvent::Gossipsub { topic, msg });
             }
         }
     }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -335,6 +335,9 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                         break;
                     }
                 }
+                Ok(NodeEvent::Gossipsub {topic, msg}) => {
+                    println!(">>>> GOSSIP MSG: {topic} ====> {msg:?}",);
+                }
                 Ok(event) => {
                     /* we ignore other events */
                     info!("Currently ignored node event {event:?}");

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -335,9 +335,6 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                         break;
                     }
                 }
-                Ok(NodeEvent::Gossipsub {topic, msg}) => {
-                    println!(">>>> GOSSIP MSG: {topic} ====> {msg:?}",);
-                }
                 Ok(event) => {
                     /* we ignore other events */
                     info!("Currently ignored node event {event:?}");

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -59,6 +59,13 @@ pub enum NodeEvent {
     ChannelClosed,
     /// AutoNAT discovered we are behind a NAT, thus private.
     BehindNat,
+    /// Gossipsub message received
+    Gossipsub {
+        /// Topic the message was published on
+        topic: String,
+        /// The raw bytes of the received message
+        msg: Vec<u8>,
+    },
 }
 
 impl NodeEvent {

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -60,7 +60,7 @@ pub enum NodeEvent {
     /// AutoNAT discovered we are behind a NAT, thus private.
     BehindNat,
     /// Gossipsub message received
-    Gossipsub {
+    GossipsubMsg {
         /// Topic the message was published on
         topic: String,
         /// The raw bytes of the received message

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -45,6 +45,21 @@ message RecordAddressesResponse {
     repeated bytes addresses = 1;
 }
 
+// Subsribe to a gossipsub topic
+message GossipsubSubscribeRequest {
+  string topic = 1;
+}
+
+message GossipsubSubscribeResponse {}
+
+// Publish a msg on a gossipsub topic
+message GossipsubPublishRequest {
+  string topic = 1;
+  bytes msg = 2;
+}
+
+message GossipsubPublishResponse {}
+
 // Stop the safenode app
 message StopRequest {
   uint64 delay_millis = 1;

--- a/sn_node/src/protocol/safenode_proto/safenode.proto
+++ b/sn_node/src/protocol/safenode_proto/safenode.proto
@@ -34,6 +34,12 @@ service SafeNode {
   // Returns the Addresses of all the Records stored by this node
   rpc RecordAddresses (RecordAddressesRequest) returns (RecordAddressesResponse);
 
+  // Subscribe to a Gossipsub topic
+  rpc SubscribeToTopic (GossipsubSubscribeRequest) returns (GossipsubSubscribeResponse);
+
+  // Publish a msg on a Gossipsub topic
+  rpc PublishOnTopic (GossipsubPublishRequest) returns (GossipsubPublishResponse);
+
   // Stop the execution of this node
   rpc Stop (StopRequest) returns (StopResponse);
 

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod common;
+
+use common::safenode_proto::{
+    safe_node_client::SafeNodeClient, GossipsubPublishRequest, GossipsubSubscribeRequest,
+    NodeEventsRequest,
+};
+use sn_node::NodeEvent;
+
+use eyre::Result;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+const NODE_COUNT: u8 = 25;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn msgs_over_gossipsub() -> Result<()> {
+    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+
+    for node_index in 1..NODE_COUNT + 1 {
+        // request current node to subscribe to a fresh new topic
+        addr.set_port(12000 + node_index as u16);
+        let topic = format!("TestTopic-{node_index}");
+        node_subscribe_to_topic(addr, topic.clone()).await?;
+
+        println!("Node {node_index} subscribed to {topic}");
+
+        let handle = tokio::spawn(async move {
+            let endpoint = format!("https://{addr}");
+            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+            let response = rpc_client
+                .node_events(Request::new(NodeEventsRequest {}))
+                .await?;
+
+            println!("Listening to node events...");
+            let mut count = 0;
+
+            let _ = timeout(Duration::from_millis(10000), async {
+                let mut stream = response.into_inner();
+                while let Some(Ok(e)) = stream.next().await {
+                    match NodeEvent::from_bytes(&e.event) {
+                        Ok(NodeEvent::GossipsubMsg { topic, msg }) => {
+                            println!(
+                                "New gossipsub msg received on '{topic}': {}",
+                                String::from_utf8(msg).unwrap()
+                            );
+                            count += 1;
+                        }
+                        Ok(_) => { /* ignored */ }
+                        Err(_) => {
+                            println!("Error while parsing received NodeEvent");
+                        }
+                    }
+                }
+            })
+            .await;
+
+            Ok::<u8, eyre::Error>(count)
+        });
+
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        // have all other nodes to publish each a different msg to that same topic
+        other_nodes_to_publish_on_topic(addr, topic).await?;
+
+        let count = handle.await??;
+        println!("Messages received by node {node_index}: {count}");
+        assert!(
+            count > 0,
+            "No message received by node at index {}",
+            node_index
+        );
+    }
+
+    Ok(())
+}
+
+async fn node_subscribe_to_topic(addr: SocketAddr, topic: String) -> Result<()> {
+    let endpoint = format!("https://{addr}");
+    let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+
+    // subscribe to given topic
+    let _response = rpc_client
+        .subscribe_to_topic(Request::new(GossipsubSubscribeRequest { topic }))
+        .await?;
+
+    Ok(())
+}
+
+async fn other_nodes_to_publish_on_topic(filter_addr: SocketAddr, topic: String) -> Result<()> {
+    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+    for node_index in 1..NODE_COUNT + 1 {
+        addr.set_port(12000 + node_index as u16);
+        if addr != filter_addr {
+            let msg = format!("TestMsgOnTopic-{topic}-from-{node_index}");
+
+            let endpoint = format!("https://{addr}");
+            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+            println!("Node {node_index} to publish on {topic} message: {msg}");
+
+            let _response = rpc_client
+                .publish_on_topic(Request::new(GossipsubPublishRequest {
+                    topic: topic.clone(),
+                    msg: msg.into(),
+                }))
+                .await?;
+        }
+    }
+
+    Ok(())
+}

--- a/sn_protocol/src/safenode_proto/req_resp_types.proto
+++ b/sn_protocol/src/safenode_proto/req_resp_types.proto
@@ -23,12 +23,42 @@ message NodeInfoResponse {
   uint64 uptime_secs = 5;
 }
 
+// Information about how this node's connections to the network and peers
+message NetworkInfoRequest {}
+
+message NetworkInfoResponse {
+  repeated bytes connected_peers = 1;
+  repeated string listeners = 2;
+}
+
 // Stream of node events
 message NodeEventsRequest {}
 
 message NodeEvent {
-  string event = 1;
+  bytes event = 1;
 }
+
+// Addresses of all the Records stored by the node
+message RecordAddressesRequest {}
+
+message RecordAddressesResponse {
+    repeated bytes addresses = 1;
+}
+
+// Subsribe to a gossipsub topic
+message GossipsubSubscribeRequest {
+  string topic = 1;
+}
+
+message GossipsubSubscribeResponse {}
+
+// Publish a msg on a gossipsub topic
+message GossipsubPublishRequest {
+  string topic = 1;
+  bytes msg = 2;
+}
+
+message GossipsubPublishResponse {}
 
 // Stop the safenode app
 message StopRequest {
@@ -51,10 +81,3 @@ message UpdateRequest {
 
 message UpdateResponse {}
 
-// Information about how this node's connections to the network and peers
-message NetworkInfoRequest {}
-
-message NetworkInfoResponse {
-  repeated bytes connected_peers = 1;
-  repeated string listeners = 2;
-}

--- a/sn_protocol/src/safenode_proto/safenode.proto
+++ b/sn_protocol/src/safenode_proto/safenode.proto
@@ -31,6 +31,15 @@ service SafeNode {
   // Returns a stream of events as triggered by this node
   rpc NodeEvents (NodeEventsRequest) returns (stream NodeEvent);
 
+  // Returns the Addresses of all the Records stored by this node
+  rpc RecordAddresses (RecordAddressesRequest) returns (RecordAddressesResponse);
+
+  // Subscribe to a Gossipsub topic
+  rpc SubscribeToTopic (GossipsubSubscribeRequest) returns (GossipsubSubscribeResponse);
+
+  // Publish a msg on a Gossipsub topic
+  rpc PublishOnTopic (GossipsubPublishRequest) returns (GossipsubPublishResponse);
+
   // Stop the execution of this node
   rpc Stop (StopRequest) returns (StopResponse);
 


### PR DESCRIPTION
In this PR, as an initial impl., the `MessageAuthenticity` type for all gossipsub messages is set to `Signed`, ref.: https://docs.rs/libp2p/latest/libp2p/gossipsub/enum.MessageAuthenticity.html

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 18:06 UTC
This pull request adds support for the gossipsub behavior/messaging in the network. It adds the necessary dependencies and modifies various files to integrate gossipsub into the existing codebase.
<!-- reviewpad:summarize:end --> 
