### PR TITLE
feat: log payment amount

### DIFF
--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -458,7 +458,7 @@ impl Node {
         wallet
             .store()
             .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
-        trace!("Payment accepted for record {pretty_key:?}");
+        info!("Payment of {received_fee:?} nanos accepted for record {pretty_key:?}");
 
         Ok(())
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Sep 23 05:36 UTC
This pull request adds a new feature to log the payment amount when a payment is accepted for a record. The patch modifies the file `sn_node/src/put_validation.rs` by changing the logging statement from `trace!("Payment accepted for record {pretty_key:?}")` to `info!("Payment of {received_fee:?} nanos accepted for record {pretty_key:?}")`.
<!-- reviewpad:summarize:end --> 
