### PR TITLE
chore(networking): enable caching of records (in theory)

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -12,7 +12,11 @@ use super::{
 };
 use bls::{PublicKey, SecretKey, Signature};
 use indicatif::ProgressBar;
-use libp2p::{identity::Keypair, kad::Record, Multiaddr};
+use libp2p::{
+    identity::Keypair,
+    kad::{Quorum, Record},
+    Multiaddr,
+};
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
 use sn_dbc::{DbcId, PublicAddress, SignedSpend, Token};
@@ -324,7 +328,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, optional_permit)
+            .put_record(record, record_to_verify, optional_permit, Quorum::One)
             .await?)
     }
 
@@ -371,7 +375,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, None)
+            .put_record(record, record_to_verify, None, Quorum::All)
             .await?)
     }
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -9,7 +9,7 @@
 use crate::{Client, Error, Result, WalletClient};
 
 use bls::PublicKey;
-use libp2p::kad::Record;
+use libp2p::kad::{Quorum, Record};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::RegisterCmd,
@@ -349,7 +349,7 @@ impl ClientRegister {
         Ok(self
             .client
             .network
-            .put_record(record, record_to_verify, None)
+            .put_record(record, record_to_verify, None, Quorum::All)
             .await?)
     }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -104,6 +104,7 @@ pub enum SwarmCmd {
     PutRecord {
         record: Record,
         sender: oneshot::Sender<Result<()>>,
+        quorum: Quorum,
     },
     /// Put record to the local RecordStore
     PutLocalRecord {
@@ -177,7 +178,11 @@ impl SwarmDriver {
                     .map(|rec| rec.into_owned());
                 let _ = sender.send(record);
             }
-            SwarmCmd::PutRecord { record, sender } => {
+            SwarmCmd::PutRecord {
+                record,
+                sender,
+                quorum,
+            } => {
                 let record_key = PrettyPrintRecordKey::from(record.key.clone());
                 trace!(
                     "Putting record sized: {:?} to network {:?}",
@@ -188,7 +193,7 @@ impl SwarmDriver {
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .put_record(record, Quorum::All)
+                    .put_record(record, quorum)
                 {
                     Ok(request_id) => {
                         trace!("Sent record {record_key:?} to network. Request id: {request_id:?} to network");

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -28,7 +28,7 @@ use libp2p::mdns;
 use libp2p::{
     autonat,
     identity::Keypair,
-    kad::{Kademlia, KademliaConfig, QueryId, Record},
+    kad::{Kademlia, KademliaCaching, KademliaConfig, QueryId, Record},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{
@@ -169,6 +169,11 @@ impl NetworkBuilder {
             .disjoint_query_paths(true)
             // Records never expire
             .set_record_ttl(None)
+            // Enable caching of records if we use Quorum::One for GetRecord (which should be used for chunks)
+            // This means the closest 16 nodes would be caching the record
+            .set_caching(KademliaCaching::Enabled {
+                max_peers: CLOSE_GROUP_SIZE as u16 * 2,
+            })
             // Emit PUT events for validation prior to insertion into the RecordStore.
             // This is no longer needed as the record_storage::put now can carry out validation.
             // .set_record_filtering(KademliaStoreInserts::FilterBoth)


### PR DESCRIPTION
theory as we dont have any Quorum::One records yet so this alone won't
do much## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Sep 23 11:45 UTC
This pull request includes two patches.

PATCH 1/2 implements caching of records in the networking driver. The caching is enabled when the `Quorum::One` is used for the `GetRecord` operation. This change means that the closest 16 nodes will cache the record. However, this alone won't have a significant impact as there are no `Quorum::One` records yet.

PATCH 2/2 allows chunks to be `Quorum::One` instead of `Quorum::All`, as they are self-verifiable and don't require a majority. This change affects multiple files in the codebase.

Overall, these patches improve the caching and performance of network operations, specifically related to records and chunks.
<!-- reviewpad:summarize:end --> 
