### PR TITLE
fix: make clearer cli send asks for whole token amounts, not nanos

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -64,7 +64,7 @@ pub enum WalletCmds {
     },
     /// Send a DBC.
     Send {
-        /// The number of nanos to send.
+        /// The number of SafeNetworkTokens to send.
         #[clap(name = "amount")]
         amount: String,
         /// Hex-encoded public address of the recipient.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 08:25 UTC
This pull request fixes an issue where the command line interface was asking for token amounts in nanos instead of whole token amounts. The patch updates the version of the `hermit-abi` crate and the `unicode-width` crate.
<!-- reviewpad:summarize:end --> 
