### PR TITLE
feat: downward compatible for patch version updates

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -79,6 +79,19 @@ const IDENTIFY_PROTOCOL_STR: &str = concat!("safe/", env!("CARGO_PKG_VERSION"));
 
 const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 
+// Protocol support shall be downward compatible for patch only version update.
+// i.e. versions of `A.B.X` shall be considered as a same protocol of `A.B`
+pub(crate) fn truncate_patch_version(full_str: &str) -> &str {
+    if full_str.matches('.').count() == 2 {
+        match full_str.rfind('.') {
+            Some(pos) => &full_str[..pos],
+            None => full_str,
+        }
+    } else {
+        full_str
+    }
+}
+
 /// NodeBehaviour struct
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "NodeEvent")]
@@ -198,7 +211,7 @@ impl NetworkBuilder {
             Some(store_cfg),
             false,
             ProtocolSupport::Full,
-            SN_NODE_VERSION_STR.to_string(),
+            truncate_patch_version(SN_NODE_VERSION_STR).to_string(),
         )?;
 
         // Listen on the provided address
@@ -241,7 +254,7 @@ impl NetworkBuilder {
             None,
             true,
             ProtocolSupport::Outbound,
-            IDENTIFY_CLIENT_VERSION_STR.to_string(),
+            truncate_patch_version(IDENTIFY_CLIENT_VERSION_STR).to_string(),
         )?;
 
         if let Some(limit) = concurrency_limit {
@@ -272,7 +285,7 @@ impl NetworkBuilder {
 
             request_response::cbor::Behaviour::new(
                 [(
-                    StreamProtocol::new(REQ_RESPONSE_VERSION_STR),
+                    StreamProtocol::new(truncate_patch_version(REQ_RESPONSE_VERSION_STR)),
                     req_res_protocol,
                 )],
                 cfg,
@@ -318,7 +331,7 @@ impl NetworkBuilder {
         // Identify Behaviour
         let identify = {
             let cfg = libp2p::identify::Config::new(
-                IDENTIFY_PROTOCOL_STR.to_string(),
+                truncate_patch_version(IDENTIFY_PROTOCOL_STR).to_string(),
                 self.keypair.public(),
             )
             .with_agent_version(identify_version);

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     close_group_majority,
-    driver::SwarmDriver,
+    driver::{truncate_patch_version, SwarmDriver},
     error::{Error, Result},
     multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE,
 };
@@ -44,7 +44,7 @@ use tracing::{info, warn};
 use xor_name::XorName;
 
 /// Our agent string has as a prefix that we can match against.
-const IDENTIFY_AGENT_STR: &str = "safe/node/";
+const IDENTIFY_AGENT_STR: &str = concat!("safe/node/", env!("CARGO_PKG_VERSION"));
 
 /// Using XorName to differentiate different record content under the same key.
 pub(super) type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
@@ -196,7 +196,9 @@ impl SwarmDriver {
                         if (self.local
                             || self.dialed_peers.contains(&peer_id)
                             || self.unroutable_peers.contains(&peer_id))
-                            && info.agent_version.starts_with(IDENTIFY_AGENT_STR)
+                            && info
+                                .agent_version
+                                .starts_with(truncate_patch_version(IDENTIFY_AGENT_STR))
                         {
                             let addrs = match self.local {
                                 true => info.listen_addrs,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 09:37 UTC
This pull request adds a feature to make the protocol downward compatible for patch version updates. It updates the `driver.rs` file in `sn_networking/src` folder. The feature ensures that versions of `A.B.X` are considered as the same protocol as `A.B`. Changes include extracting the version string and updating the `StreamProtocol` based on the extracted version.
<!-- reviewpad:summarize:end --> 
