### PR TITLE
ci: fix x-platform release builds for protobuf compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,19 @@ jobs:
             target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install protobuf-compiler
+      
+      - name: Install Protobuf Compiler (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Protobuf Compiler (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install protobuf
+
+      - name: Install Protobuf Compiler (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install protoc
+
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 10:15 UTC
This pull request fixes x-platform release builds for the protobuf compiler in the continuous integration pipeline. It adds installation steps for the protobuf compiler based on the operating system (Ubuntu, macOS, Windows).
<!-- reviewpad:summarize:end --> 
