### PR TITLE
ci: use action to install protobuf

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -17,8 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install protobuf-compiler
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -44,8 +44,10 @@ jobs:
       - shell: bash
         run: cargo install just
 
-      - run: sudo apt-get install protobuf-compiler
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - shell: bash
         run: just build-release-artifacts "${{ matrix.target }}"
       - uses: actions/upload-artifact@main

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -28,8 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install protobuf-compiler
-
+      
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -31,8 +31,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - run: sudo apt-get install protobuf-compiler
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: install ripgrep
         shell: bash
         run: sudo apt-get install -y ripgrep

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,7 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -54,7 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: sudo apt-get install protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -63,7 +69,6 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install protobuf-compiler
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -93,18 +98,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protobuf Compiler (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install Protobuf Compiler (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install protobuf
-
-      - name: Install Protobuf Compiler (Windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install protoc
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -152,18 +149,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protobuf Compiler (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install Protobuf Compiler (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install protobuf
-
-      - name: Install Protobuf Compiler (Windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install protoc
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -256,18 +245,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protobuf Compiler (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install Protobuf Compiler (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install protobuf
-
-      - name: Install Protobuf Compiler (Windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install protoc
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -347,18 +328,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protobuf Compiler (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install Protobuf Compiler (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install protobuf
-
-      - name: Install Protobuf Compiler (Windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install protoc
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -480,18 +453,10 @@ jobs:
           with:
             toolchain: stable
 
-        - name: Install Protobuf Compiler (Ubuntu)
-          if: matrix.os == 'ubuntu-latest'
-          run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-  
-        - name: Install Protobuf Compiler (macOS)
-          if: matrix.os == 'macos-latest'
-          run: brew install protobuf
-  
-        - name: Install Protobuf Compiler (Windows)
-          if: matrix.os == 'windows-latest'
-          run: choco install protoc
-    
+        - name: Install Protoc
+          uses: arduino/setup-protoc@v2
+          with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
 
         - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,8 +28,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
 
-      - run: sudo apt-get install protobuf-compiler
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Build node and client
         run: cargo build --release --bin safenode --bin safe --bin faucet
         timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,18 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Install Protobuf Compiler (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install Protobuf Compiler (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install protobuf
-
-      - name: Install Protobuf Compiler (Windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install protoc
-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -86,7 +78,10 @@ jobs:
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
 
     steps:
-      - run: sudo apt-get install protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 10:49 UTC
This pull request updates the CI workflow by using an action to install protobuf instead of using `sudo apt-get install protobuf-compiler` in multiple places. It reduces duplication and improves maintainability by centralizing the installation of protobuf.
<!-- reviewpad:summarize:end --> 
