### PR TITLE
ci: disable arm builds for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,11 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
-            target: arm-unknown-linux-musleabi
-          - os: ubuntu-latest
-            target: armv7-unknown-linux-musleabihf
+          # arm builds disabled just now as protoc buffer isntall does not work there
+          # - os: ubuntu-latest
+          #   target: arm-unknown-linux-musleabi
+          # - os: ubuntu-latest
+          #   target: armv7-unknown-linux-musleabihf
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
     steps:
@@ -100,14 +101,14 @@ jobs:
         with:
           name: safe_network-x86_64-apple-darwin
           path: artifacts/x86_64-apple-darwin/release
-      - uses: actions/download-artifact@master
-        with:
-          name: safe_network-arm-unknown-linux-musleabi
-          path: artifacts/arm-unknown-linux-musleabi/release
-      - uses: actions/download-artifact@master
-        with:
-          name: safe_network-armv7-unknown-linux-musleabihf
-          path: artifacts/armv7-unknown-linux-musleabihf/release
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: safe_network-arm-unknown-linux-musleabi
+      #     path: artifacts/arm-unknown-linux-musleabi/release
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: safe_network-armv7-unknown-linux-musleabihf
+      #     path: artifacts/armv7-unknown-linux-musleabihf/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-aarch64-unknown-linux-musl


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 11:27 UTC
This pull request disables arm builds for now. The patch modifies the release workflow file to comment out the arm build configurations, specifically `arm-unknown-linux-musleabi` and `armv7-unknown-linux-musleabihf` targets. This change is made because the installation of the protoc buffer does not work on arm builds at the moment. The other build configurations for x86_64-apple-darwin, x86_64-unknown-linux-musl, and aarch64-unknown-linux-musl remain unchanged.
<!-- reviewpad:summarize:end --> 
