### PR TITLE
fix: revert protoc/tonic-build update, remove protoc-builder install …

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -17,10 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -44,10 +44,6 @@ jobs:
       - shell: bash
         run: cargo install just
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - shell: bash
         run: just build-release-artifacts "${{ matrix.target }}"
       - uses: actions/upload-artifact@main

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -28,11 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -30,11 +30,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: install ripgrep
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -57,10 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,10 +90,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -149,10 +137,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -245,10 +229,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -328,10 +308,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -452,11 +428,6 @@ jobs:
         - uses: dtolnay/rust-toolchain@stable
           with:
             toolchain: stable
-
-        - name: Install Protoc
-          uses: arduino/setup-protoc@v2
-          with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
 
         - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,11 +27,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build node and client
         run: cargo build --release --bin safenode --bin safe --bin faucet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,20 +26,14 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          # arm builds disabled just now as protoc buffer isntall does not work there
-          # - os: ubuntu-latest
-          #   target: arm-unknown-linux-musleabi
-          # - os: ubuntu-latest
-          #   target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v3
-      
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -78,11 +72,7 @@ jobs:
       AWS_DEFAULT_REGION: eu-west-2
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
 
-    steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    st
 
       - uses: actions/checkout@v3
         with:
@@ -101,14 +91,14 @@ jobs:
         with:
           name: safe_network-x86_64-apple-darwin
           path: artifacts/x86_64-apple-darwin/release
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: safe_network-arm-unknown-linux-musleabi
-      #     path: artifacts/arm-unknown-linux-musleabi/release
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: safe_network-armv7-unknown-linux-musleabihf
-      #     path: artifacts/armv7-unknown-linux-musleabihf/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-arm-unknown-linux-musleabi
+          path: artifacts/arm-unknown-linux-musleabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-armv7-unknown-linux-musleabihf
+          path: artifacts/armv7-unknown-linux-musleabihf/release
       - uses: actions/download-artifact@master
         with:
           name: safe_network-aarch64-unknown-linux-musl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -800,7 +800,7 @@ version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -1283,7 +1283,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1690,7 +1690,7 @@ dependencies = [
  "indexmap 1.9.3",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.8",
  "tracing",
 ]
 
@@ -1720,6 +1720,15 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -2411,7 +2420,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
@@ -3248,16 +3257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3345,16 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
@@ -3355,35 +3364,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.12.1"
+name = "prost-build"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "prost-derive 0.12.1",
+ "heck 0.3.3",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.9.0",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.12.1"
+name = "prost-derive"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
- "bytes",
- "heck",
- "itertools 0.11.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.1",
- "prost-types",
- "regex",
- "syn 2.0.37",
- "tempfile",
- "which",
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3400,25 +3410,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "prost-types"
-version = "0.12.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "prost 0.12.1",
+ "bytes",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -4216,7 +4214,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "prometheus-client",
- "prost 0.12.1",
+ "prost 0.9.0",
  "rand",
  "rayon",
  "rmp-serde",
@@ -4237,7 +4235,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "tokio-stream",
- "tonic 0.10.0",
+ "tonic 0.6.2",
  "tonic-build",
  "tracing",
  "tracing-appender",
@@ -4308,10 +4306,10 @@ dependencies = [
  "libp2p",
  "mockall",
  "predicates 3.0.4",
- "prost 0.12.1",
+ "prost 0.9.0",
  "regex",
  "tokio",
- "tonic 0.10.0",
+ "tonic 0.6.2",
  "tonic-build",
  "tracing",
  "tracing-core",
@@ -4427,7 +4425,7 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4725,6 +4723,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
@@ -4735,6 +4747,37 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -4766,43 +4809,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5469afaf78a11265c343a88969045c1568aa8ecc6c787dbf756e92e70f199861"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.4",
- "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.12.1",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tonic-build"
-version = "0.10.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b477abbe1d18c0b08f56cd01d1bc288668c5b5cfd19b2ae1886bbf599c546f1"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.37",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4819,7 +4834,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4844,6 +4859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4889,6 +4905,16 @@ checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -5046,6 +5072,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -43,7 +43,10 @@ itertools = "~0.11.0"
 lazy_static = "~1.4.0"
 libp2p = { version="0.52", features = ["tokio", "dns", "kad", "macros", "autonat"] }
 prometheus-client = { version = "0.21.2", optional = true }
-prost = { version = "0.12" }
+# watch out updating this, protoc compiler needs to be installed on all build systems
+# arm builds + musl are very problematic
+prost = { version = "0.9" }
+tonic = { version = "0.6.2" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.7.0"
@@ -61,7 +64,6 @@ sn_transfers = { path = "../sn_transfers", version = "0.11.15" }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-stream = { version = "~0.1.12" }
-tonic = { version = "~0.10" }
 tracing = { version = "~0.1.26" }
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
@@ -79,4 +81,6 @@ assert_fs = "1.0.0"
 tempfile = "3.6.0"
 
 [build-dependencies]
-tonic-build = { version = "~0.10" }
+# watch out updating this, protoc compiler needs to be installed on all build systems
+# arm builds + musl are very problematic
+tonic-build = { version = "~0.6.2" }

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -29,9 +29,11 @@ eyre = "~0.6.5"
 clap = { version = "3.2.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
 libp2p = { version="0.52" }
-prost = { version = "0.12" }
+# watch out updating this, protoc compiler needs to be installed on all build systems
+# arm builds + musl are very problematic
+prost = { version = "0.9" }
 regex = "1.7.1"
-tonic = { version = "~0.10" }
+tonic = { version = "0.6.2" }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = "~0.3.1"
@@ -42,7 +44,9 @@ version = "1.17.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [build-dependencies]
-tonic-build = { version = "~0.10" }
+# watch out updating this, protoc compiler needs to be installed on all build systems
+# arm builds + musl are very problematic
+tonic-build = { version = "~0.6.2" }
 
 [dev-dependencies]
 assert_fs = "~1.0"


### PR DESCRIPTION
…on ci

Reinstate arm builds

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 13:06 UTC
This pull request includes several file diffs that contain changes to multiple files. 

Summary of changes:

1. In the file `.github/workflows/generate-benchmark-charts.yml`:
   - The step for installing Protoc has been removed.

2. In the file `.github/workflows/memcheck.yml`:
   - Lines 30 to 36: An existing step named "Install Protoc" has been removed.
   - Lines 38 to 43: A new step named "install ripgrep" has been added.

3. In the file `merge.yml`:
   - Removed the step to install Protoc.
   - Removed the `repo-token` parameter for the `arduino/setup-protoc` action.
   - Made some formatting changes.

4. In the file `Cargo.toml`:
   - The `prost` dependency has been downgraded from version 0.12 to version 0.9.
   - A new dependency `tonic` has been added with version 0.6.2.
   - The `tonic-build` build dependency has been downgraded from version 0.10 to version 0.6.2.

5. In the file `.github/workflows/benchmark-prs.yml`:
   - Removed the step to install Protoc.
   - No other changes were made to the file.

6. In the file `.github/workflows/release.yml`:
   - This file diff removes the installation of Protoc in two places.
   - There seems to be an incomplete step or a typo at the end of the file.

7. In the file `.github/workflows/nightly.yml`:
   - Lines 27 to 31 have been removed, which previously installed Protoc.
   - The build command for cargo has been updated.
   
These are the summarized changes in the diff. Let me know if you have any further questions or need additional assistance.
<!-- reviewpad:summarize:end --> 
