### PR TITLE
ci :reduce the tes duration of churn and verify.

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -341,20 +341,20 @@ jobs:
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
 
-      - name: Chunks data integrity during nodes churn (during 10min) - Linux/MacOS
+      - name: Chunks data integrity during nodes churn - Linux/MacOS
         if: matrix.os != 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
-          TEST_DURATION_MINS: 10
+          TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
         timeout-minutes: 30
 
-      - name: Chunks data integrity during nodes churn (during 10min) - Windows
+      - name: Chunks data integrity during nodes churn - Windows
         if: matrix.os == 'windows-latest'
         run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
         env:
-          TEST_DURATION_MINS: 10
+          TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
         timeout-minutes: 30
@@ -461,7 +461,7 @@ jobs:
         - name: Verify the location of the data on the network (4 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture 
           env:
-            CHURN_COUNT: 4
+            CHURN_COUNT: 3
             SN_LOG: "all"
           timeout-minutes: 30
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -98,10 +98,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build unit tests before running
-        run: cargo test --release --lib --bins --no-run 
-        timeout-minutes: 30
-
       - name: Run testnet tests
         timeout-minutes: 25
         run: cargo test --release --package sn_testnet


### PR DESCRIPTION
5 minutes should be more intense in general, and a better test. We have longer running tests on nightly to catch long running test issues

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Sep 23 13:37 UTC
This pull request reduces the test duration of churn and verify. The duration for the "Chunks data integrity during nodes churn" and "Verify the location of the data on the network" tests has been reduced from 10 minutes to 5 minutes. This change aims to make the tests more intense and efficient. The longer running tests will still be performed on nightly builds to catch any potential issues.
<!-- reviewpad:summarize:end --> 
