### PR TITLE
test(gossipsub): make CI test to be more strict 0-tolerance for missed published messages

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -409,7 +409,7 @@ fn encrypt_large(
 fn package_small(file: SmallFile) -> Result<Chunk> {
     let chunk = to_chunk(file.bytes());
     if chunk.value().len() >= self_encryption::MIN_ENCRYPTABLE_BYTES {
-        return Err(Error::SmallFilePaddingNeeded(chunk.value().len()))?;
+        return Err(Error::SmallFilePaddingNeeded(chunk.value().len()).into());
     }
     Ok(chunk)
 }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -91,9 +91,7 @@ impl Node {
                     }
                 };
 
-                let keys_to_replicate = replicate_to
-                    .entry(target_peer)
-                    .or_insert(Default::default());
+                let keys_to_replicate = replicate_to.entry(target_peer).or_default();
                 keys_to_replicate.push(key.clone());
             }
         }

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -261,7 +261,6 @@ async fn data_availability_during_churn() -> Result<()> {
         let client = client.clone();
         let net_addr = net_addr.clone();
         let cash_notes = cash_notes.clone();
-        let churn_period = churn_period;
 
         let failures = failures.clone();
         let wallet_dir = paying_wallet_dir.to_path_buf().clone();

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -29,28 +29,33 @@ const TEST_CYCLES: u8 = 20;
 
 #[tokio::test]
 async fn msgs_over_gossipsub() -> Result<()> {
-    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+    let all_nodes_addrs: Vec<_> = (0..NODE_COUNT)
+        .map(|i| {
+            (
+                i,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12001 + i as u16),
+            )
+        })
+        .collect();
+
     for c in 0..TEST_CYCLES {
         let topic = format!("TestTopic-{}", rand::random::<u64>());
         println!("Testing cicle {}/{TEST_CYCLES} - topic: {topic}", c + 1);
         println!("============================================================");
 
-        let mut subs_addrs = vec![];
-        let mut subs_handles = vec![];
-
         // get a random subset of NODES_SUBSCRIBED out of NODE_COUNT nodes to subscribe to the topic
         let mut rng = rand::thread_rng();
-        let random_indexes =
+        let random_subs_nodes: Vec<_> =
             rand::seq::index::sample(&mut rng, NODE_COUNT.into(), NODES_SUBSCRIBED.into())
-                .into_vec();
+                .iter()
+                .map(|i| all_nodes_addrs[i])
+                .collect();
 
-        for node_index in random_indexes {
+        let mut subs_handles = vec![];
+        for (node_index, addr) in random_subs_nodes.clone() {
             // request current node to subscribe to the topic
-            addr.set_port(12000 + node_index as u16);
+            println!("Node #{node_index} ({addr}) subscribing to {topic} ...");
             node_subscribe_to_topic(addr, topic.clone()).await?;
-            subs_addrs.push(addr);
-
-            println!("Node {node_index} subscribed to {topic}");
 
             let handle = tokio::spawn(async move {
                 let endpoint = format!("https://{addr}");
@@ -59,16 +64,15 @@ async fn msgs_over_gossipsub() -> Result<()> {
                     .node_events(Request::new(NodeEventsRequest {}))
                     .await?;
 
-                println!("Listening to node events...");
                 let mut count = 0;
 
-                let _ = timeout(Duration::from_millis(6000), async {
+                let _ = timeout(Duration::from_millis(30000), async {
                     let mut stream = response.into_inner();
                     while let Some(Ok(e)) = stream.next().await {
                         match NodeEvent::from_bytes(&e.event) {
                             Ok(NodeEvent::GossipsubMsg { topic, msg }) => {
                                 println!(
-                                    "New gossipsub msg received on '{topic}': {}",
+                                    "Msg received on node #{node_index} '{topic}': {}",
                                     String::from_utf8(msg).unwrap()
                                 );
                                 count += 1;
@@ -94,7 +98,9 @@ async fn msgs_over_gossipsub() -> Result<()> {
         tokio::time::sleep(Duration::from_millis(3000)).await;
 
         // have all other nodes to publish each a different msg to that same topic
-        other_nodes_to_publish_on_topic(subs_addrs, topic.clone()).await?;
+        let mut other_nodes = all_nodes_addrs.clone();
+        other_nodes.retain(|node| random_subs_nodes.iter().all(|n| n != node));
+        other_nodes_to_publish_on_topic(other_nodes, topic.clone()).await?;
 
         for (node_index, addr, handle) in subs_handles.into_iter() {
             let count = handle.await??;
@@ -137,26 +143,22 @@ async fn node_unsubscribe_from_topic(addr: SocketAddr, topic: String) -> Result<
 }
 
 async fn other_nodes_to_publish_on_topic(
-    filter_addrs: Vec<SocketAddr>,
+    nodes: Vec<(u8, SocketAddr)>,
     topic: String,
 ) -> Result<()> {
-    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
-    for node_index in 1..NODE_COUNT + 1 {
-        addr.set_port(12000 + node_index as u16);
-        if filter_addrs.iter().all(|a| a != &addr) {
-            let msg = format!("TestMsgOnTopic-{topic}-from-{node_index}");
+    for (node_index, addr) in nodes {
+        let msg = format!("TestMsgOnTopic-{topic}-from-{node_index}");
 
-            let endpoint = format!("https://{addr}");
-            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
-            println!("Node {node_index} to publish on {topic} message: {msg}");
+        let endpoint = format!("https://{addr}");
+        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+        println!("Node {node_index} to publish on {topic} message: {msg}");
 
-            let _response = rpc_client
-                .publish_on_topic(Request::new(GossipsubPublishRequest {
-                    topic: topic.clone(),
-                    msg: msg.into(),
-                }))
-                .await?;
-        }
+        let _response = rpc_client
+            .publish_on_topic(Request::new(GossipsubPublishRequest {
+                topic: topic.clone(),
+                msg: msg.into(),
+            }))
+            .await?;
     }
 
     Ok(())

--- a/sn_transfers/src/transfers/transfer.rs
+++ b/sn_transfers/src/transfers/transfer.rs
@@ -46,7 +46,7 @@ impl Transfer {
             let u = CashNoteRedemption::new(derivation_index, parent_spend_addr);
             cashnote_redemptions_map
                 .entry(recipient)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(u);
         }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Sep 23 21:05 UTC
This pull request includes the following changes:
1. The addition of new message types for subscribing and publishing to a gossipsub topic in the safenode protocol.
2. Import statements and new error variants related to publishing and subscribing in the `error.rs` file.
3. Addition of new packages and dependencies related to futures and libp2p-gossipsub modules in the `Cargo.toml` file.
4. Changes to the API functionality, including new methods for subscribing and publishing on gossipsub topics, and event handling for gossipsub messages in the `api.rs` file.
5. Addition of the gossipsub behavior to the `NodeBehaviour` struct and initialization in the `NetworkBuilder` implementation.
6. Code modifications related to subscribing and publishing to a gossipsub topic in the `main.rs` and other files.
7. Addition of a new job called "gossipsub" for running Gossipsub E2E tests.
8. Changes related to adding the `"gossipsub"` feature to the `libp2p` dependency in the `Cargo.toml` file.
9. Addition of new RPC methods for subscribing and publishing on a gossipsub topic in the `safenode.proto` file.
10. Updates to the `ClientEvent` and `NodeEvent` enums to include support for gossipsub messages.
11. Introduction of support for handling gossipsub events and messages in the networking module.
12. Addition of a new file and code for gossipsub management in the CLI tool.
13. Changes related to managing gossipsub in the `SubCmd` enum and `mod.rs` file in the CLI tool.
14. Addition of a new job called "gossipsub" and modifications in other jobs in a CI/CD pipeline configuration.
15. Changes related to handling gossipsub messages in the `event.rs` file.
16. Addition of test functions for Gossipsub functionality in different files.
17. Addition of support for gossipsub management in the CLI application.
18. Modifications in the `sn_networking` module to include methods for subscribing and publishing on gossipsub topics.
19. Introduction of two new RPC methods for subscribing and publishing on gossipsub topics in a service file.

Let me know if you need further assistance with this code review.
<!-- reviewpad:summarize:end --> 
