### PR TITLE
chore(client): serialize ClientEvent

### DIFF
--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -8,6 +8,7 @@
 
 use super::error::Result;
 
+use serde::Serialize;
 use tokio::sync::broadcast;
 
 // Channel where events will be broadcasted by the client.
@@ -35,7 +36,7 @@ impl ClientEventsChannel {
 }
 
 /// Type of events broadcasted by the client to the public API.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ClientEvent {
     /// The client has been connected to the network
     ConnectedToNetwork,


### PR DESCRIPTION
I need it for my Red bindings. Is that ok? 

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Sep 23 02:21 UTC
This pull request adds serialization support for the `ClientEvent` enum in the `sn_client/src/event.rs` file. Now the `ClientEvent` enum can be serialized using serde.
<!-- reviewpad:summarize:end --> 
