### PR TITLE
ci: reduce client bench mem limits

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="1500" # mb
-          client_avg_mem_limit_mb="1150" # mb
+          client_peak_mem_limit_mb="300" # mb
+          client_avg_mem_limit_mb="200" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Sep 23 07:35 UTC
This pull request reduces the client benchmark memory limits. The client peak memory limit is decreased from 1500 MB to 300 MB, and the client average memory limit is decreased from 1150 MB to 200 MB.
<!-- reviewpad:summarize:end --> 
