### PR TITLE
feat(cli): wrap repayment error for clarity

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -10,7 +10,7 @@ use super::wallet::{ChunkedFile, BATCH_SIZE};
 use bytes::Bytes;
 use clap::Parser;
 use color_eyre::{
-    eyre::{bail, eyre, Error},
+    eyre::{bail, eyre, Context, Error},
     Help, Result,
 };
 use libp2p::futures::future::join_all;
@@ -387,7 +387,8 @@ async fn verify_and_repay_if_needed(
                     .map(|(addr, _path)| sn_protocol::NetworkAddress::ChunkAddress(*addr)),
                 true,
             )
-            .await?;
+            .await
+            .wrap_err("Failed to repay for record storage for {failed_chunks_batch:?}.")?;
 
         // outcome here is not important as we'll verify this later
         let upload_file_api = file_api.clone();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Sep 23 08:04 UTC
This pull request adds a feature to the command-line interface (CLI) to wrap repayment errors for clarity. It makes changes to the `sn_cli/src/subcommands/files.rs` file. Specifically, it adds error context to improve error handling and adds a wrap error message for failed repayment in the `verify_and_repay_if_needed` function.

Overall, this pull request improves error handling in the CLI.
<!-- reviewpad:summarize:end --> 
