### PR TITLE
feat(apis): adding client and node APIs, as well as safenode RPC serv…

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 
 [features]
 default = ["metrics"]
-local-discovery=["sn_client/local-discovery"]
+local-discovery=["sn_client/local-discovery", "sn_peers_acquisition/local-discovery"]
 metrics = ["sn_logging/process-metrics"]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
 open-metrics = ["sn_client/open-metrics"]

--- a/sn_cli/src/subcommands/gossipsub.rs
+++ b/sn_cli/src/subcommands/gossipsub.rs
@@ -18,6 +18,12 @@ pub enum GossipsubCmds {
         #[clap(name = "topic")]
         topic: String,
     },
+    /// Unsubscribe from a topic
+    Unsubscribe {
+        /// The name of the topic.
+        #[clap(name = "topic")]
+        topic: String,
+    },
     /// Publish a message on a given topic
     Publish {
         /// The name of the topic.
@@ -41,6 +47,10 @@ pub(crate) async fn gossipsub_cmds(cmds: GossipsubCmds, client: &Client) -> Resu
                     println!("New message published: {msg}");
                 }
             }
+        }
+        GossipsubCmds::Unsubscribe { topic } => {
+            client.unsubscribe_from_topic(topic.clone())?;
+            println!("Unsubscribed from topic '{topic}'.");
         }
         GossipsubCmds::Publish { topic, msg } => {
             client.publish_on_topic(topic.clone(), msg.into())?;

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -507,6 +507,13 @@ impl Client {
         Ok(())
     }
 
+    /// Unsubscribe from given gossipsub topic
+    pub fn unsubscribe_from_topic(&self, topic_id: String) -> Result<()> {
+        info!("Unsubscribing from topic id: {topic_id}");
+        self.network.unsubscribe_from_topic(topic_id)?;
+        Ok(())
+    }
+
     /// Publish message on given topic
     pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
         info!("Publishing msg on topic id: {topic_id}");

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -116,6 +116,8 @@ pub enum SwarmCmd {
     },
     /// Subscribe to a given Gossipsub topic
     GossipsubSubscribe(String),
+    /// Unsubscribe from a given Gossipsub topic
+    GossipsubUnsubscribe(String),
     /// Publish a message through Gossipsub protocol
     GossipsubPublish {
         /// Topic to publish on
@@ -364,6 +366,13 @@ impl SwarmDriver {
             SwarmCmd::GossipsubSubscribe(topic_id) => {
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm.behaviour_mut().gossipsub.subscribe(&topic_id)?;
+            }
+            SwarmCmd::GossipsubUnsubscribe(topic_id) => {
+                let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
+                self.swarm
+                    .behaviour_mut()
+                    .gossipsub
+                    .unsubscribe(&topic_id)?;
             }
             SwarmCmd::GossipsubPublish { topic_id, msg } => {
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -233,6 +233,12 @@ impl Network {
         Ok(())
     }
 
+    /// Unsubscribe from given gossipsub topic
+    pub fn unsubscribe_from_topic(&self, topic_id: String) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::GossipsubUnsubscribe(topic_id))?;
+        Ok(())
+    }
+
     /// Publish a msg on a given topic
     pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::GossipsubPublish { topic_id, msg })?;

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -83,6 +83,12 @@ impl RunningNode {
         Ok(())
     }
 
+    /// Unsubscribe from given gossipsub topic
+    pub fn unsubscribe_from_topic(&self, topic_id: String) -> Result<()> {
+        self.network.unsubscribe_from_topic(topic_id)?;
+        Ok(())
+    }
+
     /// Publish a message on a given gossipsub topic
     pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
         self.network.publish_on_topic(topic_id, msg)?;

--- a/sn_node/src/bin/safenode/rpc.rs
+++ b/sn_node/src/bin/safenode/rpc.rs
@@ -25,10 +25,10 @@ use tracing::{debug, info, trace};
 use safenode_proto::safe_node_server::{SafeNode, SafeNodeServer};
 use safenode_proto::{
     GossipsubPublishRequest, GossipsubPublishResponse, GossipsubSubscribeRequest,
-    GossipsubSubscribeResponse, NetworkInfoRequest, NetworkInfoResponse, NodeEvent,
-    NodeEventsRequest, NodeInfoRequest, NodeInfoResponse, RecordAddressesRequest,
-    RecordAddressesResponse, RestartRequest, RestartResponse, StopRequest, StopResponse,
-    UpdateRequest, UpdateResponse,
+    GossipsubSubscribeResponse, GossipsubUnsubscribeRequest, GossipsubUnsubscribeResponse,
+    NetworkInfoRequest, NetworkInfoResponse, NodeEvent, NodeEventsRequest, NodeInfoRequest,
+    NodeInfoResponse, RecordAddressesRequest, RecordAddressesResponse, RestartRequest,
+    RestartResponse, StopRequest, StopResponse, UpdateRequest, UpdateResponse,
 };
 
 // this includes code generated from .proto files
@@ -172,6 +172,27 @@ impl SafeNode for SafeNodeRpcService {
             Err(err) => Err(Status::new(
                 Code::Internal,
                 format!("Failed to subscribe to topic '{topic}': {err}"),
+            )),
+        }
+    }
+
+    async fn unsubscribe_from_topic(
+        &self,
+        request: Request<GossipsubUnsubscribeRequest>,
+    ) -> Result<Response<GossipsubUnsubscribeResponse>, Status> {
+        trace!(
+            "RPC request received at {}: {:?}",
+            self.addr,
+            request.get_ref()
+        );
+
+        let topic = &request.get_ref().topic;
+
+        match self.running_node.unsubscribe_from_topic(topic.clone()) {
+            Ok(()) => Ok(Response::new(GossipsubUnsubscribeResponse {})),
+            Err(err) => Err(Status::new(
+                Code::Internal,
+                format!("Failed to unsubscribe from topic '{topic}': {err}"),
             )),
         }
     }

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -52,6 +52,13 @@ message GossipsubSubscribeRequest {
 
 message GossipsubSubscribeResponse {}
 
+// Unsubsribe from a gossipsub topic
+message GossipsubUnsubscribeRequest {
+  string topic = 1;
+}
+
+message GossipsubUnsubscribeResponse {}
+
 // Publish a msg on a gossipsub topic
 message GossipsubPublishRequest {
   string topic = 1;

--- a/sn_node/src/protocol/safenode_proto/safenode.proto
+++ b/sn_node/src/protocol/safenode_proto/safenode.proto
@@ -37,6 +37,9 @@ service SafeNode {
   // Subscribe to a Gossipsub topic
   rpc SubscribeToTopic (GossipsubSubscribeRequest) returns (GossipsubSubscribeResponse);
 
+  // Unsubscribe from a Gossipsub topic
+  rpc UnsubscribeFromTopic (GossipsubUnsubscribeRequest) returns (GossipsubUnsubscribeResponse);
+
   // Publish a msg on a Gossipsub topic
   rpc PublishOnTopic (GossipsubPublishRequest) returns (GossipsubPublishResponse);
 


### PR DESCRIPTION
…ice to unsubscribe from gossipsub topics

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Sep 23 19:02 UTC
This pull request includes the following changes:

- Added an `unsubscribe_from_topic` function to the `Network` struct in the `sn_networking` crate. This function unsubscribes from the specified gossipsub topic.
- Added a new command "Unsubscribe" to handle unsubscribing from a Gossipsub topic.
- Implemented the function `gossipsub_unsubscribe` to handle the "Unsubscribe" command.
- Added support for unsubscribing from Gossipsub topics in the SafeNode RPC client.
- Added functionality to handle unsubscribing from a given topic in the `SafeNodeRpcService` struct.
- Added a new function `node_unsubscribe_from_topic` to handle topic unsubscription in the "msgs_over_gossipsub.rs" file.
- Added an implementation for unsubscribing from a topic in the `SafeNodeRpcService` struct.
- Added an implementation for unsubscribing from a topic in the `RunningNode` struct.
- Added a new RPC method `UnsubscribeFromTopic` to allow clients to unsubscribe from a Gossipsub topic.
- Updated the `Cargo.toml` file to include an additional feature for local discovery.
- Added new message types for unsubscribing from a gossipsub topic in the `safenode.proto` and `req_resp_types.proto` files.
- Added a new variant to the `SwarmCmd` enum to handle topic unsubscription in the `gossipsub.rs` file.
- Updated the `api.rs` file with a new method for unsubscribing from a gossipsub topic and improvements to the `publish_on_topic` method.

These changes enhance the functionality related to unsubscribing from and publishing messages on Gossipsub topics.
<!-- reviewpad:summarize:end --> 
