### PR TITLE
feat(networking): register provider records when we store a record

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -234,6 +234,7 @@ impl SwarmDriver {
                         if !new_keys_to_fetch.is_empty() {
                             self.send_event(NetworkEvent::KeysForReplication(new_keys_to_fetch));
                         }
+                        self.swarm.behaviour_mut().kademlia.start_providing(key)?;
                     }
                     Err(err) => return Err(err.into()),
                 };

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -188,11 +188,8 @@ impl NetworkBuilder {
             .set_caching(KademliaCaching::Enabled {
                 max_peers: CLOSE_GROUP_SIZE as u16 * 2,
             })
-            // Emit PUT events for validation prior to insertion into the RecordStore.
-            // This is no longer needed as the record_storage::put now can carry out validation.
-            // .set_record_filtering(KademliaStoreInserts::FilterBoth)
             // Disable provider records publication job
-            .set_provider_publication_interval(None);
+            .set_provider_publication_interval(Some(Duration::from_secs(60)));
 
         let store_cfg = {
             // Configures the disk_store to store records under the provided path and increase the max record size

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -696,10 +696,9 @@ impl SwarmDriver {
                 let _ = self.check_for_change_in_our_close_group();
             }
             KademliaEvent::InboundRequest {
-                request: InboundRequest::PutRecord { .. },
+                request: InboundRequest::AddProvider { record },
             } => {
-                // Ignored to reduce logging. When `Record filtering` is enabled,
-                // the `record` variable will contain the content for further validation before put.
+                info!("Provider to be added: {record:?}")
             }
             KademliaEvent::InboundRequest {
                 request:

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -31,7 +31,7 @@ const MAX_RECORDS_COUNT: usize = 2048;
 
 /// A `RecordStore` that stores records on disk.
 pub struct NodeRecordStore {
-    /// The identity of the peer owning the store.
+    /// The identity of the peer owning the store as record Key
     local_key: KBucketKey<PeerId>,
     /// The configuration of the store.
     config: NodeRecordStoreConfig,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Sep 23 10:07 UTC
This pull request adds a new feature to the networking module. Specifically, it registers provider records when a record is stored. 

The changes include modifying the `SwarmDriver` implementation to start providing the key when a record is stored, updating the `NetworkBuilder` configuration to set the provider publication interval, and updating the `SwarmDriver` implementation to handle inbound requests for adding providers. 

Additionally, the `NodeRecordStore` struct in the `record_store.rs` file has been updated to include the record key as the identity of the peer owning the store.
<!-- reviewpad:summarize:end --> 
