### PR TITLE
feat: deep clean sn_transfers, reduce exposition, remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,7 +4536,6 @@ dependencies = [
  "itertools 0.11.0",
  "lazy_static",
  "pprof",
- "quickcheck",
  "rand",
  "rmp-serde",
  "serde",

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -29,7 +29,7 @@ use sn_client::Client;
 #[cfg(feature = "metrics")]
 use sn_logging::{init_logging, metrics::init_metrics, LogFormat};
 use sn_peers_acquisition::parse_peers_args;
-use sn_transfers::wallet::bls_secret_from_hex;
+use sn_transfers::bls_secret_from_hex;
 use std::path::PathBuf;
 use tracing::Level;
 

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -11,7 +11,7 @@ use clap::Subcommand;
 use color_eyre::{eyre::WrapErr, Result, Section};
 use sn_client::{Client, ClientRegister, Error as ClientError, WalletClient};
 use sn_protocol::storage::RegisterAddress;
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use std::path::Path;
 use xor_name::XorName;
 

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -9,8 +9,8 @@
 use clap::Parser;
 use color_eyre::{eyre::eyre, Result};
 use sn_client::{Client, Files, WalletClient};
-use sn_transfers::wallet::{parse_main_pubkey, LocalWallet};
 use sn_transfers::NanoTokens;
+use sn_transfers::{parse_main_pubkey, LocalWallet};
 use std::{
     io::Read,
     path::{Path, PathBuf},

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -31,7 +31,7 @@ use sn_protocol::{
 use sn_transfers::{MainPubkey, NanoTokens, SignedSpend, UniquePubkey};
 
 use sn_registers::SignedRegister;
-use sn_transfers::{transfers::SpendRequest, wallet::Transfer};
+use sn_transfers::{SpendRequest, Transfer};
 use std::time::Duration;
 use tokio::{sync::OwnedSemaphorePermit, task::spawn};
 use tracing::trace;

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 #[allow(missing_docs)]
 pub enum Error {
     #[error("Genesis error {0}")]
-    GenesisError(#[from] sn_transfers::genesis::Error),
+    GenesisError(#[from] sn_transfers::GenesisError),
 
     /// Could not acquire a Semaphore permit.
     #[error("Could not acquire a Semaphore permit.")]
@@ -29,7 +29,7 @@ pub enum Error {
     NoNetworkConcurrencyLimiterFound,
 
     #[error("Transfer Error {0}.")]
-    Transfers(#[from] sn_transfers::wallet::Error),
+    Transfers(#[from] sn_transfers::WalletError),
 
     #[error("Network Error {0}.")]
     Network(#[from] sn_networking::Error),

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -1,8 +1,8 @@
 use super::{wallet::send, Result};
 use crate::Client;
 
-use sn_transfers::genesis::{create_faucet_wallet, load_genesis_wallet};
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
+use sn_transfers::{create_faucet_wallet, load_genesis_wallet};
 use sn_transfers::{CashNote, MainPubkey, NanoTokens};
 
 /// Returns a cash_note with the requested number of tokens, for use by E2E test instances.

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -21,7 +21,7 @@ use sn_protocol::{
     storage::{Chunk, ChunkAddress},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 
 use std::{
     fs::{self, create_dir_all, File},

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -19,7 +19,7 @@ use sn_protocol::{
 use sn_registers::{
     Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister, User,
 };
-use sn_transfers::wallet::Transfer;
+use sn_transfers::Transfer;
 
 use std::collections::{BTreeSet, LinkedList};
 use xor_name::XorName;

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -15,8 +15,8 @@ use sn_protocol::{
     storage::{try_deserialize_record, RecordHeader, RecordKind, SpendAddress},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::wallet::{LocalWallet, Transfer};
 use sn_transfers::{CashNote, DerivationIndex, SignedSpend, Transaction, UniquePubkey};
+use sn_transfers::{LocalWallet, Transfer};
 use tokio::task::JoinSet;
 
 impl Network {

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -8,7 +8,7 @@
 
 use sn_client::{Client, Error, WalletClient};
 use sn_registers::RegisterAddress;
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use xor_name::XorName;
 
 use bls::SecretKey;

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -20,7 +20,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use sn_transfers::MainSecretKey;
 use std::{
     collections::HashSet,

--- a/sn_node/src/bin/faucet/main.rs
+++ b/sn_node/src/bin/faucet/main.rs
@@ -14,7 +14,7 @@ use faucet_server::run_faucet_server;
 use sn_client::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet, Client};
 use sn_logging::{init_logging, LogFormat, LogOutputDest};
 use sn_peers_acquisition::{parse_peers_args, PeersArgs};
-use sn_transfers::{wallet::parse_main_pubkey, NanoTokens};
+use sn_transfers::{parse_main_pubkey, NanoTokens};
 use std::path::PathBuf;
 use tracing::info;
 use tracing_core::Level;

--- a/sn_node/src/error.rs
+++ b/sn_node/src/error.rs
@@ -8,7 +8,7 @@
 
 use sn_networking::Error as NetworkError;
 use sn_protocol::error::Error as ProtocolError;
-use sn_transfers::wallet::Error as RewardsWalletError;
+use sn_transfers::WalletError;
 use thiserror::Error;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
@@ -27,5 +27,5 @@ pub enum Error {
     NodeEventParsingFailed,
 
     #[error("Node's rewards wallet error {0}")]
-    RewardsWallet(#[from] RewardsWalletError),
+    RewardsWallet(#[from] WalletError),
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -20,10 +20,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_registers::SignedRegister;
-use sn_transfers::{
-    genesis::{is_genesis_parent_tx, GENESIS_CASHNOTE},
-    wallet::{LocalWallet, Transfer},
-};
+use sn_transfers::{is_genesis_parent_tx, LocalWallet, Transfer, GENESIS_CASHNOTE};
 use sn_transfers::{CashNote, NanoTokens, SignedSpend, UniquePubkey};
 use std::collections::{BTreeSet, HashSet};
 

--- a/sn_node/src/spends.rs
+++ b/sn_node/src/spends.rs
@@ -11,7 +11,7 @@ use sn_protocol::{
     error::{Error, Result},
     storage::SpendAddress,
 };
-use sn_transfers::genesis::{is_genesis_parent_tx, GENESIS_CASHNOTE};
+use sn_transfers::{is_genesis_parent_tx, GENESIS_CASHNOTE};
 use sn_transfers::{SignedSpend, UniquePubkey};
 use std::{
     collections::{BTreeSet, HashSet},

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -18,7 +18,7 @@ use self_encryption::MIN_ENCRYPTABLE_BYTES;
 use sn_client::{load_faucet_wallet_from_genesis_wallet, send, Client, Files};
 use sn_peers_acquisition::parse_peer_addr;
 use sn_protocol::storage::ChunkAddress;
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 
 use bytes::Bytes;
 use eyre::{eyre, Result};

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -22,7 +22,7 @@ use sn_protocol::{
     storage::{Chunk, ChunkAddress, RegisterAddress, SpendAddress},
     NetworkAddress,
 };
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use sn_transfers::{CashNote, MainSecretKey, NanoTokens};
 use std::{
     collections::{BTreeMap, VecDeque},

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -15,7 +15,7 @@ use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress},
     NetworkAddress,
 };
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use sn_transfers::NanoTokens;
 use xor_name::XorName;
 

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -12,7 +12,7 @@ use common::{get_client_and_wallet, get_wallet, init_logging};
 
 use sn_client::send;
 
-use sn_transfers::transfers::create_offline_transfer;
+use sn_transfers::create_offline_transfer;
 use sn_transfers::{rng, Hash, NanoTokens, UniquePubkey};
 
 use assert_fs::TempDir;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -25,7 +25,7 @@ use sn_client::{Client, Files, WalletClient};
 use sn_logging::{init_logging, LogFormat, LogOutputDest};
 use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{storage::ChunkAddress, NetworkAddress, PrettyPrintRecordKey};
-use sn_transfers::wallet::LocalWallet;
+use sn_transfers::LocalWallet;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs::File,

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -30,7 +30,6 @@ xor_name = "5.0.0"
 
 [dev-dependencies]
 criterion = "0.4.0"
-quickcheck = "1.0.3"
 assert_fs = "1.0.0"
 eyre = "0.6.8"
 

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -37,6 +37,6 @@ eyre = "0.6.8"
 version = "0.11.0"
 features = [ "flamegraph" ]
 
-# [[bench]]
-# name = "reissue"
-# harness = false
+[[bench]]
+name = "reissue"
+harness = false

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -38,6 +38,6 @@ eyre = "0.6.8"
 version = "0.11.0"
 features = [ "flamegraph" ]
 
-[[bench]]
-name = "reissue"
-harness = false
+# [[bench]]
+# name = "reissue"
+# harness = false

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -44,9 +44,9 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
 
     // simulate spentbook to check for double spends
     let mut spentbook_node = BTreeMap::new();
-    for spend in offline_transfer.all_spend_requests.clone().into_iter() {
+    for spend in &offline_transfer.all_spend_requests {
         if spentbook_node
-            .insert(*spend.signed_spend.unique_pubkey(), spend)
+            .insert(*spend.signed_spend.unique_pubkey(), spend.clone())
             .is_some()
         {
             panic!("cashnote double spend");

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -13,7 +13,7 @@ use sn_transfers::{
     create_first_cash_note_from_key, create_offline_transfer, rng, CashNote, DerivationIndex, Hash,
     MainSecretKey, NanoTokens, UniquePubkey,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 const N_OUTPUTS: u64 = 100;
 
@@ -43,12 +43,9 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     .expect("transfer to succeed");
 
     // simulate spentbook to check for double spends
-    let mut spentbook_node = BTreeMap::new();
+    let mut spentbook_node = BTreeSet::new();
     for spend in &offline_transfer.all_spend_requests {
-        if spentbook_node
-            .insert(*spend.signed_spend.unique_pubkey(), spend.clone())
-            .is_some()
-        {
+        if !spentbook_node.insert(*spend.signed_spend.unique_pubkey()) {
             panic!("cashnote double spend");
         };
     }
@@ -110,7 +107,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     .expect("transfer to succeed");
 
     // simulate spentbook to check for double spends
-    let mut spentbook_node = BTreeMap::new();
+    let mut spentbook_node = BTreeSet::new();
     let signed_spends: BTreeSet<_> = offline_transfer
         .all_spend_requests
         .clone()
@@ -118,10 +115,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .map(|spend| spend.signed_spend)
         .collect();
     for spend in signed_spends.into_iter() {
-        if spentbook_node
-            .insert(*spend.unique_pubkey(), spend)
-            .is_some()
-        {
+        if !spentbook_node.insert(*spend.unique_pubkey()) {
             panic!("cashnote double spend");
         };
     }

--- a/sn_transfers/src/builder.rs
+++ b/sn_transfers/src/builder.rs
@@ -52,32 +52,6 @@ impl TransactionBuilder {
         self
     }
 
-    /// Add an input given a CashNote and its DerivedSecretKey.
-    pub fn add_input_cashnote(
-        mut self,
-        cashnote: &CashNote,
-        derived_key: &DerivedSecretKey,
-    ) -> Result<Self> {
-        let input_src_tx = cashnote.src_tx.clone();
-        let input = Input {
-            unique_pubkey: cashnote.unique_pubkey(),
-            amount: cashnote.value()?,
-        };
-        self = self.add_input(input, derived_key.clone(), input_src_tx);
-        Ok(self)
-    }
-
-    /// Add an input given a list of CashNotes and associated DerivedSecretKeys.
-    pub fn add_input_cashnotes(
-        mut self,
-        cashnotes: &[(CashNote, DerivedSecretKey)],
-    ) -> Result<Self> {
-        for (cashnote, derived_key) in cashnotes.iter() {
-            self = self.add_input_cashnote(cashnote, derived_key)?;
-        }
-        Ok(self)
-    }
-
     /// Add an output given the token, the MainPubkey and the DerivationIndex
     pub fn add_output(
         mut self,
@@ -110,38 +84,6 @@ impl TransactionBuilder {
     pub fn set_fee_output(mut self, output: FeeOutput) -> Self {
         self.fee = output;
         self
-    }
-
-    /// Get a list of input ids.
-    pub fn input_ids(&self) -> Vec<UniquePubkey> {
-        self.inputs.iter().map(|i| i.unique_pubkey()).collect()
-    }
-
-    /// Get sum of inputs
-    pub fn inputs_tokens_sum(&self) -> NanoTokens {
-        let amount = self.inputs.iter().map(|i| i.amount.as_nano()).sum();
-        NanoTokens::from(amount)
-    }
-
-    /// Get sum of outputs
-    pub fn outputs_tokens_sum(&self) -> NanoTokens {
-        let amount = self
-            .outputs
-            .iter()
-            .map(|o| o.amount.as_nano())
-            .chain(std::iter::once(self.fee.token.as_nano()))
-            .sum();
-        NanoTokens::from(amount)
-    }
-
-    /// Get inputs.
-    pub fn inputs(&self) -> &Vec<Input> {
-        &self.inputs
-    }
-
-    /// Get outputs.
-    pub fn outputs(&self) -> &Vec<Output> {
-        &self.outputs
     }
 
     /// Build the Transaction by signing the inputs. Return a CashNoteBuilder.

--- a/sn_transfers/src/cashnote.rs
+++ b/sn_transfers/src/cashnote.rs
@@ -199,8 +199,6 @@ pub(crate) mod tests {
     use super::*;
 
     use crate::{transaction::Output, FeeOutput, Hash, NanoTokens, UniquePubkey};
-    use bls::SecretKey;
-    use std::convert::TryInto;
 
     #[test]
     fn from_hex_should_deserialize_a_hex_encoded_string_to_a_cashnote() -> Result<(), Error> {
@@ -325,19 +323,5 @@ pub(crate) mod tests {
         ));
 
         Ok(())
-    }
-
-    fn get_secret_key_from_hex(sk_hex: &str) -> Result<SecretKey, Error> {
-        let sk_bytes =
-            hex::decode(sk_hex).map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
-        let mut sk_bytes: [u8; bls::SK_SIZE] = sk_bytes.try_into().unwrap_or_else(|v: Vec<u8>| {
-            panic!(
-                "Expected vec of length {} but received vec of length {}",
-                bls::SK_SIZE,
-                v.len()
-            )
-        });
-        sk_bytes.reverse();
-        Ok(SecretKey::from_bytes(sk_bytes)?)
     }
 }

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -111,7 +111,7 @@ fn create_genesis_wallet() -> LocalWallet {
 }
 
 /// Create a first CashNote given any key (i.e. not specifically the hard coded genesis key).
-/// The derivation index and blinding factor are hard coded to ensure deterministic creation.
+/// The derivation index is hard coded to ensure deterministic creation.
 /// This is useful in tests.
 pub fn create_first_cash_note_from_key(
     first_cash_note_key: &MainSecretKey,

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -5,101 +5,54 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-#![allow(dead_code)]
-#![allow(clippy::result_large_err)]
 
 #[macro_use]
 extern crate tracing;
-
-/// Genesis utilities.
-pub mod genesis;
-/// Client handling of token transfers.
-pub mod transfers;
-/// A wallet for network tokens.
-pub mod wallet;
 
 mod address;
 mod builder;
 mod cashnote;
 mod error;
 mod fee_output;
+mod genesis;
 mod nano;
+mod reason_hash;
 mod signed_spend;
 mod transaction;
+mod transfers;
 mod unique_keys;
+mod wallet;
 
-// re-export crates used in our public API
+pub(crate) use crate::{builder::TransactionBuilder, fee_output::FeeOutput, transaction::Input};
+
+/// Types used in the public API
 pub use crate::{
     address::SpendAddress,
-    builder::TransactionBuilder,
     cashnote::CashNote,
     error::{Error, Result},
-    fee_output::FeeOutput,
     nano::NanoTokens,
+    reason_hash::Hash,
     signed_spend::{SignedSpend, Spend},
-    transaction::{Input, Output, Transaction},
+    transaction::Transaction,
+    transfers::{OfflineTransfer, SpendRequest},
     unique_keys::{DerivationIndex, DerivedSecretKey, MainPubkey, MainSecretKey, UniquePubkey},
+    wallet::Transfer,
 };
-pub use bls::{self, rand, Ciphertext, PublicKey, PublicKeySet, Signature, SignatureShare};
 
-use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
+/// Utilities exposed
+pub use crate::{
+    genesis::{
+        create_faucet_wallet, create_first_cash_note_from_key, is_genesis_parent_tx,
+        load_genesis_wallet,
+    },
+    genesis::{Error as GenesisError, GENESIS_CASHNOTE},
+    transfers::create_offline_transfer,
+    wallet::{bls_secret_from_hex, parse_main_pubkey},
+    wallet::{Error as WalletError, LocalWallet, Result as WalletResult},
+};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize)]
-pub struct Hash([u8; 32]);
-
-impl Hash {
-    #[allow(clippy::self_named_constructors)]
-    /// sha3 256 hash
-    pub fn hash(input: &[u8]) -> Self {
-        Self::from(sha3_256(input))
-    }
-
-    /// Access the 32 byte slice of the hash
-    pub fn slice(&self) -> &[u8; 32] {
-        &self.0
-    }
-
-    /// Deserializes a `Hash` represented as a hex string to a `Hash`.
-    pub fn from_hex(hex: &str) -> Result<Self, Error> {
-        let mut h = Self::default();
-        hex::decode_to_slice(hex, &mut h.0)
-            .map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
-        Ok(h)
-    }
-
-    /// Serialize this `Hash` instance to a hex string.
-    pub fn to_hex(&self) -> String {
-        hex::encode(self.0)
-    }
-}
-
-impl FromStr for Hash {
-    type Err = Error;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Hash::from_hex(s)
-    }
-}
-
-impl From<[u8; 32]> for Hash {
-    fn from(val: [u8; 32]) -> Hash {
-        Hash(val)
-    }
-}
-
-// Display Hash value as hex in Debug output.  consolidates 36 lines to 3 for pretty output
-impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Hash").field(&self.to_hex()).finish()
-    }
-}
-
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
+// re-export crates used in our public API
+pub use bls::{self, rand, Ciphertext, Signature};
 
 /// This is a helper module to make it a bit easier
 /// and regular for API callers to instantiate
@@ -117,115 +70,5 @@ pub mod rng {
 
     pub fn from_seed(seed: <StdRng as SeedableRng>::Seed) -> StdRng {
         StdRng::from_seed(seed)
-    }
-}
-
-pub(crate) fn sha3_256(input: &[u8]) -> [u8; 32] {
-    use tiny_keccak::{Hasher, Sha3};
-
-    let mut sha3 = Sha3::v256();
-    let mut output = [0; 32];
-    sha3.update(input);
-    sha3.finalize(&mut output);
-    output
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use quickcheck::{Arbitrary, Gen};
-
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct TinyInt(pub u8);
-
-    impl TinyInt {
-        pub fn coerce<T: From<u8>>(self) -> T {
-            self.0.into()
-        }
-    }
-
-    impl std::fmt::Debug for TinyInt {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl Arbitrary for TinyInt {
-        fn arbitrary(g: &mut Gen) -> Self {
-            Self(u8::arbitrary(g) % 5)
-        }
-
-        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            Box::new((0..(self.0)).rev().map(Self))
-        }
-    }
-
-    #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct TinyVec<T>(pub Vec<T>);
-
-    impl<T> TinyVec<T> {
-        pub fn into_iter(self) -> impl Iterator<Item = T> {
-            self.0.into_iter()
-        }
-    }
-
-    impl<T: std::fmt::Debug> std::fmt::Debug for TinyVec<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
-        }
-    }
-
-    impl<T: Arbitrary> Arbitrary for TinyVec<T> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let n = u8::arbitrary(g) % 7;
-            let mut vec = Vec::new();
-            for _ in 0..n {
-                vec.push(T::arbitrary(g));
-            }
-            Self(vec)
-        }
-
-        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            Box::new(self.0.shrink().map(Self))
-        }
-    }
-
-    #[test]
-    fn hash() {
-        let data = b"hello world";
-        let expected = b"\
-            \x64\x4b\xcc\x7e\x56\x43\x73\x04\x09\x99\xaa\xc8\x9e\x76\x22\xf3\
-            \xca\x71\xfb\xa1\xd9\x72\xfd\x94\xa3\x1c\x3b\xfb\xf2\x4e\x39\x38\
-        ";
-        assert_eq!(sha3_256(data), *expected);
-
-        let hash = Hash::hash(data);
-        assert_eq!(hash.slice(), expected);
-    }
-
-    #[test]
-    fn hex_encoding() {
-        let data = b"hello world";
-        let expected_hex = "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
-
-        let hash = Hash::hash(data);
-
-        assert_eq!(hash.to_hex(), expected_hex.to_string());
-        assert_eq!(Hash::from_hex(expected_hex), Ok(hash));
-
-        let too_long_hex = format!("{expected_hex}ab");
-        assert_eq!(
-            Hash::from_hex(&too_long_hex),
-            Err(Error::HexDeserializationFailed(
-                "Invalid string length".to_string()
-            ))
-        );
-
-        assert_eq!(
-            Hash::from_hex(&expected_hex[0..30]),
-            Err(Error::HexDeserializationFailed(
-                "Invalid string length".to_string()
-            ))
-        );
     }
 }

--- a/sn_transfers/src/reason_hash.rs
+++ b/sn_transfers/src/reason_hash.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+use crate::Error;
+
+/// sha3 256 hash used for Spend Reasons, Transaction hashes, anything hash related in this crate
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize)]
+pub struct Hash([u8; 32]);
+
+impl Hash {
+    #[allow(clippy::self_named_constructors)]
+    /// sha3 256 hash
+    pub fn hash(input: &[u8]) -> Self {
+        Self::from(sha3_256(input))
+    }
+
+    /// Access the 32 byte slice of the hash
+    pub fn slice(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Deserializes a `Hash` represented as a hex string to a `Hash`.
+    pub fn from_hex(hex: &str) -> Result<Self, Error> {
+        let mut h = Self::default();
+        hex::decode_to_slice(hex, &mut h.0)
+            .map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
+        Ok(h)
+    }
+
+    /// Serialize this `Hash` instance to a hex string.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+impl FromStr for Hash {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Hash::from_hex(s)
+    }
+}
+
+impl From<[u8; 32]> for Hash {
+    fn from(val: [u8; 32]) -> Hash {
+        Hash(val)
+    }
+}
+
+// Display Hash value as hex in Debug output.  consolidates 36 lines to 3 for pretty output
+impl fmt::Debug for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Hash").field(&self.to_hex()).finish()
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+pub(crate) fn sha3_256(input: &[u8]) -> [u8; 32] {
+    use tiny_keccak::{Hasher, Sha3};
+
+    let mut sha3 = Sha3::v256();
+    let mut output = [0; 32];
+    sha3.update(input);
+    sha3.finalize(&mut output);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash() {
+        let data = b"hello world";
+        let expected = b"\
+            \x64\x4b\xcc\x7e\x56\x43\x73\x04\x09\x99\xaa\xc8\x9e\x76\x22\xf3\
+            \xca\x71\xfb\xa1\xd9\x72\xfd\x94\xa3\x1c\x3b\xfb\xf2\x4e\x39\x38\
+        ";
+        assert_eq!(sha3_256(data), *expected);
+
+        let hash = Hash::hash(data);
+        assert_eq!(hash.slice(), expected);
+    }
+
+    #[test]
+    fn hex_encoding() {
+        let data = b"hello world";
+        let expected_hex = "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938";
+
+        let hash = Hash::hash(data);
+
+        assert_eq!(hash.to_hex(), expected_hex.to_string());
+        assert_eq!(Hash::from_hex(expected_hex), Ok(hash));
+
+        let too_long_hex = format!("{expected_hex}ab");
+        assert_eq!(
+            Hash::from_hex(&too_long_hex),
+            Err(Error::HexDeserializationFailed(
+                "Invalid string length".to_string()
+            ))
+        );
+
+        assert_eq!(
+            Hash::from_hex(&expected_hex[0..30]),
+            Err(Error::HexDeserializationFailed(
+                "Invalid string length".to_string()
+            ))
+        );
+    }
+}

--- a/sn_transfers/src/transfers/mod.rs
+++ b/sn_transfers/src/transfers/mod.rs
@@ -34,34 +34,20 @@ use std::collections::BTreeMap;
 
 use xor_name::XorName;
 
-pub(crate) use self::error::{Error, Result};
-pub use self::transfer::create_offline_transfer;
+use crate::{CashNote, SignedSpend, Transaction, UniquePubkey};
 
-use crate::{
-    CashNote, DerivationIndex, DerivedSecretKey, MainPubkey, NanoTokens, SignedSpend, Transaction,
-    UniquePubkey,
-};
-
+pub use self::error::{Error, Result};
 pub type ContentPaymentsIdMap = BTreeMap<XorName, Vec<UniquePubkey>>;
 
-/// The input details necessary to
-/// carry out a transfer of tokens.
-#[derive(Debug)]
-pub struct TranferInputs {
-    /// The selected cash_notes to spend, with the necessary amounts contained
-    /// to transfer the below specified amount of tokens to each recipients.
-    pub cash_notes_to_spend: Vec<(CashNote, DerivedSecretKey)>,
-    /// The amounts and cash_note ids for the cash_notes that will be created to hold the transferred tokens.
-    pub recipients: Vec<(NanoTokens, MainPubkey, DerivationIndex)>,
-    /// Any surplus amount after spending the necessary input cash_notes.
-    pub change: (NanoTokens, MainPubkey),
-}
+/// Utility function to create an offline transfer
+pub use self::transfer::create_offline_transfer;
 
-/// Output data of a Transfer.
+/// Offline Transfer
+/// This struct contains all the necessary information to carry out the transfer.
 /// The created cash_notes and change cash_note from a transfer
 /// of tokens from one or more cash_notes, into one or more new cash_notes.
 #[derive(custom_debug::Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-pub struct TransferOutputs {
+pub struct OfflineTransfer {
     /// This is the transaction where all the below
     /// spends were made and cash_notes created.
     pub tx: Transaction,

--- a/sn_transfers/src/unique_keys.rs
+++ b/sn_transfers/src/unique_keys.rs
@@ -6,11 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    rand::{distributions::Standard, Rng, RngCore},
-    PublicKey,
-};
-use bls::{serde_impl::SerdeSecret, SecretKey, PK_SIZE};
+use crate::rand::{distributions::Standard, Rng, RngCore};
+use bls::{serde_impl::SerdeSecret, PublicKey, SecretKey, PK_SIZE};
 use serde::{Deserialize, Serialize};
 
 /// This is used to generate a new UniquePubkey
@@ -126,7 +123,7 @@ impl MainPubkey {
 pub struct MainSecretKey(SerdeSecret<SecretKey>);
 
 impl MainSecretKey {
-    ///
+    /// Create a new MainSecretKey from a bls SecretKey.
     pub fn new(secret_key: SecretKey) -> Self {
         Self(SerdeSecret(secret_key))
     }

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 use crate::transfers::{
-    create_offline_transfer, ContentPaymentsIdMap, SpendRequest, TransferOutputs,
+    create_offline_transfer, ContentPaymentsIdMap, OfflineTransfer, SpendRequest,
 };
 use crate::{
     CashNote, DerivationIndex, DerivedSecretKey, Hash, MainPubkey, MainSecretKey, NanoTokens,
@@ -169,12 +169,6 @@ impl LocalWallet {
         available_cash_notes
     }
 
-    /// Add given storage payment proofs to the wallet's cache,
-    /// so they can be used when uploading the paid content.
-    pub fn add_content_payments_map(&mut self, proofs: ContentPaymentsIdMap) {
-        self.wallet.payment_transactions.extend(proofs);
-    }
-
     /// Return the payment cash_note ids for the given content address name if cached.
     pub fn get_payment_unique_pubkeys(&self, name: &XorName) -> Option<&Vec<UniquePubkey>> {
         self.wallet.payment_transactions.get(name)
@@ -308,7 +302,7 @@ impl LocalWallet {
         Ok(())
     }
 
-    fn update_local_wallet(&mut self, transfer: TransferOutputs) -> Result<()> {
+    fn update_local_wallet(&mut self, transfer: OfflineTransfer) -> Result<()> {
         // First of all, update client local state.
         let spent_unique_pubkeys: BTreeSet<_> = transfer
             .tx
@@ -375,7 +369,7 @@ impl LocalWallet {
     }
 
     pub fn unwrap_transfer(&self, transfer: Transfer) -> Result<Vec<CashNoteRedemption>> {
-        transfer.cashnote_redemptions(self.key.secret_key())
+        transfer.cashnote_redemptions(&self.key)
     }
 
     pub fn derive_key(&self, derivation_index: &DerivationIndex) -> DerivedSecretKey {

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -68,7 +68,7 @@ pub use self::{
 pub(crate) use keys::store_new_keypair;
 pub use transfer::{CashNoteRedemption, Transfer};
 
-use crate::{MainPubkey, NanoTokens, UniquePubkey};
+use crate::{NanoTokens, UniquePubkey};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -87,9 +87,4 @@ pub(super) struct KeyLessWallet {
     cash_notes_created_for_others: BTreeSet<UniquePubkey>,
     /// Cached proofs of storage transactions made to be used for uploading the paid content.
     payment_transactions: ContentPaymentsIdMap,
-}
-
-/// Return the name of a MainPubkey.
-pub fn main_pubkey_name(main_pubkey: &MainPubkey) -> xor_name::XorName {
-    xor_name::XorName::from_content(&main_pubkey.to_bytes())
 }


### PR DESCRIPTION
- remove lots of dead code
- reduce variable exposition in `sn_transfers`, hide `TransactionBuilder` and other implementation details
- make exposed types explicit all in `sn_transfers` `lib.rs`, all modules now private
- rewrite benchmarks with the more high level exposed API

BREAKING CHANGE: sn_transfers type API exposision changes

## Description

reviewpad:summary 
