### PR TITLE
feat(logging): set default logging to data-dir

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -93,7 +93,7 @@ jobs:
           client_avg_mem_limit_mb="200" # mb
 
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |
             awk -F':' '/"memory_used_mb":/{print $2}' |
             sort -n |
             tail -n 1
@@ -105,11 +105,11 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename |
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -157,17 +157,17 @@ jobs:
         shell: bash
         run: |
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/{print $2}' | 
             sort -n | 
             tail -n 1
           )
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -219,7 +219,7 @@ jobs:
           client_avg_mem_limit_mb="120" # mb
           
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/{print $2}' | 
             sort -n | 
             tail -n 1
@@ -231,11 +231,11 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs/safe.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(
-            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs/safe.* -c --stats |
+            rg "\"memory_used_mb\"" $CLIENT_DATA_PATH/logs --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -39,12 +39,14 @@ pub(crate) struct Opt {
     ///
     /// Valid values are "stdout", "data-dir", or a custom path.
     ///
+    /// `data-dir` is the default value.
+    ///
     /// The data directory location is platform specific:
     ///  - Linux: $HOME/.local/share/safe/client/logs
     ///  - macOS: $HOME/Library/Application Support/safe/client/logs
     ///  - Windows: C:\Users\<username>\AppData\Roaming\safe\client\logs
     #[allow(rustdoc::invalid_html_tags)]
-    #[clap(long, value_parser = parse_log_output, verbatim_doc_comment)]
+    #[clap(long, value_parser = parse_log_output, verbatim_doc_comment, default_value = "data-dir")]
     pub log_output_dest: Option<LogOutputDest>,
 
     /// Specify the logging format.

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -17,11 +17,16 @@ pub fn parse_log_output(val: &str) -> Result<LogOutputDest> {
     match val {
         "stdout" => Ok(LogOutputDest::Stdout),
         "data-dir" => {
+            // Get the current timestamp and format it to be human readable
+            let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+
+            // Get the data directory path and append the timestamp to the log file name
             let dir = dirs_next::data_dir()
                 .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
                 .join("safe")
                 .join("client")
-                .join("logs");
+                .join("logs")
+                .join(format!("log_{}", timestamp));
             Ok(LogOutputDest::Path(dir))
         }
         // The path should be a directory, but we can't use something like `is_dir` to check

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -41,9 +41,17 @@ async fn main() -> Result<()> {
     let opt = Opt::parse();
     let _log_appender_guard = if let Some(log_output_dest) = opt.log_output_dest {
         let logging_targets = vec![
-            ("safe".to_string(), Level::INFO),
-            ("sn_client".to_string(), Level::INFO),
-            ("sn_networking".to_string(), Level::INFO),
+            // TODO: Reset to nice and clean defaults once we have a better idea of what we want
+            ("sn_networking".to_string(), Level::DEBUG),
+            ("safe".to_string(), Level::TRACE),
+            ("sn_build_info".to_string(), Level::TRACE),
+            ("sn_cli".to_string(), Level::TRACE),
+            ("sn_client".to_string(), Level::TRACE),
+            ("sn_logging".to_string(), Level::TRACE),
+            ("sn_peers_acquisition".to_string(), Level::TRACE),
+            ("sn_protocol".to_string(), Level::TRACE),
+            ("sn_registers".to_string(), Level::TRACE),
+            ("sn_transfers".to_string(), Level::TRACE),
         ];
         init_logging(
             logging_targets,

--- a/sn_node/src/bin/faucet/main.rs
+++ b/sn_node/src/bin/faucet/main.rs
@@ -59,13 +59,15 @@ struct Opt {
     ///
     /// Valid values are "stdout", "data-dir", or a custom path.
     ///
+    /// `data-dir` is the default value.
+    ///
     /// The data directory location is platform specific:
     ///  - Linux: $HOME/.local/share/safe/client/logs
     ///  - macOS: $HOME/Library/Application Support/safe/client/logs
     ///  - Windows: C:\Users\<username>\AppData\Roaming\safe\client\logs
     #[allow(rustdoc::invalid_html_tags)]
-    #[clap(long, value_parser = parse_log_output, verbatim_doc_comment)]
-    log_output_dest: Option<LogOutputDest>,
+    #[clap(long, value_parser = parse_log_output, verbatim_doc_comment, default_value = "data-dir")]
+    pub log_output_dest: Option<LogOutputDest>,
 
     #[command(flatten)]
     peers: PeersArgs,

--- a/sn_node/src/bin/faucet/main.rs
+++ b/sn_node/src/bin/faucet/main.rs
@@ -33,9 +33,17 @@ async fn main() -> Result<()> {
 
     let _log_appender_guard = if let Some(log_output_dest) = opt.log_output_dest {
         let logging_targets = vec![
-            ("safe".to_string(), Level::INFO),
-            ("sn_client".to_string(), Level::INFO),
-            ("sn_networking".to_string(), Level::INFO),
+            // TODO: Reset to nice and clean defaults once we have a better idea of what we want
+            ("sn_networking".to_string(), Level::DEBUG),
+            ("safenode".to_string(), Level::TRACE),
+            ("sn_build_info".to_string(), Level::TRACE),
+            ("sn_logging".to_string(), Level::TRACE),
+            ("sn_node".to_string(), Level::TRACE),
+            ("sn_peers_acquisition".to_string(), Level::TRACE),
+            ("sn_protocol".to_string(), Level::TRACE),
+            ("sn_registers".to_string(), Level::TRACE),
+            ("sn_testnet".to_string(), Level::TRACE),
+            ("sn_transfers".to_string(), Level::TRACE),
         ];
         init_logging(logging_targets, log_output_dest, LogFormat::Default)?
     } else {

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -325,10 +325,17 @@ fn init_logging(
     format: Option<LogFormat>,
 ) -> Result<(String, Option<WorkerGuard>)> {
     let logging_targets = vec![
-        ("safenode".to_string(), Level::INFO),
-        ("sn_transfers".to_string(), Level::INFO),
-        ("sn_networking".to_string(), Level::INFO),
-        ("sn_node".to_string(), Level::INFO),
+        // TODO: Reset to nice and clean defaults once we have a better idea of what we want
+        ("sn_networking".to_string(), Level::DEBUG),
+        ("safenode".to_string(), Level::TRACE),
+        ("sn_build_info".to_string(), Level::TRACE),
+        ("sn_logging".to_string(), Level::TRACE),
+        ("sn_node".to_string(), Level::TRACE),
+        ("sn_peers_acquisition".to_string(), Level::TRACE),
+        ("sn_protocol".to_string(), Level::TRACE),
+        ("sn_registers".to_string(), Level::TRACE),
+        ("sn_testnet".to_string(), Level::TRACE),
+        ("sn_transfers".to_string(), Level::TRACE),
     ];
 
     let output_dest = match log_output_dest {

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -71,12 +71,14 @@ struct Opt {
     ///
     /// Valid values are "stdout", "data-dir", or a custom path.
     ///
+    /// `data-dir` is the default value.
+    ///
     /// The data directory location is platform specific:
     ///  - Linux: $HOME/.local/share/safe/node/<peer-id>/logs
     ///  - macOS: $HOME/Library/Application Support/safe/node/<peer-id>/logs
     ///  - Windows: C:\Users\<username>\AppData\Roaming\safe\node\<peer-id>\logs
     #[allow(rustdoc::invalid_html_tags)]
-    #[clap(long, default_value_t = LogOutputDestArg::Stdout, value_parser = parse_log_output, verbatim_doc_comment)]
+    #[clap(long, default_value_t = LogOutputDestArg::DataDir, value_parser = parse_log_output, verbatim_doc_comment)]
     log_output_dest: LogOutputDestArg,
 
     /// Specify the logging format.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Sep 23 07:58 UTC
This pull request makes several changes related to logging. First, it sets the default logging output destination to the data directory for the `sn_cli`, `sn_node`, and `safenode` binaries. Previously, the default was not specified. Second, it updates the default log levels to be more verbose for the `sn_cli`, `faucet`, and `safenode` binaries. Third, it adds a timestamp to the log file path for the `sn_cli` binary to avoid logs running together over multiple runs. These changes aim to improve the logging functionality and provide more detailed information when needed.
<!-- reviewpad:summarize:end --> 
