### PR TITLE
feat(client): fail fast when a chunk is missing

### DIFF
--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -62,6 +62,9 @@ pub enum Error {
         missing_chunks: Vec<XorName>,
     },
 
+    #[error("Chunk could not be retrieved from the network: {0:?}")]
+    ChunkMissing(XorName),
+
     #[error("Not all data was chunked, expected {expected}, but we have {chunked}.)")]
     NotAllDataWasChunked {
         /// Number of Chunks expected to be generated


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Sep 23 09:22 UTC
This pull request adds a feature to the client where it fails fast when a chunk is missing. It includes changes to the `sn_client/src/chunks/error.rs` and `sn_client/src/file_apis.rs` files. Overall, the patch adds 26 insertions and removes 39 deletions. The changes include adding a new error variant for a missing chunk in the `Error` enum, modifying the `Files` struct to handle missing chunks and update progress, and handling missing chunks in the file download process.
<!-- reviewpad:summarize:end --> 
