### PR TITLE
feat: transfer notification through gossipsub

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -279,11 +279,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build safe bins
-        run: cargo build --release --features local-discovery --bin safenode --bin faucet
+        run: cargo build --release --features local-discovery,network-royalties-notif --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
+        run: cargo test --release -p sn_node --features=local-discovery,network-royalties-notif --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
         timeout-minutes: 30
 
       - name: Start a local network
@@ -307,19 +307,19 @@ jobs:
         
       # This should be first to avoid slow reward acceptance etc
       - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test nodes_rewards -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
         timeout-minutes: 25
 
       - name: execute the spend tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test sequential_transfers -- --nocapture
         env:
           SN_LOG: "all"
         timeout-minutes: 25
 
       - name: execute the storage payment tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test storage_payments -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
         timeout-minutes: 25

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -279,7 +279,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build safe bins
-        run: cargo build --release --features local-discovery,network-royalties-notif --bin safenode --bin faucet
+        run: cargo build --release --features=local-discovery,network-royalties-notif --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,7 +214,7 @@ jobs:
         continue-on-error: true
 
       - name: Build safe bins
-        run: cargo build --release --features local-discovery,network-royalties-notif --bin safenode --bin faucet
+        run: cargo build --release --features=local-discovery,network-royalties-notif --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,11 +214,11 @@ jobs:
         continue-on-error: true
 
       - name: Build safe bins
-        run: cargo build --release --features local-discovery --bin safenode --bin faucet
+        run: cargo build --release --features local-discovery,network-royalties-notif --bin safenode --bin faucet
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
+        run: cargo test --release -p sn_node --features=local-discovery,network-royalties-notif --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
         timeout-minutes: 30
         env:
           CARGO_TARGET_DIR: "./transfer-target"
@@ -234,21 +234,21 @@ jobs:
 
       # This should be first to avoid slow reward acceptance etc
       - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test nodes_rewards -- --nocapture --test-threads=1
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 25
 
       - name: execute the spend test
-        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test sequential_transfers -- --nocapture
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the storage payment tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1          
+        run: cargo test --release -p sn_node --features="local-discovery,network-royalties-notif" --test storage_payments -- --nocapture --test-threads=1          
         env:
           CARGO_TARGET_DIR: "./transfer-target"
           SN_LOG: "all"

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -330,7 +330,7 @@ async fn receive(transfer: String, is_file: bool, client: &Client, root_dir: &Pa
 
     println!("Verifying transfer with the Network...");
     let mut wallet = LocalWallet::load_from(root_dir)?;
-    let cashnotes = match client.receive(transfer, &wallet).await {
+    let cashnotes = match client.receive(&transfer, &wallet).await {
         Ok(cashnotes) => cashnotes,
         Err(err) => {
             println!("Failed to verify and redeem transfer: {err:?}");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -290,7 +290,7 @@ impl Client {
     /// Receive a Transfer, verify and redeem CashNotes from the Network.
     pub async fn receive(
         &self,
-        transfer: Transfer,
+        transfer: &Transfer,
         wallet: &LocalWallet,
     ) -> WalletResult<Vec<CashNote>> {
         let cashnotes = self

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -15,6 +15,7 @@ default=[]
 local-discovery=["libp2p/mdns"]
 quic=["libp2p-quic"]
 open-metrics=["libp2p-metrics", "prometheus-client", "hyper", "sysinfo"]
+network-royalties-notif=[] # wether to subscribe to network royalties payments notifications on gossipsub
 
 [dependencies]
 async-trait = "0.1"

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -70,7 +70,7 @@ impl Network {
     /// Else returns a list of CashNotes that can be deposited to our wallet and spent
     pub async fn verify_and_unpack_transfer(
         &self,
-        transfer: Transfer,
+        transfer: &Transfer,
         wallet: &LocalWallet,
     ) -> Result<Vec<CashNote>> {
         // get CashNoteRedemptions from encrypted Transfer

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -25,6 +25,7 @@ metrics = ["sn_logging/process-metrics"]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 quic=["sn_networking/quic"]
+network-royalties-notif=["sn_networking/network-royalties-notif"] 
 
 [dependencies]
 async-trait = "0.1"

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -213,7 +213,10 @@ impl Node {
         };
 
         // subscribe to receive transfer notifications over gossipsub topic TRANSFER_NOTIF_TOPIC
-        running_node.subscribe_to_topic(TRANSFER_NOTIF_TOPIC.to_string())?;
+        #[cfg(feature = "network-royalties-notif")]
+        running_node
+            .subscribe_to_topic(TRANSFER_NOTIF_TOPIC.to_string())
+            .map(|()| info!("Node has been subscribed to gossipsub topic '{TRANSFER_NOTIF_TOPIC}' to receive network royalties payments notifications."))?;
 
         Ok(running_node)
     }

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -7,9 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::error::{Error, Result};
+use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::UniquePubkey;
+use sn_transfers::{Transfer, UniquePubkey};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
@@ -65,6 +66,13 @@ pub enum NodeEvent {
         topic: String,
         /// The raw bytes of the received message
         msg: Vec<u8>,
+    },
+    /// Transfer notification message received for a public key
+    TransferNotif {
+        /// Public key the transfer notification is about
+        key: PublicKey,
+        /// The encrypted transfer
+        transfer: Transfer,
     },
 }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -461,11 +461,11 @@ impl Node {
                     let mut msg: Vec<u8> = pk.to_vec();
                     msg.extend(transfer_hex.as_bytes());
                     if let Err(err) = self.network.publish_on_topic(topic.clone(), msg) {
-                        warn!("Failed to publish a transfer notification over gossipsub: {err:?}");
+                        debug!("Failed to publish a transfer notification over gossipsub: {err:?}");
                     }
                 }
             }
-            Err(err) => warn!("Failed to serialise transfer data to publish a notification over gossipsub: {err:?}"),
+            Err(err) => debug!("Failed to serialise transfer data to publish a notification over gossipsub: {err:?}"),
         }
 
         // deposit the CashNotes in our wallet

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -27,7 +27,7 @@ use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use tokio::{
     task::JoinHandle,
-    time::{sleep, timeout, Duration},
+    time::{sleep, Duration},
 };
 use tokio_stream::StreamExt;
 use tonic::Request;
@@ -138,8 +138,9 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
     let handle = spawn_transfer_notifs_listener("https://127.0.0.1:12001".to_string());
 
     files_api.upload_with_payments(content_bytes, true).await?;
+    println!("Random chunks stored");
 
-    let count = timeout(Duration::from_millis(5000), async { handle.await? }).await??;
+    let count = handle.await??;
     println!("Number of notifications received by node: {count}");
     assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
 
@@ -175,8 +176,9 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let _register = client
         .create_register(register_addr, &mut wallet_client, false)
         .await?;
+    println!("Random Register created");
 
-    let count = timeout(Duration::from_millis(5000), async { handle.await? }).await??;
+    let count = handle.await??;
     println!("Number of notifications received by node: {count}");
     assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
 

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -19,6 +19,7 @@ local-discovery = []
 quic = []
 network-contacts = []
 open-metrics = []
+network-royalties-notif = []
 
 [[bin]]
 path="src/main.rs"

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -280,6 +280,9 @@ fn build_binaries(binaries_to_build: Vec<String>) -> Result<()> {
     if cfg!(feature = "open-metrics") {
         args.extend(["--features", "open-metrics"]);
     }
+    if cfg!(feature = "network-royalties-notif") {
+        args.extend(["--features", "network-royalties-notif"]);
+    }
 
     let bins_string = binaries_to_build.join(", ");
     info!("Building the following binaries: {bins_string}");

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -362,7 +362,7 @@ impl LocalWallet {
         Ok(())
     }
 
-    pub fn unwrap_transfer(&self, transfer: Transfer) -> Result<Vec<CashNoteRedemption>> {
+    pub fn unwrap_transfer(&self, transfer: &Transfer) -> Result<Vec<CashNoteRedemption>> {
         transfer
             .cashnote_redemptions(&self.key)
             .map_err(|_| Error::FailedToDecypherTransfer)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Sep 23 19:42 UTC
This pull request contains three patches:

1. The first patch adds logging when a new Gossipsub message is received in the `sn_node/examples/safenode_rpc_client.rs` file. It also introduces a new command called `RewardsEvents` for listening to node rewards events.

2. The second patch enables RPC by default in the `sn_node/src/bin/safenode/main.rs` file.

3. The third patch improves the logging in the `sn_node/examples/safenode_rpc_client.rs` and `sn_node/src/api.rs` files. It specifically improves the logging of received Gossipsub messages.

Please review the changes thoroughly.
<!-- reviewpad:summarize:end --> 
