### PR TITLE
feat: replicate fetch from peer first then from network

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -148,7 +148,7 @@ jobs:
           sending_list_count=$(rg "Sending a replication list" $NODE_DATA_PATH -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "Sent $sending_list_count replication lists"
-          received_list_count=$(rg "Replicate list received" $NODE_DATA_PATH -c --stats | \
+          received_list_count=$(rg "Received replication list from" $NODE_DATA_PATH -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "Received $received_list_count replication lists"
           fetching_attempt_count=$(rg "FetchingKeysForReplication" $NODE_DATA_PATH -c --stats | \

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -111,6 +111,7 @@ pub enum SwarmCmd {
     },
     /// The keys added to the replication fetcher are later used to fetch the Record from network
     AddKeysToReplicationFetcher {
+        holder: PeerId,
         keys: Vec<NetworkAddress>,
     },
     /// Subscribe to a given Gossipsub topic
@@ -143,7 +144,7 @@ impl SwarmDriver {
         );
 
         match cmd {
-            SwarmCmd::AddKeysToReplicationFetcher { keys } => {
+            SwarmCmd::AddKeysToReplicationFetcher { holder, keys } => {
                 // Only store record from Replication that close enough to us.
                 let all_peers = self.get_all_local_peers();
                 let keys_to_store = keys
@@ -158,7 +159,9 @@ impl SwarmDriver {
                     .kademlia
                     .store_mut()
                     .record_addresses_ref();
-                let keys_to_fetch = self.replication_fetcher.add_keys(keys_to_store, all_keys);
+                let keys_to_fetch =
+                    self.replication_fetcher
+                        .add_keys(holder, keys_to_store, all_keys);
                 if !keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -487,8 +487,12 @@ impl Network {
     }
 
     // Add a list of keys of a holder to Replication Fetcher.
-    pub fn add_keys_to_replication_fetcher(&self, keys: Vec<NetworkAddress>) -> Result<()> {
-        self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { keys })
+    pub fn add_keys_to_replication_fetcher(
+        &self,
+        holder: PeerId,
+        keys: Vec<NetworkAddress>,
+    ) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { holder, keys })
     }
 
     /// Send `Request` to the given `PeerId` and await for the response. If `self` is the recipient,

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -70,7 +70,7 @@ impl<'a> Marker<'a> {
     }
 
     /// Helper to log the FetchingKeysForReplication variant
-    pub fn fetching_keys_for_replication(keys: &Vec<RecordKey>) -> Self {
+    pub fn fetching_keys_for_replication(keys: &Vec<(PeerId, RecordKey)>) -> Self {
         Marker::FetchingKeysForReplication {
             fetching_keys_len: keys.len(),
         }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     storage::{RecordKind, RegisterAddress, SpendAddress},
-    PrettyPrintRecordKey,
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use serde::{Deserialize, Serialize};
 use sn_transfers::{NanoTokens, SignedSpend};
@@ -81,6 +81,16 @@ pub enum Error {
     FailedToGetTransferParentSpend,
     #[error("Transfer is invalid: {0}")]
     InvalidTransfer(String),
+
+    // ---------- replication errors
+    /// Replication not found.
+    #[error("Peer {holder:?} cannot find Record {key:?}")]
+    ReplicatedRecordNotFound {
+        /// Holder that being contacted
+        holder: Box<NetworkAddress>,
+        /// Key of the missing record
+        key: Box<NetworkAddress>,
+    },
 
     // ---------- record errors
     #[error("Record was not stored: {0:?}: {1:?}")]

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -21,6 +21,17 @@ use serde::{Deserialize, Serialize};
 pub enum Query {
     /// Retrieve the cost of storing a record at the given address.
     GetStoreCost(NetworkAddress),
+    /// Retrieve a specific record from a specific peer.
+    ///
+    /// This should eventually lead to a [`GetReplicatedRecord`] response.
+    ///
+    /// [`GetReplicatedRecord`]: super::QueryResponse::GetReplicatedRecord
+    GetReplicatedRecord {
+        /// Sender of the query
+        requester: NetworkAddress,
+        /// Key of the record to be fetched
+        key: NetworkAddress,
+    },
 }
 
 impl Query {
@@ -28,6 +39,9 @@ impl Query {
     pub fn dst(&self) -> NetworkAddress {
         match self {
             Query::GetStoreCost(address) => address.clone(),
+            // Shall not be called for this, as this is a `one-to-one` message,
+            // and the destionation shall be decided by the requester already.
+            Query::GetReplicatedRecord { key, .. } => key.clone(),
         }
     }
 }
@@ -37,6 +51,9 @@ impl std::fmt::Display for Query {
         match self {
             Query::GetStoreCost(address) => {
                 write!(f, "Query::GetStoreCost({address:?})")
+            }
+            Query::GetReplicatedRecord { key, requester } => {
+                write!(f, "Query::GetStoreCost({requester:?} {key:?})")
             }
         }
     }

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::error::Result;
+use crate::{error::Result, NetworkAddress};
 
 use serde::{Deserialize, Serialize};
 use sn_transfers::{MainPubkey, NanoTokens};
@@ -22,6 +22,12 @@ pub enum QueryResponse {
         /// The cash_note MainPubkey to pay this node's store cost to.
         payment_address: MainPubkey,
     },
+    // ===== ReplicatedRecord =====
+    //
+    /// Response to [`GetReplicatedRecord`]
+    ///
+    /// [`GetReplicatedRecord`]: crate::messages::Query::GetReplicatedRecord
+    GetReplicatedRecord(Result<(NetworkAddress, Vec<u8>)>),
 }
 
 /// The response to a Cmd, containing the query result.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Sep 23 14:50 UTC
This pull request includes several changes across multiple files. Here is a summary of the changes:

- In the `cmd.rs` file:
    - Added a new variant to the `SwarmCmd` enum called `AddKeysToReplicationFetcher`.
    - Updated the `SwarmDriver` implementation to handle the new variant.
    - Modified the call to `self.replication_fetcher.add_keys` to include the new `holder` parameter.
    - Added an `if` condition to check for non-empty `keys_to_fetch` before sending a `NetworkEvent::KeysForReplication`.

- In the `replication.rs` file:
    - Made import statement changes related to the `Record` and `RecordKey` modules.
    - Updated log messages to include additional information about peers, keys, and replication lists.
    - Modified function parameters to include `holder` and additional key-related fields.
    - Updated log messages, requests, and response handling.
  
- In the `log_markers.rs` file:
    - Changed the function `fetching_keys_for_replication()` to accept a vector of tuples containing `PeerId` and `RecordKey`.

- In the `event.rs` file:
    - Modified the `NetworkEvent` enum to include the `PeerId` in the `KeysForReplication` variant.
    - Updated the `SwarmDriver` struct to include the `cache_candidates` field in the `OutboundQueryProgressed` variant.

- In the `replication_fetcher.rs` file:
    - Made various changes related to import statements, field types, return types, and method implementations.
    - Introduced optimizations and improvements for fetching and storing keys for replication.

- In the `query.rs` file:
    - Added a new variant to the `Query` enum called `GetReplicatedRecord`.
    - Implemented the `std::fmt::Display` trait for the `Query` enum.

- In the `messages/mod.rs` file:
    - Made changes related to imports, the `QueryResponse` enum, and the `Query` implementation.

- In the `storage` module of a different file:
    - Added an import statement for the `NetworkAddress` struct.

- In the `sn_protocol/src/messages/mod.rs` file:
    - Removed various imports and methods, and replaced the `ReplicatedData` enum with a modified implementation.

Overall, these changes focus on improving replication functionality, error handling, logging, and code organization across multiple files.
<!-- reviewpad:summarize:end --> 
