### PR TITLE
fix(client): just skip empty files

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -137,7 +137,17 @@ pub(super) async fn chunk_path(
             };
 
             let (file_addr, _size, chunks) =
-                file_api.chunk_file(entry.path(), chunks_dir.as_path())?;
+                match file_api.chunk_file(entry.path(), chunks_dir.as_path()) {
+                    Ok((file_addr, size, chunks)) => (file_addr, size, chunks),
+                    Err(err) => {
+                        println!(
+                            "Skipping file {:?} as it could not be chunked: {:?}",
+                            entry.path(),
+                            err
+                        );
+                        continue;
+                    }
+                };
             num_of_chunks += chunks.len();
 
             chunked_files.insert(file_addr, ChunkedFile { file_name, chunks });


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Sep 23 18:28 UTC
This pull request fixes the issue where empty files were not being skipped during file chunking. The patch now includes a check to skip empty files and provides an error message indicating which files were skipped.
<!-- reviewpad:summarize:end --> 
