### PR TITLE
fix(cli): dont bail on errors during repay/upload

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -407,7 +407,9 @@ async fn verify_and_repay_if_needed(
 
         // lets check there were no odd errors during upload
         for result in upload_results {
-            result??;
+            if let Err(error) = result? {
+                error!("Error uploading chunk during repayment: {error}");
+            };
         }
     }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Sep 23 08:31 UTC
This pull request fixes an issue in the CLI where errors during repayment or upload would cause the process to bail out. The patch adds error handling and logging for any errors that occur during chunk upload.
<!-- reviewpad:summarize:end --> 
