### PR TITLE
chore(client): more logs around StoreCost retrieveal

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -139,10 +139,13 @@ impl WalletClient {
                     .get_store_costs_at_address(&content_addr)
                     .await
                     .map_err(|error| WalletError::CouldNotSendMoney(error.to_string()));
+
+                debug!("Storecosts retrieved for {content_addr:?}");
                 (content_addr, costs)
             });
         }
 
+        debug!("Pending store cost tasks: {:?}", tasks.len());
         while let Some(res) = tasks.join_next().await {
             // In case of cann't fetch cost from network for a content,
             // just skip it as it will then get verification failure,
@@ -151,6 +154,7 @@ impl WalletClient {
                 Ok((content_addr, Ok(cost))) => {
                     if let Some(xorname) = content_addr.as_xorname() {
                         let _ = payment_map.insert(xorname, cost);
+                        debug!("Storecosts inserted into payment map for {content_addr:?}");
                     } else {
                         warn!("Cannot get store cost for a content that is not a data type: {content_addr:?}");
                         println!("Cannot get store cost for a content that is not a data type: {content_addr:?}");

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -207,7 +207,7 @@ impl Network {
             .into_iter()
             .collect_vec();
 
-        let request = Request::Query(Query::GetStoreCost(record_address));
+        let request = Request::Query(Query::GetStoreCost(record_address.clone()));
         let responses = self
             .send_and_get_responses(close_nodes, &request, true)
             .await;
@@ -215,7 +215,10 @@ impl Network {
         // loop over responses, generating an average fee and storing all responses along side
         let mut all_costs = vec![];
         for response in responses.into_iter().flatten() {
-            debug!("StoreCostReq received response: {:?}", response);
+            debug!(
+                "StoreCostReq for {record_address:?} received response: {:?}",
+                response
+            );
             if let Response::Query(QueryResponse::GetStoreCost {
                 store_cost: Ok(cost),
                 payment_address,


### PR DESCRIPTION
We're seeing odd hangs, this may well help

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Sep 23 10:15 UTC
This pull request adds more log statements around retrieving StoreCosts in the client code. The purpose of this change is to help investigate and resolve odd hangs that have been observed. The patch adds debug log statements to track the retrieval of StoreCosts and the insertion of them into a payment map. It also adds a log statement to indicate the number of pending store cost tasks. In the networking code, the patch modifies a log statement to include the specific record address for which a StoreCost request received a response. Overall, this patch aims to improve the visibility and debugging of StoreCost retrieval in the client code.
<!-- reviewpad:summarize:end --> 
