### PR TITLE
feat(client): show feedback on long wait for costs

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -202,6 +202,10 @@ async fn upload_files(
         progress += chunks_batch.len();
 
         // pay for and verify payment... if we don't verify here, chunks uploads will surely fail
+        println!(
+            "Getting upload costs from network for {} chunks...",
+            chunks_batch.len()
+        );
         file_api
             .pay_for_chunks(chunks_batch.iter().map(|(name, _)| *name).collect(), true)
             .await?;


### PR DESCRIPTION
Adds a line of feedback to the uploader during the long wait while cost is fetched from the network.

Without this there's no indication of why a wait is happening, because the last line of the feedback is 'Total number of chunks to be stored: X' which doesn't indicate why 'nothing is happening'.

Example log:

```diff
🔗 Connected to the Network
Total number of chunks to be stored: 21
+ Getting upload costs from network for 20 chunks...
Transfers applied locally
All transfers completed in 18.333608883s
Total payment: NanoTokens(47357937) nano tokens for 20 chunks
Made payment of 0.047357937 for 20 chunks
Stored wallet with cached payment proofs. New balance: 98.834034126
Uploaded chunk #248116.. in 0 seconds
Uploaded chunk #9394a1.. in 0 seconds

```