### PR TITLE
Remove failed records

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -109,6 +109,11 @@ pub enum SwarmCmd {
     PutLocalRecord {
         record: Record,
     },
+    /// Remove a local record from the RecordStore
+    /// Typically because the write failed
+    RemoveFailedLocalRecord {
+        key: RecordKey,
+    },
     /// The keys added to the replication fetcher are later used to fetch the Record from network
     AddKeysToReplicationFetcher {
         holder: PeerId,
@@ -235,6 +240,9 @@ impl SwarmDriver {
                     }
                     Err(err) => return Err(err.into()),
                 };
+            }
+            SwarmCmd::RemoveFailedLocalRecord { key } => {
+                self.swarm.behaviour_mut().kademlia.store_mut().remove(&key)
             }
             SwarmCmd::RecordStoreHasKey { key, sender } => {
                 let has_key = self

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -134,6 +134,8 @@ pub enum NetworkEvent {
     NatStatusChanged(NatStatus),
     /// Report unverified record
     UnverifiedRecord(Record),
+    /// Report failed write to cleanup record store
+    FailedToWrite(RecordKey),
     /// Gossipsub message received
     GossipsubMsg {
         /// Topic the message was published on
@@ -175,6 +177,10 @@ impl Debug for NetworkEvent {
             NetworkEvent::UnverifiedRecord(record) => {
                 let pretty_key = PrettyPrintRecordKey::from(record.key.clone());
                 write!(f, "NetworkEvent::UnverifiedRecord({pretty_key:?})")
+            }
+            NetworkEvent::FailedToWrite(record_key) => {
+                let pretty_key = PrettyPrintRecordKey::from(record_key.clone());
+                write!(f, "NetworkEvent::FailedToWrite({pretty_key:?})")
             }
             NetworkEvent::GossipsubMsg { topic, .. } => {
                 write!(f, "NetworkEvent::GossipsubMsg({topic})")

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -466,6 +466,12 @@ impl Network {
         self.send_swarm_cmd(SwarmCmd::PutLocalRecord { record })
     }
 
+    /// Remove a local record from the RecordStore after a failed write
+    pub fn remove_failed_local_record(&self, key: RecordKey) -> Result<()> {
+        trace!("Removing Record locally, for {:?}", key);
+        self.send_swarm_cmd(SwarmCmd::RemoveFailedLocalRecord { key })
+    }
+
     /// Returns true if a RecordKey is present locally in the RecordStore
     pub async fn is_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
         let (sender, receiver) = oneshot::channel();

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -231,6 +231,7 @@ impl Node {
                 // until we have enough nodes, else these might fail.
                 NetworkEvent::RequestReceived { .. }
                 | NetworkEvent::UnverifiedRecord(_)
+                | NetworkEvent::FailedToWrite(_)
                 | NetworkEvent::ResponseReceived { .. }
                 | NetworkEvent::KeysForReplication(_) => {
                     if log_when_not_enough_peers {
@@ -317,6 +318,11 @@ impl Node {
                         self.record_metrics(Marker::RecordRejected(&key));
                         trace!("UnverifiedRecord {key} failed to be stored with error {err:?}.")
                     }
+                }
+            }
+            NetworkEvent::FailedToWrite(key) => {
+                if let Err(e) = self.network.remove_failed_local_record(key) {
+                    error!("Failed to remove local record: {e:?}");
                 }
             }
             NetworkEvent::GossipsubMsg { topic, msg } => {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Oct 23 08:11 UTC
This pull request adds a feature to log the command that was invoked in the client for safe. It collects the arguments into a single string and logs the entire command that was run.
<!-- reviewpad:summarize:end --> 
