### PR TITLE
feat: re-attempt when get chunk from network

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -324,7 +324,7 @@ impl Client {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, false)
+            .get_record_from_network(key, None, true)
             .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -331,6 +331,16 @@ impl Network {
                         }
                     }
                 }
+                Err(Error::RecordNotFound) => {
+                    // libp2p RecordNotFound does mean no holders answered.
+                    // In that case, a retry will be somehow pointless,
+                    // hence return with error immediately.
+                    warn!(
+                        "No holder of record '{:?}' from network!. Terminating the fetch ...",
+                        PrettyPrintRecordKey::from(key.clone()),
+                    );
+                    break;
+                }
                 Err(error) => {
                     error!("{error:?}");
                     if verification_attempts >= total_attempts {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Oct 23 13:21 UTC
This pull request makes a feature enhancement by adding the ability to re-attempt when getting a chunk from the network. The patch modifies the `get_record_from_network` method in the `Client` implementation to pass `true` as the last parameter, indicating that re-attempts should be made.
<!-- reviewpad:summarize:end --> 
