### PR TITLE
chore: remove all spans.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,19 +1342,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
@@ -1890,15 +1877,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "hyper"
@@ -2673,15 +2651,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
 
 [[package]]
 name = "matches"
@@ -3653,7 +3622,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger",
  "log",
  "rand",
 ]
@@ -3838,17 +3807,8 @@ checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
+ "regex-automata",
  "regex-syntax 0.7.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5170,7 +5130,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "env_logger 0.7.1",
  "lazy_static",
  "log",
  "tracing-core",
@@ -5208,16 +5167,12 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -62,7 +62,6 @@ impl Files {
         Ok(WalletClient::new(self.client.clone(), wallet))
     }
 
-    #[instrument(skip(self), level = "debug")]
     /// Reads a file from the network, whose contents are contained within one or more chunks.
     pub async fn read_bytes(
         &self,
@@ -93,7 +92,6 @@ impl Files {
     /// and the length of bytes to be read.
     /// Passing `0` to position reads the data from the beginning,
     /// and the `length` is just an upper limit.
-    #[instrument(skip_all, level = "trace")]
     pub async fn read_from(
         &self,
         address: ChunkAddress,
@@ -122,7 +120,6 @@ impl Files {
 
     /// Directly writes [`Bytes`] to the network in the
     /// form of immutable chunks, without any batching.
-    #[instrument(skip(self, bytes), level = "debug")]
     pub async fn upload_with_payments(
         &self,
         bytes: Bytes,
@@ -134,7 +131,6 @@ impl Files {
 
     /// Tries to chunk the file, returning `(head_address, file_size, chunk_names)`
     /// and writes encrypted chunks to disk.
-    #[instrument(skip_all, level = "trace")]
     pub fn chunk_file(&self, file_path: &Path, chunk_dir: &Path) -> ChunkFileResult {
         let mut file = File::open(file_path)?;
         let metadata = file.metadata()?;
@@ -160,7 +156,6 @@ impl Files {
     /// Directly writes Chunks to the network in the
     /// form of immutable self encrypted chunks.
     ///
-    #[instrument(skip_all, level = "trace")]
     pub async fn get_local_payment_and_upload_chunk(
         &self,
         chunk: Chunk,
@@ -223,7 +218,6 @@ impl Files {
     // --------------------------------------------
 
     /// Used for testing
-    #[instrument(skip(self, bytes), level = "trace")]
     async fn upload_bytes(&self, bytes: Bytes, verify: bool) -> Result<NetworkAddress> {
         let temp_dir = tempdir()?;
         let file_path = temp_dir.path().join("tempfile");
@@ -306,7 +300,6 @@ impl Files {
     /// Extracts a file DataMapLevel from a chunk.
     /// If the DataMapLevel is not the first level mapping directly to the user's contents,
     /// the process repeats itself until it obtains the first level DataMapLevel.
-    #[instrument(skip_all, level = "trace")]
     async fn unpack_chunk(&self, mut chunk: Chunk) -> Result<DataMap> {
         loop {
             match deserialize(chunk.value()).map_err(Error::Serialisation)? {
@@ -322,7 +315,6 @@ impl Files {
     }
     // Gets a subset of chunks from the network, decrypts and
     // reads `len` bytes of the data starting at given `pos` of original file.
-    #[instrument(skip_all, level = "trace")]
     async fn seek(&self, data_map: DataMap, pos: usize, len: usize) -> Result<Bytes> {
         let info = self_encryption::seek_info(data_map.file_size(), pos, len);
         let range = &info.index_range;
@@ -344,7 +336,6 @@ impl Files {
         Ok(bytes)
     }
 
-    #[instrument(skip_all, level = "trace")]
     async fn try_get_chunks(&self, chunks_info: Vec<ChunkInfo>) -> Result<Vec<EncryptedChunk>> {
         let expected_count = chunks_info.len();
         let mut retrieved_chunks = vec![];

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -68,10 +68,10 @@ tracing = { version = "~0.1.26" }
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
 tracing-opentelemetry = { version = "0.21", optional = true }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.16" }
 walkdir = "2.3.1"
 xor_name = "5.0.0"
-tracing-log = { version = "0.1.3", features = ["env_logger"] }
+tracing-log = { version = "0.1.3" }
 strum = { version = "0.25.0", features = ["derive"] }
 tiny_http = { version="0.12", features = ["ssl-rustls"] }
 color-eyre = "0.6.2"


### PR DESCRIPTION
There's potential for mem leaks here and they are not well utilised

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Oct 23 13:44 UTC
This pull request removes all the spans in the "sn_client/src/file_apis.rs" file. The reason for this change is to address potential memory leaks and because the spans were not being well utilized. The patch deletes 9 lines of code in total.
<!-- reviewpad:summarize:end --> 
