### PR TITLE
chore: log status of pending_get_record

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -180,6 +180,15 @@ impl SwarmDriver {
                 {
                     warn!("An existing get_record task {query_id:?} got replaced");
                 }
+                // Logging the status of the `pending_get_record`.
+                // We also interested in the status of `result_map` (which contains record) inside.
+                let total_records: usize = self
+                    .pending_get_record
+                    .iter()
+                    .map(|(_, (_, result_map))| result_map.len())
+                    .sum();
+                info!("We now have {} pending get record attempts and cached {total_records} fetched copies",
+                      self.pending_get_record.len());
             }
             SwarmCmd::GetLocalStoreCost { sender } => {
                 let cost = self.swarm.behaviour_mut().kademlia.store_mut().store_cost();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Oct 23 10:29 UTC
This pull request adds logging for the status and record count of the `pending_get_record` in the `SwarmDriver` implementation. This helps track the number of pending get record attempts and the number of fetched copies cached.
<!-- reviewpad:summarize:end --> 
