### PR TITLE
feat: faucet retry genesis claim on failure

### DIFF
--- a/sn_node/src/bin/faucet/faucet_server.rs
+++ b/sn_node/src/bin/faucet/faucet_server.rs
@@ -36,7 +36,10 @@ use tiny_http::{Response, Server};
 pub async fn run_faucet_server(client: &Client) -> Result<()> {
     let server =
         Server::http("0.0.0.0:8000").map_err(|e| eyre!("Failed to start server: {}", e))?;
-    claim_genesis(client).await;
+    claim_genesis(client).await.map_err(|e| {
+        eprintln!("Faucet Server couldn't start as we failed to claim Genesis");
+        e
+    })?;
 
     println!("Starting http server listening on port 8000...");
     for request in server.incoming_requests() {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Oct 23 10:50 UTC
This pull request adds a new feature to the faucet server. It introduces a retry mechanism for claiming the Genesis in case of failure. The patch modifies the `faucet_server.rs` and `main.rs` files to implement this feature.
<!-- reviewpad:summarize:end --> 
