### PR TITLE
feat: verify put_record with expected_holders

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Start a client to upload files
         run: |
           ls -l
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./the-test-data.zip"
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders
         env:
           SN_LOG: "all"
         timeout-minutes: 25
@@ -173,7 +173,7 @@ jobs:
       # Download the same files again to ensure files won't get corrupted.
       - name: Start a client to download the same files again
         run: |
-          cargo run --bin safe --release -- --log-output-dest=data-dir files download
+          cargo run --bin safe --release -- --log-output-dest=data-dir files download --show-holders
           ls -l $CLIENT_DATA_PATH/downloaded_files
           downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
           if [ $downloaded_files -lt 1 ]; then
@@ -237,7 +237,7 @@ jobs:
         # limits here are lower that benchmark tests as there is less going on.
         run: |
           client_peak_mem_limit_mb="300" # mb
-          client_avg_mem_limit_mb="120" # mb
+          client_avg_mem_limit_mb="150" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -181,7 +181,16 @@ impl SwarmDriver {
                 quorum,
                 expected_holders,
             } => {
-                let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
+                let query_id = self.swarm.behaviour_mut().kademlia.get_record(key.clone());
+
+                let quorum = if expected_holders.is_empty() {
+                    quorum
+                } else {
+                    println!("Record {:?} with task {query_id:?} expected to be held by {expected_holders:?}", PrettyPrintRecordKey::from(key));
+                    // Forcing the Quorum to ALL
+                    GetQuorum::All
+                };
+
                 if self
                     .pending_get_record
                     .insert(

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -55,6 +55,9 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
+/// List of expected record holders to be verified.
+pub(super) type ExpectedHoldersList = HashSet<PeerId>;
+
 type PendingGetClosest = HashMap<QueryId, (oneshot::Sender<HashSet<PeerId>>, HashSet<PeerId>)>;
 type PendingGetRecord = HashMap<
     QueryId,
@@ -62,6 +65,7 @@ type PendingGetRecord = HashMap<
         oneshot::Sender<Result<Record>>,
         GetRecordResultMap,
         GetQuorum,
+        ExpectedHoldersList,
     ),
 >;
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -431,7 +431,7 @@ impl Network {
         })?;
         let response = receiver.await?;
 
-        if verify_store.is_some() {
+        if verify_store.is_some() || !expected_holders.is_empty() {
             // Small wait before we attempt to verify.
             // There will be `re-attempts` to be carried out within the later step anyway.
             tokio::time::sleep(std::time::Duration::from_millis(

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -24,7 +24,7 @@ impl Network {
     pub async fn get_spend(&self, address: SpendAddress, re_attempt: bool) -> Result<SignedSpend> {
         let key = NetworkAddress::from_cash_note_address(address).to_record_key();
         let record = self
-            .get_record_from_network(key, None, GetQuorum::All, re_attempt)
+            .get_record_from_network(key, None, GetQuorum::All, re_attempt, Default::default())
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!(

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -161,7 +161,13 @@ impl Node {
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
                     );
                     node.network
-                        .get_record_from_network(key, None, GetQuorum::Majority, false)
+                        .get_record_from_network(
+                            key,
+                            None,
+                            GetQuorum::Majority,
+                            false,
+                            Default::default(),
+                        )
                         .await?
                 };
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -444,7 +444,7 @@ fn store_chunks_task(
                     }
                 };
                 match file_api
-                    .get_local_payment_and_upload_chunk(chunk, true)
+                    .get_local_payment_and_upload_chunk(chunk, true, false)
                     .await
                 {
                     Ok(()) => content
@@ -663,7 +663,7 @@ async fn query_content(
         }
         NetworkAddress::ChunkAddress(addr) => {
             let file_api = Files::new(client.clone(), wallet_dir.to_path_buf());
-            let _ = file_api.read_bytes(*addr, None).await?;
+            let _ = file_api.read_bytes(*addr, None, false).await?;
             Ok(())
         }
         _other => Ok(()), // we don't create/store any other type of content in this test yet

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -203,7 +203,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
 
     files_api.upload_with_payments(content_bytes, true).await?;
 
-    files_api.read_bytes(content_addr, None).await?;
+    files_api.read_bytes(content_addr, None, false).await?;
 
     Ok(())
 }
@@ -263,7 +263,7 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
         .await?;
 
     assert!(matches!(
-        files_api.read_bytes(content_addr, None).await,
+        files_api.read_bytes(content_addr, None, false).await,
         Err(ClientError::Network(NetworkError::RecordNotFound))
     ));
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Oct 23 14:45 UTC
This pull request introduces a new feature where early completion is implemented when getting a chunk. The patch adds a function `try_early_completion_for_chunk` that checks if the chunk is self-verifiable and completes the flow with the first copy that is fetched. If the early completion is successful, the function returns `true`; otherwise, it returns `false`. Additionally, some code formatting changes and minor improvements are made in the `SwarmDriver` implementation.
<!-- reviewpad:summarize:end --> 
