### PR TITLE
Testing gossipsub

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -357,7 +357,10 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .flood_publish(true) // this is the default anyways
+            .build()
+            .unwrap();
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -190,10 +190,10 @@ pub async fn node_events(addr: SocketAddr, only_rewards: bool) -> Result<()> {
     let mut stream = response.into_inner();
     while let Some(Ok(e)) = stream.next().await {
         let event = match NodeEvent::from_bytes(&e.event) {
-            Ok(NodeEvent::GossipsubMsg { topic, msg }) if only_rewards => {
+            Ok(NodeEvent::TransferNotif { key, transfer }) if only_rewards => {
                 println!(
-                    "New node reward notification received: {topic} {}",
-                    String::from_utf8(msg)?
+                    "New node reward notification received: {key:?} {}",
+                    transfer.to_hex()?
                 );
                 continue;
             }

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -198,6 +198,10 @@ pub async fn node_events(addr: SocketAddr, only_rewards: bool) -> Result<()> {
                 continue;
             }
             Ok(_) if only_rewards => continue,
+            Ok(NodeEvent::GossipsubMsg { topic, msg }) => {
+                println!("New event received: {topic} - {}", String::from_utf8(msg)?);
+                continue;
+            }
             Ok(event) => event,
             Err(_) => {
                 println!("Error while parsing received NodeEvent");

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -191,7 +191,10 @@ pub async fn node_events(addr: SocketAddr, only_rewards: bool) -> Result<()> {
     while let Some(Ok(e)) = stream.next().await {
         let event = match NodeEvent::from_bytes(&e.event) {
             Ok(NodeEvent::GossipsubMsg { topic, msg }) if only_rewards => {
-                println!("New node reward notification received: {topic} {msg:?}");
+                println!(
+                    "New node reward notification received: {topic} {}",
+                    String::from_utf8(msg)?
+                );
                 continue;
             }
             Ok(_) if only_rewards => continue,

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -326,6 +326,7 @@ impl Node {
                 }
             }
             NetworkEvent::GossipsubMsg { topic, msg } => {
+                info!(">>> New Gossipsub msg received on topic '{topic}': {msg:?}");
                 self.events_channel
                     .broadcast(NodeEvent::GossipsubMsg { topic, msg });
             }

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -326,7 +326,10 @@ impl Node {
                 }
             }
             NetworkEvent::GossipsubMsg { topic, msg } => {
-                info!(">>> New Gossipsub msg received on topic '{topic}': {msg:?}");
+                info!(
+                    ">>> New Gossipsub msg received on topic '{topic}': {}",
+                    String::from_utf8(msg.clone()).unwrap_or_else(|m| format!("{m:?}"))
+                );
                 self.events_channel
                     .broadcast(NodeEvent::GossipsubMsg { topic, msg });
             }

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -240,6 +240,24 @@ You can check your reward balance by running:
             ctrl_tx,
             started_instant,
         );
+    } else {
+        info!("======= PID: {pid} =======");
+        let mut addr = node_socket_addr;
+        if pid > 1025 {
+            addr.set_port(pid as u16);
+        } else {
+            addr.set_port(12000 + pid as u16);
+        }
+        info!("================================");
+        info!("======= RPC ADDR: {addr} =======");
+        info!("================================");
+        rpc::start_rpc_service(
+            addr,
+            log_output_dest,
+            running_node.clone(),
+            ctrl_tx,
+            started_instant,
+        );
     }
 
     // Keep the node and gRPC service (if enabled) running.

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -7,9 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::error::{Error, Result};
+use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::UniquePubkey;
+use sn_transfers::{Transfer, UniquePubkey};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
@@ -65,6 +66,13 @@ pub enum NodeEvent {
         topic: String,
         /// The raw bytes of the received message
         msg: Vec<u8>,
+    },
+    /// Transfer notification message received for a public key
+    TransferNotif {
+        /// Public key the transfer notification is about
+        key: PublicKey,
+        /// The encrypted transfer
+        transfer: Transfer,
     },
 }
 

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -95,12 +95,7 @@ async fn msgs_over_gossipsub() -> Result<()> {
 
 #[tokio::test]
 async fn msgs_over_gossipsub_to_testnet() -> Result<()> {
-    let addresses = [
-        "127.0.0.1:12002",
-        "127.0.0.1:12003",
-        "127.0.0.1:12004",
-        "127.0.0.1:12005",
-    ];
+    let addresses = ["127.0.0.1:12001"];
 
     let topic = "genesis-test-1".to_string();
 
@@ -108,7 +103,7 @@ async fn msgs_over_gossipsub_to_testnet() -> Result<()> {
         let addr: SocketAddr = addr.parse()?;
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
-        let msg = format!("TestMsg-from-{index}");
+        let msg = format!("TestMsg-from-{index}={addr}");
 
         let endpoint = format!("https://{addr}");
         let mut rpc_client = SafeNodeClient::connect(endpoint).await?;

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -93,6 +93,38 @@ async fn msgs_over_gossipsub() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn msgs_over_gossipsub_to_testnet() -> Result<()> {
+    let addresses = [
+        "127.0.0.1:12002",
+        "127.0.0.1:12003",
+        "127.0.0.1:12004",
+        "127.0.0.1:12005",
+    ];
+
+    let topic = "genesis-test-1".to_string();
+
+    for (index, addr) in addresses.iter().enumerate() {
+        let addr: SocketAddr = addr.parse()?;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        let msg = format!("TestMsg-from-{index}");
+
+        let endpoint = format!("https://{addr}");
+        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+        println!("Node {index} to publish on {topic} message: {msg}");
+
+        let _response = rpc_client
+            .publish_on_topic(Request::new(GossipsubPublishRequest {
+                topic: topic.clone(),
+                msg: msg.into(),
+            }))
+            .await?;
+    }
+
+    Ok(())
+}
+
 async fn node_subscribe_to_topic(addr: SocketAddr, topic: String) -> Result<()> {
     let endpoint = format!("https://{addr}");
     let mut rpc_client = SafeNodeClient::connect(endpoint).await?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Oct 23 21:32 UTC
This pull request includes the following changes across multiple files:

1. File: `driver.rs`
   - Modified the initialization of `gossipsub_config` to use the `ConfigBuilder` instead of the `Config` struct, setting the `flood_publish` parameter to `true`.
   - Added a comment to explain the expected message authenticity.

2. File: `swarm_driver.rs`
   - Added additional logging and debugging information for the GossipsubPublish function.
   - Fetch all the peers, log the number of peers, log the topics of each peer, and publish the message with Gossipsub.
   - Added error handling to log any errors that occur during the publishing process.

3. File: `api.rs`
   - Added a constant `TRANSFER_NOTIF_TOPIC_PREFIX` to represent the expected prefix string in a topic name for transfer notifications.
   - Modified the `impl Node` block to handle `NetworkEvent::GossipsubMsg` events. It now processes transfer notifications if the topic starts with the `TRANSFER_NOTIF_TOPIC_PREFIX`, and broadcasts other Gossipsub messages as before.

4. File: `event.rs`
   - Imported the `PublicKey` type from the `bls` module.
   - Imported the `Transfer` type from the `sn_transfers` module.
   - Added a new variant `TransferNotif` to the `NodeEvent` enum, representing a transfer notification message received for a public key. It contains `key` of type `PublicKey` and `transfer` of type `Transfer`.

5. File: `rpc.rs`
   - Added logging statements to print the process ID (PID) and the RPC address.
   - Configured the RPC address based on the PID.
   - Called the `start_rpc_service()` function with the newly configured RPC address.

6. File: `safenode_rpc_client.rs`
   - Added a new command `RewardsEvents` to listen for node rewards events separately.
   - Modified the `node_events` function to accept a boolean parameter `only_rewards`.
   - Updated the `main` function to handle the new `RewardsEvents` command and pass the `only_rewards` argument.
   - Modified the implementation of the `node_events` function to handle rewards notifications separately and print the appropriate message.

7. File: `msgs_over_gossipsub.rs`
   - Added a loop that generates random numbers and subscribes nodes to new topics.
   - Updated the `node_subscribe_to_topic` function to connect to the endpoint using the `SafeNodeClient`.
   - Listens to node events and prints received gossipsub messages.
   - Modified the `other_nodes_to_publish_on_topic` function to publish messages from nodes other than the filter address.
   - Modified the loop in the `msgs_over_gossipsub` function to delay for 5 seconds, publish messages, and wait for handles to complete.
   - Added a commented-out test function `msgs_over_gossipsub_to_testnet` to perform similar operations with different addresses and topics.

Let me know if there's anything else I can help you with.
<!-- reviewpad:summarize:end --> 
