### PR TITLE
feat: improve register API

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -239,6 +239,11 @@ impl Client {
         self.signer.sign(data)
     }
 
+    /// Return a reference to the signer secret key
+    pub fn signer(&self) -> &SecretKey {
+        &self.signer
+    }
+
     /// Return the public key of the data signing key
     pub fn signer_pk(&self) -> PublicKey {
         self.signer.public_key()

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -16,9 +16,7 @@ use sn_protocol::{
     storage::{try_serialize_record, RecordKind},
     NetworkAddress,
 };
-use sn_registers::{
-    Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister, User,
-};
+use sn_registers::{Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister};
 use sn_transfers::Transfer;
 
 use std::collections::{BTreeSet, LinkedList};
@@ -154,12 +152,11 @@ impl ClientRegister {
     pub fn write_atop(&mut self, entry: &[u8], children: BTreeSet<EntryHash>) -> Result<()> {
         // check permissions first
         let public_key = self.client.signer_pk();
-        self.register
-            .check_user_permissions(User::Key(public_key))?;
+        self.register.check_user_permissions(public_key)?;
 
-        let (_hash, mut op) = self.register.write(entry.into(), children)?;
-        let signature = self.client.sign(op.bytes_for_signing());
-        op.add_signature(public_key, signature)?;
+        let (_hash, op) = self
+            .register
+            .write(entry.into(), children, self.client.signer())?;
         let cmd = RegisterCmd::Edit(op);
 
         self.ops.push_front(cmd);

--- a/sn_registers/src/error.rs
+++ b/sn_registers/src/error.rs
@@ -6,10 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{EntryHash, RegisterAddress, User};
+use crate::{EntryHash, RegisterAddress};
 
 #[derive(Error, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Error {
@@ -34,7 +35,7 @@ pub enum Error {
     },
     /// Access denied for user
     #[error("Access denied for user: {0:?}")]
-    AccessDenied(User),
+    AccessDenied(PublicKey),
     /// Cannot add another entry since the register entry cap has been reached.
     #[error("Cannot add another entry since the register entry cap has been reached: {0}")]
     TooManyEntries(usize),

--- a/sn_registers/src/lib.rs
+++ b/sn_registers/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::{
     address::RegisterAddress,
     error::Error,
     metadata::{Entry, EntryHash},
-    permissions::{Permissions, User},
+    permissions::Permissions,
     register::{Register, SignedRegister},
     register_op::RegisterOp,
 };

--- a/sn_registers/src/permissions.rs
+++ b/sn_registers/src/permissions.rs
@@ -46,12 +46,12 @@ impl Permissions {
     }
 
     /// Checks is everyone can write to this Register
-    pub fn everyone_can_write(&self) -> bool {
+    pub fn anyone_can_write(&self) -> bool {
         self.anyone_can_write
     }
 
     /// Returns true if the given user can write to this Register
     pub fn can_write(&self, user: &PublicKey) -> bool {
-        self.everyone_can_write() || self.writers.contains(user)
+        self.anyone_can_write() || self.writers.contains(user)
     }
 }

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -235,7 +235,7 @@ impl Register {
     /// Check if a register op is valid for our current register
     pub fn check_register_op(&self, op: &RegisterOp) -> Result<()> {
         self.check_user_permissions(op.source)?;
-        if self.permissions.everyone_can_write() {
+        if self.permissions.anyone_can_write() {
             return Ok(()); // anyone can write, so no need to check the signature
         }
 


### PR DESCRIPTION
Improve Register API and remove code smells:

- no more clunky manual signing of ops after they are created `register.write()` now signs the Ops before returning them
- remove weird and extra `User` type, now operations are identified by a `PublicKey`
- `Signatures` are not Optional for RegisterOps anymore
- simplify `Permissions`

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Oct 23 08:38 UTC
This pull request modifies several files in the codebase. Here is a summary of the changes:

1. The `error.rs` file:
   - Adds the import statement `use bls::PublicKey`.
   - Removes the import statement `use crate::User`.
   - Changes the input type of the `AccessDenied` variant of the `Error` enum from `User` to `PublicKey`.
   - Modifies the error message for the `TooManyEntries` variant.

2. The `lib.rs` file:
   - Removes the import statements for `User` from the `permissions` module.
   - Indicates that the code no longer depends on the `User` struct from the `permissions` module.

3. The `reg_crdt.rs` file:
   - Modifies the `RegisterCrdt` implementation.
   - Removes the `User` import from the crate.
   - Imports the `MerkleDagEntry` type from the `crdts::merkle_reg` module.
   - Changes the return type of the `write` method to include the `RegisterAddress` and `MerkleDagEntry<Entry>` types.
   - Removes the `source` parameter from the `write` method and updates the method implementation accordingly.
   - Modifies the `Ok` value returned by the `write` method to include the `RegisterAddress` and `MerkleDagEntry<Entry>` values.
   - Makes changes to the test cases to reflect the updated `write` method signature.

4. The `register.rs` file:
   - Contains several changes.
   - Modifies the import statements.
   - Modifies the `write_atop` function, changing the call to `check_user_permissions` and `write`.
   - Adds a new line before the call to `self.register.write`.
   - Reassigns the result of `self.register.write` to `op`.
   - The `self.ops.push_front(cmd)` line remains unchanged.

5. The `permissions.rs` file:
   - Contains changes related to handling permissions for accessing a register.
   - Adds the `use bls::PublicKey` import statement.
   - Removes the `User` enum.
   - Adds a new field `anyone_can_write` to the `Permissions` struct.
   - Changes the `writers` field of the `Permissions` struct to use `BTreeSet<PublicKey>`.
   - Updates the `new_with` method of the `Permissions` struct.
   - Adds a new method `everyone_can_write` to check if everyone can write to this register.
   - Updates the `can_write` method of the `Permissions` struct to accept `user` of type `&PublicKey`.

6. The `register_op.rs` file:
   - Updates the `RegisterOp` struct.
   - Adds the import statements for `SecretKey` and `PublicKey` from the `bls` module.
   - Modifies the `source` field in the `RegisterOp` struct from `User` to `PublicKey`.
   - Modifies the `signature` field to be a required `bls::Signature`.
   - Changes the visibility of the `new` function.
   - Modifies the `new` function to take a `signer` argument of type `&SecretKey`.
   - Updates the implementation of the `new` function.
   - Modifies the `source` method to return a `PublicKey`.
   - Adds a new method `verify_signature` to check the signature of the `RegisterOp`.
   - Modifies the implementation of the `bytes_for_signing` method.
   - Removes the `sign_with` and `add_signature` methods.

7. The `api.rs` file:
   - Contains changes including the addition of a new method `signer()` in the `impl Client` block.

This pull request includes various changes that update and improve different parts of the codebase. Let me know if you need any further assistance!
<!-- reviewpad:summarize:end --> 
