### PR TITLE
feat: quorum for records get

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -346,8 +346,8 @@ async fn verify_and_repay_if_needed(
             // Spawn a new task to fetch each chunk concurrently
             let handle = tokio::spawn(async move {
                 let chunk_address: ChunkAddress = ChunkAddress::new(name);
-                // Attempt to fetch the chunk
-                let res = file_api.client().get_chunk(chunk_address).await;
+                // make sure the chunk is stored
+                let res = file_api.client().verify_chunk_stored(chunk_address).await;
 
                 Ok::<_, Error>(((chunk_address, path), res.is_err()))
             });

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -18,7 +18,7 @@ use crate::{
     record_store::{ClientRecordStore, NodeRecordStore, NodeRecordStoreConfig},
     record_store_api::UnifiedRecordStore,
     replication_fetcher::ReplicationFetcher,
-    Network, CLOSE_GROUP_SIZE,
+    GetQuorum, Network, CLOSE_GROUP_SIZE,
 };
 use futures::StreamExt;
 #[cfg(feature = "quic")]
@@ -56,7 +56,14 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
 type PendingGetClosest = HashMap<QueryId, (oneshot::Sender<HashSet<PeerId>>, HashSet<PeerId>)>;
-type PendingGetRecord = HashMap<QueryId, (oneshot::Sender<Result<Record>>, GetRecordResultMap)>;
+type PendingGetRecord = HashMap<
+    QueryId,
+    (
+        oneshot::Sender<Result<Record>>,
+        GetRecordResultMap,
+        GetQuorum,
+    ),
+>;
 
 /// What is the largest packet to send over the network.
 /// Records larger than this will be rejected.

--- a/sn_networking/src/quorum.rs
+++ b/sn_networking/src/quorum.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+/// When fetching a Record, the quorum to use.
+/// The answer threshold we need to reach to consider the fetch successful.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum GetQuorum {
+    All,
+    Majority,
+    One,
+}

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -8,7 +8,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::Network;
+use crate::{GetQuorum, Network};
 
 use sn_protocol::{
     error::{Error, Result},
@@ -24,7 +24,7 @@ impl Network {
     pub async fn get_spend(&self, address: SpendAddress, re_attempt: bool) -> Result<SignedSpend> {
         let key = NetworkAddress::from_cash_note_address(address).to_record_key();
         let record = self
-            .get_record_from_network(key, None, re_attempt)
+            .get_record_from_network(key, None, GetQuorum::All, re_attempt)
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!(

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -12,7 +12,7 @@ use libp2p::{
     kad::{Record, RecordKey, K_VALUE},
     PeerId,
 };
-use sn_networking::{sort_peers_by_address, CLOSE_GROUP_SIZE};
+use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
@@ -163,7 +163,7 @@ impl Node {
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
                     );
                     node.network
-                        .get_record_from_network(key, None, false)
+                        .get_record_from_network(key, None, GetQuorum::One, false)
                         .await?
                 };
 

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -163,7 +163,7 @@ impl Node {
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
                     );
                     node.network
-                        .get_record_from_network(key, None, GetQuorum::One, false)
+                        .get_record_from_network(key, None, GetQuorum::Majority, false)
                         .await?
                 };
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Oct 23 11:57 UTC
This pull request modifies the code in multiple files. 

In the `sn_client/src/api.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used in the `get_record_from_network` method calls.

In the `sn_networking/src/cmd.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a field in the `GetNetworkRecord` enum variant of the `SwarmCmd` enum.

In the `sn_networking/src/driver.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a field in the `PendingGetRecord` type alias.

In the `sn_networking/src/event.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a field in the `GetNetworkRecord` enum variant of the `SwarmCmd` enum, and as a field in the `SwarmDriver` struct.

In the `sn_networking/src/lib.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a field in the `GetNetworkRecord` enum variant of the `SwarmCmd` enum and as a parameter in the `get_record_from_network` method.

In the `sn_networking/src/quorum.rs` file, a new module is added that defines the `GetQuorum` enum.

In the `sn_networking/src/transfers.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a parameter in the `get_record_from_network` method.

In the `sn_node/src/replication.rs` file, the `GetQuorum` enum is imported from `sn_networking` and used as a parameter in the `get_record_from_network` method.

Overall, this pull request makes changes related to using the `GetQuorum` enum in the code.
<!-- reviewpad:summarize:end --> 
