### PR TITLE
fix: record_to_verify for store_chunk shall be a Chunk

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -303,14 +303,22 @@ impl Client {
         let key = chunk.network_address().to_record_key();
 
         let record = Record {
-            key,
-            value: try_serialize_record(&(payment, chunk), RecordKind::ChunkWithPayment)?,
+            key: key.clone(),
+            value: try_serialize_record(&(payment, chunk.clone()), RecordKind::ChunkWithPayment)?,
             publisher: None,
             expires: None,
         };
 
         let record_to_verify = if verify_store {
-            Some(record.clone())
+            // The `ChunkWithPayment` is only used to send out via PutRecord.
+            // The holders shall only hold the `Chunk` copies.
+            // Hence the fetched record shall only be a `Chunk`
+            Some(Record {
+                key,
+                value: try_serialize_record(&chunk, RecordKind::Chunk)?,
+                publisher: None,
+                expires: None,
+            })
         } else {
             None
         };


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Oct 23 13:17 UTC
This pull request fixes the `record_to_verify` function in the `store_chunk` method of the `Client` struct. Previously, the `record_to_verify` was set to a cloned version of the `record`, which caused potential issues with storing the chunk with payment. Now, the `record_to_verify` is set to a `Chunk` which is the correct type for verification purposes.
<!-- reviewpad:summarize:end --> 
