### PR TITLE
feat: use progress bars on `files upload`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ dependencies = [
  "criterion 0.5.1",
  "dirs-next",
  "hex",
+ "indicatif",
  "libp2p",
  "reqwest",
  "sn_build_info",

--- a/Justfile
+++ b/Justfile
@@ -212,3 +212,10 @@ upload-release-assets-to-s3 bin_name:
   for file in *.zip *.tar.gz; do
     aws s3 cp "$file" "s3://$bucket/$file" --acl public-read
   done
+
+run-local-network:
+  #!/usr/bin/env bash
+  pgrep safenode | xargs kill -9
+  pgrep faucet | xargs kill -9
+  rm -rf ~/.local/share/safe
+  cargo run --bin testnet --features local-discovery -- --build-node --build-faucet --interval 1000

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -34,6 +34,7 @@ clap = { version = "4.2.1", features = ["derive"]}
 color-eyre = "~0.6"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
+indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = { version="0.52", features = ["identify", "kad"] }
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -206,9 +206,14 @@ async fn upload_files(
             "Getting upload costs from network for {} chunks...",
             chunks_batch.len()
         );
-        file_api
+        let (cost, new_balance) = file_api
             .pay_for_chunks(chunks_batch.iter().map(|(name, _)| *name).collect(), true)
             .await?;
+        println!("Made payment of {cost} for {} chunks", chunks_batch.len());
+        println!(
+            "Stored wallet with cached payment proofs. New balance: {}",
+            new_balance
+        );
 
         // Verification will be carried out later on, if being asked to.
         // Hence no need to carry out verification within the first attempt.

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -21,7 +21,7 @@ use sn_protocol::{
     storage::{Chunk, ChunkAddress},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::LocalWallet;
+use sn_transfers::{LocalWallet, NanoTokens};
 
 use std::{
     fs::{self, create_dir_all, File},
@@ -186,8 +186,14 @@ impl Files {
         Ok(())
     }
 
-    /// Pay for a given set of chunks
-    pub async fn pay_for_chunks(&self, chunks: Vec<XorName>, verify_store: bool) -> Result<()> {
+    /// Pay for a given set of chunks.
+    ///
+    /// Returns the cost and the resulting new balance of the local wallet.
+    pub async fn pay_for_chunks(
+        &self,
+        chunks: Vec<XorName>,
+        verify_store: bool,
+    ) -> Result<(NanoTokens, NanoTokens)> {
         let mut wallet_client = self.wallet()?;
         info!("Paying for and uploading {:?} chunks", chunks.len());
 
@@ -199,18 +205,10 @@ impl Files {
                 verify_store,
             )
             .await?;
-        println!("Made payment of {cost} for {} chunks", chunks.len(),);
 
-        if let Err(err) = wallet_client.store_local_wallet() {
-            println!("Failed to store wallet: {err:?}");
-        } else {
-            println!(
-                "Stored wallet with cached payment proofs. New balance: {}",
-                wallet_client.balance()
-            );
-        }
-
-        Ok(())
+        wallet_client.store_local_wallet()?;
+        let new_balance = wallet_client.balance();
+        Ok((cost, new_balance))
     }
 
     // --------------------------------------------

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -20,7 +20,7 @@ use futures::future::join_all;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter::Iterator,
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tokio::{task::JoinSet, time::sleep};
 
@@ -198,9 +198,6 @@ impl WalletClient {
     ) -> WalletResult<NanoTokens> {
         // TODO:
         // Check for any existing payment CashNotes, and use them if they exist, only topping up if needs be
-        let num_of_payments = all_data_payments.len();
-
-        let now = Instant::now();
         let mut total_cost = NanoTokens::zero();
         for (_data, costs) in all_data_payments.iter() {
             for (_target, cost) in costs {
@@ -229,10 +226,6 @@ impl WalletClient {
             info!("Spend has completed: {:?}", spend_attempt_result);
             self.wallet.clear_unconfirmed_spend_requests();
         }
-
-        let elapsed = now.elapsed();
-        println!("All transfers completed in {elapsed:?}");
-        println!("Total payment: {total_cost:?} nano tokens for {num_of_payments:?} chunks");
 
         Ok(total_cost)
     }

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -289,7 +289,6 @@ impl LocalWallet {
         }
 
         self.update_local_wallet(transfer_outputs)?;
-        println!("Transfers applied locally");
 
         self.wallet
             .payment_transactions


### PR DESCRIPTION
- 7d95d862 **refactor: pay_for_chunks returns cost and new balance**

  Rather than the client printing out information relating to the cost of the chunks and the resulting
  new balance, the information is returned to the caller, who can then print it out.

  The error handling for storing the wallet is also changed to propagate the error rather than
  suppressing it by printing output.

- ce3c5853 **refactor: use one files api and clarify variable names**

  The `file_api` was being created multiple times when it didn't seem to need to be. It is easier to
  pass around the `file_api` that you create once, rather than the client and the wallet directory
  path.

  I also renamed `root_dir` to `wallet_dir_path` because there didn't seem to be any need for it to
  not be more specific as to what it actually refers to.

- 6665ff2d **feat: use progress bars on `files upload`**

  Change the user interface for the `files upload` command to use progress bars to indicate the status
  of the following operations:

  * Splitting the input files into chunks
  * Uploading the split chunks
  * Verifying the chunks that were uploaded
  * Re-uploading any chunks that failed verification

  It uses a simple approach, which is to create a new `ProgressBar` for each of the operations, rather
  than attempt to use a `MultiBar` or re-use the same progress bar. In this simple approach, the
  `finish_and_clear` function removes the bar from stderr, then a new bar is created for the next
  operation.

  The `println!` output from the client was removed in favour of returning that information back to
  the caller.

  There is much less text in the output of the command now, but it hopefully communicates everything
  that's important.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Oct 23 00:05 UTC
This pull request includes the following changes:

1. The `NanoTokens` struct has been imported from the `sn_transfers` module.
2. The `pay_for_chunks` method now returns the cost and new balance of the local wallet.
3. The documentation for the `pay_for_chunks` method has been improved.

The "Justfile" script has been modified to add a new task called "run-local-network". This task kills the processes "safenode" and "faucet", removes the directory "~/.local/share/safe", and then builds the testnet with local discovery using "cargo" with an interval of 1000.

In the "Cargo.toml" file, the following changes have been made:
- Added dependency `indicatif` with version `0.17.5` and features `["tokio"]`.
- Updated dependency `libp2p` to version `0.52` and added features `["identify", "kad"]`.
- Updated dependency `reqwest` to version `0.11.18` with default features disabled and added feature `["rustls"]`.

In the `wallet.rs` file, there are several changes:
1. The `root_dir` parameter has been replaced with `wallet_dir_path`.
2. The `send`, `receive`, and `get_faucet` functions now include the `wallet_dir_path` parameter.
3. The `WalletCmds::Pay` variant has been modified to include a `path` parameter and `batch_size` field.
4. The `chunk_path` function now takes a `file_api` parameter instead of `client` and `root_dir`.
5. The creation of `file_api` has been moved outside the `WalletCmds::Pay` variant.

The "indicatif" dependency has been added to the `Cargo.lock` file.

In the `local_store.rs` file, the `println!("Transfers applied locally");` statement has been removed from the `update_local_wallet` method of the `LocalWallet` struct.

The `wallet.rs` file has the following changes:
- The import statement for `Instant` has been removed.
- The variable `num_of_payments` has been removed.
- The variable `now` and its usage in time tracking have been removed.
- The print statements for transfer completion and total payment have been removed.

Please let me know if you need more information on any specific lines of code.
<!-- reviewpad:summarize:end --> 
