### PR TITLE
fix(client): remove concurrency limitations

### DIFF
--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -73,12 +73,6 @@ pub(crate) struct Opt {
     #[clap(long = "timeout", global = true, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_secs)?) })]
     pub timeout: Option<Duration>,
 
-    /// Maximum concurrent uploads/downloads.
-    ///
-    /// Defaults to 5.
-    #[clap(long = "concurrency", short = 'c', global = true)]
-    pub concurrency: Option<usize>,
-
     /// Prevent verification of data storage on the network.
     ///
     /// This may increase operation speed, but offers no guarantees that operations were successful.

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
         Some(bootstrap_peers)
     };
 
-    let client = Client::new(secret_key, bootstrap_peers, opt.timeout, opt.concurrency).await?;
+    let client = Client::new(secret_key, bootstrap_peers, opt.timeout).await?;
 
     // default to verifying storage
     let should_verify_store = !opt.no_verify;

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -250,6 +250,11 @@ async fn upload_files(
         chunks_to_upload.len()
     );
     println!("New wallet balance: {final_balance}");
+    info!(
+        "Made payment of {total_cost} for {} chunks",
+        chunks_to_upload.len()
+    );
+    info!("New wallet balance: {final_balance}");
 
     // If we are not verifying, we can skip this
     if verify_store {
@@ -279,6 +284,7 @@ async fn upload_files(
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
         println!("Uploaded {} to {:x}", file_name, addr);
+        info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }
     file.flush()?;

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -31,10 +31,6 @@ use tokio::task::spawn;
 use tracing::trace;
 use xor_name::XorName;
 
-// Maximum number of concurrency to be allowed at any time
-// eg, concurrent uploads/downloads of chunks, managed by a semaphore
-pub const DEFAULT_CLIENT_CONCURRENCY: usize = 5;
-
 /// The timeout duration for the client to receive any response from the network.
 const INACTIVITY_TIMEOUT: std::time::Duration = tokio::time::Duration::from_secs(30);
 
@@ -44,7 +40,6 @@ impl Client {
         signer: SecretKey,
         peers: Option<Vec<Multiaddr>>,
         req_response_timeout: Option<Duration>,
-        custom_concurrency_limit: Option<usize>,
     ) -> Result<Self> {
         // If any of our contact peers has a global address, we'll assume we're in a global network.
         let local = match peers {
@@ -61,8 +56,6 @@ impl Client {
         if let Some(request_timeout) = req_response_timeout {
             network_builder.request_timeout(request_timeout);
         }
-        network_builder
-            .concurrency_limit(custom_concurrency_limit.unwrap_or(DEFAULT_CLIENT_CONCURRENCY));
 
         #[cfg(feature = "open-metrics")]
         network_builder.metrics_registry(Registry::default());

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -249,18 +249,13 @@ impl NetworkBuilder {
                 NonZeroUsize::new(CLOSE_GROUP_SIZE).ok_or_else(|| Error::InvalidCloseGroupSize)?,
             );
 
-        let concurrency_limit = self.concurrency_limit;
-        let (mut network, net_event_recv, driver) = self.build(
+        let (network, net_event_recv, driver) = self.build(
             kad_cfg,
             None,
             true,
             ProtocolSupport::Outbound,
             truncate_patch_version(IDENTIFY_CLIENT_VERSION_STR).to_string(),
         )?;
-
-        if let Some(limit) = concurrency_limit {
-            network.set_concurrency_limit(limit);
-        }
 
         Ok((network, net_event_recv, driver))
     }
@@ -444,7 +439,6 @@ impl NetworkBuilder {
                 peer_id,
                 root_dir_path: self.root_dir,
                 keypair: self.keypair,
-                concurrency_limiter: None,
             },
             network_event_receiver,
             swarm_driver,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -117,7 +117,7 @@ pub struct Network {
     keypair: Keypair,
     /// Optional Concurrent limiter to limit the number of concurrent requests
     /// Intended for client side use
-    concurrency_limiter: Option<Arc<Semaphore>>,
+    concurrency_limiter: None,
 }
 
 impl Network {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -45,8 +45,8 @@ use sn_protocol::{
 };
 use sn_transfers::MainPubkey;
 use sn_transfers::NanoTokens;
-use std::{collections::HashSet, path::PathBuf, sync::Arc};
-use tokio::sync::{mpsc, oneshot, Semaphore};
+use std::{collections::HashSet, path::PathBuf};
+use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
 /// The maximum number of peers to return in a `GetClosestPeers` response.
@@ -115,25 +115,12 @@ pub struct Network {
     pub peer_id: PeerId,
     pub root_dir_path: PathBuf,
     keypair: Keypair,
-    /// Optional Concurrent limiter to limit the number of concurrent requests
-    /// Intended for client side use
-    concurrency_limiter: None,
 }
 
 impl Network {
     /// Signs the given data with the node's keypair.
     pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
         self.keypair.sign(msg).map_err(Error::from)
-    }
-
-    /// Get the network's concurrency limiter
-    pub fn concurrency_limiter(&self) -> Option<Arc<Semaphore>> {
-        self.concurrency_limiter.clone()
-    }
-
-    /// Set a new concurrency semaphore to limit client network operations
-    pub fn set_concurrency_limit(&mut self, limit: usize) {
-        self.concurrency_limiter = Some(Arc::new(Semaphore::new(limit)));
     }
 
     /// Dial the given peer at the given address.
@@ -187,13 +174,6 @@ impl Network {
         record_address: NetworkAddress,
     ) -> Result<Vec<(MainPubkey, NanoTokens)>> {
         let (sender, receiver) = oneshot::channel();
-        // get permit if semaphore supplied
-        let mut _permit = None;
-        if let Some(semaphore) = self.concurrency_limiter.clone() {
-            let our_permit = semaphore.acquire_owned().await?;
-            _permit = Some(our_permit);
-        }
-
         trace!("Attempting to get store cost");
         // first we need to get CLOSE_GROUP of the unique_pubkey
         self.send_swarm_cmd(SwarmCmd::GetClosestPeers {
@@ -261,17 +241,11 @@ impl Network {
         target_record: Option<Record>,
         re_attempt: bool,
     ) -> Result<Record> {
-        let mut _permit = None;
-
         let total_attempts = if re_attempt { VERIFICATION_ATTEMPTS } else { 1 };
 
         let mut verification_attempts = 0;
 
         while verification_attempts < total_attempts {
-            if let Some(semaphore) = self.concurrency_limiter.clone() {
-                let our_permit = semaphore.acquire_owned().await?;
-                _permit = Some(our_permit);
-            }
             verification_attempts += 1;
             info!(
                 "Getting record of {:?} attempts {verification_attempts:?}/{total_attempts:?}",
@@ -353,9 +327,6 @@ impl Network {
                 }
             }
 
-            // drop any permit while we wait
-            _permit = None;
-
             // wait for a bit before re-trying
             if re_attempt {
                 tokio::time::sleep(REVERIFICATION_WAIT_TIME_S).await;
@@ -394,7 +365,6 @@ impl Network {
     pub async fn put_record(&self, record: Record, verify_store: Option<Record>) -> Result<()> {
         let mut retries = 0;
 
-        // let mut has_permit = optional_permit.is_some();
         // TODO: Move this put retry loop up above store cost checks so we can re-put if storecost failed.
         while retries < PUT_RECORD_RETRIES {
             info!(
@@ -415,14 +385,6 @@ impl Network {
     }
 
     async fn put_record_once(&self, record: Record, verify_store: Option<Record>) -> Result<()> {
-        // get permit if semaphore supplied
-        let _permit = if let Some(semaphore) = self.concurrency_limiter.clone() {
-            let our_permit = semaphore.acquire_owned().await?;
-            Some(our_permit)
-        } else {
-            None
-        };
-
         let record_key = record.key.clone();
         let pretty_key = PrettyPrintRecordKey::from(record_key.clone());
         info!(
@@ -438,8 +400,6 @@ impl Network {
             sender,
         })?;
         let response = receiver.await?;
-
-        drop(_permit);
 
         if verify_store.is_some() {
             // Small wait before we attempt to verify.

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     let signer = SecretKey::random();
 
     println!("Starting SAFE client...");
-    let client = Client::new(signer, None, None, None).await?;
+    let client = Client::new(signer, None, None).await?;
     println!("SAFE client signer public key: {:?}", client.signer_pk());
 
     let root_dir = dirs_next::data_dir()

--- a/sn_node/src/bin/faucet/main.rs
+++ b/sn_node/src/bin/faucet/main.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     info!("Instantiating a SAFE Test Faucet...");
 
     let secret_key = bls::SecretKey::random();
-    let client = Client::new(secret_key, bootstrap_peers, None, None).await?;
+    let client = Client::new(secret_key, bootstrap_peers, None).await?;
 
     faucet_cmds(opt.cmd, &client).await?;
 

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -84,7 +84,7 @@ pub async fn get_client() -> Client {
     };
 
     println!("Client bootstrap with peer {bootstrap_peers:?}");
-    Client::new(secret_key, bootstrap_peers, None, None)
+    Client::new(secret_key, bootstrap_peers, None)
         .await
         .expect("Client shall be successfully created.")
 }

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -65,10 +65,6 @@ impl LocalWallet {
         store_created_cash_notes(cash_note, &self.wallet_dir)
     }
 
-    pub fn get_cash_note(&mut self, unique_pubkey: &UniquePubkey) -> Option<CashNote> {
-        load_cash_note(unique_pubkey, &self.wallet_dir)
-    }
-
     /// Store unconfirmed_spend_requests to disk.
     pub fn store_unconfirmed_spend_requests(&mut self) -> Result<()> {
         store_unconfirmed_spend_requests(&self.wallet_dir, self.unconfirmed_spend_requests())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Oct 23 07:31 UTC
This pull request removes the `concurrency` option from the CLI struct in `sn_cli/src/cli.rs`. The `concurrency` field was previously used to specify the maximum number of concurrent uploads/downloads, but it is no longer needed. The `Client::new` function in `sn_cli/src/main.rs` is updated to remove the `concurrency` parameter when creating a new client. The code in `sn_cli/src/subcommands/files.rs` and `sn_networking/src/api.rs` that references `concurrency` is also updated accordingly. Additionally, the `concurrency_limiter` field in the `Network` struct in `sn_networking/src/lib.rs` and the corresponding methods are removed since they are no longer used. Finally, the `get_cash_note` method in `sn_transfers/src/wallet/local_store.rs` is removed as it is no longer used.
<!-- reviewpad:summarize:end --> 
