### PR TITLE
fix(sn_transfers): be sure we store CashNotes before writing the wall…

### DIFF
--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -54,7 +54,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
 
     faucet_wallet.deposit(&vec![cash_note.clone()])?;
     faucet_wallet
-        .store()
+        .store(vec![])
         .expect("Faucet wallet shall be stored successfully.");
     println!("Faucet wallet balance: {}", faucet_wallet.balance());
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -39,7 +39,7 @@ impl WalletClient {
 
     /// Stores the wallet to disk.
     pub fn store_local_wallet(&self) -> WalletResult<()> {
-        self.wallet.store()
+        self.wallet.store(vec![])
     }
 
     /// Get the wallet balance
@@ -383,9 +383,8 @@ pub async fn send(
         }
     }
 
-    let mut wallet = wallet_client.into_wallet();
-    wallet.store()?;
-    wallet.store_cash_note(&new_cash_note)?;
+    let wallet = wallet_client.into_wallet();
+    wallet.store(vec![&new_cash_note])?;
 
     if did_error {
         return Err(WalletError::UnconfirmedTxAfterRetries);

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -122,7 +122,8 @@ impl Node {
         let reward_address = reward_key.main_pubkey();
 
         let wallet = LocalWallet::load_from_main_key(&root_dir, reward_key)?;
-        wallet.store()?;
+        // store in case it's a fresh wallet created if none was found
+        wallet.store(vec![])?;
 
         #[cfg(feature = "open-metrics")]
         let (metrics_registry, node_metrics) = {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -456,7 +456,7 @@ impl Node {
             .deposit(&cash_notes)
             .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
         wallet
-            .store()
+            .store(vec![])
             .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
         info!("Payment of {received_fee:?} nanos accepted for record {pretty_key:?}");
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -85,7 +85,7 @@ pub fn load_genesis_wallet() -> Result<LocalWallet, Error> {
         .deposit(&vec![GENESIS_CASHNOTE.clone()])
         .map_err(|err| Error::WalletError(err.to_string()))?;
     genesis_wallet
-        .store()
+        .store(vec![])
         .expect("Genesis wallet shall be stored successfully.");
 
     let genesis_balance = genesis_wallet.balance();

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -49,7 +49,8 @@ pub struct LocalWallet {
 
 impl LocalWallet {
     /// Stores the wallet to disk.
-    pub fn store(&self) -> Result<()> {
+    pub fn store(&self, new_cash_notes: Vec<&CashNote>) -> Result<()> {
+        self.store_cash_notes(new_cash_notes)?;
         store_wallet(&self.wallet_dir, &self.wallet)
     }
 
@@ -61,7 +62,7 @@ impl LocalWallet {
 
     /// Stores the given cash_notes to the `created cash_notes dir` in the wallet dir.
     /// These can then be sent to the recipients out of band, over any channel preferred.
-    pub fn store_cash_notes(&mut self, cash_note: Vec<&CashNote>) -> Result<()> {
+    pub fn store_cash_notes(&self, cash_note: Vec<&CashNote>) -> Result<()> {
         store_created_cash_notes(cash_note, &self.wallet_dir)
     }
 
@@ -335,6 +336,7 @@ impl LocalWallet {
         Ok(())
     }
 
+    /// Store the given cash_notes to the `received cash_notes dir` in the wallet dir.
     pub fn deposit(&mut self, cash_notes: &Vec<CashNote>) -> Result<()> {
         if cash_notes.is_empty() {
             return Ok(());
@@ -636,7 +638,7 @@ mod tests {
         let genesis =
             create_first_cash_note_from_key(&depositor.key).expect("Genesis creation to succeed.");
         depositor.deposit(&vec![genesis])?;
-        depositor.store()?;
+        depositor.store(vec![])?;
 
         let deserialized = LocalWallet::load_from(&root_dir)?;
 
@@ -722,7 +724,7 @@ mod tests {
         let to = vec![(NanoTokens::from(send_amount), recipient_main_pubkey)];
         let _created_cash_notes = sender.local_send(to, None)?;
 
-        sender.store()?;
+        sender.store(vec![])?;
 
         let deserialized = LocalWallet::load_from(&root_dir)?;
 


### PR DESCRIPTION
…et file

This should prevent concurrency issues with referenced Notes not existing on disk yet

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Oct 23 10:18 UTC
This pull request fixes an issue related to concurrency when storing CashNotes in the wallet file. It ensures that CashNotes are stored before writing the wallet file to prevent any concurrency issues with referenced Notes not existing on disk yet. There are changes made in multiple files to address this issue.
<!-- reviewpad:summarize:end --> 
