### PR TITLE
ci: reduce memcheck churn test time

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Chunks data integrity during nodes churn
         run: cargo test --release -p sn_node --test data_with_churn -- --nocapture
         env:
-          TEST_DURATION_MINS: 15
+          TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
         timeout-minutes: 30


### PR DESCRIPTION
Brings this inline with other churn tests, doing more in less time

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Oct 23 11:07 UTC
This pull request reduces the test time for the memcheck churn test in the CI workflow. It brings it inline with other churn tests, doing more in less time. The TEST_DURATION_MINS environment variable has been changed from 15 to 5, while TEST_TOTAL_CHURN_CYCLES remains at 15.
<!-- reviewpad:summarize:end --> 
