### PR TITLE
fix: make client handle payment error

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -223,9 +223,16 @@ async fn upload_files(
     let now = Instant::now();
     for chunks_batch in chunks_to_upload.chunks(batch_size) {
         // pay for and verify payment... if we don't verify here, chunks uploads will surely fail
-        let (cost, new_balance) = file_api
+        let (cost, new_balance) = match file_api
             .pay_for_chunks(chunks_batch.iter().map(|(name, _)| *name).collect(), true)
-            .await?;
+            .await
+        {
+            Ok((cost, new_balance)) => (cost, new_balance),
+            Err(err) => {
+                error!("Error paying for chunks: {err:?}");
+                continue;
+            }
+        };
         final_balance = new_balance;
         total_cost = total_cost
             .checked_add(cost)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Oct 23 14:21 UTC
This pull request fixes an issue where the client was not handling payment errors properly when uploading files. The patch in `sn_cli/src/subcommands/files.rs` modifies the `upload_files` function to handle payment errors by logging an error message and continuing the upload process.
<!-- reviewpad:summarize:end --> 
