### PR TITLE
chore: remove redundant client function, prettify CLI send

### DIFF
--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -20,14 +20,6 @@ pub enum Error {
     #[error("Genesis error {0}")]
     GenesisError(#[from] sn_transfers::GenesisError),
 
-    /// Could not acquire a Semaphore permit.
-    #[error("Could not acquire a Semaphore permit.")]
-    CouldNotAcquireSemaphorePermit(#[from] tokio::sync::AcquireError),
-
-    /// Could not acquire a network semaphore
-    #[error("Network layer does not have the expected concurrency limiter.")]
-    NoNetworkConcurrencyLimiterFound,
-
     #[error("Transfer Error {0}.")]
     Transfers(#[from] sn_transfers::WalletError),
 
@@ -40,6 +32,15 @@ pub enum Error {
     #[error("Register error {0}.")]
     Register(#[from] sn_registers::Error),
 
+    #[error("Chunks error {0}.")]
+    Chunks(#[from] super::chunks::Error),
+
+    #[error("SelfEncryption Error {0}.")]
+    SelfEncryptionIO(#[from] self_encryption::Error),
+
+    #[error("System IO Error {0}.")]
+    SystemIO(#[from] std::io::Error),
+
     #[error("Events receiver error {0}.")]
     EventsReceiver(#[from] tokio::sync::broadcast::error::RecvError),
 
@@ -50,20 +51,12 @@ pub enum Error {
     #[error("Failed to verify transfer validity in the network {0}")]
     CouldNotVerifyTransfer(String),
 
-    #[error("Chunks error {0}.")]
-    Chunks(#[from] super::chunks::Error),
-
     #[error(
         "Content branches detected in the Register which need to be merged/resolved by user. \
         Entries hashes of branches are: {0:?}"
     )]
     ContentBranchDetected(BTreeSet<(EntryHash, Entry)>),
 
-    /// File system access error.
-    #[error("System IO Error {0}.")]
-    SystemIO(#[from] std::io::Error),
-
-    /// SelfEncryption error.
-    #[error("SelfEncryption Error {0}.")]
-    SelfEncryptionIO(#[from] self_encryption::Error),
+    #[error("The provided amount contains zero nanos")]
+    AmountIsZero,
 }

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -12,7 +12,7 @@ pub async fn get_tokens_from_faucet(
     to: MainPubkey,
     client: &Client,
 ) -> Result<CashNote> {
-    Ok(send(
+    send(
         load_faucet_wallet_from_genesis_wallet(client).await?,
         amount,
         to,
@@ -20,7 +20,7 @@ pub async fn get_tokens_from_faucet(
         // we should not need to wait for this
         true,
     )
-    .await?)
+    .await
 }
 
 /// Use the client to load the faucet wallet from the genesis Wallet.

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -97,9 +97,13 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     // send both transfers to the network
     // upload won't error out, only error out during verification.
     println!("Sending both transfers to the network...");
-    let res = client.send_without_verify(transfer_to_2.clone()).await;
+    let res = client
+        .send(transfer_to_2.all_spend_requests.iter(), false)
+        .await;
     assert!(res.is_ok());
-    let res = client.send_without_verify(transfer_to_3.clone()).await;
+    let res = client
+        .send(transfer_to_3.all_spend_requests.iter(), false)
+        .await;
     assert!(res.is_ok());
 
     // check the CashNotes, it should fail

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -252,7 +252,7 @@ async fn storage_payment_chunk_upload_fails() -> Result<()> {
 
     // invalid spends
     client
-        .send(wallet_client.unconfirmed_spend_requests(), true)
+        .send(wallet_client.unconfirmed_spend_requests().iter(), true)
         .await?;
 
     sleep(Duration::from_secs(5)).await;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Oct 23 05:33 UTC
This pull request includes several changes across multiple files:

In the `src/wallet.rs` file:
- Imports: The `Error` enum is now imported from `crate` and the `Result` type is imported from `super`.
- Reordering of imports: Imports related to `futures` and `xor_name` are now placed above the `super::Client` import.
- Method signature change: The `send` method in the `WalletClient` struct now takes an iterator of `&SignedSpend` instead of a reference to `BTreeSet<SignedSpend>`.
- Additional method parameter: The `send` method calls now include an additional parameter, `verify_store`, when passed the iterator of `wallet.unconfirmed_spend_requests()`.
- Method implementation changes: The `send` method in the `Client` struct has been modified to take an iterator of `&SignedSpend` instead of a reference to `BTreeSet<SignedSpend>`.
- Method calls using iterator: The `send` method calls in the `WalletClient` and `Client` structs now pass an iterator of `wallet.unconfirmed_spend_requests().iter()` instead of a reference to the `BTreeSet<SignedSpend>`.
- Method removal: The `send_without_verify` method has been removed from the `Client` struct.
- Error handling changes: The `send` method in the `Client` struct now returns a `WalletResult<()>` instead of directly returning `Ok(())`. Additionally, the `send` function now returns a `Result<CashNote>` instead of directly returning `Err(WalletError::UnconfirmedTxAfterRetries)`.
- Early return: The `send` function includes an early return when the `amount` passed is zero, returning an `Err(Error::AmountIsZero)`.

In the `storage_payments.rs` file:
- Modification in `send` method: The `unconfirmed_spend_requests` method is now called with `.iter()`.

In the `mod.rs` file:
- Changes in the `get_tokens_from_faucet` function: The `Ok` wrapper is removed from the return value of the `send` function call. A closing parenthesis is moved from the end of the `await` line to the end of the function call line. A comment is added that waiting for a certain condition should not be necessary.

In the `sequential_transfers.rs` test file:
- Modification in sending transfers: The `send_without_verify()` method is replaced with the `send()` method using an iterator of `all_spend_requests` from each transfer. A boolean flag (`false`) is added as a second argument to the `send()` method.

In the `wallet.rs` file:
- Added import statements for `Error` from `sn_client` and `WalletError` from `sn_transfers`.
- Added the `TransferError` enum to the list of uses from `sn_transfers`.
- Added `FromStr` trait to the list of uses from `std::str`.
- Added a `from` variable to hold the result of loading the wallet from the root directory.
- Added match statements to parse the `amount` and `to` address and handle parsing errors.
- Wrapped the sending logic within a match statement to handle the result of the `send` function call.
- Added logic to handle different errors that may occur during the sending process and print relevant messages.
- Added printing of the new wallet balance after a successful send.
- Added creation of a transfer from the cash note and printing of the transfer in hex format.

In the `error.rs` file:
- Added variants `Chunks`, `SelfEncryptionIO`, and `SystemIO` to the `Error` enum.
- Removed variants `CouldNotAcquireSemaphorePermit`, `NoNetworkConcurrencyLimiterFound`, `Register`, `GenesisError`, `Transfers`, `EventsReceiver`, `CouldNotVerifyTransfer`, and `ContentBranchDetected`.
- Added `AmountIsZero` variant to the enum.

These changes involve modifications related to imports, method signatures, error handling, and enum variants across various files.
<!-- reviewpad:summarize:end --> 
