### PR TITLE
client fixes for recordnotfound

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -213,7 +213,7 @@ fn deposit(root_dir: &Path, read_from_stdin: bool, cash_note: Option<String>) ->
         return deposit_from_cash_note_hex(root_dir, cash_note_hex);
     }
 
-    let wallet = LocalWallet::load_from(root_dir)?;
+    let mut wallet = LocalWallet::load_from(root_dir)?;
 
     let previous_balance = wallet.balance();
 
@@ -221,7 +221,7 @@ fn deposit(root_dir: &Path, read_from_stdin: bool, cash_note: Option<String>) ->
         sn_transfers::NanoTokens::from(wallet.balance().as_nano() - previous_balance.as_nano());
     if deposited.is_zero() {
         println!("Nothing deposited.");
-    } else if let Err(err) = wallet.store(vec![]) {
+    } else if let Err(err) = wallet.deposit_and_store_to_disk(&vec![]) {
         println!("Failed to store deposited ({deposited}) amount: {:?}", err);
     } else {
         println!("Deposited {deposited}.");
@@ -242,9 +242,8 @@ fn deposit_from_cash_note_hex(root_dir: &Path, input: String) -> Result<()> {
     let cash_note = sn_transfers::CashNote::from_hex(input.trim())?;
 
     let old_balance = wallet.balance();
-    wallet.deposit(&vec![cash_note])?;
+    wallet.deposit_and_store_to_disk(&vec![cash_note])?;
     let new_balance = wallet.balance();
-    wallet.store(vec![])?;
     println!("Successfully stored cash_note to wallet dir. \nOld balance: {old_balance}\nNew balance: {new_balance}");
 
     Ok(())
@@ -336,7 +335,7 @@ async fn receive(transfer: String, is_file: bool, client: &Client, root_dir: &Pa
     println!("Successfully verified transfer.");
 
     let old_balance = wallet.balance();
-    wallet.deposit(&cashnotes)?;
+    wallet.deposit_and_store_to_disk(&cashnotes)?;
     let new_balance = wallet.balance();
 
     println!("Successfully stored cash_note to wallet dir. \nOld balance: {old_balance}\nNew balance: {new_balance}");

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -213,11 +213,9 @@ fn deposit(root_dir: &Path, read_from_stdin: bool, cash_note: Option<String>) ->
         return deposit_from_cash_note_hex(root_dir, cash_note_hex);
     }
 
-    let mut wallet = LocalWallet::load_from(root_dir)?;
+    let wallet = LocalWallet::load_from(root_dir)?;
 
     let previous_balance = wallet.balance();
-
-    wallet.try_load_deposits()?;
 
     let deposited =
         sn_transfers::NanoTokens::from(wallet.balance().as_nano() - previous_balance.as_nano());
@@ -247,7 +245,6 @@ fn deposit_from_cash_note_hex(root_dir: &Path, input: String) -> Result<()> {
     wallet.deposit(&vec![cash_note])?;
     let new_balance = wallet.balance();
     wallet.store(vec![])?;
-
     println!("Successfully stored cash_note to wallet dir. \nOld balance: {old_balance}\nNew balance: {new_balance}");
 
     Ok(())
@@ -341,7 +338,6 @@ async fn receive(transfer: String, is_file: bool, client: &Client, root_dir: &Pa
     let old_balance = wallet.balance();
     wallet.deposit(&cashnotes)?;
     let new_balance = wallet.balance();
-    wallet.store(vec![])?;
 
     println!("Successfully stored cash_note to wallet dir. \nOld balance: {old_balance}\nNew balance: {new_balance}");
     Ok(())

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -52,9 +52,8 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
     )
     .await?;
 
-    faucet_wallet.deposit(&vec![cash_note.clone()])?;
     faucet_wallet
-        .store(vec![])
+        .deposit_and_store_to_disk(&vec![cash_note.clone()])
         .expect("Faucet wallet shall be stored successfully.");
     println!("Faucet wallet balance: {}", faucet_wallet.balance());
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -36,8 +36,8 @@ impl WalletClient {
     }
 
     /// Stores the wallet to disk.
-    pub fn store_local_wallet(&self) -> WalletResult<()> {
-        self.wallet.store(vec![])
+    pub fn store_local_wallet(&mut self) -> WalletResult<()> {
+        self.wallet.deposit_and_store_to_disk(&vec![])
     }
 
     /// Get the wallet balance
@@ -371,7 +371,9 @@ pub async fn send(
         }
     }
 
-    wallet_client.into_wallet().store(vec![&new_cash_note])?;
+    wallet_client
+        .into_wallet()
+        .deposit_and_store_to_disk(&vec![new_cash_note.clone()])?;
 
     if did_error {
         return Err(WalletError::UnconfirmedTxAfterRetries.into());

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -158,16 +158,13 @@ impl WalletClient {
                         debug!("Storecosts inserted into payment map for {content_addr:?}");
                     } else {
                         warn!("Cannot get store cost for a content that is not a data type: {content_addr:?}");
-                        println!("Cannot get store cost for a content that is not a data type: {content_addr:?}");
                     }
                 }
                 Ok((content_addr, Err(err))) => {
                     warn!("Cannot get store cost for {content_addr:?} with error {err:?}");
-                    println!("Cannot get store cost for {content_addr:?} with error {err:?}");
                 }
                 Err(e) => {
                     warn!("Cannot get a store cost for a content with error {e:?}");
-                    println!("Cannot get a store cost for a content with error {e:?}");
                 }
             }
         }

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -24,9 +24,6 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("Could not acquire a Semaphore permit.")]
-    CouldNotAcquireSemaphorePermit(#[from] tokio::sync::AcquireError),
-
     #[error(
         "Not enough store cost prices returned from the network to ensure a valid fee is paid"
     )]

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -314,16 +314,16 @@ impl Network {
                 }
                 Err(Error::RecordNotFound) => {
                     // libp2p RecordNotFound does mean no holders answered.
-                    // In that case, a retry will be somehow pointless,
-                    // hence return with error immediately.
-                    warn!(
-                        "No holder of record '{:?}' from network!. Terminating the fetch ...",
-                        PrettyPrintRecordKey::from(key.clone()),
-                    );
-
+                    // it does not actually mean the record does not exist.
+                    // just that those asked did not have it
                     if verification_attempts >= total_attempts {
                         break;
                     }
+
+                    warn!(
+                        "No holder of record '{:?}' found. Retrying the fetch ...",
+                        PrettyPrintRecordKey::from(key.clone()),
+                    );
                 }
                 Err(error) => {
                     error!("{error:?}");

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -422,14 +422,7 @@ impl Network {
 
             // Verify the record is stored, requiring re-attempts
             self.get_record_from_network(record_key, verify_store, GetQuorum::All, true)
-                .await
-                .map_err(|e| {
-                    error!(
-                        "Failing to verify the put record {:?} with error {e:?}",
-                        pretty_key
-                    );
-                    Error::FailedToVerifyRecordWasStored(pretty_key)
-                })?;
+                .await?;
         }
 
         response

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -297,6 +297,7 @@ impl Network {
                     }
                 }
                 Err(Error::RecordNotEnoughCopies(returned_record)) => {
+                    debug!("Not enough copies found yet...");
                     // Only return when completed all attempts
                     if verification_attempts >= total_attempts {
                         if target_record.is_none()
@@ -319,7 +320,10 @@ impl Network {
                         "No holder of record '{:?}' from network!. Terminating the fetch ...",
                         PrettyPrintRecordKey::from(key.clone()),
                     );
-                    break;
+
+                    if verification_attempts >= total_attempts {
+                        break;
+                    }
                 }
                 Err(error) => {
                     error!("{error:?}");

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -121,9 +121,9 @@ impl Node {
         let reward_key = MainSecretKey::random();
         let reward_address = reward_key.main_pubkey();
 
-        let wallet = LocalWallet::load_from_main_key(&root_dir, reward_key)?;
+        let mut wallet = LocalWallet::load_from_main_key(&root_dir, reward_key)?;
         // store in case it's a fresh wallet created if none was found
-        wallet.store(vec![])?;
+        wallet.deposit_and_store_to_disk(&vec![])?;
 
         #[cfg(feature = "open-metrics")]
         let (metrics_registry, node_metrics) = {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -453,10 +453,7 @@ impl Node {
 
         // deposit the CashNotes in our wallet
         wallet
-            .deposit(&cash_notes)
-            .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
-        wallet
-            .store(vec![])
+            .deposit_and_store_to_disk(&cash_notes)
             .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
         #[cfg(feature = "open-metrics")]
         let _ = self

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -107,7 +107,7 @@ pub async fn get_funded_wallet(
 
     println!("Verifying the transfer from faucet...");
     client.verify(&tokens).await?;
-    local_wallet.deposit(&vec![tokens])?;
+    local_wallet.deposit_and_store_to_disk(&vec![tokens])?;
     assert_eq!(local_wallet.balance(), wallet_balance);
     println!("CashNotes deposited to the wallet that'll pay for storage: {wallet_balance}.");
 

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -45,7 +45,7 @@ async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
     .await?;
     println!("Verifying the transfer from first wallet...");
     client.verify(&tokens).await?;
-    second_wallet.deposit(&vec![tokens])?;
+    second_wallet.deposit_and_store_to_disk(&vec![tokens])?;
     assert_eq!(second_wallet.balance(), second_wallet_balance);
     println!("CashNotes deposited to second wallet: {second_wallet_balance}.");
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -82,10 +82,8 @@ pub fn load_genesis_wallet() -> Result<LocalWallet, Error> {
         GENESIS_CASHNOTE.unique_pubkey()
     );
     genesis_wallet
-        .deposit(&vec![GENESIS_CASHNOTE.clone()])
-        .map_err(|err| Error::WalletError(err.to_string()))?;
-    genesis_wallet
-        .store(vec![])
+        .deposit_and_store_to_disk(&vec![GENESIS_CASHNOTE.clone()])
+        .map_err(|err| Error::WalletError(err.to_string()))
         .expect("Genesis wallet shall be stored successfully.");
 
     let genesis_balance = genesis_wallet.balance();

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -779,7 +779,7 @@ mod tests {
         // Send to a new address.
         let recipient_root_dir = create_temp_dir();
         let recipient_root_dir = recipient_root_dir.path().to_path_buf();
-        let mut recipient = LocalWallet::load_from(&recipient_root_dir)?;
+        let recipient = LocalWallet::load_from(&recipient_root_dir)?;
         let recipient_main_pubkey = recipient.key.main_pubkey();
 
         let to = vec![(NanoTokens::from(send_amount), recipient_main_pubkey)];

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -13,23 +13,13 @@ use super::{
     KeyLessWallet,
 };
 
-use std::{
-    collections::BTreeSet,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{collections::BTreeSet, fs, path::Path};
 
 // Filename for storing a wallet.
 const WALLET_FILE_NAME: &str = "wallet";
-const CREATED_CASHNOTES_DIR_NAME: &str = "created_cash_notes";
-const RECEIVED_CASHNOTES_DIR_NAME: &str = "received_cash_notes";
+const CASHNOTES_DIR_NAME: &str = "cash_notes";
 const UNCONFRIMED_TX_NAME: &str = "unconfirmed_spend_requests";
 
-pub(super) fn create_received_cash_notes_dir(wallet_dir: &Path) -> Result<()> {
-    let received_cash_notes_dir = wallet_dir.join(RECEIVED_CASHNOTES_DIR_NAME);
-    fs::create_dir_all(received_cash_notes_dir)?;
-    Ok(())
-}
 /// Writes the `KeyLessWallet` to the specified path.
 pub(super) fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
     let wallet_path = wallet_dir.join(WALLET_FILE_NAME);
@@ -84,12 +74,13 @@ pub(super) fn store_created_cash_notes(
     wallet_dir: &Path,
 ) -> Result<()> {
     // The create cash_notes dir within the wallet dir.
-    let created_cash_notes_path = wallet_dir.join(CREATED_CASHNOTES_DIR_NAME);
+    let created_cash_notes_path = wallet_dir.join(CASHNOTES_DIR_NAME);
     for cash_note in created_cash_notes.iter() {
         let unique_pubkey_name =
             *SpendAddress::from_unique_pubkey(&cash_note.unique_pubkey()).xorname();
         let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));
 
+        debug!("Writing cash note to: {:?}", created_cash_notes_path);
         fs::create_dir_all(&created_cash_notes_path)?;
 
         let cash_note_file_path = created_cash_notes_path.join(unique_pubkey_file_name);
@@ -102,52 +93,10 @@ pub(super) fn store_created_cash_notes(
     Ok(())
 }
 
-/// Loads all the cash_notes found in the received cash_notes dir.
-pub(super) fn load_received_cash_notes(wallet_dir: &Path) -> Result<Vec<CashNote>> {
-    let received_cash_notes_path = match std::env::var("RECEIVED_CASHNOTES_PATH") {
-        Ok(path) => PathBuf::from(path),
-        Err(_) => wallet_dir.join(RECEIVED_CASHNOTES_DIR_NAME),
-    };
-
-    let mut deposits = vec![];
-    for entry in walkdir::WalkDir::new(&received_cash_notes_path)
-        .into_iter()
-        .flatten()
-    {
-        if entry.file_type().is_file() {
-            let file_name = entry.file_name();
-            println!("Reading deposited tokens from {file_name:?}.");
-
-            let cash_note_data = fs::read_to_string(entry.path())?;
-            let cash_note = match CashNote::from_hex(cash_note_data.trim()) {
-                Ok(cash_note) => cash_note,
-                Err(_) => {
-                    println!(
-                        "This file does not appear to have valid hex-encoded CashNote data. \
-                        Skipping it."
-                    );
-                    continue;
-                }
-            };
-
-            deposits.push(cash_note);
-        }
-    }
-
-    if deposits.is_empty() {
-        println!(
-            "No deposits found at {}.",
-            received_cash_notes_path.display()
-        );
-    }
-
-    Ok(deposits)
-}
-
 /// Loads a specific cash_note from path
-pub fn load_cash_note(unique_pubkey: &UniquePubkey, wallet_dir: &Path) -> Option<CashNote> {
+pub fn load_created_cash_note(unique_pubkey: &UniquePubkey, wallet_dir: &Path) -> Option<CashNote> {
     trace!("Loading cash_note from file with pubkey: {unique_pubkey:?}");
-    let created_cash_notes_path = wallet_dir.join(CREATED_CASHNOTES_DIR_NAME);
+    let created_cash_notes_path = wallet_dir.join(CASHNOTES_DIR_NAME);
     let unique_pubkey_name = *SpendAddress::from_unique_pubkey(unique_pubkey).xorname();
     let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));
     // Construct the path to the cash_note file


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Oct 23 10:25 UTC
This pull request includes the following changes:

1. In the file "sn_client/src/faucet/mod.rs":
   - The line `faucet_wallet.deposit(&vec![cash_note.clone()])?;` has been removed.
   - The line `faucet_wallet.store(vec![])` has been replaced with `.deposit_and_store_to_disk(&vec![cash_note.clone()])`.
   - A print statement has been added to display the faucet wallet balance.

2. In the file "wallet.rs":
   - The function `store_local_wallet` has been modified to take a mutable reference to `self`.
   - The function `store_local_wallet` has been modified to call the method `deposit_and_store_to_disk` on `self.wallet` instead of directly calling `store`.
   - Some logging messages that used to print to the console have been removed.
   - In the function `send`, the line `wallet_client.into_wallet().store(vec![&new_cash_note])?;` has been modified to call the method `deposit_and_store_to_disk` on `wallet_client.into_wallet()` instead of directly calling `store`.

3. In the file `local_store.rs`:
   - The `store` function has been changed from `pub` to private (`fn`) and renamed to `store_cash_notes_to_disk`.
   - The `store_cash_notes` function has been renamed to `store_cash_notes_to_disk`.
   - The `try_load_deposits` function has been removed.
   - The `deposit` function has been renamed to `deposit_and_store_to_disk`.
   - The `load_cash_note` function has been renamed to `load_created_cash_note` in two places.
   - The `store_cash_notes` function has been changed to take a vector of `&CashNote` as an argument instead of `cash_note`.
   - The `load_from_path` function no longer calls the `create_received_cash_notes_dir` function.

4. In the file `put_validation.rs`:
   - Line 453: The `deposit` method of the wallet is replaced with `deposit_and_store_to_disk` method.
   - Line 457: The `store` method call is removed.

5. The file "sequential_transfers.rs" has a few changes:
   - In line 49, the function `second_wallet.deposit(&vec![tokens])?` has been modified to `second_wallet.deposit_and_store_to_disk(&vec![tokens])?`.

6. The code changes in the file `sn_node/tests/common/mod.rs` involve modifying the `get_funded_wallet` function to call `deposit_and_store_to_disk` instead of `deposit` on `local_wallet`.

7. The file `genesis.rs` underwent changes:
   - Lines 82-84: The code now calls the `deposit_and_store_to_disk` method instead of `deposit` on `genesis_wallet`.
   - Line 86: The line calling the `store` method on `genesis_wallet` with an empty vector has been removed.

8. The file "api.rs" in the `sn_node` module has been modified:
   - Line 123: Replacing `wallet.store(vec![])` with `wallet.deposit_and_store_to_disk(&vec![])`.

9. The file `error.rs` has removed the variant `CouldNotAcquireSemaphorePermit` from the `Error` enum.

10. The file diff for "local_store.rs" includes various changes:
   - Removed the `RECEIVED_CASHNOTES_DIR_NAME` constant and related functions.
   - Renamed the `CREATED_CASHNOTES_DIR_NAME` constant to `CASHNOTES_DIR_NAME`.
   - Updated the functions to use the `CASHNOTES_DIR_NAME` constant instead.
   - Removed the `load_received_cash_notes` function and related code.
   - Renamed the `load_cash_note` function to `load_created_cash_note`.
   - Updated the path for the `created_cash_notes_path` variable in the `store_created_cash_notes` and `load_created_cash_note` functions to use the `CASHNOTES_DIR_NAME` constant.

11. The file diff in "verification.rs" includes the following changes:
   - Added a debug log message indicating that not enough copies are found yet.
   - Added a condition to break the loop if the verification attempts reach the total attempts.
   - Removed the break statement after logging an error message.
   - Removed the error logging and error handling code for failing to verify the put record.

These changes seem to involve various modifications such as function renaming, reorganizing code, updating method calls, and removing certain code blocks.
<!-- reviewpad:summarize:end --> 
