### PR TITLE
chore: remove deposit vs received cashnote disctinction

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -251,8 +251,10 @@ async fn upload_files(
             .await
         {
             Ok((cost, new_balance)) => (cost, new_balance),
-            Err(err) => {
-                error!("Error paying for chunks: {err:?}");
+            Err(error) => {
+                warn!(
+                    "Failed to pay for chunks. Validation steps should retry this batch: {error}"
+                );
                 continue;
             }
         };

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -44,9 +44,9 @@ pub enum WalletCmds {
     /// Or Read a hex encoded CashNote from stdin.
     ///
     /// The default received directory is platform specific:
-    ///  - Linux: $HOME/.local/share/safe/wallet/received_cash_notes
-    ///  - macOS: $HOME/Library/Application Support/safe/wallet/received_cash_notes
-    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\wallet\received_cash_notes
+    ///  - Linux: $HOME/.local/share/safe/wallet/cash_notes
+    ///  - macOS: $HOME/Library/Application Support/safe/wallet/cash_notes
+    ///  - Windows: C:\Users\{username}\AppData\Roaming\safe\wallet\cash_notes
     ///
     /// If you find the default path unwieldy, you can also set the RECEIVED_CASHNOTES_PATH environment
     /// variable to a path you would prefer to work with.

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -309,7 +309,8 @@ impl Client {
 
         let mut spent_cash_notes = Vec::new();
         for (cash_note_key, spend_attempt_result) in join_all(tasks).await {
-            // if this is a record mismatch on spend, we need to clean up and remove the spent CashNote from the wallet
+            // This is a record mismatch on spend, we need to clean up and remove the spent CashNote from the wallet
+            // This only happens if we're verifying the store
             if let Err(Error::Network(sn_networking::Error::ReturnedRecordDoesNotMatch(
                 record_key,
             ))) = spend_attempt_result

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -8,12 +8,18 @@
 
 use thiserror::Error;
 
+use crate::UniquePubkey;
+
 /// Specialisation of `std::Result`.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Transfer errors.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// The cashnote that was attempted to be spent has already been spent and is not the same
+    #[error("Double spend attempted")]
+    DoubleSpendAttempted(Vec<UniquePubkey>),
+
     /// Address provided is of the wrong type
     #[error("Invalid address type")]
     InvalidAddressType,

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 use crate::UniquePubkey;
@@ -16,9 +17,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Transfer errors.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// The cashnote that was attempted to be spent has already been spent and is not the same
-    #[error("Double spend attempted")]
-    DoubleSpendAttempted(Vec<UniquePubkey>),
+    /// The cashnotes that were attempted to be spent have already been spent to another address
+    #[error("Double spend attempted with cashnotes: {0:?}")]
+    DoubleSpendAttemptedForCashNotes(BTreeSet<UniquePubkey>),
 
     /// Address provided is of the wrong type
     #[error("Invalid address type")]

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -71,6 +71,12 @@ impl LocalWallet {
         store_unconfirmed_spend_requests(&self.wallet_dir, self.unconfirmed_spend_requests())
     }
 
+    /// Remove CashNote from available_cash_notes and add it to spent_cash_notes.
+    pub fn mark_note_as_spent(&mut self, cash_note_id: UniquePubkey) {
+        self.wallet.available_cash_notes.remove(&cash_note_id);
+        self.wallet.spent_cash_notes.insert(cash_note_id);
+    }
+
     pub fn unconfirmed_spend_requests_exist(&self) -> bool {
         !self.unconfirmed_spend_requests.is_empty()
     }
@@ -130,6 +136,12 @@ impl LocalWallet {
 
     pub fn unconfirmed_spend_requests(&self) -> &BTreeSet<SignedSpend> {
         &self.unconfirmed_spend_requests
+    }
+
+    /// To remove a specific spend from the requests, if eg, we see one spend is _bad_
+    pub fn clear_specific_spend_request(&mut self, unique_pub_key: UniquePubkey) {
+        self.unconfirmed_spend_requests
+            .retain(|signed_spend| signed_spend.spend.unique_pubkey.ne(&unique_pub_key))
     }
 
     pub fn clear_unconfirmed_spend_requests(&mut self) {

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -338,7 +338,7 @@ impl LocalWallet {
         Ok(())
     }
 
-    /// Store the given cash_notes to the `received cash_notes dir` in the wallet dir.
+    /// Store the given cash_notes to the `cash_notes` dir in the wallet dir.
     pub fn deposit_and_store_to_disk(&mut self, received_cash_notes: &Vec<CashNote>) -> Result<()> {
         if received_cash_notes.is_empty() {
             return Ok(());

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -56,12 +56,6 @@ impl LocalWallet {
 
     /// Stores the given cash_notes to the `created cash_notes dir` in the wallet dir.
     /// These can then be sent to the recipients out of band, over any channel preferred.
-    pub fn store_cash_note(&mut self, cash_note: &CashNote) -> Result<()> {
-        store_created_cash_notes(vec![cash_note], &self.wallet_dir)
-    }
-
-    /// Stores the given cash_notes to the `created cash_notes dir` in the wallet dir.
-    /// These can then be sent to the recipients out of band, over any channel preferred.
     pub fn store_cash_notes_to_disk(&self, cash_note: Vec<&CashNote>) -> Result<()> {
         store_created_cash_notes(cash_note, &self.wallet_dir)
     }
@@ -366,7 +360,7 @@ impl LocalWallet {
             let value = cash_note.value()?;
             self.wallet.available_cash_notes.insert(id, value);
 
-            self.store_cash_note(cash_note)?;
+            self.store_cash_notes_to_disk(vec![cash_note])?;
         }
 
         self.store(vec![])?;
@@ -806,7 +800,7 @@ mod tests {
         let created_cash_notes = sender.local_send(to, None)?;
         let cash_note = created_cash_notes[0].clone();
         let unique_pubkey = cash_note.unique_pubkey();
-        sender.store_cash_note(&cash_note)?;
+        sender.store_cash_notes_to_disk(vec![&cash_note])?;
 
         let unique_pubkey_name = *SpendAddress::from_unique_pubkey(&unique_pubkey).xorname();
         let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Oct 23 11:18 UTC
This pull request includes multiple file diffs. Here's a summary of the changes:

1. In the `wallet.rs` file:
   - Added `UniquePubkey` import from `sn_transfers` module.
   - Added a new method `mark_note_as_spent` to remove a `CashNote` from `available_cash_notes`.
   - Modified the `send_cash_note` method to handle double spend attempts by removing the `CashNote` from the wallet.
   - Modified the `send_cash_note` method to return a specific error message when the storage payment transfer is not successfully registered.
   - Modified the `Client` struct to handle record mismatch errors by removing the `CashNote` from the wallet.
   - Updated the `send_spend_requests` method to handle multiple spend requests and remove corresponding `CashNotes` on double spend or record mismatch errors. These changes improve error handling during cash note sending and redeeming.

2. In the `api.rs` file:
   - Removed commented-out code related to handling a record mismatch error while storing a spend. This code is not currently being used.

3. In the `files.rs` file:
   - Changes to the `upload_files` function include error handling for paying for chunks. Instead of failing, the function now logs a warning message and continues to the next batch if payment fails. This change improves the robustness of the function.

4. In the `error.rs` file in the `wallet` module:
   - Imported the `UniquePubkey` type from the crate.
   - Added a new variant `DoubleSpendAttempted` to the `Error` enum to handle double spend attempts.
   - Added a new variant `InvalidAddressType` to the `Error` enum to handle invalid address types. These changes add support for handling double spend attempts and invalid address types in the wallet module.

5. In the `wallet_file.rs` file:
   - Replaced the `CREATED_CASHNOTES_DIR_NAME` and `RECEIVED_CASHNOTES_DIR_NAME` constants with the `CASHNOTES_DIR_NAME` constant.
   - Removed the `create_received_cash_notes_dir` function.
   - Updated the `store_created_cash_notes` function to write to the `cash_notes` directory instead of `created_cash_notes` directory.
   - Removed the `load_received_cash_notes` function.
   - Renamed the `load_cash_note` function to `load_created_cash_note` and updated it to read from the `cash_notes` directory. These changes involve code refactoring and renaming directories for better organization.

6. In the `wallet_file.rs` file:
   - Renamed the function `load_cash_note` to `load_created_cash_note`.
   - Renamed the function `store_cash_notes` to `store_cash_notes_to_disk`.
   - Removed the function `try_load_deposits`.
   - Modified the function `store` to call `store_cash_notes_to_disk` instead of `store_cash_notes`.
   - Modified the function `deposit` to accept `received_cash_notes` as an argument instead of `cash_notes`.
   - Modified the function `clear_specific_spend_request` to use a `UniquePubkey` parameter instead of `&CashNote`.
   - Removed the function `create_received_cash_notes_dir` and its call inside the `load_from_path` function.
   - Removed unused imports. These changes mainly involve renaming functions and removing unnecessary code.

Overall, this pull request consists of various improvements, including better error handling, code refactoring, and renaming functions for better organization.
<!-- reviewpad:summarize:end --> 
