### PR TITLE
remove unroutable peers

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -440,7 +440,6 @@ impl NetworkBuilder {
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
-            unroutable_peers: CircularVec::new(127),
         };
 
         Ok((
@@ -477,7 +476,6 @@ pub struct SwarmDriver {
     pub(crate) pending_get_record: PendingGetRecord,
     /// A list of the most recent peers we have dialed ourselves.
     pub(crate) dialed_peers: CircularVec<PeerId>,
-    pub(crate) unroutable_peers: CircularVec<PeerId>,
 }
 
 impl SwarmDriver {


### PR DESCRIPTION
Aiming to reduce a bit of mem allocaiton here for each inbound conn## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 07:35 UTC
This pull request includes two patches:
1. The first patch aims to reduce memory allocation for each inbound connection by removing identify clone and collect operations in the sn_networking/src/event.rs file.
2. The second patch simplifies connection handling and removes potential memory leak sources by removing unroutable peers in the sn_networking/src/driver.rs and sn_networking/src/event.rs files.
<!-- reviewpad:summarize:end --> 
