### PR TITLE
feat: ensure temp SE chunks got cleaned after uploading

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -43,6 +43,7 @@ sn_transfers = { path = "../sn_transfers", version = "0.13.9" }
 sn_logging = { path = "../sn_logging", version = "0.2.10" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.7" }
 sn_protocol = { path = "../sn_protocol", version = "0.7.15" }
+tempfile = "3.6.0"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -17,6 +17,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use tempfile::tempdir;
 use url::Url;
 use xor_name::XorName;
 
@@ -145,7 +146,11 @@ pub(crate) async fn wallet_cmds(
             batch_size: _,
         } => {
             let file_api: Files = Files::new(client.clone(), wallet_dir_path.to_path_buf());
-            let chunked_files = chunk_path(&file_api, &path).await?;
+
+            // Temp folder to hold SE chunks, which is cleaned up automatically once out of scope.
+            let temp_dir = tempdir()?;
+
+            let chunked_files = chunk_path(&file_api, &path, temp_dir.path()).await?;
 
             let all_chunks: Vec<_> = chunked_files
                 .values()


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 10:45 UTC
This pull request adds the feature to ensure that temporary SE (Safe Network) chunks are properly cleaned up after uploading files. It includes changes to the `sn_cli` Cargo.toml, `files.rs`, and `wallet.rs` files, adding the `tempfile` dependency and using `tempdir` to create temporary directories for storing SE chunks during file chunking and uploading processes.
<!-- reviewpad:summarize:end --> 
