### PR TITLE
test: compare files after download twice

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -90,15 +90,16 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 15
 
+      - name: Download 95mb file to be uploaded with the safe client
+        shell: bash
+        run: wget https://sn-node.s3.eu-west-2.amazonaws.com/the-test-data.zip
+
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!
       - name: Start a client to upload files
         run: |
-          ls -l ./target/release
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/faucet"
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/safe"
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/safenode"
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./target/release/testnet"
+          ls -l
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./the-test-data.zip"
         env:
           SN_LOG: "all"
         timeout-minutes: 25
@@ -161,8 +162,28 @@ jobs:
           cargo run --bin safe --release -- --log-output-dest=data-dir files download
           ls -l $CLIENT_DATA_PATH/downloaded_files
           downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
-          if [ $downloaded_files -lt 4 ]; then
-            echo "Only downloaded $downloaded_files files, less than the 4 files uploaded"
+          if [ $downloaded_files -lt 1 ]; then
+            echo "Only downloaded $downloaded_files files, less than the 1 file uploaded"
+            exit 1
+          fi
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      # Download the same files again to ensure files won't get corrupted.
+      - name: Start a client to download the same files again
+        run: |
+          cargo run --bin safe --release -- --log-output-dest=data-dir files download
+          ls -l $CLIENT_DATA_PATH/downloaded_files
+          downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
+          if [ $downloaded_files -lt 1 ]; then
+            echo "Only downloaded $downloaded_files files, less than the 1 file uploaded"
+            exit 1
+          fi
+          file_size1=$(stat -c "%s" ./the-test-data.zip)
+          file_size2=$(stat -c "%s" $CLIENT_DATA_PATH/downloaded_files/the-test-data.zip)
+          if [ $file_size1 != $file_size2 ]; then
+            echo "The downloaded file has a different size $file_size2 to the original $file_size1."
             exit 1
           fi
         env:

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,7 +28,7 @@ libp2p = { version="0.52", features = ["identify"] }
 prometheus-client = { version = "0.21.2", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "1.7.0"
-self_encryption = "~0.28.4"
+self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_networking = { path = "../sn_networking", version = "0.8.18" }
 sn_protocol = { path = "../sn_protocol", version = "0.7.15" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -51,7 +51,7 @@ tonic = { version = "0.6.2" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.7.0"
-self_encryption = "~0.28.4"
+self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.7" }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
-self_encryption = "~0.28.4"
+self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 13:13 UTC
This pull request adds a step to the workflow for comparing files after downloading them twice. It ensures that the downloaded files are not corrupted by comparing them to the original files. If the number of downloaded files is less than the number of uploaded files or if any of the files do not match the original files, the workflow will fail. This helps to ensure the integrity of the downloaded files.
<!-- reviewpad:summarize:end --> 
