### PR TITLE
chore(sn_networking): reduce default channel size and await

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -84,7 +84,7 @@ const REQ_RESPONSE_VERSION_STR: &str = concat!("/safe/node/", env!("CARGO_PKG_VE
 const IDENTIFY_CLIENT_VERSION_STR: &str = concat!("safe/client/", env!("CARGO_PKG_VERSION"));
 const IDENTIFY_PROTOCOL_STR: &str = concat!("safe/", env!("CARGO_PKG_VERSION"));
 
-const NETWORKING_CHANNEL_SIZE: usize = 10_000;
+const NETWORKING_CHANNEL_SIZE: usize = 10;
 
 // Protocol support shall be downward compatible for patch only version update.
 // i.e. versions of `A.B.X` shall be considered as a same protocol of `A.B`
@@ -519,13 +519,10 @@ impl SwarmDriver {
         let capacity = event_sender.capacity();
 
         if capacity == 0 {
-            warn!(
-                "NetworkEvent channel is full. Dropping NetworkEvent: {:?}",
+            debug!(
+                "NetworkEvent channel is full. Awaiting to send NetworkEvent: {:?}",
                 event
             );
-
-            // Lets error out just now.
-            return;
         }
 
         // push the event off thread so as to be non-blocking

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -87,9 +87,6 @@ pub enum Error {
     #[error("SnProtocol Error")]
     ProtocolError(#[from] sn_protocol::error::Error),
 
-    #[error("No SwarmCmd channel capacity")]
-    NoSwarmCmdChannelCapacity,
-
     #[error("Failed to sign the message with the PeerId keypair")]
     SigningFailed(#[from] libp2p::identity::SigningError),
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -524,10 +524,10 @@ impl Network {
         let capacity = self.swarm_cmd_sender.capacity();
 
         if capacity == 0 {
-            error!("SwarmCmd channel is full. Dropping SwarmCmd: {:?}", cmd);
-
-            // Lets error out just now.
-            return Err(Error::NoSwarmCmdChannelCapacity);
+            debug!(
+                "SwarmCmd channel is full. Awaiting to send SwarmCmd: {:?}",
+                cmd
+            );
         }
         let cmd_sender = self.swarm_cmd_sender.clone();
 


### PR DESCRIPTION
This should prevent too many calls hitting the network at once.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 14:21 UTC
This pull request reduces the default channel size and adds an await function in the sn_networking module. This change is intended to prevent too many calls hitting the network at once.
<!-- reviewpad:summarize:end --> 
