### PR TITLE
fix: wallet concurrent access bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,6 +4549,7 @@ dependencies = [
  "custom_debug",
  "dirs-next",
  "eyre",
+ "fs2",
  "hex",
  "itertools 0.11.0",
  "lazy_static",

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -59,7 +59,7 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     let first_wallet_balance = 1_000_000_000;
     let first_wallet_dir = TempDir::new()?;
 
-    let (client, first_wallet) =
+    let (client, mut first_wallet) =
         get_client_and_wallet(first_wallet_dir.path(), first_wallet_balance).await?;
 
     // create wallet 2 and 3 to receive money from 1
@@ -76,7 +76,7 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     let to2 = second_wallet.address();
     let to3 = third_wallet.address();
 
-    let some_cash_notes = first_wallet.available_cash_notes();
+    let (some_cash_notes, _exclusive_access) = first_wallet.available_cash_notes().unwrap();
     let same_cash_notes = some_cash_notes.clone();
 
     let mut rng = rng::thread_rng();

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -76,7 +76,7 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     let to2 = second_wallet.address();
     let to3 = third_wallet.address();
 
-    let (some_cash_notes, _exclusive_access) = first_wallet.available_cash_notes().unwrap();
+    let (some_cash_notes, _exclusive_access) = first_wallet.available_cash_notes()?;
     let same_cash_notes = some_cash_notes.clone();
 
     let mut rng = rng::thread_rng();

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3.3"
 bls = { package = "blsttc", version = "8.0.1" }
 custom_debug = "~0.5.0"
 dirs-next = "~2.0.0"
+fs2 = "0.4.3"
 hex = "~0.4.3"
 itertools = "~0.11.0"
 lazy_static = "~1.4.0"

--- a/sn_transfers/src/cashnotes/unique_keys.rs
+++ b/sn_transfers/src/cashnotes/unique_keys.rs
@@ -120,7 +120,6 @@ impl MainPubkey {
 /// The secret MainSecretKey has a static MainPubkey, which
 /// is shared with others in order to receive payments.
 /// With this MainSecretKey, new DerivedSecretKey:UniquePubkey pairs can be generated.
-#[derive(Clone)]
 pub struct MainSecretKey(SerdeSecret<SecretKey>);
 
 impl MainSecretKey {

--- a/sn_transfers/src/cashnotes/unique_keys.rs
+++ b/sn_transfers/src/cashnotes/unique_keys.rs
@@ -120,6 +120,7 @@ impl MainPubkey {
 /// The secret MainSecretKey has a static MainPubkey, which
 /// is shared with others in order to receive payments.
 /// With this MainSecretKey, new DerivedSecretKey:UniquePubkey pairs can be generated.
+#[derive(Clone)]
 pub struct MainSecretKey(SerdeSecret<SecretKey>);
 
 impl MainSecretKey {

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -64,8 +64,12 @@ impl LocalWallet {
 
     /// reloads the wallet from disk.
     fn reload(&mut self) -> Result<()> {
+        // placeholder random MainSecretKey to take it out
+        let current_key = std::mem::replace(&mut self.key, MainSecretKey::random());
         let (key, wallet, unconfirmed_spend_requests) =
-            load_from_path(&self.wallet_dir, Some(self.key.clone()))?;
+            load_from_path(&self.wallet_dir, Some(current_key))?;
+
+        // and move the original back in
         *self = Self {
             key,
             wallet,

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -10,7 +10,7 @@ use super::{
     wallet_file::{
         get_unconfirmed_spend_requests, get_wallet, load_cash_notes_from_disk,
         load_created_cash_note, store_created_cash_notes, store_unconfirmed_spend_requests,
-        store_wallet,
+        store_wallet, wallet_file_name,
     },
     Error, KeyLessWallet, Result,
 };
@@ -74,7 +74,7 @@ impl LocalWallet {
     /// Locks the wallet dir and returns exclusive access to the wallet
     /// This lock prevents any other process from locking the wallet dir, effectively acts as a mutex for the wallet
     pub fn lock(&self) -> Result<WalletExclusiveAccess> {
-        let file = File::open(&self.wallet_dir)?;
+        let file = File::open(wallet_file_name(&self.wallet_dir))?;
         file.lock_exclusive()?;
         Ok(file)
     }

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -21,6 +21,7 @@ use std::{
 
 // Filename for storing a wallet.
 const WALLET_FILE_NAME: &str = "wallet";
+const WALLET_LOCK_FILE_NAME: &str = "wallet.lock";
 const CASHNOTES_DIR_NAME: &str = "cash_notes";
 const UNCONFRIMED_TX_NAME: &str = "unconfirmed_spend_requests";
 
@@ -35,6 +36,11 @@ pub(super) fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<
 /// Returns the wallet filename
 pub(super) fn wallet_file_name(wallet_dir: &Path) -> PathBuf {
     wallet_dir.join(WALLET_FILE_NAME)
+}
+
+/// Returns the wallet lockfile filename
+pub(super) fn wallet_lockfile_name(wallet_dir: &Path) -> PathBuf {
+    wallet_dir.join(WALLET_LOCK_FILE_NAME)
 }
 
 /// Returns `Some(KeyLessWallet)` or None if file doesn't exist.

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -32,9 +32,14 @@ pub(super) fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<
     Ok(())
 }
 
+/// Returns the wallet filename
+pub(super) fn wallet_file_name(wallet_dir: &Path) -> PathBuf {
+    wallet_dir.join(WALLET_FILE_NAME)
+}
+
 /// Returns `Some(KeyLessWallet)` or None if file doesn't exist.
 pub(super) fn get_wallet(wallet_dir: &Path) -> Result<Option<KeyLessWallet>> {
-    let path = wallet_dir.join(WALLET_FILE_NAME);
+    let path = wallet_file_name(wallet_dir);
     if !path.is_file() {
         return Ok(None);
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 13:07 UTC
This pull request fixes concurrent access bugs in the wallet module. It includes changes in `Cargo.lock`, `sn_transfers/Cargo.toml`, `sn_transfers/src/cashnotes/unique_keys.rs`, and `sn_transfers/src/wallet/local_store.rs`. The changes include adding the `fs2` crate, adding a `WalletExclusiveAccess` type, implementing locking and unlocking of the wallet directory, and making modifications to the `available_cash_notes` function to provide exclusive access to the wallet while retrieving available cash notes. Overall, these changes aim to fix concurrent access issues in the wallet module.
<!-- reviewpad:summarize:end --> 
