### PR TITLE
fix: handling GetClosestPeers query error branch

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -20,8 +20,8 @@ use libp2p::mdns;
 use libp2p::{
     autonat::{self, NatStatus},
     kad::{
-        GetRecordError, GetRecordOk, InboundRequest, KademliaEvent, PeerRecord, QueryId,
-        QueryResult, Record, RecordKey, K_VALUE,
+        GetClosestPeersError, GetRecordError, GetRecordOk, InboundRequest, KademliaEvent,
+        PeerRecord, QueryId, QueryResult, Record, RecordKey, K_VALUE,
     },
     multiaddr::Protocol,
     request_response::{self, Message, ResponseChannel as PeerResponseChannel},
@@ -535,6 +535,35 @@ impl SwarmDriver {
                         .pending_get_closest_peers
                         .insert(id, (sender, current_closest));
                 }
+            }
+            ref event @ KademliaEvent::OutboundQueryProgressed {
+                id,
+                result: QueryResult::GetClosestPeers(Err(ref err)),
+                ref stats,
+                ref step,
+            } => {
+                error!("GetClosest Query task {id:?} errored with {err:?}, {stats:?} - {step:?}");
+
+                let (sender, mut current_closest) =
+                    self.pending_get_closest_peers.remove(&id).ok_or_else(|| {
+                        trace!(
+                            "Can't locate query task {id:?}, it has likely been completed already."
+                        );
+                        Error::ReceivedKademliaEventDropped(event.clone())
+                    })?;
+
+                // We have `current_closest` from previous progress,
+                // and `peers` from `GetClosestPeersError`.
+                // Trust them and leave for the caller to check whether they are enough.
+                match err {
+                    GetClosestPeersError::Timeout { ref peers, .. } => {
+                        current_closest.extend(peers);
+                    }
+                }
+
+                sender
+                    .send(current_closest)
+                    .map_err(|_| Error::InternalMsgChannelDropped)?;
             }
             // For `get_record` returning behaviour:
             //   1, targeting a non-existing entry

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -35,7 +35,6 @@ pub use self::{
 
 use self::{cmd::SwarmCmd, error::Result};
 use futures::future::select_all;
-use itertools::Itertools;
 use libp2p::{
     identity::Keypair,
     kad::{KBucketKey, Record, RecordKey},
@@ -177,19 +176,9 @@ impl Network {
         &self,
         record_address: NetworkAddress,
     ) -> Result<Vec<(MainPubkey, NanoTokens)>> {
-        let (sender, receiver) = oneshot::channel();
-        trace!("Attempting to get store cost");
-        // first we need to get CLOSE_GROUP of the unique_pubkey
-        self.send_swarm_cmd(SwarmCmd::GetClosestPeers {
-            key: record_address.clone(),
-            sender,
-        })?;
-
-        let close_nodes = receiver
-            .await
-            .map_err(|_e| Error::InternalMsgChannelDropped)?
-            .into_iter()
-            .collect_vec();
+        // The requirement of having at least CLOSE_GROUP_SIZE
+        // close nodes will be checked internally automatically.
+        let close_nodes = self.get_closest_peers(&record_address, true).await?;
 
         let request = Request::Query(Query::GetStoreCost(record_address.clone()));
         let responses = self


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 15:27 UTC
This pull request fixes the error handling in the GetClosestPeers query branch. It handles the case where the query task for GetClosestPeers encounters an error and sends the current closest peers to the caller. The patch also updates a function in the lib.rs file to use the updated error handling.
<!-- reviewpad:summarize:end --> 
