### PR TITLE
ci: prevent concurrent release and version bumping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: release
 
+# prevent concurrent version bumps + releases from running at the same time
+concurrency:
+  group: "version-bump-release"
+
 on:
   push:
     branches:

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,8 +1,8 @@
 name: Version Bump
 
-# prevent concurrent version bumps
+# prevent concurrent version bumps + releases from running at the same time
 concurrency:
-  group: "version-bumping"
+  group: "version-bump-release"
 
 on:
   push:


### PR DESCRIPTION
This can lead to unreleased versions and some crates.io hassle

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Oct 23 07:25 UTC
This pull request updates the CI workflows to prevent concurrent release and version bumping, which can cause unreleased versions and issues with crates.io.
<!-- reviewpad:summarize:end --> 
