### PR TITLE
chore(client): only pay the majority of a CLOSE_GROUP

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -16,6 +16,7 @@ use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use sn_client::WalletClient;
 use sn_networking::{close_group_majority, CLOSE_GROUP_SIZE};
+
 use sn_node::NodeEvent;
 use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress},
@@ -144,7 +145,11 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(
+        count,
+        close_group_majority(),
+        "Not enough notifications received"
+    );
 
     Ok(())
 }
@@ -182,7 +187,11 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(
+        count,
+        close_group_majority(),
+        "Not enough notifications received"
+    );
 
     Ok(())
 }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -15,7 +15,7 @@ use crate::common::{
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use sn_client::WalletClient;
-use sn_networking::CLOSE_GROUP_SIZE;
+use sn_networking::{close_group_majority, CLOSE_GROUP_SIZE};
 use sn_node::NodeEvent;
 use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress},
@@ -238,7 +238,7 @@ fn spawn_transfer_notifs_listener(endpoint: String) -> JoinHandle<Result<usize, 
                 Ok(NodeEvent::TransferNotif { key, transfer: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     count += 1;
-                    if count == CLOSE_GROUP_SIZE {
+                    if count == close_group_majority() {
                         break;
                     }
                 }


### PR DESCRIPTION
## Description

This should be blocked until we tweak the expected holders to acocunt for majority only perhaps

reviewpad:summary 
