### PR TITLE
chore(networking): handle GetRecord kad timeouts

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -24,6 +24,9 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("Netowrk query timed out")]
+    QueryTimeout,
+
     #[error(
         "Not enough store cost prices returned from the network to ensure a valid fee is paid"
     )]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Oct 23 09:55 UTC
This pull request adds handling of GetRecord kad timeouts in the networking module. It adds an error variant for QueryTimeout in the Error enum. It also includes changes in the event module to handle the timeouts properly and send the corresponding error to the sender.
<!-- reviewpad:summarize:end --> 
