### PR TITLE
chore: more detailed logging when client creating store cash_note

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -152,9 +152,9 @@ impl WalletClient {
             // just skip it as it will then get verification failure,
             // and repay/re-upload will be triggered correspondently.
             match res {
-                Ok((content_addr, Ok(cost))) => {
+                Ok((content_addr, Ok(costs))) => {
                     if let Some(xorname) = content_addr.as_xorname() {
-                        let _ = payment_map.insert(xorname, cost);
+                        let _ = payment_map.insert(xorname, costs);
                         debug!("Storecosts inserted into payment map for {content_addr:?}");
                     } else {
                         warn!("Cannot get store cost for a content that is not a data type: {content_addr:?}");

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -179,6 +179,10 @@ impl LocalWallet {
         if let Some(ids) = ids {
             for id in ids {
                 if let Some(cash_note) = load_created_cash_note(id, &self.wallet_dir) {
+                    trace!(
+                        "Current cash_note of chunk {name:?} is paying {:?} tokens.",
+                        cash_note.value()
+                    );
                     cash_notes.push(cash_note);
                 }
             }
@@ -267,7 +271,7 @@ impl LocalWallet {
         let mut used_cash_notes = std::collections::HashSet::new();
 
         for (content_addr, payees) in all_data_payments {
-            for (payee, _token) in payees {
+            for (payee, token) in payees {
                 if let Some(cash_note) =
                     &transfer_outputs
                         .created_cash_notes
@@ -277,6 +281,8 @@ impl LocalWallet {
                                 && !used_cash_notes.contains(&cash_note.unique_pubkey().to_bytes())
                         })
                 {
+                    trace!("Created transaction regarding {content_addr:?} paying {:?}(origin {token:?}) to payee {payee:?}.",
+                        cash_note.value());
                     used_cash_notes.insert(cash_note.unique_pubkey().to_bytes());
                     let cash_notes_for_content: &mut Vec<UniquePubkey> =
                         all_transfers_per_address.entry(content_addr).or_default();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Oct 23 13:42 UTC
This pull request fixes the issue with the paying store_cost. The patch corrects the variable name from 'cost' to 'costs' in the WalletClient implementation. Additionally, it adds a logging statement in the LocalWallet implementation to track the created transaction for chunk payment.
<!-- reviewpad:summarize:end --> 
