### PR TITLE
feat(sn_transfers): dont load Cns from disk, store value along w/ pub…

### DIFF
--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -148,7 +148,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
         .iter()
         .take(subset_len)
         .all(|name| paying_wallet
-            .get_payment_unique_pubkeys(&name.as_xorname().unwrap())
+            .get_payment_unique_pubkeys_and_values(&name.as_xorname().unwrap())
             .is_some()));
 
     // now let's request to pay for all addresses, even that we've already paid for a subset of them

--- a/sn_transfers/src/cashnotes/unique_keys.rs
+++ b/sn_transfers/src/cashnotes/unique_keys.rs
@@ -38,6 +38,10 @@ impl UniquePubkey {
         rng.fill_bytes(&mut bytes);
         bytes
     }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.0
+    }
 }
 
 /// This is the key that unlocks the value of a CashNote.
@@ -110,6 +114,11 @@ impl MainPubkey {
 
     pub fn to_bytes(self) -> [u8; PK_SIZE] {
         self.0.to_bytes()
+    }
+
+    // Get the underlying PublicKey
+    pub fn public_key(&self) -> PublicKey {
+        self.0
     }
 }
 

--- a/sn_transfers/src/transfers/mod.rs
+++ b/sn_transfers/src/transfers/mod.rs
@@ -30,5 +30,7 @@
 mod offline_transfer;
 mod transfer;
 
-pub use offline_transfer::{create_offline_transfer, ContentPaymentsIdMap, OfflineTransfer};
+pub use offline_transfer::{
+    create_offline_transfer, ContentPaymentsIdMap, OfflineTransfer, PaymentDetails,
+};
 pub use transfer::{CashNoteRedemption, Transfer};

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -36,7 +36,11 @@ pub struct OfflineTransfer {
     pub all_spend_requests: Vec<SignedSpend>,
 }
 
-pub type ContentPaymentsIdMap = BTreeMap<XorName, Vec<UniquePubkey>>;
+pub type PaymentDetails = (UniquePubkey, MainPubkey, NanoTokens);
+
+/// Xorname of data from which the content was fetched, mapping to the CashNote UniquePubkey (its id on disk)
+/// the main key for that CashNote and the value
+pub type ContentPaymentsIdMap = BTreeMap<XorName, Vec<PaymentDetails>>;
 
 /// The input details necessary to
 /// carry out a transfer of tokens.


### PR DESCRIPTION
…key in wallet

BREAKING CHANGE: updates wallet file to also store value of CN in payment map

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Oct 23 07:08 UTC
This pull request updates the wallet file to store the value of CN (CashNote) in the payment map along with the public key. It also makes changes to several files related to storage and transfers. The patch introduces a breaking change.
<!-- reviewpad:summarize:end --> 
