### PR TITLE
feat: forced replication after fixed interval

### DIFF
--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -29,6 +29,9 @@ pub enum Marker<'a> {
     /// No network activity in some time
     NoNetworkActivity(Duration),
 
+    /// Forced Replication by simulating a churned out node within close range.
+    ForcedReplication(PeerId),
+
     /// Network Cmd message received
     NodeCmdReceived(&'a Cmd),
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Oct 23 10:30 UTC
This pull request introduces a new feature that enforces replication after a fixed interval. It modifies the `api.rs` and `log_markers.rs` files. In `api.rs`, it adds a forced replication interval and implements the logic for triggering replication at the specified interval. Additionally, it updates the inactivity timeout range and introduces a new metric for forced replication. In `log_markers.rs`, it adds a new marker for forced replication. Overall, this patch adds functionality to ensure replication occurs at regular intervals.
<!-- reviewpad:summarize:end --> 
