### PR TITLE
fix(node): println->debug statement

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -639,7 +639,7 @@ impl SwarmDriver {
                     if expected_holders.is_empty() {
                         debug!("{log_string}");
                     } else {
-                        println!(
+                        debug!(
                             "{log_string}, and {expected_holders:?} expected holders not responded"
                         );
                     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Oct 23 13:27 UTC
This pull request fixes a println statement in the `event.rs` file in the `sn_networking` module. The `println` statement has been replaced with a `debug` statement.
<!-- reviewpad:summarize:end --> 
