### PR TITLE
chore(client): dont println for sn_networking

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -913,7 +913,6 @@ impl SwarmDriver {
                     trace!("For record {pretty_key:?} task {query_id:?}, received a copy from an expected holder {peer_id:?}");
                 } else {
                     trace!("For record {pretty_key:?} task {query_id:?}, received a copy from an unexpected holder {peer_id:?}");
-                    println!("For record {pretty_key:?} task {query_id:?}, received a copy from an unexpected holder {peer_id:?}");
                 }
             }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Oct 23 14:12 UTC
This pull request removes a `println` statement in `sn_networking/src/event.rs` file in the `chore(client)` section.
<!-- reviewpad:summarize:end --> 
