### PR TITLE
fix(network): check `RecordHeader` during chunk early completion

### DIFF
--- a/sn_protocol/src/storage/header.rs
+++ b/sn_protocol/src/storage/header.rs
@@ -88,6 +88,11 @@ impl RecordHeader {
         }
         Self::try_deserialize(&record.value[..RecordHeader::SIZE + 1])
     }
+
+    pub fn is_record_of_type_chunk(record: &Record) -> Result<bool, Error> {
+        let kind = Self::from_record(record)?.kind;
+        Ok(kind == RecordKind::Chunk)
+    }
 }
 
 /// Utility to deserialize a `KAD::Record` into any type.


### PR DESCRIPTION
- this would prevent deserializing the whole Record every time we encounter a `GetRecord::FoundRecord`

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Oct 23 16:39 UTC
This pull request fixes a bug related to chunk early completion in the network. It checks the `RecordHeader` during the process and prevents deserializing the whole record every time a `GetRecord::FoundRecord` is encountered. The patch includes changes to the `sn_networking/src/event.rs` and `sn_protocol/src/storage/header.rs` files, with a total of 18 insertions and 2 deletions.
<!-- reviewpad:summarize:end --> 
