### PR TITLE
fix: consider record split an error, handle it for regs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -102,6 +102,10 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release --package sn_testnet
 
+      - name: Run client tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_client
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release --package sn_networking

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,6 +124,10 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release --package sn_testnet
 
+      - name: Run client tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_client
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release -p sn_networking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,6 +4338,7 @@ dependencies = [
  "bincode",
  "blsttc",
  "bytes",
+ "eyre",
  "futures",
  "hex",
  "indicatif",

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -40,3 +40,6 @@ tiny-keccak = "~2.0.2"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
 tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
+
+[dev-dependencies]
+eyre = "0.6.8"

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -265,7 +265,8 @@ impl Client {
                 return merge_split_register_records(address, &map)
             }
             Err(e) => {
-                return Err(e.into());
+                warn!("Failed to get record at {address:?} from the network: {e:?}");
+                return Err(ProtocolError::RegisterNotFound(Box::new(address)).into());
             }
         };
 

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -11,12 +11,17 @@ use libp2p::{
     kad::{self, Record},
     request_response::{OutboundFailure, RequestId},
     swarm::DialError,
-    TransportError,
+    PeerId, TransportError,
 };
 use sn_protocol::{messages::Response, PrettyPrintRecordKey};
-use std::{io, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    path::PathBuf,
+};
 use thiserror::Error;
 use tokio::sync::oneshot;
+use xor_name::XorName;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -111,6 +116,9 @@ pub enum Error {
 
     #[error("Gossipsub subscribe Error: {0}")]
     GossipsubSubscriptionError(#[from] SubscriptionError),
+
+    #[error("Split Record: {0:?}")]
+    SplitRecord(HashMap<XorName, (Record, HashSet<PeerId>)>),
 }
 
 #[cfg(test)]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -900,9 +900,9 @@ impl SwarmDriver {
 
             if !expected_holders.is_empty() {
                 if expected_holders.remove(&peer_id) {
-                    trace!("For record {pretty_key:?} task {query_id:?}, received a copy from an expected holder {peer_id:?}");
+                    debug!("For record {pretty_key:?} task {query_id:?}, received a copy from an expected holder {peer_id:?}");
                 } else {
-                    trace!("For record {pretty_key:?} task {query_id:?}, received a copy from an unexpected holder {peer_id:?}");
+                    debug!("For record {pretty_key:?} task {query_id:?}, received a copy from an unexpected holder {peer_id:?}");
                 }
             }
 
@@ -935,13 +935,13 @@ impl SwarmDriver {
 
             if let Some(result) = result {
                 if !expected_holders.is_empty() {
-                    println!("For record {pretty_key:?} task {query_id:?}, fetch completed with non-responded expected holders {expected_holders:?}");
+                    debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with non-responded expected holders {expected_holders:?}");
                 }
 
                 if result_map.len() == 1 {
                     let _ = sender.send(result);
                 } else {
-                    println!("For record {pretty_key:?} task {query_id:?}, fetch completed with split record");
+                    debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with split record");
                     let _ = sender.send(Err(Error::SplitRecord(result_map)));
                 }
             } else {


### PR DESCRIPTION
## Description

Consider records split (when we receive different values from different nodes for the same key) an error instead of accepting the most popular one.
A split means: 
- for chunks we use `GetQuorum::One` so this error doesn't happen
- for spends it means DOUBLE SPEND
- for registers it means we could have 2 different versions that should be merged

This PR considers this situation to be an error, except for Registers where this error is handled on the client side, which merges the registers into one. 

> If we one day change the GetQuorum of chunks, it would be wise to handle this error accordingly by keeping the valid one (correct hash). 

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Oct 23 08:58 UTC
This pull request includes several changes across multiple files. 

In the `Cargo.toml` file, a new dependency on "eyre" has been added.

In the `sn_networking/src/error.rs` file, there are changes related to imports, type aliases, and the addition of a new variant to the `Error` enum.

In another file, there are changes related to imports, method modifications, and formatting comments.

Lastly, in a different file, there are changes related to imports, the addition of new functions, and the implementation of a new struct.

Overall, the diff includes various changes improving dependency management, error handling, and register handling in the project.
<!-- reviewpad:summarize:end --> 
