### PR TITLE
feat(network): slow down the continuous bootstrapping even further

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -253,7 +253,7 @@ jobs:
           platform: ${{ matrix.os }}
 
       - name: Gossipsub - nodes to subscribe to topics, and publish messages 
-        run: cargo test --release -p sn_node --features local-discovery msgs_over_gossipsub -- --nocapture
+        run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
         timeout-minutes: 20
 
       - name: Stop the local network and upload logs
@@ -261,7 +261,7 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_e2e
+          log_file_prefix: safe_test_logs_gossipsub_e2e
           platform: ${{ matrix.os }}
 
   spend_test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,7 +189,7 @@ jobs:
           platform: ${{ matrix.os }}
 
       - name: Gossipsub - nodes to subscribe to topics, and publish messages 
-        run: cargo test --release -p sn_node --features local-discovery msgs_over_gossipsub -- --nocapture
+        run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
         timeout-minutes: 20
 
       - name: Stop the local network and upload logs
@@ -197,7 +197,7 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_e2e
+          log_file_prefix: safe_test_logs_gossipsub_e2e
           platform: ${{ matrix.os }}
 
   spend_test:

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::SwarmDriver;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::time::Interval;
 
 /// The interval in which kad.bootstrap is called
@@ -17,36 +17,111 @@ pub(crate) const BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5);
 /// process
 const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 50;
 
+/// If the previously added peer has been before LAST_PEER_ADDED_TIME_LIMIT, then we should slowdown the bootstrapping
+/// process. This is to make sure we don't flood the network with `FindNode` msgs.
+const LAST_PEER_ADDED_TIME_LIMIT: Duration = Duration::from_secs(180);
+
+/// The bootstrap interval to use if we haven't added any new peers in a while.
+const NO_PEER_ADDED_SLOWDOWN_INTERVAL: Duration = Duration::from_secs(300);
+
 impl SwarmDriver {
     pub(crate) async fn run_bootstrap_continuously(
         &mut self,
-        mut bootstrap_interval: Interval,
-    ) -> Interval {
-        // kad bootstrap process needs at least one peer in the RT be carried out.
-        let connected_peers = self.swarm.connected_peers().count() as u32;
-        if !self.bootstrap_ongoing && connected_peers >= 1 {
-            debug!(
-                "Trying to initiate bootstrap. Current bootstrap_interval {:?}",
-                bootstrap_interval.period()
-            );
+        current_bootstrap_interval: Duration,
+    ) -> Option<Interval> {
+        let peers_in_rt = self.swarm.connected_peers().count() as u32;
+
+        let (should_bootstrap, new_interval) = self
+            .bootstrap
+            .should_we_bootstrap(peers_in_rt, current_bootstrap_interval)
+            .await;
+        if should_bootstrap {
+            debug!("Trying to initiate bootstrap. Current bootstrap_interval {current_bootstrap_interval:?}");
             match self.swarm.behaviour_mut().kademlia.bootstrap() {
                 Ok(query_id) => {
                     debug!("Initiated kad bootstrap process with query id {query_id:?}");
-                    self.bootstrap_ongoing = true;
+                    self.bootstrap.initiated();
                 }
                 Err(err) => {
-                    error!("Failed to initiate kad bootstrap with error: {err:?}")
+                    error!("Failed to initiate kad bootstrap with error: {err:?}");
                 }
             };
         }
-        // increment bootstrap_interval in steps of INITIAL_BOOTSTRAP_INTERVAL every BOOTSTRAP_CONNECTED_PEERS_STEP
-        let step = connected_peers / BOOTSTRAP_CONNECTED_PEERS_STEP;
+        if let Some(new_interval) = &new_interval {
+            debug!(
+                "The new bootstrap_interval has been updated to {:?}",
+                new_interval.period()
+            );
+        }
+        new_interval
+    }
+}
+
+/// Tracks and helps with the continuous kad::bootstrapping process
+pub(crate) struct ContinuousBootstrap {
+    is_ongoing: bool,
+    last_peer_added_instant: Instant,
+}
+
+impl ContinuousBootstrap {
+    pub(crate) fn new() -> Self {
+        Self {
+            is_ongoing: false,
+            last_peer_added_instant: Instant::now(),
+        }
+    }
+
+    /// The Kademlia Bootstrap request has been sent successfully.
+    pub(crate) fn initiated(&mut self) {
+        self.is_ongoing = true;
+    }
+
+    /// Notify about a newly added peer to the RT. This will help with slowing down the bootstrap process.
+    pub(crate) fn notify_new_peer(&mut self) {
+        self.last_peer_added_instant = Instant::now();
+    }
+
+    /// A previous Kademlia Bootstrap process has been completed. Now a new bootstrap process can start.
+    pub(crate) fn completed(&mut self) {
+        self.is_ongoing = false;
+    }
+
+    /// Returns `true` if we should carry out the Kademlia Bootstrap process immediately.
+    /// Also optionally returns the new interval to re-bootstrap.
+    pub(crate) async fn should_we_bootstrap(
+        &mut self,
+        peers_in_rt: u32,
+        current_interval: Duration,
+    ) -> (bool, Option<Interval>) {
+        // kad bootstrap process needs at least one peer in the RT be carried out.
+        let should_bootstrap = !self.is_ongoing && peers_in_rt >= 1;
+
+        // if it has been a while (LAST_PEER_ADDED_TIME_LIMIT) since we have added a new peer to our RT, then, slowdown
+        // the bootstrapping process.
+        // Don't slow down if we haven't even added one peer to our RT.
+        if self.last_peer_added_instant.elapsed() > LAST_PEER_ADDED_TIME_LIMIT && peers_in_rt != 0 {
+            info!(
+                "It has been {LAST_PEER_ADDED_TIME_LIMIT:?} since we last added a peer to RT.
+                Slowing down the continuous bootstrapping process"
+            );
+
+            let mut new_interval = tokio::time::interval(NO_PEER_ADDED_SLOWDOWN_INTERVAL);
+            new_interval.tick().await; // the first tick completes immediately
+            return (should_bootstrap, Some(new_interval));
+        }
+
+        // increment bootstrap_interval in steps of BOOTSTRAP_INTERVAL every BOOTSTRAP_CONNECTED_PEERS_STEP
+        let step = peers_in_rt / BOOTSTRAP_CONNECTED_PEERS_STEP;
         let step = std::cmp::max(1, step);
         let new_interval = BOOTSTRAP_INTERVAL * step;
-        if new_interval > bootstrap_interval.period() {
-            bootstrap_interval = tokio::time::interval(new_interval);
-            bootstrap_interval.tick().await; // the first tick completes immediately
-        }
-        bootstrap_interval
+        let new_interval = if new_interval > current_interval {
+            info!("More peers have been added to our RT!. Slowing down the continuous bootstrapping process");
+            let mut interval = tokio::time::interval(new_interval);
+            interval.tick().await; // the first tick completes immediately
+            Some(interval)
+        } else {
+            None
+        };
+        (should_bootstrap, new_interval)
     }
 }

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -36,16 +36,7 @@ impl SwarmDriver {
             .should_we_bootstrap(peers_in_rt, current_bootstrap_interval)
             .await;
         if should_bootstrap {
-            debug!("Trying to initiate bootstrap. Current bootstrap_interval {current_bootstrap_interval:?}");
-            match self.swarm.behaviour_mut().kademlia.bootstrap() {
-                Ok(query_id) => {
-                    debug!("Initiated kad bootstrap process with query id {query_id:?}");
-                    self.bootstrap.initiated();
-                }
-                Err(err) => {
-                    error!("Failed to initiate kad bootstrap with error: {err:?}");
-                }
-            };
+            self.initiate_bootstrap();
         }
         if let Some(new_interval) = &new_interval {
             debug!(
@@ -55,11 +46,26 @@ impl SwarmDriver {
         }
         new_interval
     }
+
+    /// Helper to initiate the Kademlia bootstrap process.
+    pub(crate) fn initiate_bootstrap(&mut self) {
+        match self.swarm.behaviour_mut().kademlia.bootstrap() {
+            Ok(query_id) => {
+                debug!("Initiated kad bootstrap process with query id {query_id:?}");
+                self.bootstrap.initiated();
+            }
+            Err(err) => {
+                error!("Failed to initiate kad bootstrap with error: {err:?}");
+            }
+        };
+    }
 }
 
 /// Tracks and helps with the continuous kad::bootstrapping process
 pub(crate) struct ContinuousBootstrap {
     is_ongoing: bool,
+    initial_bootstrap_done: bool,
+    stop_bootstrapping: bool,
     last_peer_added_instant: Instant,
 }
 
@@ -67,7 +73,9 @@ impl ContinuousBootstrap {
     pub(crate) fn new() -> Self {
         Self {
             is_ongoing: false,
+            initial_bootstrap_done: false,
             last_peer_added_instant: Instant::now(),
+            stop_bootstrapping: false,
         }
     }
 
@@ -77,13 +85,27 @@ impl ContinuousBootstrap {
     }
 
     /// Notify about a newly added peer to the RT. This will help with slowing down the bootstrap process.
-    pub(crate) fn notify_new_peer(&mut self) {
+    /// Returns `true` if we have to perform the initial bootstrapping.
+    pub(crate) fn notify_new_peer(&mut self) -> bool {
         self.last_peer_added_instant = Instant::now();
+        // true to kick off the initial bootstrapping. `run_bootstrap_continuously` might kick of so soon that we might
+        // not have a single peer in the RT and we'd not perform any bootstrapping for a while.
+        if !self.initial_bootstrap_done {
+            self.initial_bootstrap_done = true;
+            true
+        } else {
+            false
+        }
     }
 
     /// A previous Kademlia Bootstrap process has been completed. Now a new bootstrap process can start.
     pub(crate) fn completed(&mut self) {
         self.is_ongoing = false;
+    }
+
+    /// Set the flag to stop any further re-bootstrapping.
+    pub(crate) fn stop_bootstrapping(&mut self) {
+        self.stop_bootstrapping = true;
     }
 
     /// Returns `true` if we should carry out the Kademlia Bootstrap process immediately.
@@ -93,6 +115,14 @@ impl ContinuousBootstrap {
         peers_in_rt: u32,
         current_interval: Duration,
     ) -> (bool, Option<Interval>) {
+        // stop bootstrapping if flag is set
+        if self.stop_bootstrapping {
+            info!("stop_bootstrapping flag has been set to true. Disabling further bootstrapping");
+            let mut new_interval = tokio::time::interval(Duration::from_secs(86400));
+            new_interval.tick().await; // the first tick completes immediately
+            return (false, Some(new_interval));
+        }
+
         // kad bootstrap process needs at least one peer in the RT be carried out.
         let should_bootstrap = !self.is_ongoing && peers_in_rt >= 1;
 
@@ -101,8 +131,7 @@ impl ContinuousBootstrap {
         // Don't slow down if we haven't even added one peer to our RT.
         if self.last_peer_added_instant.elapsed() > LAST_PEER_ADDED_TIME_LIMIT && peers_in_rt != 0 {
             info!(
-                "It has been {LAST_PEER_ADDED_TIME_LIMIT:?} since we last added a peer to RT.
-                Slowing down the continuous bootstrapping process"
+                "It has been {LAST_PEER_ADDED_TIME_LIMIT:?} since we last added a peer to RT. Slowing down the continuous bootstrapping process"
             );
 
             let mut new_interval = tokio::time::interval(NO_PEER_ADDED_SLOWDOWN_INTERVAL);

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::SwarmDriver;
+use std::time::Duration;
+use tokio::time::Interval;
+
+/// The interval in which kad.bootstrap is called
+pub(crate) const BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Every BOOTSTRAP_CONNECTED_PEERS_STEP connected peer, we step up the BOOTSTRAP_INTERVAL to slow down bootstrapping
+/// process
+const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 50;
+
+impl SwarmDriver {
+    pub(crate) async fn run_bootstrap_continuously(
+        &mut self,
+        mut bootstrap_interval: Interval,
+    ) -> Interval {
+        // kad bootstrap process needs at least one peer in the RT be carried out.
+        let connected_peers = self.swarm.connected_peers().count() as u32;
+        if !self.bootstrap_ongoing && connected_peers >= 1 {
+            debug!(
+                "Trying to initiate bootstrap. Current bootstrap_interval {:?}",
+                bootstrap_interval.period()
+            );
+            match self.swarm.behaviour_mut().kademlia.bootstrap() {
+                Ok(query_id) => {
+                    debug!("Initiated kad bootstrap process with query id {query_id:?}");
+                    self.bootstrap_ongoing = true;
+                }
+                Err(err) => {
+                    error!("Failed to initiate kad bootstrap with error: {err:?}")
+                }
+            };
+        }
+        // increment bootstrap_interval in steps of INITIAL_BOOTSTRAP_INTERVAL every BOOTSTRAP_CONNECTED_PEERS_STEP
+        let step = connected_peers / BOOTSTRAP_CONNECTED_PEERS_STEP;
+        let step = std::cmp::max(1, step);
+        let new_interval = BOOTSTRAP_INTERVAL * step;
+        if new_interval > bootstrap_interval.period() {
+            bootstrap_interval = tokio::time::interval(new_interval);
+            bootstrap_interval.tick().await; // the first tick completes immediately
+        }
+        bootstrap_interval
+    }
+}

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -40,6 +40,8 @@ pub enum SwarmCmd {
         opts: DialOpts,
         sender: oneshot::Sender<Result<()>>,
     },
+    // Stop the continuous Kademlia Bootstrap process.
+    StopBootstrapping,
     // Get closest peers from the network
     GetClosestPeers {
         key: NetworkAddress,
@@ -306,6 +308,9 @@ impl SwarmDriver {
                     Ok(_) => sender.send(Ok(())),
                     Err(e) => sender.send(Err(e.into())),
                 };
+            }
+            SwarmCmd::StopBootstrapping => {
+                self.bootstrap.stop_bootstrapping();
             }
             SwarmCmd::GetClosestPeers { key, sender } => {
                 let query_id = self

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -770,7 +770,10 @@ impl SwarmDriver {
                     info!("New peer added to routing table: {peer:?}");
                     self.log_kbuckets(&peer);
 
-                    self.bootstrap.notify_new_peer();
+                    if self.bootstrap.notify_new_peer() {
+                        info!("Performing the first bootstrap");
+                        self.initiate_bootstrap();
+                    }
                     self.send_event(NetworkEvent::PeerAdded(peer));
                 }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -134,6 +134,11 @@ impl Network {
         receiver.await?
     }
 
+    /// Stop the continuous Kademlia Bootstrapping process
+    pub fn stop_bootstrapping(&self) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::StopBootstrapping)
+    }
+
     /// Returns the closest peers to the given `XorName`, sorted by their distance to the xor_name.
     /// Excludes the client's `PeerId` while calculating the closest peers.
     pub async fn client_get_closest_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 extern crate tracing;
 
+mod bootstrap;
 mod circular_vec;
 mod cmd;
 mod driver;

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -154,7 +154,6 @@ impl Node {
             node_metrics,
         };
 
-        let network_clone = network.clone();
         let node_event_sender = node_events_channel.clone();
         let mut rng = StdRng::from_entropy();
 
@@ -189,20 +188,7 @@ impl Node {
                     }
                     _ = tokio::time::sleep(inactivity_timeout) => {
                         trace!("NetworkEvent inactivity timeout hit");
-                        let network_clone = network_clone.clone();
-
                         Marker::NoNetworkActivity( inactivity_timeout ).log();
-                        let _handle = spawn ( async move {
-                            let random_target = NetworkAddress::from_peer(PeerId::random());
-                            debug!("No network activity in the past {inactivity_timeout:?}, performing a random get_closest query to target: {random_target:?}");
-                            match network_clone.node_get_closest_peers(&random_target).await {
-                                Ok(closest) => debug!("Network inactivity: get_closest returned {closest:?}"),
-                                Err(e) => {
-                                    warn!("get_closest query failed after network inactivity timeout - check your connection: {}", e);
-                                    Marker::OperationFailedAfterNetworkInactivityTimeout.log();
-                                }
-                            }
-                        });
                     }
                 }
 

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -20,9 +20,6 @@ use strum::Display;
 /// Changing these log markers is a breaking change.
 #[derive(Debug, Clone, Display)]
 pub enum Marker<'a> {
-    /// An operation failed after timing out due to a period of no network activity
-    OperationFailedAfterNetworkInactivityTimeout,
-
     /// The node has started
     NodeConnectedToNetwork,
 


### PR DESCRIPTION
- Slows down the continuous bootstrap process if we have not added any new peers to the RT
- Stop continuous bootstrap on the client if we have K_VALUE peers in RT
- Remove random `get_closest` query from network, the bootstrap process should take care of it!

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 09:53 UTC
This pull request includes changes to multiple files in the codebase. Here's a summary of the changes:

1. In the `Node` struct implementation, the variable `network_clone` has been removed along with a block of code related to handling network inactivity timeouts and performing random `get_closest` queries.

2. The `api.rs` file has been modified to import the `K_VALUE` constant from `libp2p::kad`. Additionally, a condition was added to stop further bootstrapping if the number of peers added is equal to or greater than `K_VALUE`. Debug and progress log messages now include the total number of initial peers found.

3. The `cmd.rs` file now includes a new variant called `StopBootstrapping` in the `SwarmCmd` enum. The handling of this command calls the `stop_bootstrapping` function from the `bootstrap` module. There were no changes related to the existing code for the `GetClosestPeers` command.

4. The `sn_networking/src/bootstrap.rs` file has been added. This file contains code related to the bootstrap process in the SAFE Network. It defines constants, structs, and implements methods for running the bootstrap process continuously, initiating the bootstrap process, and tracking bootstrapping status. The code also handles slowing down the bootstrapping process based on certain conditions.

5. The `NetworkBuilder` and `SwarmDriver` structs now use a `bootstrap` field of type `ContinuousBootstrap` instead of a boolean field called `bootstrap_ongoing`. The bootstrap process has been updated to utilize the `ContinuousBootstrap` struct to improve handling.

6. The `event.rs` file in the `sn_networking` module has undergone changes. The `SwarmDriver` implementation now removes the line setting `self.bootstrap_ongoing` to `false` and includes a call to `self.bootstrap.completed()` when `step.last` is true. The code also adds a log statement when a new peer is added to the routing table and sends a `NetworkEvent::PeerAdded` event. The condition for considering a peer as old has been updated.

7. Lastly, the `log_markers.rs` file has had the `OperationFailedAfterNetworkInactivityTimeout` log marker enum variant removed.

These changes aim to introduce or improve functionality related to networking, bootstrapping, and log handling in the codebase.
<!-- reviewpad:summarize:end --> 
