### PR TITLE
Only pay one node

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -14,7 +14,7 @@ use bls::{PublicKey, SecretKey, Signature};
 use indicatif::ProgressBar;
 use libp2p::{
     identity::Keypair,
-    kad::{Record, K_VALUE},
+    kad::{Quorum, Record, K_VALUE},
     Multiaddr, PeerId,
 };
 #[cfg(feature = "open-metrics")]
@@ -387,7 +387,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::One)
             .await?)
     }
 
@@ -428,7 +428,7 @@ impl Client {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
+            .get_record_from_network(key, None, GetQuorum::One, false, Default::default())
             .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {
@@ -491,7 +491,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
             .await?)
     }
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -277,7 +277,7 @@ impl Client {
 
         let maybe_record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
+            .get_record_from_network(key, None, GetQuorum::One, true, Default::default())
             .await;
         let record = match maybe_record {
             Ok(r) => r,

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -378,7 +378,7 @@ impl ClientRegister {
         Ok(self
             .client
             .network
-            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
+            .put_record(record, record_to_verify, expected_holders, Quorum::One)
             .await?)
     }
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -9,7 +9,7 @@
 use crate::{Client, Error, Result, WalletClient};
 
 use bls::PublicKey;
-use libp2p::kad::Record;
+use libp2p::kad::{Quorum, Record};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::RegisterCmd,
@@ -378,7 +378,7 @@ impl ClientRegister {
         Ok(self
             .client
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
             .await?)
     }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -109,6 +109,7 @@ pub enum SwarmCmd {
     PutRecord {
         record: Record,
         sender: oneshot::Sender<Result<()>>,
+        quorum: Quorum,
     },
     /// Put record to the local RecordStore
     PutLocalRecord {
@@ -335,7 +336,11 @@ impl SwarmDriver {
                     .map(|rec| rec.into_owned());
                 let _ = sender.send(record);
             }
-            SwarmCmd::PutRecord { record, sender } => {
+            SwarmCmd::PutRecord {
+                record,
+                sender,
+                quorum,
+            } => {
                 let record_key = PrettyPrintRecordKey::from(&record.key).into_owned();
                 trace!(
                     "Putting record sized: {:?} to network {:?}",
@@ -346,7 +351,7 @@ impl SwarmDriver {
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .put_record(record, Quorum::All)
+                    .put_record(record, quorum)
                 {
                     Ok(request_id) => {
                         trace!("Sent record {record_key:?} to network. Request id: {request_id:?} to network");

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -683,7 +683,7 @@ fn get_fees_from_store_cost_responses(
 ) -> Result<Vec<(MainPubkey, NanoTokens)>> {
     // TODO: we should make this configurable based upon data type
     // or user requirements for resilience.
-    let desired_quote_count = CLOSE_GROUP_SIZE;
+    let desired_quote_count = close_group_majority();
 
     // sort all costs by fee, lowest to highest
     all_costs.sort_by(|(_, cost_a), (_, cost_b)| {
@@ -692,7 +692,7 @@ fn get_fees_from_store_cost_responses(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    // get the first desired_quote_count of all_costs
+    // get the lowest desired_quote_counts of all_costs
     all_costs.truncate(desired_quote_count);
 
     info!(
@@ -760,8 +760,8 @@ mod tests {
             .iter()
             .fold(0, |acc, (_, price)| acc + price.as_nano());
 
-        // sum all the numbers from 0 to CLOSE_GROUP_SIZE
-        let expected_price = CLOSE_GROUP_SIZE * (CLOSE_GROUP_SIZE - 1) / 2;
+        // sum all the numbers from 0 to close_group_majority()
+        let expected_price = close_group_majority() * (close_group_majority() - 1) / 2;
 
         assert_eq!(
             total_price, expected_price as u64,
@@ -772,7 +772,6 @@ mod tests {
         Ok(())
     }
     #[test]
-    #[ignore = "we want to pay the entire CLOSE_GROUP for now"]
     fn test_get_any_fee_from_store_cost_responses_errs_if_insufficient_responses(
     ) -> eyre::Result<()> {
         // for a vec of different costs of CLOSE_GROUP size
@@ -790,8 +789,8 @@ mod tests {
         Ok(())
     }
     #[test]
-    #[ignore = "we want to pay the entire CLOSE_GROUP for now"]
-    fn test_get_some_fee_from_store_cost_responses_errs_if_sufficient() -> eyre::Result<()> {
+    fn test_get_some_fee_from_store_cost_responses_even_if_one_errs_and_sufficient(
+    ) -> eyre::Result<()> {
         // for a vec of different costs of CLOSE_GROUP size
         let responses_count = CLOSE_GROUP_SIZE as u64 - 1;
         let mut costs = vec![];
@@ -812,7 +811,7 @@ mod tests {
             .fold(0, |acc, (_, price)| acc + price.as_nano());
 
         // sum all the numbers from 0 to CLOSE_GROUP_SIZE / 2 + 1
-        let expected_price = (CLOSE_GROUP_SIZE / 2) * (CLOSE_GROUP_SIZE / 2 + 1) / 2;
+        let expected_price = close_group_majority() * (close_group_majority() - 1) / 2;
 
         assert_eq!(
             total_price, expected_price as u64,

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -7,8 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 #![allow(clippy::mutable_key_type)]
 
-use crate::CLOSE_GROUP_SIZE;
-use libp2p::{kad::RecordKey, PeerId};
+use libp2p::{
+    kad::{RecordKey, K_VALUE},
+    PeerId,
+};
 use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
 use std::{
     collections::{HashMap, HashSet},
@@ -16,11 +18,11 @@ use std::{
 };
 
 // Max parallel fetches that can be undertaken at the same time.
-const MAX_PARALLEL_FETCH: usize = CLOSE_GROUP_SIZE * 2;
+const MAX_PARALLEL_FETCH: usize = K_VALUE.get();
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.
-const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
 
 // The time at which the key was sent to be fetched from the peer.
 type ReplicationRequestSentTime = Instant;

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -183,7 +183,7 @@ impl Node {
                         .get_record_from_network(
                             key,
                             None,
-                            GetQuorum::Majority,
+                            GetQuorum::One,
                             false,
                             Default::default(),
                         )

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -123,11 +123,7 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(
-        count,
-        close_group_majority(),
-        "Not enough notifications received"
-    );
+    assert_eq!(count, 1, "Not enough notifications received");
 
     Ok(())
 }
@@ -157,11 +153,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(
-        count,
-        close_group_majority(),
-        "Not enough notifications received"
-    );
+    assert_eq!(count, 1, "Not enough notifications received");
 
     Ok(())
 }
@@ -217,7 +209,8 @@ fn spawn_transfer_notifs_listener(endpoint: String) -> JoinHandle<Result<usize, 
                 Ok(NodeEvent::TransferNotif { key, transfer: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     count += 1;
-                    if count == close_group_majority() {
+                    // we're not only paying 1 node each time, so one notification only
+                    if count == 1 {
                         break;
                     }
                 }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -16,7 +16,7 @@ use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use sn_client::WalletClient;
 use sn_logging::LogBuilder;
-use sn_networking::CLOSE_GROUP_SIZE;
+use sn_networking::{close_group_majority, CLOSE_GROUP_SIZE};
 use sn_node::NodeEvent;
 use sn_transfers::{LocalWallet, NanoTokens};
 use tokio::{
@@ -208,7 +208,7 @@ fn spawn_transfer_notifs_listener(endpoint: String) -> JoinHandle<Result<usize, 
                 Ok(NodeEvent::TransferNotif { key, transfer: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     count += 1;
-                    if count == CLOSE_GROUP_SIZE {
+                    if count == close_group_majority() {
                         break;
                     }
                 }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -17,6 +17,7 @@ use eyre::{eyre, Result};
 use sn_client::WalletClient;
 use sn_logging::LogBuilder;
 use sn_networking::{close_group_majority, CLOSE_GROUP_SIZE};
+
 use sn_node::NodeEvent;
 use sn_transfers::{LocalWallet, NanoTokens};
 use tokio::{
@@ -122,7 +123,11 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(
+        count,
+        close_group_majority(),
+        "Not enough notifications received"
+    );
 
     Ok(())
 }
@@ -152,7 +157,11 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(
+        count,
+        close_group_majority(),
+        "Not enough notifications received"
+    );
 
     Ok(())
 }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -16,7 +16,6 @@ use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use sn_client::WalletClient;
 use sn_logging::LogBuilder;
-use sn_networking::{close_group_majority, CLOSE_GROUP_SIZE};
 
 use sn_node::NodeEvent;
 use sn_transfers::{LocalWallet, NanoTokens};


### PR DESCRIPTION
This should no longer be needed with repayments reusing existing payments
This also removes some client indirection## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 11:14 UTC
This pull request includes the following changes across multiple files:

- In file `sn_client/register.rs`, the `Quorum` type is imported from the `libp2p::kad` module. The `put_record` method call has also been modified to include the `Quorum::Majority` argument.
- In file `file_apis.rs`, several changes have been made, including import modifications, function removal, addition of new functions, change in visibility, and code changes to accommodate the new functions.
- In file `sn_client/src/api.rs`, the `sn_transfers::{MainPubkey, NanoTokens, SignedSpend, Transfer, UniquePubkey}` import has been removed, and the `libp2p::kad::Quorum` import has been added. Also, modifications have been made in the `Client` implementation related to the `put_record` and `get_record_from_network` functions.
- File `error.rs` has a new variant added to the `Error` enum called `JoinError`, which wraps a `tokio::task::JoinError` error.
- In file `event.rs`, the logging level of a message has changed from `trace` to `debug` level, indicating an increase in importance.
- File `SwarmCmd::PutRecord` now has a new field `quorum` added, which is used in the `SwarmDriver` implementation.
- File `sn_cli/src/subcommands/files.rs` includes changes related to logging and storing a result in the `verify_and_repay_if_needed` function.
- In file `wallet.rs`, modifications have been made to the signature and implementation of the `get_store_cost_at_address` function, closure parameters, and method calls.
- File `lib.rs` has several changes, including import addition, addition of a `quorum` field, modifications to method signatures and implementations, addition of a new function, and updates to a test function.
- File `verify_data_location.rs` has a change in the `store_chunks` function, where the method call has been modified to call `pay_and_upload_bytes_test` instead of `upload_with_payments`.
- File `sn_networking/src/api.rs` includes several changes related to import statements, function parameter additions, removal of parameters, print statement removal, variable reassignment, function implementation updates, and loop duration adjustments.
- File `replication.rs` has a change in the `GetQuorum` value from `Majority` to `One` in the `get_record_from_network` function call.
- File `put_validation.rs` includes various changes related to payment validation and chunk storage, including added validation, early return, code reorganization, moved logic, removed checks, modified logging, and added checks.
- File `storage_payment.rs` includes changes in tests related to function replacements, parameter modifications, and assertion additions.

Let me know if you need any further assistance.
<!-- reviewpad:summarize:end --> 
