### PR TITLE
chore: logging a node's representitive record_key address

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -44,7 +44,10 @@ use libp2p::{
 use libp2p_quic as quic;
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
-use sn_protocol::messages::{Request, Response};
+use sn_protocol::{
+    messages::{Request, Response},
+    NetworkAddress, PrettyPrintRecordKey,
+};
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
@@ -292,6 +295,10 @@ impl NetworkBuilder {
     ) -> Result<(Network, mpsc::Receiver<NetworkEvent>, SwarmDriver)> {
         let peer_id = PeerId::from(self.keypair.public());
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
+        info!(
+            "Self PeerID {peer_id} is represented as record_key {:?}",
+            PrettyPrintRecordKey::from(NetworkAddress::from_peer(peer_id).to_record_key())
+        );
 
         #[cfg(feature = "open-metrics")]
         let network_metrics = {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -67,9 +67,20 @@ impl Node {
         for key in all_records {
             let sorted_based_on_key =
                 sort_peers_by_address(all_peers.clone(), &key, CLOSE_GROUP_SIZE + 1)?;
+            let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
+                .iter()
+                .map(|peer_id| {
+                    format!(
+                        "{peer_id:?}({:?})",
+                        PrettyPrintRecordKey::from(
+                            NetworkAddress::from_peer(*peer_id).to_record_key()
+                        )
+                    )
+                })
+                .collect();
 
             if sorted_based_on_key.contains(&peer_id) {
-                trace!("replication: close for {key:?} are: {sorted_based_on_key:?}");
+                trace!("replication: close for {key:?} are: {sorted_peers_pretty_print:?}");
                 let target_peer = if is_removal {
                     // For dead peer, only replicate to farthest close_group peer,
                     // when the dead peer was one of the close_group peers to the record.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 16:22 UTC
This pull request adds logging for a node's representative record_key address in the `sn_networking/src/driver.rs` file. It uses the `info` macro to log the self PeerID and its corresponding record_key.
<!-- reviewpad:summarize:end --> 
