### PR TITLE
feat: keep transfers in mem instead of mem and i/o heavy cashnotes

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -59,13 +59,13 @@ impl WalletClient {
     pub fn get_payment_transfers(&self, address: &NetworkAddress) -> WalletResult<Vec<Transfer>> {
         match &address.as_xorname() {
             Some(xorname) => {
-                let cash_notes = self.wallet.get_payment_cash_notes(xorname);
+                let transfers = self.wallet.get_payment_transfers(xorname);
 
                 info!(
-                    "Payment cash notes retrieved from wallet: {:?}",
-                    cash_notes.len()
+                    "Payment transfers retrieved for {xorname:?} from wallet: {:?}",
+                    transfers.len()
                 );
-                Ok(Transfer::transfers_from_cash_notes(cash_notes)?)
+                Ok(transfers)
             }
             None => Err(WalletError::InvalidAddressType),
         }
@@ -205,8 +205,6 @@ impl WalletClient {
         all_data_payments: BTreeMap<XorName, Vec<(MainPubkey, NanoTokens)>>,
         verify_store: bool,
     ) -> WalletResult<NanoTokens> {
-        // TODO:
-        // Check for any existing payment CashNotes, and use them if they exist, only topping up if needs be
         let mut total_cost = NanoTokens::zero();
         for (_data, costs) in all_data_payments.iter() {
             for (_target, cost) in costs {

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     rng, CashNote, DerivationIndex, DerivedSecretKey, Hash, Input, MainPubkey, NanoTokens,
-    SignedSpend, Transaction, TransactionBuilder, UniquePubkey,
+    SignedSpend, Transaction, TransactionBuilder, Transfer, UniquePubkey,
 };
 use crate::{Error, Result};
 
@@ -36,7 +36,7 @@ pub struct OfflineTransfer {
     pub all_spend_requests: Vec<SignedSpend>,
 }
 
-pub type PaymentDetails = (UniquePubkey, MainPubkey, NanoTokens);
+pub type PaymentDetails = (Transfer, MainPubkey, NanoTokens);
 
 /// Xorname of data from which the content was fetched, mapping to the CashNote UniquePubkey (its id on disk)
 /// the main key for that CashNote and the value

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -230,24 +230,17 @@ impl LocalWallet {
     }
 
     /// Return the payment cash_note ids for the given content address name if cached.
-    pub fn get_payment_cash_notes(&self, name: &XorName) -> Vec<CashNote> {
-        let ids = self.get_payment_unique_pubkeys_and_values(name);
-        // now grab all those cash_notes
-        let mut cash_notes: Vec<CashNote> = vec![];
+    pub fn get_payment_transfers(&self, name: &XorName) -> Vec<Transfer> {
+        let mut transfers: Vec<Transfer> = vec![];
 
-        if let Some(ids) = ids {
-            for (id, _main_pub_key, _value) in ids {
-                if let Some(cash_note) = load_created_cash_note(id, &self.wallet_dir) {
-                    trace!(
-                        "Current cash_note of chunk {name:?} is paying {:?} tokens.",
-                        cash_note.value()
-                    );
-                    cash_notes.push(cash_note);
-                }
+        if let Some(payment) = self.get_payment_unique_pubkeys_and_values(name) {
+            for (trans, _main_pub_key, value) in payment {
+                trace!("Current transfer for chunk {name:?} is of {value:?} tokens.");
+                transfers.push(trans.to_owned());
             }
         }
 
-        cash_notes
+        transfers
     }
 
     /// Make a transfer and return all created cash_notes
@@ -333,7 +326,7 @@ impl LocalWallet {
         for (content_addr, payees) in all_data_payments {
             for (payee, token) in payees {
                 if let Some(cash_note) =
-                    &offline_transfer
+                    offline_transfer
                         .created_cash_notes
                         .iter()
                         .find(|cash_note| {
@@ -347,7 +340,7 @@ impl LocalWallet {
                     let cash_notes_for_content: &mut Vec<PaymentDetails> =
                         all_transfers_per_address.entry(content_addr).or_default();
                     cash_notes_for_content.push((
-                        cash_note.unique_pubkey(),
+                        Transfer::transfers_from_cash_note(cash_note.to_owned())?,
                         *cash_note.main_pubkey(),
                         cash_note.value()?,
                     ));


### PR DESCRIPTION
## Description

Transform CashNotes into transfers ASAP to avoid repetitive cash note disk I/O and reduce memory footprint as Transfers are much smaller than CashNotes. 

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Oct 23 05:52 UTC
This pull request introduces a feature to keep transfers in memory instead of in both memory and I/O heavy cashnotes. It modifies the `get_payment_transfers` function in `wallet.rs` to directly return the payment transfers instead of first retrieving payment cash notes and then transforming them into transfers. It also updates the types and struct definitions in `offline_transfer.rs` and `local_store.rs` to reflect this change. Additionally, it removes some commented out code and unused variables. Overall, this change optimizes the memory and I/O usage in the wallet module.
<!-- reviewpad:summarize:end --> 
