### PR TITLE
test: retry and verify reg upload during reward test

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -141,7 +141,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let handle = spawn_transfer_notifs_listener("https://127.0.0.1:12001".to_string());
 
     let _register = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(register_addr, &mut wallet_client, true)
         .await?;
     println!("Random Register created");
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Oct 23 12:15 UTC
This pull request makes a small change to the `nodes_rewards.rs` test file. It modifies the `nodes_rewards_for_register_notifs_over_gossipsub` function to retry and verify registration upload during the reward test. Specifically, it changes the third argument of the `create_and_pay_for_register` function call from `false` to `true`.
<!-- reviewpad:summarize:end --> 
