### PR TITLE
feat(cli): new wallet create cmd allowing users to create a wallet from a given secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ CashNote received with UniquePubkey(PublicKey(19ee..1580)), value: 0.000000001
 
 ```
 
+A path to local disk where to store royalties payments cash notes received can be provided as well, e.g.:
+```
+$ cargo run --release --example safenode_rpc_client -- 127.0.0.1:12001 transfers ./royalties-cash-notes
+Listening to transfers notifications... (press Ctrl+C to exit)
+Writing cash notes to: ./royalties-cash-notes
+
+```
+Each CashNote is written to a separate file in respective recipient public address dir in the created cash_notes dir. Each file is named after the CashNote id.
+
 # Metrics Dashboard
 
 Use the `open-metrics` feature flag on the node / client to start an [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/) exporter. The metrics are served via a webserver started at a random port. Check the log file / stdout to find the webserver URL, `Metrics server on http://127.0.0.1:xxxx/metrics`

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -72,7 +72,10 @@ async fn main() -> Result<()> {
     let client_data_dir_path = get_client_data_dir_path()?;
     // Perform actions that do not require us connecting to the network and return early
     if let SubCmd::Wallet(cmds) = &opt.cmd {
-        if let WalletCmds::Address | WalletCmds::Balance { .. } | WalletCmds::Deposit { .. } = cmds
+        if let WalletCmds::Address
+        | WalletCmds::Balance { .. }
+        | WalletCmds::Deposit { .. }
+        | WalletCmds::Create { .. } = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
             return Ok(());

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -241,6 +241,8 @@ fn deposit(root_dir: &Path, read_from_stdin: bool, cash_note: Option<String>) ->
 
     let previous_balance = wallet.balance();
 
+    wallet.try_load_cash_notes()?;
+
     let deposited =
         sn_transfers::NanoTokens::from(wallet.balance().as_nano() - previous_balance.as_nano());
     if deposited.is_zero() {

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -62,4 +62,7 @@ pub enum Error {
 
     #[error("The provided amount contains zero nanos")]
     AmountIsZero,
+    /// CashNote add would overflow
+    #[error("Total price exceed possible token amount")]
+    TotalPriceTooHigh,
 }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -203,9 +203,12 @@ impl ClientRegister {
                 // Let's check if the user has already paid for this address first
                 let net_addr = sn_protocol::NetworkAddress::RegisterAddress(addr);
                 // Let's make the storage payment
-                cost = wallet_client
+                let (storage_cost, royalties_fees) = wallet_client
                     .pay_for_storage(std::iter::once(net_addr.clone()))
                     .await?;
+                cost = storage_cost
+                    .checked_add(royalties_fees)
+                    .ok_or(Error::TotalPriceTooHigh)?;
 
                 println!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");
                 info!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -137,7 +137,7 @@ impl WalletClient {
     pub async fn pay_for_storage(
         &mut self,
         content_addrs: impl Iterator<Item = NetworkAddress>,
-    ) -> WalletResult<NanoTokens> {
+    ) -> WalletResult<(NanoTokens, NanoTokens)> {
         let verify_store = true;
         let mut payment_map = BTreeMap::default();
 
@@ -183,7 +183,7 @@ impl WalletClient {
         info!("Storecosts retrieved");
 
         if payment_map.is_empty() {
-            Ok(NanoTokens::zero())
+            Ok((NanoTokens::zero(), NanoTokens::zero()))
         } else {
             self.wallet.adjust_payment_map(&mut payment_map);
             self.pay_for_records(payment_map, verify_store).await
@@ -199,7 +199,7 @@ impl WalletClient {
         &mut self,
         all_data_payments: BTreeMap<XorName, Vec<(MainPubkey, NanoTokens)>>,
         verify_store: bool,
-    ) -> WalletResult<NanoTokens> {
+    ) -> WalletResult<(NanoTokens, NanoTokens)> {
         // TODO:
         // Check for any existing payment CashNotes, and use them if they exist, only topping up if needs be
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/bin/safenode/main.rs"
 name = "faucet"
 path = "src/bin/faucet/main.rs"
 
+[[bin]]
+name = "safenode_rpc_client"
+path = "examples/safenode_rpc_client.rs"
+
 [features]
 default=["metrics"]
 local-discovery=["sn_networking/local-discovery"]

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -48,18 +48,11 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
     )?;
 
     println!("Paying for {} random addresses...", chunks.len());
-    let expected_royalties_fees =
-        NanoTokens::from(chunks.len() as u64 * NETWORK_ROYALTIES_AMOUNT_PER_ADDR.as_nano());
-
     let prev_rewards_balance = current_rewards_balance()?;
 
-    let (_file_addr, cost) = files_api
+    let (_file_addr, rewards_paid, _royalties_fees) = files_api
         .pay_and_upload_bytes_test(*content_addr.xorname(), chunks)
         .await?;
-
-    let rewards_paid = cost
-        .checked_sub(expected_royalties_fees)
-        .ok_or_else(|| eyre!("Failed to substract rewards balance"))?;
 
     let expected_rewards_balance = prev_rewards_balance
         .checked_add(rewards_paid)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Oct 23 17:02 UTC
This pull request includes changes to multiple files.

In `storage_payments.rs`:
- Lines 224-237: The code for paying for random addresses has been removed.
- Lines 237-335: The code for invalid spends, as well as a sleep operation, has been commented out.
- Lines 335-377: The code related to storage payment registration, creation, and mutation has been modified.

In `transfer.rs`:
- The `Transfer` struct has been changed to an enum with two variants: `Encrypted` and `NetworkRoyalties`.
- The `encrypted_cashnote_redemptions` field has been replaced with the `Encrypted` variant, which holds a vector of `Ciphertext`.
- The `NetworkRoyalties` variant has been added, which holds a vector of `CashNoteRedemption`.
- The `create` method has been updated to handle the new enum variants.
- The `cashnote_redemptions` method has been updated to handle the new enum variants.

In `wallet.rs`:
- Several changes have been made to the `WalletClient` struct implementation, including removing the declaration and initialization of the `total_cost` variable, modifying the logic in the `send_to_network` method, updating the return type of the `pay_for_records` method, removing nested loops in the `pay_for_records` method, and modifying the implementation of the `pay_for_records` method to directly call the `local_send_storage_payment` method.

In `Cargo.toml`:
- The `network-royalties-notif` dependency has been removed.

In `notifications.rs`:
- Added a section for listening to network royalties payments events.
- Added code to listen to transfers notifications and print information about received cash notes.
- Updated the instructions on starting the Metrics Dashboard and accessing the metrics server.

In `main.rs`:
- A new conditional branch has been added in the `if let` statement under the `SubCmd::Wallet(cmds)` section to handle the `WalletCmds::Create` variant.

In `safenode_rpc_client.rs`:
- Line 188: Added a `println!()` statement for formatting purposes.
- Line 191: Renamed the `transfer` variable to `cash_notes` and updated the corresponding message.
- Lines 193-203: Added a loop to iterate over each `cash_note` in the `cash_notes` vector and print information about each one.

In `transfers.rs`:
- Import statements have been modified, adding the `CashNoteRedemption` and `MainPubkey` types and removing the `Transfer` type.
- A new function `verify_cash_notes_redemptions` has been added to verify cash note redemptions and return a list of spendable cash notes.
- The existing function `unwrap_transfer_request` has been modified to call the `verify_cash_notes_redemptions` function.

In `put_validation.rs`:
- Import statements have been added for `NETWORK_ROYALTIES_PK` and `network_ROYALTIES_AMOUNT_PER_ADDR`.
- The `cash_notes_from_payment` function has been modified to handle network royalties payment and return two vectors: `cash_notes` and `royalties_cash_notes`.
- The `perform_validations` function has been modified to handle network royalties payment and publish notifications for cash notes received and network royalties payment.
- A new helper function `total_cash_notes_amount` has been added to calculate the total amount of tokens received in a given set of cash notes.

Please let me know if you need more information or specific details about any of these changes.
<!-- reviewpad:summarize:end --> 
