### PR TITLE
increase replication area

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -290,26 +290,23 @@ impl Client {
     /// Tops up payments and retries if necessary and verification failed
     pub async fn create_and_pay_for_register(
         &self,
-        address: XorName,
+        meta: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
     ) -> Result<(ClientRegister, NanoTokens)> {
-        info!("Instantiating a new Register replica with address {address:?}");
+        info!("Instantiating a new Register replica with address {meta:?}");
         let (reg, mut total_cost) =
-            ClientRegister::create_online(self.clone(), address, wallet_client, false).await?;
+            ClientRegister::create_online(self.clone(), meta, wallet_client, false).await?;
 
-        debug!("{address:?} Created in theorryyyyy");
         let reg_address = reg.address();
         if verify_store {
-            debug!("WE SHOULD VERRRRIFYING");
             let mut stored = self.verify_register_stored(*reg_address).await.is_ok();
 
             while !stored {
                 info!("Register not completely stored on the network yet. Retrying...");
                 // this verify store call here ensures we get the record from Quorum::all
                 let (reg, top_up_cost) =
-                    ClientRegister::create_online(self.clone(), address, wallet_client, true)
-                        .await?;
+                    ClientRegister::create_online(self.clone(), meta, wallet_client, true).await?;
                 let reg_address = reg.address();
 
                 total_cost = total_cost.checked_add(top_up_cost).ok_or(Error::Transfers(

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -12,7 +12,7 @@ use libp2p::{
     kad::{Record, RecordKey, K_VALUE},
     PeerId,
 };
-use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
+use sn_networking::{close_group_majority, sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
@@ -65,8 +65,11 @@ impl Node {
         }
 
         for key in all_records {
-            let sorted_based_on_key =
-                sort_peers_by_address(all_peers.clone(), &key, CLOSE_GROUP_SIZE + 1)?;
+            let sorted_based_on_key = sort_peers_by_address(
+                all_peers.clone(),
+                &key,
+                CLOSE_GROUP_SIZE + close_group_majority(),
+            )?;
             let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
                 .iter()
                 .map(|peer_id| {

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -400,7 +400,6 @@ fn store_chunks_task(
                 chunks.len(),
                 chunk_size
             );
-            sleep(delay).await;
 
             let chunks_len = chunks.len();
 
@@ -587,7 +586,7 @@ async fn final_retry_query_content(
                 bail!("Final check: Content is still not retrievable at {net_addr} after {attempts} attempts: {last_err:?}");
             } else {
                 attempts += 1;
-                let delay = 2 * churn_period;
+                let delay = 5 * churn_period;
                 println!("Delaying last check for {delay:?} ...");
                 sleep(delay).await;
                 continue;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -257,7 +257,7 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
                 .for_each(|(idx, peer)| println!("{} : {peer:?}", idx + 1));
             verification_attempts += 1;
             println!("Sleeping before retrying verification");
-            tokio::time::sleep(Duration::from_secs(20)).await;
+            tokio::time::sleep(Duration::from_secs(60)).await;
         } else {
             // if successful, break out of the loop
             break;
@@ -340,7 +340,7 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
     );
 
     // to make sure the last chunk was stored
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(30)).await;
 
     Ok(())
 }


### PR DESCRIPTION
The address is dereived from the meta AND the PK## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 05:29 UTC
This pull request includes two patches.

The first patch is titled "chore: rename register meta from addr" and it modifies the `create_and_pay_for_register` method in the `Client` struct in `sn_client/src/api.rs`. The patch renames the `address` parameter to `meta` and updates the code accordingly.

The second patch is titled "chore(node): increase how far we try and replicate data" and it modifies the `Node` struct in `sn_node/src/replication.rs`. The patch increases the value used for determining the number of peers to replicate data to. This is done by replacing `CLOSE_GROUP_SIZE + 1` with `CLOSE_GROUP_SIZE + close_group_majority()` in the code.

Overall, these patches make improvements and adjustments to the code related to registering and replicating data.
<!-- reviewpad:summarize:end --> 
