### PR TITLE
Replicate to cache candidates

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -201,7 +201,7 @@ impl SwarmDriver {
                 }
                 if self
                     .pending_get_record_for_cache_candidates
-                    .insert(query_id, key)
+                    .insert(query_id, (key, Default::default()))
                     .is_some()
                 {
                     warn!("An existing pending_get_record_for_cache_candidates task {query_id:?} got replaced");

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -186,7 +186,7 @@ impl SwarmDriver {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key.clone());
 
                 if !expected_holders.is_empty() {
-                    debug!("Record {:?} with task {query_id:?} expected to be held by {expected_holders:?}", PrettyPrintRecordKey::from(key));
+                    debug!("Record {:?} with task {query_id:?} expected to be held by {expected_holders:?}", PrettyPrintRecordKey::from(key.clone()));
                 }
 
                 if self
@@ -197,8 +197,16 @@ impl SwarmDriver {
                     )
                     .is_some()
                 {
-                    warn!("An existing get_record task {query_id:?} got replaced");
+                    warn!("An existing pending_get_record task {query_id:?} got replaced");
                 }
+                if self
+                    .pending_get_record_for_cache_candidates
+                    .insert(query_id, key)
+                    .is_some()
+                {
+                    warn!("An existing pending_get_record_for_cache_candidates task {query_id:?} got replaced");
+                }
+
                 // Logging the status of the `pending_get_record`.
                 // We also interested in the status of `result_map` (which contains record) inside.
                 let total_records: usize = self

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -57,8 +57,8 @@ pub enum SwarmCmd {
     GetAllLocalPeers {
         sender: oneshot::Sender<Vec<PeerId>>,
     },
-    // Returns the peers that are closet to our PeerId.
-    GetOurCloseGroup {
+    // Returns the K_VALUE number of peers that are closet to our PeerId.
+    GetOurClosestKValuePeers {
         sender: oneshot::Sender<Vec<PeerId>>,
     },
     GetSwarmLocalState(oneshot::Sender<SwarmLocalState>),
@@ -349,8 +349,8 @@ impl SwarmDriver {
             SwarmCmd::GetAllLocalPeers { sender } => {
                 let _ = sender.send(self.get_all_local_peers());
             }
-            SwarmCmd::GetOurCloseGroup { sender } => {
-                let _ = sender.send(self.close_group.clone());
+            SwarmCmd::GetOurClosestKValuePeers { sender } => {
+                let _ = sender.send(self.close_k_value_peers.clone());
             }
             SwarmCmd::SendRequest { req, peer, sender } => {
                 // If `self` is the recipient, forward the request directly to our upper layer to

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -160,7 +160,17 @@ impl SwarmDriver {
                 let all_peers = self.get_all_local_peers();
                 let keys_to_store = keys
                     .iter()
-                    .filter(|key| self.is_in_close_range(key, &all_peers))
+                    .filter(|key| {
+                        let close_group_size = CLOSE_GROUP_SIZE + 2;
+                        let is_close =
+                            self.is_in_close_range(key, &all_peers, close_group_size);
+                        if !is_close {
+                            trace!(
+                                "AddKeysToReplicationFetcher: self not within {close_group_size} peers that are close to key {key:?}. Not adding key for replication."
+                            );
+                        }
+                        is_close
+                    })
                     .cloned()
                     .collect();
                 #[allow(clippy::mutable_key_type)]
@@ -451,13 +461,18 @@ impl SwarmDriver {
     // are none among target b011111's close range.
     // Hence, the ilog2 calculation based on close_range cannot cover such case.
     // And have to sort all nodes to figure out whether self is among the close_group to the target.
-    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &[PeerId]) -> bool {
-        if all_peers.len() <= CLOSE_GROUP_SIZE + 2 {
+    fn is_in_close_range(
+        &self,
+        target: &NetworkAddress,
+        all_peers: &[PeerId],
+        close_group_size: usize,
+    ) -> bool {
+        if all_peers.len() <= close_group_size {
             return true;
         }
 
         // Margin of 2 to allow our RT being bit lagging.
-        match sort_peers_by_address(all_peers, target, CLOSE_GROUP_SIZE + 2) {
+        match sort_peers_by_address(all_peers, target, close_group_size) {
             Ok(close_group) => close_group.contains(&&self.self_peer_id),
             Err(err) => {
                 warn!("Could not get sorted peers for {target:?} with error {err:?}");

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -31,7 +31,7 @@ use libp2p::mdns;
 use libp2p::{
     autonat,
     identity::Keypair,
-    kad::{Kademlia, KademliaConfig, QueryId, Record},
+    kad::{Kademlia, KademliaConfig, QueryId, Record, RecordKey},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{
@@ -459,6 +459,7 @@ impl NetworkBuilder {
             pending_get_closest_peers: Default::default(),
             pending_requests: Default::default(),
             pending_get_record: Default::default(),
+            pending_get_record_for_cache_candidates: Default::default(),
             // We use 63 here, as in practice the capacity will be rounded to the nearest 2^n-1.
             // Source: https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/8
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
@@ -498,6 +499,7 @@ pub struct SwarmDriver {
     pub(crate) pending_get_closest_peers: PendingGetClosest,
     pub(crate) pending_requests: HashMap<RequestId, Option<oneshot::Sender<Result<Response>>>>,
     pub(crate) pending_get_record: PendingGetRecord,
+    pub(crate) pending_get_record_for_cache_candidates: HashMap<QueryId, RecordKey>,
     /// A list of the most recent peers we have dialed ourselves.
     pub(crate) dialed_peers: CircularVec<PeerId>,
 }

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -457,7 +457,7 @@ impl NetworkBuilder {
             local: self.local,
             is_client,
             bootstrap: ContinuousBootstrap::new(),
-            close_group: Default::default(),
+            close_k_value_peers: Default::default(),
             replication_fetcher: Default::default(),
             #[cfg(feature = "open-metrics")]
             network_metrics,
@@ -493,8 +493,8 @@ pub struct SwarmDriver {
     pub(crate) local: bool,
     pub(crate) is_client: bool,
     pub(crate) bootstrap: ContinuousBootstrap,
-    /// The peers that are closer to our PeerId. Includes self.
-    pub(crate) close_group: Vec<PeerId>,
+    /// The K_VALUE number of peers that are closer to our PeerId. Includes self.
+    pub(crate) close_k_value_peers: Vec<PeerId>,
     pub(crate) replication_fetcher: ReplicationFetcher,
     #[cfg(feature = "open-metrics")]
     pub(crate) network_metrics: NetworkMetrics,

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -32,7 +32,7 @@ use libp2p::mdns;
 use libp2p::{
     autonat,
     identity::Keypair,
-    kad::{Kademlia, KademliaCaching, KademliaConfig, QueryId, Record, RecordKey},
+    kad::{KBucketDistance, Kademlia, KademliaCaching, KademliaConfig, QueryId, Record, RecordKey},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, ProtocolSupport, RequestId},
     swarm::{
@@ -51,7 +51,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintKBucketKey,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -73,6 +73,7 @@ type PendingGetRecord = HashMap<
         ExpectedHoldersList,
     ),
 >;
+type CacheCandidate = BTreeMap<KBucketDistance, PeerId>;
 
 /// What is the largest packet to send over the network.
 /// Records larger than this will be rejected.
@@ -505,7 +506,8 @@ pub struct SwarmDriver {
     pub(crate) pending_get_closest_peers: PendingGetClosest,
     pub(crate) pending_requests: HashMap<RequestId, Option<oneshot::Sender<Result<Response>>>>,
     pub(crate) pending_get_record: PendingGetRecord,
-    pub(crate) pending_get_record_for_cache_candidates: HashMap<QueryId, RecordKey>,
+    pub(crate) pending_get_record_for_cache_candidates:
+        HashMap<QueryId, (RecordKey, CacheCandidate)>,
     /// A list of the most recent peers we have dialed ourselves.
     pub(crate) dialed_peers: CircularVec<PeerId>,
 }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -781,10 +781,10 @@ impl SwarmDriver {
                 step,
                 ..
             } => {
-                // here BootstrapOk::num_remaining refers to the remaining random peer IDs to query, one per
-                // bucket that still needs refreshing.
-                trace!("Kademlia Bootstrap with {id:?} progressed with {bootstrap_result:?} and step {step:?}");
                 if step.last {
+                    // here BootstrapOk::num_remaining refers to the remaining random peer IDs to query, one per
+                    // bucket that still needs refreshing.
+                    trace!("Kademlia Bootstrap with {id:?} completed with {bootstrap_result:?} and step {step:?}");
                     // inform the bootstrap process about the completion.
                     self.bootstrap.completed();
                 }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -697,10 +697,12 @@ impl SwarmDriver {
                     );
                     // combine with the accumulated cache candidates
                     stored_cache_candidates.extend(cache_candidates);
-                    self.send_event(NetworkEvent::PotentialRecordHolders {
-                        key: record_key,
-                        holders: stored_cache_candidates.into_values().collect(),
-                    })
+                    if !stored_cache_candidates.is_empty() {
+                        self.send_event(NetworkEvent::PotentialRecordHolders {
+                            key: record_key,
+                            holders: stored_cache_candidates.into_values().collect(),
+                        })
+                    }
                 } else {
                     warn!("A query has been already removed from pending_get_record_for_cache_candidates {id:?}");
                 }
@@ -800,20 +802,22 @@ impl SwarmDriver {
                 if let Some((record_key, stored_cache_candidates)) =
                     self.pending_get_record_for_cache_candidates.remove(&id)
                 {
-                    // log the pending_get_record* stats; get_record_for_cache should not explode and should always be
-                    // greater or equal to get_record
-                    debug!(
-                        "pending_get_record has got {} entries",
-                        self.pending_get_record.len()
-                    );
-                    debug!(
-                        "pending_get_record_for_cache_candidates has got {} entries",
-                        self.pending_get_record_for_cache_candidates.len()
-                    );
-                    self.send_event(NetworkEvent::PotentialRecordHolders {
-                        key: record_key,
-                        holders: stored_cache_candidates.into_values().collect(),
-                    })
+                    if !stored_cache_candidates.is_empty() {
+                        // log the pending_get_record* stats; get_record_for_cache should not explode and should always be
+                        // greater or equal to get_record
+                        debug!(
+                            "pending_get_record has got {} entries",
+                            self.pending_get_record.len()
+                        );
+                        debug!(
+                            "pending_get_record_for_cache_candidates has got {} entries",
+                            self.pending_get_record_for_cache_candidates.len()
+                        );
+                        self.send_event(NetworkEvent::PotentialRecordHolders {
+                            key: record_key,
+                            holders: stored_cache_candidates.into_values().collect(),
+                        })
+                    }
                 } else {
                     warn!("A query has been already removed from pending_get_record_for_cache_candidates {id:?}");
                 }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -901,12 +901,16 @@ impl SwarmDriver {
             sort_peers_by_address(
                 &all_peers,
                 &NetworkAddress::from_peer(self.self_peer_id),
-                CLOSE_GROUP_SIZE,
+                K_VALUE.into(),
             )
             .ok()?
         };
 
-        let old = self.close_group.iter().cloned().collect::<HashSet<_>>();
+        let old = self
+            .close_k_value_peers
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
         let new_members = new_closest_peers
             .iter()
             .filter(|p| !old.contains(p))
@@ -915,7 +919,7 @@ impl SwarmDriver {
         if !new_members.is_empty() {
             debug!("The close group has been updated. The new members are {new_members:?}");
             debug!("New close group: {new_closest_peers:?}");
-            self.close_group = new_closest_peers.into_iter().cloned().collect();
+            self.close_k_value_peers = new_closest_peers.into_iter().cloned().collect();
             let _ = self.update_record_distance_range();
             Some(new_members.into_iter().cloned().collect())
         } else {
@@ -928,7 +932,7 @@ impl SwarmDriver {
     fn update_record_distance_range(&mut self) -> Option<()> {
         let our_address = NetworkAddress::from_peer(self.self_peer_id);
         let distance_range = self
-            .close_group
+            .close_k_value_peers
             .last()
             .map(|peer| NetworkAddress::from_peer(*peer).distance(&our_address))?;
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -215,10 +215,11 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)
     }
 
-    // Returns the peers that are closet to our PeerId.
-    pub async fn get_close_group(&self) -> Result<Vec<PeerId>> {
+    // Returns the K_VALUE number of peers that are closet to our PeerId. Contains self.
+    // The values are sorted by the distance from self.
+    pub async fn get_our_closest_k_value_peers(&self) -> Result<Vec<PeerId>> {
         let (sender, receiver) = oneshot::channel();
-        self.send_swarm_cmd(SwarmCmd::GetOurCloseGroup { sender })?;
+        self.send_swarm_cmd(SwarmCmd::GetOurClosestKValuePeers { sender })?;
 
         receiver
             .await

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -215,6 +215,16 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)
     }
 
+    // Returns the peers that are closet to our PeerId.
+    pub async fn get_close_group(&self) -> Result<Vec<PeerId>> {
+        let (sender, receiver) = oneshot::channel();
+        self.send_swarm_cmd(SwarmCmd::GetOurCloseGroup { sender })?;
+
+        receiver
+            .await
+            .map_err(|_e| Error::InternalMsgChannelDropped)
+    }
+
     pub async fn get_store_costs_from_network(
         &self,
         record_address: NetworkAddress,

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -44,6 +44,9 @@ pub enum Marker<'a> {
     /// Replication trigger was fired
     ReplicationTriggered,
 
+    /// Replication trigger was fired for cache candidates
+    ReplicationTriggeredForPotentialHolders,
+
     /// Keys of Records we are fetching to replicate locally
     FetchingKeysForReplication {
         /// fetching_keys_len: number of keys we are fetching from network

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -254,6 +254,7 @@ impl Node {
                 NetworkEvent::RequestReceived { .. }
                 | NetworkEvent::UnverifiedRecord(_)
                 | NetworkEvent::FailedToWrite(_)
+                | NetworkEvent::PotentialRecordHolders { .. }
                 | NetworkEvent::ResponseReceived { .. }
                 | NetworkEvent::KeysForReplication(_) => {
                     if log_when_not_enough_peers {
@@ -346,6 +347,11 @@ impl Node {
             NetworkEvent::FailedToWrite(key) => {
                 if let Err(e) = self.network.remove_failed_local_record(key) {
                     error!("Failed to remove local record: {e:?}");
+                }
+            }
+            NetworkEvent::PotentialRecordHolders { key, holders } => {
+                if let Err(err) = self.try_replicate_to_potential_holders(key, holders).await {
+                    error!("Error while trying replicate to potential holders {err:?}");
                 }
             }
             NetworkEvent::GossipsubMsgReceived { topic, msg }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -126,7 +126,7 @@ impl Node {
         potential_holders: HashSet<PeerId>,
     ) -> Result<()> {
         let key_addr = NetworkAddress::RecordKey(key.to_vec());
-        let close_group = self.network.get_close_group().await?;
+        let closest_peers = self.network.get_our_closest_k_value_peers().await?;
 
         self.record_metrics(Marker::ReplicationTriggeredForPotentialHolders);
 
@@ -139,12 +139,14 @@ impl Node {
         );
 
         for holder in potential_holders {
-            if close_group.contains(&holder) {
+            if closest_peers.contains(&holder) {
                 self.send_replicate_cmd_without_wait(
                     &our_address,
                     &holder,
                     vec![key_addr.clone()],
                 )?;
+            } else {
+                trace!("cache_candidate {holder:?} is not part of our close group");
             }
         }
 

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -93,6 +93,7 @@ async fn verify_data_location() -> Result<()> {
     // set of all the node indexes that stores a record key
     let record_holders = get_records_and_holders().await?;
     // Verify data location initially
+    print_node_close_groups(&all_peers);
     verify_location(&record_holders, &all_peers).await?;
 
     // Churn nodes and verify the location of the data after VERIFICATION_DELAY
@@ -205,14 +206,14 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
                 actual_holders.len()
             );
 
-            if actual_holders != expected_holders {
-                // print any expect holders that are not in actual holders
-                let mut missing_peers = Vec::new();
-                expected_holders
-                    .iter()
-                    .filter(|expected| !actual_holders.contains(expected))
-                    .for_each(|expected| missing_peers.push(*expected));
+            // print any expect holders that are not in actual holders
+            let mut missing_peers = Vec::new();
+            expected_holders
+                .iter()
+                .filter(|expected| !actual_holders.contains(expected))
+                .for_each(|expected| missing_peers.push(*expected));
 
+            if !missing_peers.is_empty() {
                 error!(
                     "Record {:?} is not stored by {missing_peers:?}",
                     PrettyPrintRecordKey::from(key.clone()),


### PR DESCRIPTION
## Description
- Propagate the `cache_candiates` that we get from `kad::get_record` to the upper layer.
- This is used to trigger replication on those candidates if they're within our close group.
- Remove targeted replication and instead fetch from network. This would give us more `kad::get record` queries and hence more `cache_candidates`
- Accumulate the `cache_candidates` and return the accumulated ones if our query errors out. We cannot fetch the `cache_candidates` from `swarm.kademlia.query(id)` if the query errors out, hence we have to accumulate them.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 08:19 UTC
This pull request includes the following changes:

- Added a new variant `PotentialRecordHolders` to the `NetworkEvent` enum, which includes a `key` of type `RecordKey` and a `holders` of type `HashSet<PeerId>`.
- Implemented the `Debug` trait for the `NetworkEvent` enum to print the new variant `PotentialRecordHolders`.
- Added code to handle the `PotentialRecordHolders` event in the `SwarmDriver` struct. It logs statistics and sends a `PotentialRecordHolders` event with the record key and the cache candidates to the network event handler.
- Added a warning message for the case when a query has already been removed from `pending_get_record_for_cache_candidates`.
- Added handling for `NetworkEvent::PotentialRecordHolders` in the `impl Node` block in `api.rs`.
- Added logic to `try_replicate_to_potential_holders` when receiving `NetworkEvent::PotentialRecordHolders` in `api.rs`.
- Added a new variant `ReplicationTriggeredForPotentialHolders` to the `Marker` enum.
- Modified the comment for the `ReplicationTriggered` variant to clarify that it was fired for cache candidates.
- Added a new section for the keys of records being fetched for local replication, including a field `fetching_keys_len` that represents the number of keys being fetched from the network.
- Import statements have been modified to remove unused imports.
- The `try_replicate_to_potential_holders` method has been added to handle replication requests to potential holders of a record key.
- The `add_keys_to_replication_fetcher` method has been modified to fetch records from the network instead of specific nodes.
- Various changes related to logging and error handling in `api.rs`.
- A new function `get_close_group` has been added in `lib.rs` starting at line 193. This function returns the peers that are closest to our PeerId and uses a channel to communicate with the networking module.
- The function `get_store_costs_from_network` in `lib.rs` has been modified to accept a new parameter `record_address` of type `NetworkAddress`.
- Line 190 in `lib.rs` was modified to include the cloned key in the log message.
- Line 203 in `lib.rs` was modified to indicate that an existing `pending_get_record` task was replaced.
- Lines 206-213 in `lib.rs` contain a new if statement to check if an existing `pending_get_record_for_cache_candidates` task was replaced.
- Lines 222-232 in `lib.rs` contain a modified logging statement to indicate the status of the `pending_get_record`.

Please let me know if you need further clarification or assistance with anything else.
<!-- reviewpad:summarize:end --> 
