### PR TITLE
increase wait time for churn/verification

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -290,26 +290,23 @@ impl Client {
     /// Tops up payments and retries if necessary and verification failed
     pub async fn create_and_pay_for_register(
         &self,
-        address: XorName,
+        meta: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
     ) -> Result<(ClientRegister, NanoTokens)> {
-        info!("Instantiating a new Register replica with address {address:?}");
+        info!("Instantiating a new Register replica with address {meta:?}");
         let (reg, mut total_cost) =
-            ClientRegister::create_online(self.clone(), address, wallet_client, false).await?;
+            ClientRegister::create_online(self.clone(), meta, wallet_client, false).await?;
 
-        debug!("{address:?} Created in theorryyyyy");
         let reg_address = reg.address();
         if verify_store {
-            debug!("WE SHOULD VERRRRIFYING");
             let mut stored = self.verify_register_stored(*reg_address).await.is_ok();
 
             while !stored {
                 info!("Register not completely stored on the network yet. Retrying...");
                 // this verify store call here ensures we get the record from Quorum::all
                 let (reg, top_up_cost) =
-                    ClientRegister::create_online(self.clone(), address, wallet_client, true)
-                        .await?;
+                    ClientRegister::create_online(self.clone(), meta, wallet_client, true).await?;
                 let reg_address = reg.address();
 
                 total_cost = total_cost.checked_add(top_up_cost).ok_or(Error::Transfers(

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -400,7 +400,6 @@ fn store_chunks_task(
                 chunks.len(),
                 chunk_size
             );
-            sleep(delay).await;
 
             let chunks_len = chunks.len();
 
@@ -531,7 +530,7 @@ fn retry_query_content_task(
     wallet_dir: PathBuf,
 ) {
     let _handle = tokio::spawn(async move {
-        let delay = 2 * churn_period;
+        let delay = 5 * churn_period;
         loop {
             sleep(delay).await;
 
@@ -587,7 +586,7 @@ async fn final_retry_query_content(
                 bail!("Final check: Content is still not retrievable at {net_addr} after {attempts} attempts: {last_err:?}");
             } else {
                 attempts += 1;
-                let delay = 2 * churn_period;
+                let delay = 10 * churn_period;
                 println!("Delaying last check for {delay:?} ...");
                 sleep(delay).await;
                 continue;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -43,7 +43,7 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(90);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(120);
 
 // Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 3;
@@ -257,7 +257,7 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
                 .for_each(|(idx, peer)| println!("{} : {peer:?}", idx + 1));
             verification_attempts += 1;
             println!("Sleeping before retrying verification");
-            tokio::time::sleep(Duration::from_secs(20)).await;
+            tokio::time::sleep(Duration::from_secs(60)).await;
         } else {
             // if successful, break out of the loop
             break;
@@ -340,7 +340,7 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
     );
 
     // to make sure the last chunk was stored
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(30)).await;
 
     Ok(())
 }


### PR DESCRIPTION
The address is dereived from the meta AND the PK## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 09:32 UTC
This pull request includes two patches. 

The first patch is titled "chore: rename register meta from addr" and it modifies the `create_and_pay_for_register` function in the `api.rs` file. It renames the `address` parameter to `meta` and updates its usages throughout the function. This change ensures that the address is derived from both the meta and the PK.

The second patch is titled "ci: increase sleeps for churn and verification tests" and it makes changes in two test files: `data_with_churn.rs` and `verify_data_location.rs`. It increases the sleep durations in certain areas of the code to allow for replication to complete in the tests. This change aims to improve the reliability of the tests by giving more time for the required operations to finish.

Overall, these patches make some important changes related to the address derivation and test reliability.
<!-- reviewpad:summarize:end --> 
