### PR TITLE
fix(network): emit NetworkEvent when we publish a gossipsub msg

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -218,7 +218,8 @@ impl Client {
                     }
                 }
             }
-            NetworkEvent::GossipsubMsg { topic, msg } => {
+            NetworkEvent::GossipsubMsgReceived { topic, msg }
+            | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
                 self.events_channel
                     .broadcast(ClientEvent::GossipsubMsg { topic, msg })?;
             }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -407,6 +407,12 @@ impl SwarmDriver {
                     .unsubscribe(&topic_id)?;
             }
             SwarmCmd::GossipsubPublish { topic_id, msg } => {
+                // If we publish a Gossipsub message, we might not receive the same message on our side.
+                // Hence push an event to notify that we've published a message
+                self.send_event(NetworkEvent::GossipsubMsgPublished {
+                    topic: topic_id.clone(),
+                    msg: msg.clone(),
+                });
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm
                     .behaviour_mut()

--- a/sn_node/src/api.rs
+++ b/sn_node/src/api.rs
@@ -292,7 +292,8 @@ impl Node {
                 | NetworkEvent::PeerRemoved(_)
                 | NetworkEvent::NewListenAddr(_)
                 | NetworkEvent::NatStatusChanged(_)
-                | NetworkEvent::GossipsubMsg { .. } => break,
+                | NetworkEvent::GossipsubMsgReceived { .. }
+                | NetworkEvent::GossipsubMsgPublished { .. } => break,
             }
         }
         trace!("Handling NetworkEvent {event:?}");
@@ -372,7 +373,8 @@ impl Node {
                     error!("Failed to remove local record: {e:?}");
                 }
             }
-            NetworkEvent::GossipsubMsg { topic, msg } => {
+            NetworkEvent::GossipsubMsgReceived { topic, msg }
+            | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
                 if topic == TRANSFER_NOTIF_TOPIC {
                     // this is expected to be a notification of a transfer which we treat specially
                     match try_decode_transfer_notif(&msg) {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -453,6 +453,7 @@ impl Node {
         // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for each cash-note received.
         match transfer_for_us.to_hex() {
             Ok(transfer_hex) => {
+                trace!("Publishing a gossipsub msgs for transfer_for_us: {transfer_for_us:?}");
                 let topic = TRANSFER_NOTIF_TOPIC.to_string();
                 for cash_note in cash_notes.iter() {
                     let pk = cash_note.unique_pubkey();


### PR DESCRIPTION
- should fix the reward test failures
- they were caused because the `genesis_node` that we used to monitor the gossipsub messages from, was the one who published the message.
- Hence, it would not emit the `NodeEvent` that we were listening for.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 10:05 UTC
This pull request fixes an issue with the rewards test failures by emitting a NetworkEvent when a gossipsub message is published. The previous issue was caused because the `genesis_node` that was used to monitor the gossipsub messages also published the message, resulting in the event not being emitted and causing failures. The patch adds the `GossipsubMsgPublished` event to notify that a message has been published.
<!-- reviewpad:summarize:end --> 
