### PR TITLE
fix: RegisterAddress logging with correct network addressing

### DIFF
--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -10,11 +10,14 @@ use crate::error::{Error, Result};
 
 use bls::{PublicKey, PK_SIZE};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, hash::Hash};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Address of a Register on the SAFE Network
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct RegisterAddress {
     /// User chosen meta, can be anything, the register's name on the network will be the hash of this meta and the owner
     pub(crate) meta: XorName,
@@ -24,7 +27,19 @@ pub struct RegisterAddress {
 
 impl Display for RegisterAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_hex())
+        write!(f, "{}({:?})", self.to_hex(), self.xorname())
+    }
+}
+
+impl Debug for RegisterAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RegisterAddress({:?}) {{ meta: {:?}, owner: {:?} }}",
+            self.xorname(),
+            self.meta,
+            self.owner
+        )
     }
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 12:42 UTC
This pull request fixes the logging of RegisterAddress with correct network addressing. The patch modifies the Display and Debug implementations for the RegisterAddress struct, ensuring that the correct information is displayed when formatting the struct. Specifically, the RegisterAddress now includes the xorname, meta, and owner fields when formatting.
<!-- reviewpad:summarize:end --> 
