### PR TITLE
ci: prevent concurrent version bumps, and await on release before we …

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,8 +1,8 @@
 name: Version Bump
 
-# prevent concurrent version bumps + releases from running at the same time
+# prevent concurrent version bumps
 concurrency:
-  group: "version-bump-release"
+  group: "version-bump"
 
 on:
   push:
@@ -20,6 +20,14 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-22.04
     steps:
+      - name: Wait for release workflow to complete
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: release
+          timeoutSeconds: 3600 # 1 hour
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"


### PR DESCRIPTION
…complete the bump

The git commit is pushed earlier, and should trigger a release run which we then check for

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 13:43 UTC
This pull request updates the version bump workflow to prevent concurrent version bumps and adds a wait step for the release workflow before completing the bump. This ensures that the release run is triggered by the earlier commit and is checked before proceeding.
<!-- reviewpad:summarize:end --> 
