### PR TITLE
ci: wait on the specific last bumped version to release, not this commit

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -25,6 +25,7 @@ jobs:
         id: wait-for-release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: git log --grep='chore(release):' -n 1 --pretty=format:"%H"
           checkName: release
           timeoutSeconds: 3600 # 1 hour
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 14:02 UTC
This pull request updates the CI workflow to wait for the specific last bumped version to release, instead of waiting on this commit. The `ref` parameter is set to `git log --grep='chore(release):' -n 1 --pretty=format:"%H"` to get the last commit ID that contains the release keyword.
<!-- reviewpad:summarize:end --> 
