### PR TITLE
ci: wait on the specific last bumped version to release, not this commit

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -20,12 +20,15 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-22.04
     steps:
+      - name: Get the SHA of the last release commit
+        id: get-sha
+        run: echo "::set-output name=sha::$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")"
       - name: Wait for release workflow to complete
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: git log --grep='chore(release):' -n 1 --pretty=format:"%H"
+          ref: ${{ steps.get-sha.outputs.sha }}
           checkName: release
           timeoutSeconds: 3600 # 1 hour
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 14:04 UTC
This pull request includes two patches to the `.github/workflows/version_bump.yml` file. 

Patch 1/2 updates the CI workflow to wait for the last bumped version to be released instead of waiting for the current commit.

Patch 2/2 adds a step to retrieve the SHA of the last release commit before the wait step in the CI workflow.
<!-- reviewpad:summarize:end --> 
