### PR TITLE
ci: find the sha before the wait step

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -20,6 +20,10 @@ jobs:
       !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
       - name: Get the SHA of the last release commit
         id: get-sha
         run: echo "::set-output name=sha::$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")"
@@ -32,10 +36,6 @@ jobs:
           checkName: release
           timeoutSeconds: 3600 # 1 hour
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "0"
-          token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 14:06 UTC
This pull request fixes an issue with the continuous integration workflow. Before trying to obtain a git hash, the repository is now pulled. This ensures that the correct version is used for the workflow. The patch also includes some minor code cleanup and optimization.
<!-- reviewpad:summarize:end --> 
