### PR TITLE
ci: update CI for github env

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -26,13 +26,13 @@ jobs:
           token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
       - name: Get the SHA of the last release commit
         id: get-sha
-        run: echo "::set-output name=sha::$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")"
+        run: echo "sha=$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")" >> $GITHUB_ENV
       - name: Wait for release workflow to complete
         uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-release
+        id: wait-for-releasegit 
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ steps.get-sha.outputs.sha }}
+          ref: ${{ env.sha }}
           checkName: release
           timeoutSeconds: 3600 # 1 hour
 

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -28,13 +28,12 @@ jobs:
         id: get-sha
         run: echo "sha=$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")" >> $GITHUB_ENV
       - name: Wait for release workflow to complete
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-releasegit 
+        uses: explorium-ai/wait-github-status-action@v1.0.2
         with:
+          name: release
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ env.sha }}
-          checkName: release
-          timeoutSeconds: 3600 # 1 hour
+          sha: ${{ env.sha }}
+      
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 14:18 UTC
This pull request includes two patches that update the CI configuration for a GitHub environment. The first patch updates the "Wait for release workflow to complete" step by setting the SHA of the last release commit in the environment variable. The second patch replaces the "fountainhead/action-wait-for-check" action with the "explorium-ai/wait-github-status-action" action for waiting on the release workflow to complete.
<!-- reviewpad:summarize:end --> 
