### PR TITLE
ci: try a different wait action once more

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -27,13 +27,17 @@ jobs:
       - name: Get the SHA of the last release commit
         id: get-sha
         run: echo "sha=$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")" >> $GITHUB_ENV
+
       - name: Wait for release workflow to complete
-        uses: explorium-ai/wait-github-status-action@v1.0.2
+        uses: mostafahussein/workflow-watcher@v1.0.0
+        if: ${{ github.ref != 'refs/heads/develop' }}
         with:
-          name: release
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ env.sha }}
-      
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          repository-name: ${{ github.repository }}
+          repository-owner: ${{ github.repository_owner }}
+          head-sha: ${{ env.sha }}
+          base-branch: "main"
+          polling-interval: 60
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Oct 23 14:26 UTC
This pull request updates the CI workflow to try a different wait action for the release workflow to complete. It replaces the existing "wait-github-status-action" with "workflow-watcher". The new action is only triggered if the branch is not "develop".
<!-- reviewpad:summarize:end --> 
