### PR TITLE
chore: print the PeerId along with the raw bytes

### DIFF
--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -161,7 +161,13 @@ impl NetworkAddress {
 impl Debug for NetworkAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name_str = match self {
-            NetworkAddress::PeerId(_) => "NetworkAddress::PeerId(".to_string(),
+            NetworkAddress::PeerId(_) => {
+                if let Some(peer_id) = self.as_peer_id() {
+                    format!("NetworkAddress::PeerId({peer_id} - ")
+                } else {
+                    "NetworkAddress::PeerId(".to_string()
+                }
+            }
             NetworkAddress::ChunkAddress(chunk_address) => {
                 format!(
                     "NetworkAddress::ChunkAddress({:?} - ",
@@ -182,7 +188,7 @@ impl Debug for NetworkAddress {
         };
         write!(
             f,
-            "{name_str} - {:?})",
+            "{name_str}{:?})",
             PrettyPrintRecordKey::from(self.to_record_key()),
         )
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Oct 23 06:59 UTC
This pull request makes a chore to print the PeerId along with the raw bytes in the NetworkAddress debug implementation. This change adds the PeerId value to the debug output if it exists, improving the readability of the output.
<!-- reviewpad:summarize:end --> 
