### PR TITLE
feat: log network address with KBucketKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
  "libp2p",
  "rmp-serde",
  "serde",
+ "sha2",
  "sn_registers",
  "sn_transfers",
  "thiserror",

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -47,7 +47,7 @@ use libp2p_quic as quic;
 use prometheus_client::registry::Registry;
 use sn_protocol::{
     messages::{Request, Response},
-    NetworkAddress, PrettyPrintRecordKey,
+    NetworkAddress, PrettyPrintKBucketKey,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -299,8 +299,8 @@ impl NetworkBuilder {
         let peer_id = PeerId::from(self.keypair.public());
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
         info!(
-            "Self PeerID {peer_id} is represented as record_key {:?}",
-            PrettyPrintRecordKey::from(NetworkAddress::from_peer(peer_id).to_record_key())
+            "Self PeerID {peer_id} is represented as kbucket_key {:?}",
+            PrettyPrintKBucketKey(NetworkAddress::from_peer(peer_id).as_kbucket_key())
         );
 
         #[cfg(feature = "open-metrics")]

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -123,7 +123,7 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use sn_protocol::{storage::ChunkAddress, NetworkAddress};
+    use sn_protocol::{storage::ChunkAddress, NetworkAddress, PrettyPrintKBucketKey};
     use xor_name::XorName;
 
     use super::*;
@@ -133,10 +133,15 @@ mod tests {
         let mut rng = rand::thread_rng();
         let xor_name = XorName::random(&mut rng);
         let address = ChunkAddress::new(xor_name);
-        let record_key = NetworkAddress::from_chunk_address(address).to_record_key();
+        let network_address = NetworkAddress::from_chunk_address(address);
+        let record_key = network_address.to_record_key();
         let pretty_record: PrettyPrintRecordKey = record_key.into();
         let record_str = format!("{}", pretty_record);
-        let xor_name_str = format!("{:64x}", xor_name);
+        let xor_name_str = format!(
+            "{:64x}({:?})",
+            xor_name,
+            PrettyPrintKBucketKey(network_address.as_kbucket_key())
+        );
         println!("record_str: {}", record_str);
         println!("xor_name_str: {}", xor_name_str);
         assert_eq!(record_str, xor_name_str);

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -45,7 +45,7 @@ use libp2p::{
 use sn_protocol::{
     messages::{Query, QueryResponse, Request, Response},
     storage::{RecordHeader, RecordKind},
-    NetworkAddress, PrettyPrintRecordKey,
+    NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use sn_transfers::MainPubkey;
 use sn_transfers::NanoTokens;
@@ -169,8 +169,8 @@ impl Network {
                     .map(|peer_id| {
                         format!(
                             "{peer_id:?}({:?})",
-                            PrettyPrintRecordKey::from(
-                                NetworkAddress::from_peer(*peer_id).to_record_key()
+                            PrettyPrintKBucketKey(
+                                NetworkAddress::from_peer(*peer_id).as_kbucket_key()
                             )
                         )
                     })
@@ -618,7 +618,7 @@ impl Network {
             .map(|peer_id| {
                 format!(
                     "{peer_id:?}({:?})",
-                    PrettyPrintRecordKey::from(NetworkAddress::from_peer(*peer_id).to_record_key())
+                    PrettyPrintKBucketKey(NetworkAddress::from_peer(*peer_id).as_kbucket_key())
                 )
             })
             .collect();

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -15,7 +15,7 @@ use libp2p::{
 use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
-    NetworkAddress, PrettyPrintRecordKey,
+    NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use std::collections::BTreeMap;
 use tokio::task::JoinHandle;
@@ -72,9 +72,7 @@ impl Node {
                 .map(|peer_id| {
                     format!(
                         "{peer_id:?}({:?})",
-                        PrettyPrintRecordKey::from(
-                            NetworkAddress::from_peer(*peer_id).to_record_key()
-                        )
+                        PrettyPrintKBucketKey(NetworkAddress::from_peer(*peer_id).as_kbucket_key())
                     )
                 })
                 .collect();

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -18,6 +18,7 @@ hex = "~0.4.3"
 libp2p = { version="0.52", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
+sha2 = "0.10.7"
 sn_transfers = { path = "../sn_transfers", version = "0.14.3" }
 sn_registers = { path = "../sn_registers", version = "0.3.2" }
 thiserror = "1.0.23"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Oct 23 07:38 UTC
This pull request adds a feature to log the network address with KBucketKey in several files. It modifies the `driver.rs`, `lib.rs`, `replication.rs`, and `lib.rs` files, adding the `PrettyPrintKBucketKey` struct and updating the log statements to use it for pretty printing the KBucketKey. The patch also updates the import statements accordingly. Overall, this pull request improves the logging functionality related to network addresses.
<!-- reviewpad:summarize:end --> 
