### PR TITLE
ci: allow wait workflow to fail

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           fetch-depth: "0"
           token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+          
       - name: Get the SHA of the last release commit
         id: get-sha
         run: echo "sha=$(git log --grep='chore(release):' -n 1 --pretty=format:"%H")" >> $GITHUB_ENV
@@ -41,6 +42,9 @@ jobs:
           head-sha: ${{ env.sha }}
           base-branch: "main"
           polling-interval: 60
+
+      - name: Fetch the latest code from main
+        run: git pull origin main
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -30,7 +30,10 @@ jobs:
 
       - name: Wait for release workflow to complete
         uses: mostafahussein/workflow-watcher@v1.0.0
-        if: ${{ github.ref != 'refs/heads/develop' }}
+        # Don't fail the whole run if this step fails
+        # this action will fail if the previous workflows failed or was skipped, 
+        # which isn't helpful
+        continue-on-error: true  
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
           repository-name: ${{ github.repository }}


### PR DESCRIPTION
Fail happens if prev run failed or skipped, but that has no real impact...

As long as there isnt a run in process, we continue## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Oct 23 08:40 UTC
This pull request includes two patches:
1. The first patch modifies the version_bump.yml file in the .github/workflows directory. It allows the wait workflow to fail without impacting the overall run. This change is made by setting the `continue-on-error` option to true.
2. The second patch also modifies the version_bump.yml file. After waiting, it ensures that we are on the latest main branch before proceeding. This is done by adding a step to fetch the latest code from the main branch using `git pull origin main`.
<!-- reviewpad:summarize:end --> 
