### PR TITLE
refactor(gossipsub): allow self-origin pubished msgs with gossipsub c…

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -229,8 +229,7 @@ impl Client {
                     self.network.stop_bootstrapping()?;
                 }
             }
-            NetworkEvent::GossipsubMsgReceived { topic, msg }
-            | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
+            NetworkEvent::GossipsubMsgReceived { topic, msg } => {
                 self.events_channel
                     .broadcast(ClientEvent::GossipsubMsg { topic, msg })?;
             }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -412,12 +412,6 @@ impl SwarmDriver {
                     .unsubscribe(&topic_id)?;
             }
             SwarmCmd::GossipsubPublish { topic_id, msg } => {
-                // If we publish a Gossipsub message, we might not receive the same message on our side.
-                // Hence push an event to notify that we've published a message
-                self.send_event(NetworkEvent::GossipsubMsgPublished {
-                    topic: topic_id.clone(),
-                    msg: msg.clone(),
-                });
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm
                     .behaviour_mut()

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -392,9 +392,13 @@ impl NetworkBuilder {
             .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
             .boxed();
 
-        // Gossipsub behaviour
-        // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        // Gossipsub behaviour.
+        // Set default parameters for gossipsub. By default gossipsub will reject messages that are sent to us
+        // that has the same message source as we have specified locally. We allow self-origin msgs in the config.
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .allow_self_origin(true)
+            .build()
+            .expect("Failed to build Gossipsub config.");
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -144,13 +144,6 @@ pub enum NetworkEvent {
         /// The raw bytes of the received message
         msg: Vec<u8>,
     },
-    /// The Gossipsub message that we published
-    GossipsubMsgPublished {
-        /// Topic the message was published on
-        topic: String,
-        /// The raw bytes of the sent message
-        msg: Vec<u8>,
-    },
 }
 
 // Manually implement Debug as `#[debug(with = "unverified_record_fmt")]` not working as expected.
@@ -192,9 +185,6 @@ impl Debug for NetworkEvent {
             }
             NetworkEvent::GossipsubMsgReceived { topic, .. } => {
                 write!(f, "NetworkEvent::GossipsubMsgReceived({topic})")
-            }
-            NetworkEvent::GossipsubMsgPublished { topic, .. } => {
-                write!(f, "NetworkEvent::GossipsubMsgPublished({topic})")
             }
         }
     }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -267,8 +267,7 @@ impl Node {
                 | NetworkEvent::PeerRemoved(_)
                 | NetworkEvent::NewListenAddr(_)
                 | NetworkEvent::NatStatusChanged(_)
-                | NetworkEvent::GossipsubMsgReceived { .. }
-                | NetworkEvent::GossipsubMsgPublished { .. } => break,
+                | NetworkEvent::GossipsubMsgReceived { .. } => break,
             }
         }
         trace!("Handling NetworkEvent {event:?}");
@@ -348,8 +347,7 @@ impl Node {
                     error!("Failed to remove local record: {e:?}");
                 }
             }
-            NetworkEvent::GossipsubMsgReceived { topic, msg }
-            | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
+            NetworkEvent::GossipsubMsgReceived { topic, msg } => {
                 if topic == TRANSFER_NOTIF_TOPIC {
                     // this is expected to be a notification of a transfer which we treat specially
                     match try_decode_transfer_notif(&msg) {


### PR DESCRIPTION
…onfig flag

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Oct 23 16:17 UTC
This pull request refactors the gossipsub feature by allowing self-origin published messages with a gossipsub configuration flag. The changes include removing the event that notifies of a gossipsub message being published, updating the handling of gossipsub messages in the client and node modules, and modifying the gossipsub configuration to allow self-origin messages.
<!-- reviewpad:summarize:end --> 
