### PR TITLE
fix(network): prevent cloning of all our peers while sorting them

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -160,7 +160,7 @@ impl SwarmDriver {
                 let all_peers = self.get_all_local_peers();
                 let keys_to_store = keys
                     .iter()
-                    .filter(|key| self.is_in_close_range(key, all_peers.clone()))
+                    .filter(|key| self.is_in_close_range(key, &all_peers))
                     .cloned()
                     .collect();
                 #[allow(clippy::mutable_key_type)]
@@ -443,7 +443,7 @@ impl SwarmDriver {
     // are none among target b011111's close range.
     // Hence, the ilog2 calculation based on close_range cannot cover such case.
     // And have to sort all nodes to figure out whether self is among the close_group to the target.
-    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: Vec<PeerId>) -> bool {
+    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &[PeerId]) -> bool {
         if all_peers.len() <= CLOSE_GROUP_SIZE + 2 {
             return true;
         }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -450,7 +450,7 @@ impl SwarmDriver {
 
         // Margin of 2 to allow our RT being bit lagging.
         match sort_peers_by_address(all_peers, target, CLOSE_GROUP_SIZE + 2) {
-            Ok(close_group) => close_group.contains(&self.self_peer_id),
+            Ok(close_group) => close_group.contains(&&self.self_peer_id),
             Err(err) => {
                 warn!("Could not get sorted peers for {target:?} with error {err:?}");
                 true

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -822,7 +822,7 @@ impl SwarmDriver {
         let new_closest_peers = {
             let all_peers = self.get_all_local_peers();
             sort_peers_by_address(
-                all_peers,
+                &all_peers,
                 &NetworkAddress::from_peer(self.self_peer_id),
                 CLOSE_GROUP_SIZE,
             )

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -819,8 +819,9 @@ impl SwarmDriver {
 
     // Check for changes in our close group
     fn check_for_change_in_our_close_group(&mut self) -> Option<Vec<PeerId>> {
+        let all_peers = self.get_all_local_peers();
+
         let new_closest_peers = {
-            let all_peers = self.get_all_local_peers();
             sort_peers_by_address(
                 &all_peers,
                 &NetworkAddress::from_peer(self.self_peer_id),
@@ -838,9 +839,9 @@ impl SwarmDriver {
         if !new_members.is_empty() {
             debug!("The close group has been updated. The new members are {new_members:?}");
             debug!("New close group: {new_closest_peers:?}");
-            self.close_group = new_closest_peers;
+            self.close_group = new_closest_peers.into_iter().cloned().collect();
             let _ = self.update_record_distance_range();
-            Some(new_members)
+            Some(new_members.into_iter().cloned().collect())
         } else {
             None
         }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -66,7 +66,7 @@ impl Node {
 
         for key in all_records {
             let sorted_based_on_key =
-                sort_peers_by_address(all_peers.clone(), &key, CLOSE_GROUP_SIZE + 1)?;
+                sort_peers_by_address(&all_peers, &key, CLOSE_GROUP_SIZE + 1)?;
             let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
                 .iter()
                 .map(|peer_id| {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -69,7 +69,7 @@ impl Node {
                 sort_peers_by_address(&all_peers, &key, CLOSE_GROUP_SIZE + 1)?;
             let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
                 .iter()
-                .map(|peer_id| {
+                .map(|&peer_id| {
                     format!(
                         "{peer_id:?}({:?})",
                         PrettyPrintKBucketKey(NetworkAddress::from_peer(*peer_id).as_kbucket_key())
@@ -77,12 +77,12 @@ impl Node {
                 })
                 .collect();
 
-            if sorted_based_on_key.contains(&peer_id) {
+            if sorted_based_on_key.contains(&&peer_id) {
                 trace!("replication: close for {key:?} are: {sorted_peers_pretty_print:?}");
                 let target_peer = if is_removal {
                     // For dead peer, only replicate to farthest close_group peer,
                     // when the dead peer was one of the close_group peers to the record.
-                    if let Some(farthest_peer) = sorted_based_on_key.last() {
+                    if let Some(&farthest_peer) = sorted_based_on_key.last() {
                         if *farthest_peer != peer_id {
                             *farthest_peer
                         } else {
@@ -93,7 +93,7 @@ impl Node {
                     }
                 } else {
                     // For new peer, always replicate to it when it is close_group of the record.
-                    if Some(&peer_id) != sorted_based_on_key.last() {
+                    if Some(&&peer_id) != sorted_based_on_key.last() {
                         peer_id
                     } else {
                         continue;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -144,8 +144,8 @@ fn print_node_close_groups(all_peers: &[PeerId]) {
     for (node_index, peer) in all_peers.iter().enumerate() {
         let node_index = node_index + 1;
         let key = NetworkAddress::from_peer(*peer).as_kbucket_key();
-        let closest_peers = sort_peers_by_key(all_peers.clone(), &key, CLOSE_GROUP_SIZE)
-            .expect("failed to sort peer");
+        let closest_peers =
+            sort_peers_by_key(&all_peers, &key, CLOSE_GROUP_SIZE).expect("failed to sort peer");
         let closest_peers_idx = closest_peers
             .iter()
             .map(|peer| all_peers.iter().position(|p| p == peer).unwrap() + 1)
@@ -186,10 +186,9 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
         for (key, actual_holders_idx) in record_holders.iter() {
             println!("Verifying {:?}", PrettyPrintRecordKey::from(key.clone()));
             let record_key = KBucketKey::from(key.to_vec());
-            let expected_holders =
-                sort_peers_by_key(all_peers.to_vec(), &record_key, CLOSE_GROUP_SIZE)?
-                    .into_iter()
-                    .collect::<BTreeSet<_>>();
+            let expected_holders = sort_peers_by_key(all_peers, &record_key, CLOSE_GROUP_SIZE)?
+                .into_iter()
+                .collect::<BTreeSet<_>>();
 
             let actual_holders = actual_holders_idx
                 .iter()

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -148,7 +148,7 @@ fn print_node_close_groups(all_peers: &[PeerId]) {
             sort_peers_by_key(&all_peers, &key, CLOSE_GROUP_SIZE).expect("failed to sort peer");
         let closest_peers_idx = closest_peers
             .iter()
-            .map(|peer| all_peers.iter().position(|p| p == peer).unwrap() + 1)
+            .map(|&&peer| all_peers.iter().position(|&p| p == peer).unwrap() + 1)
             .collect::<Vec<_>>();
         println!("Close for {node_index}: {peer:?} are {closest_peers_idx:?}");
     }
@@ -188,6 +188,7 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
             let record_key = KBucketKey::from(key.to_vec());
             let expected_holders = sort_peers_by_key(all_peers, &record_key, CLOSE_GROUP_SIZE)?
                 .into_iter()
+                .cloned()
                 .collect::<BTreeSet<_>>();
 
             let actual_holders = actual_holders_idx


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Oct 23 20:44 UTC
This pull request includes a fix to prevent cloning of all peers while sorting them. The changes are made in multiple files: `sn_networking/src/cmd.rs`, `sn_networking/src/event.rs`, `sn_networking/src/lib.rs`, `sn_node/src/replication.rs`, and `sn_node/tests/verify_data_location.rs`. The patch modifies the `is_in_close_range` function to take a reference to the `all_peers` vector instead of cloning it, and updates the usage of this function in other parts of the code accordingly. It also modifies the `sort_peers_by_address` and `sort_peers_by_key` functions to accept slices instead of vectors for the `peers` argument. Overall, these changes aim to optimize the code and improve performance.
<!-- reviewpad:summarize:end --> 
