### PR TITLE
feat: keep transfers in payment instead of cashnotes

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -59,13 +59,13 @@ impl WalletClient {
     pub fn get_payment_transfers(&self, address: &NetworkAddress) -> WalletResult<Vec<Transfer>> {
         match &address.as_xorname() {
             Some(xorname) => {
-                let cash_notes = self.wallet.get_payment_cash_notes(xorname);
+                let transfers = self.wallet.get_payment_transfers(xorname);
 
                 info!(
-                    "Payment cash notes retrieved from wallet: {:?}",
-                    cash_notes.len()
+                    "Payment transfers retrieved for {xorname:?} from wallet: {:?}",
+                    transfers.len()
                 );
-                Ok(Transfer::transfers_from_cash_notes(cash_notes)?)
+                Ok(transfers)
             }
             None => Err(WalletError::InvalidAddressType),
         }
@@ -200,9 +200,6 @@ impl WalletClient {
         all_data_payments: BTreeMap<XorName, Vec<(MainPubkey, NanoTokens)>>,
         verify_store: bool,
     ) -> WalletResult<(NanoTokens, NanoTokens)> {
-        // TODO:
-        // Check for any existing payment CashNotes, and use them if they exist, only topping up if needs be
-
         let total_cost = self
             .wallet
             .local_send_storage_payment(all_data_payments, None)?;

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     rng, CashNote, DerivationIndex, DerivedSecretKey, Hash, Input, MainPubkey, NanoTokens,
-    SignedSpend, Transaction, TransactionBuilder, UniquePubkey,
+    SignedSpend, Transaction, TransactionBuilder, Transfer, UniquePubkey,
 };
 use crate::{Error, Result};
 
@@ -36,7 +36,7 @@ pub struct OfflineTransfer {
     pub all_spend_requests: Vec<SignedSpend>,
 }
 
-pub type PaymentDetails = (UniquePubkey, MainPubkey, NanoTokens);
+pub type PaymentDetails = (Transfer, MainPubkey, NanoTokens);
 
 /// Xorname of data from which the content was fetched, mapping to the CashNote UniquePubkey (its id on disk)
 /// the main key for that CashNote and the value

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -227,24 +227,17 @@ impl LocalWallet {
     }
 
     /// Return the payment cash_note ids for the given content address name if cached.
-    pub fn get_payment_cash_notes(&self, name: &XorName) -> Vec<CashNote> {
-        let ids = self.get_payment_unique_pubkeys_and_values(name);
-        // now grab all those cash_notes
-        let mut cash_notes: Vec<CashNote> = vec![];
+    pub fn get_payment_transfers(&self, name: &XorName) -> Vec<Transfer> {
+        let mut transfers: Vec<Transfer> = vec![];
 
-        if let Some(ids) = ids {
-            for (id, _main_pub_key, _value) in ids {
-                if let Some(cash_note) = load_created_cash_note(id, &self.wallet_dir) {
-                    trace!(
-                        "Current cash_note of chunk {name:?} is paying {:?} tokens.",
-                        cash_note.value()
-                    );
-                    cash_notes.push(cash_note);
-                }
+        if let Some(payment) = self.get_payment_unique_pubkeys_and_values(name) {
+            for (trans, _main_pub_key, value) in payment {
+                trace!("Current transfer for chunk {name:?} is of {value:?} tokens.");
+                transfers.push(trans.to_owned());
             }
         }
 
-        cash_notes
+        transfers
     }
 
     /// Make a transfer and return all created cash_notes
@@ -350,7 +343,7 @@ impl LocalWallet {
         for (content_addr, payees) in all_data_payments {
             for (payee, token) in payees {
                 if let Some(cash_note) =
-                    &offline_transfer
+                    offline_transfer
                         .created_cash_notes
                         .iter()
                         .find(|cash_note| {
@@ -364,7 +357,7 @@ impl LocalWallet {
                     let cash_notes_for_content: &mut Vec<PaymentDetails> =
                         all_transfers_per_address.entry(content_addr).or_default();
                     cash_notes_for_content.push((
-                        cash_note.unique_pubkey(),
+                        Transfer::transfers_from_cash_note(cash_note.to_owned())?,
                         *cash_note.main_pubkey(),
                         cash_note.value()?,
                     ));
@@ -484,17 +477,17 @@ impl LocalWallet {
         // For each target address
         for (xor, payments) in payment_map.iter_mut() {
             // All payments done for an address, should be multiple nodes.
-            if let Some(notes) = self.get_payment_unique_pubkeys_and_values(xor) {
-                for (_note_main_key, main_pub_key, note_value) in notes {
-                    // Find new payment to a node, for which we have a cashnote already
+            if let Some(prev_payment) = self.get_payment_unique_pubkeys_and_values(xor) {
+                for (_transfer, prev_payment_pub_key, prev_payment_value) in prev_payment {
+                    // Find new payment to a node, for which we have a transfer already
                     if let Some((_main_pub_key, payment_tokens)) = payments
                         .iter_mut()
-                        .find(|(pubkey, _)| pubkey.public_key() == main_pub_key.public_key())
+                        .find(|(pubkey, _)| pubkey == prev_payment_pub_key)
                     {
                         // Subtract what we already paid from what we're about to pay.
                         // `checked_sub` overflows if would be negative, so we set it to 0.
                         *payment_tokens = payment_tokens
-                            .checked_sub(*note_value)
+                            .checked_sub(*prev_payment_value)
                             .unwrap_or(NanoTokens::zero());
                     }
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Oct 23 12:43 UTC
This pull request makes changes to the code related to payment transfers. 

In the `sn_client/src/wallet.rs` file, the code now retrieves payment transfers instead of payment cash notes. The log message is updated to reflect this change.

In the `sn_transfers/src/transfers/offline_transfer.rs` file, the type `PaymentDetails` is changed to include a `Transfer` instead of a `CashNote`.

In the `sn_transfers/src/wallet/local_store.rs` file, the method `get_payment_cash_notes` is renamed to `get_payment_transfers` and now returns a vector of `Transfer` objects instead of `CashNote` objects. The log message is updated to reflect this change. The method `make_transfer` now uses the `Transfer` type instead of `CashNote` when adding cash notes.

There are also other changes in this patch that involve variable renaming and removal of unused code.
<!-- reviewpad:summarize:end --> 
