### PR TITLE
chore(client): verify chunks only reach majority.

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -420,7 +420,7 @@ impl Client {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, true, Default::default())
+            .get_record_from_network(key, None, GetQuorum::Majority, true, Default::default())
             .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -269,7 +269,7 @@ impl Client {
 
         let maybe_record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
+            .get_record_from_network(key, None, GetQuorum::Majority, false, Default::default())
             .await;
         let record = match maybe_record {
             Ok(r) => r,
@@ -437,7 +437,7 @@ impl Client {
         let key = NetworkAddress::from_register_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, true, Default::default())
+            .get_record_from_network(key, None, GetQuorum::Majority, true, Default::default())
             .await?;
 
         let header = RecordHeader::from_record(&record)?;

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -32,11 +32,6 @@ pub enum Error {
     #[error("Netowrk query timed out")]
     QueryTimeout,
 
-    #[error(
-        "Not enough store cost prices returned from the network to ensure a valid fee is paid"
-    )]
-    NotEnoughCostPricesReturned,
-
     #[error("Close group size must be a non-zero usize")]
     InvalidCloseGroupSize,
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -501,7 +501,7 @@ impl Network {
     }
 
     /// Returns true if a RecordKey is present locally in the RecordStore
-    pub async fn is_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
+    pub async fn is_record_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::RecordStoreHasKey {
             key: key.clone(),
@@ -682,10 +682,6 @@ fn get_fees_from_store_cost_responses(
 
     // get the first desired_quote_count of all_costs
     all_costs.truncate(desired_quote_count);
-
-    if all_costs.len() < desired_quote_count {
-        return Err(Error::NotEnoughCostPricesReturned);
-    }
 
     info!(
         "Final fees calculated as: {all_costs:?}, from: {:?}",

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -394,19 +394,42 @@ impl Node {
 
     async fn handle_query(&self, query: Query) -> Response {
         let resp: QueryResponse = match query {
-            Query::GetStoreCost(_address) => {
-                trace!("Got GetStoreCost");
+            Query::GetStoreCost(address) => {
+                trace!("Got GetStoreCost request for {address:?}");
                 let payment_address = self.reward_address;
 
-                let store_cost = self
-                    .network
-                    .get_local_storecost()
-                    .await
-                    .map_err(|_| ProtocolError::GetStoreCostFailed);
+                let record_exists = {
+                    if let Some(key) = address.as_record_key() {
+                        match self.network.is_record_key_present_locally(&key).await {
+                            Ok(res) => res,
+                            Err(error) => {
+                                error!("Problem getting record key's existence: {error:?}");
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                };
 
-                QueryResponse::GetStoreCost {
-                    store_cost,
-                    payment_address,
+                if record_exists {
+                    QueryResponse::GetStoreCost {
+                        store_cost: Err(ProtocolError::RecordExists(PrettyPrintRecordKey::from(
+                            address.to_record_key(),
+                        ))),
+                        payment_address,
+                    }
+                } else {
+                    let store_cost = self
+                        .network
+                        .get_local_storecost()
+                        .await
+                        .map_err(|_| ProtocolError::GetStoreCostFailed);
+
+                    QueryResponse::GetStoreCost {
+                        store_cost,
+                        payment_address,
+                    }
                 }
             }
             Query::GetReplicatedRecord { requester, key } => {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -182,7 +182,7 @@ impl Node {
 
         let present_locally = self
             .network
-            .is_key_present_locally(&data_key)
+            .is_record_key_present_locally(&data_key)
             .await
             .map_err(|err| {
                 let msg = format!("Error while checking if Chunk's key is present locally {err}");
@@ -245,7 +245,7 @@ impl Node {
         let key = NetworkAddress::from_register_address(*reg_addr).to_record_key();
         let present_locally = self
             .network
-            .is_key_present_locally(&key)
+            .is_record_key_present_locally(&key)
             .await
             .map_err(|err| {
                 warn!("Error while checking if register's key is present locally {err}");
@@ -319,7 +319,7 @@ impl Node {
 
         let present_locally = self
             .network
-            .is_key_present_locally(&key)
+            .is_record_key_present_locally(&key)
             .await
             .map_err(|_err| {
                 let err = ProtocolError::SpendNotStored(format!(

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -107,4 +107,7 @@ pub enum Error {
     // The RecordKind that was obtained did not match with the expected one
     #[error("The RecordKind obtained from the Record did not match with the expected kind: {0}")]
     RecordKindMismatch(RecordKind),
+    // The record already exists at this node
+    #[error("The record already exists, so do not charge for it: {0:?}")]
+    RecordExists(PrettyPrintRecordKey),
 }


### PR DESCRIPTION
This shoudl be sufficient with replication increased.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Oct 23 12:54 UTC
This pull request updates the `get_record_from_network` method in the `api.rs` file of the `sn_client` module. The patch changes the `GetQuorum` parameter from `GetQuorum::All` to `GetQuorum::Majority` to ensure that only chunks that reach the majority are verified. This change is deemed sufficient with the increased replication.
<!-- reviewpad:summarize:end --> 
