### PR TITLE
NoStoreCost if existing

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -32,11 +32,6 @@ pub enum Error {
     #[error("Netowrk query timed out")]
     QueryTimeout,
 
-    #[error(
-        "Not enough store cost prices returned from the network to ensure a valid fee is paid"
-    )]
-    NotEnoughCostPricesReturned,
-
     #[error("Close group size must be a non-zero usize")]
     InvalidCloseGroupSize,
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -517,7 +517,7 @@ impl Network {
     }
 
     /// Returns true if a RecordKey is present locally in the RecordStore
-    pub async fn is_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
+    pub async fn is_record_key_present_locally(&self, key: &RecordKey) -> Result<bool> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::RecordStoreHasKey {
             key: key.clone(),
@@ -702,10 +702,6 @@ fn get_fees_from_store_cost_responses(
 
     // get the first desired_quote_count of all_costs
     all_costs.truncate(desired_quote_count);
-
-    if all_costs.len() < desired_quote_count {
-        return Err(Error::NotEnoughCostPricesReturned);
-    }
 
     info!(
         "Final fees calculated as: {all_costs:?}, from: {:?}",

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -394,19 +394,42 @@ impl Node {
 
     async fn handle_query(&self, query: Query) -> Response {
         let resp: QueryResponse = match query {
-            Query::GetStoreCost(_address) => {
-                trace!("Got GetStoreCost");
+            Query::GetStoreCost(address) => {
+                trace!("Got GetStoreCost request for {address:?}");
                 let payment_address = self.reward_address;
 
-                let store_cost = self
-                    .network
-                    .get_local_storecost()
-                    .await
-                    .map_err(|_| ProtocolError::GetStoreCostFailed);
+                let record_exists = {
+                    if let Some(key) = address.as_record_key() {
+                        match self.network.is_record_key_present_locally(&key).await {
+                            Ok(res) => res,
+                            Err(error) => {
+                                error!("Problem getting record key's existence: {error:?}");
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                };
 
-                QueryResponse::GetStoreCost {
-                    store_cost,
-                    payment_address,
+                if record_exists {
+                    QueryResponse::GetStoreCost {
+                        store_cost: Err(ProtocolError::RecordExists(PrettyPrintRecordKey::from(
+                            address.to_record_key(),
+                        ))),
+                        payment_address,
+                    }
+                } else {
+                    let store_cost = self
+                        .network
+                        .get_local_storecost()
+                        .await
+                        .map_err(|_| ProtocolError::GetStoreCostFailed);
+
+                    QueryResponse::GetStoreCost {
+                        store_cost,
+                        payment_address,
+                    }
                 }
             }
             Query::GetReplicatedRecord { requester, key } => {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -165,7 +165,7 @@ impl Node {
         let _handle = spawn(async move {
             // use a random inactivity timeout to ensure that the nodes do not sync when messages
             // are being transmitted.
-            let inactivity_timeout: i32 = rng.gen_range(20..40);
+            let inactivity_timeout: i32 = rng.gen_range(5..15);
             let inactivity_timeout = Duration::from_secs(inactivity_timeout as u64);
 
             let mut replication_time = Instant::now();

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -182,7 +182,7 @@ impl Node {
 
         let present_locally = self
             .network
-            .is_key_present_locally(&data_key)
+            .is_record_key_present_locally(&data_key)
             .await
             .map_err(|err| {
                 let msg = format!("Error while checking if Chunk's key is present locally {err}");
@@ -245,7 +245,7 @@ impl Node {
         let key = NetworkAddress::from_register_address(*reg_addr).to_record_key();
         let present_locally = self
             .network
-            .is_key_present_locally(&key)
+            .is_record_key_present_locally(&key)
             .await
             .map_err(|err| {
                 warn!("Error while checking if register's key is present locally {err}");
@@ -319,7 +319,7 @@ impl Node {
 
         let present_locally = self
             .network
-            .is_key_present_locally(&key)
+            .is_record_key_present_locally(&key)
             .await
             .map_err(|_err| {
                 let err = ProtocolError::SpendNotStored(format!(

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -107,4 +107,7 @@ pub enum Error {
     // The RecordKind that was obtained did not match with the expected one
     #[error("The RecordKind obtained from the Record did not match with the expected kind: {0}")]
     RecordKindMismatch(RecordKind),
+    // The record already exists at this node
+    #[error("The record already exists, so do not charge for it: {0:?}")]
+    RecordExists(PrettyPrintRecordKey),
 }


### PR DESCRIPTION
This shoudl be sufficient with replication increased.## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Oct 23 13:17 UTC
This pull request includes two patches. 

The first patch is a chore to the client, specifically in the `api.rs` file. It changes the `GetQuorum` parameter in the `get_record_from_network` function call from `GetQuorum::All` to `GetQuorum::Majority`. This change is made to ensure that chunks only reach the majority in replication scenarios.

The second patch is a feature addition to the protocol, involving multiple files. It allows nodes to error `StoreCosts` if they already have the data. This change means that clients won't keep repaying for data that is already stored somewhere. It aims to simplify repayment/updates and prevent looping over ever-increasing prices when the nodes already have the data stored.

Overall, these patches aim to improve the efficiency and reliability of the codebase.
<!-- reviewpad:summarize:end --> 
