### PR TITLE
chore: log and debug SwarmCmd

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -120,9 +120,17 @@ impl Client {
                                 continue;
                             }
                         };
+
+                        let start = std::time::Instant::now();
+                        let event_string = format!("{:?}", the_event);
                         if let Err(err) = client_clone.handle_network_event(the_event) {
                             warn!("Error handling network event: {err}");
                         }
+                        trace!(
+                            "Handled network event in {:?}: {:?}",
+                            start.elapsed(),
+                            event_string
+                        );
                     }
                     Err(_elapse_err) => {
                         debug!("Client inactivity... waiting for a network event");

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -154,27 +154,27 @@ impl Debug for SwarmCmd {
                 expected_holders,
                 ..
             } => {
-                write!(f, "SwarmCmd::GetNetworkRecord {{ key: {:?}, quorum: {:?}, expected_holders: {:?} }}", PrettyPrintRecordKey::from(key.clone()), quorum, expected_holders)
+                write!(f, "SwarmCmd::GetNetworkRecord {{ key: {:?}, quorum: {:?}, expected_holders: {:?} }}", PrettyPrintRecordKey::from(key), quorum, expected_holders)
             }
             SwarmCmd::PutRecord { record, .. } => {
                 write!(
                     f,
                     "SwarmCmd::PutRecord {{ key: {:?} }}",
-                    PrettyPrintRecordKey::from(record.key.clone())
+                    PrettyPrintRecordKey::from(&record.key)
                 )
             }
             SwarmCmd::PutLocalRecord { record } => {
                 write!(
                     f,
                     "SwarmCmd::PutLocalRecord {{ key: {:?} }}",
-                    PrettyPrintRecordKey::from(record.key.clone())
+                    PrettyPrintRecordKey::from(&record.key)
                 )
             }
             SwarmCmd::RemoveFailedLocalRecord { key } => {
                 write!(
                     f,
                     "SwarmCmd::RemoveFailedLocalRecord {{ key: {:?} }}",
-                    PrettyPrintRecordKey::from(key.clone())
+                    PrettyPrintRecordKey::from(key)
                 )
             }
             SwarmCmd::AddKeysToReplicationFetcher { holder, keys } => {
@@ -218,7 +218,7 @@ impl Debug for SwarmCmd {
                 write!(
                     f,
                     "SwarmCmd::GetLocalRecord {{ key: {:?} }}",
-                    PrettyPrintRecordKey::from(key.clone())
+                    PrettyPrintRecordKey::from(key)
                 )
             }
             SwarmCmd::GetAllLocalRecordAddresses { .. } => {
@@ -237,7 +237,7 @@ impl Debug for SwarmCmd {
                 write!(
                     f,
                     "SwarmCmd::RecordStoreHasKey {:?}",
-                    PrettyPrintRecordKey::from(key.clone())
+                    PrettyPrintRecordKey::from(key)
                 )
             }
             SwarmCmd::SendResponse { resp, .. } => {

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -21,12 +21,11 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use sn_transfers::NanoTokens;
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Debug};
 use tokio::sync::oneshot;
 
 /// Commands to send to the Swarm
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
 pub enum SwarmCmd {
     StartListening {
         addr: Multiaddr,
@@ -138,6 +137,118 @@ pub enum SwarmCmd {
     },
 }
 
+/// Debug impl for SwarmCmd to avoid printing full Record, instead only RecodKey
+/// and RecordKind are printed.
+impl Debug for SwarmCmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SwarmCmd::StartListening { addr, .. } => {
+                write!(f, "SwarmCmd::StartListening {{ addr: {:?} }}", addr)
+            }
+            SwarmCmd::Dial { addr, .. } => {
+                write!(f, "SwarmCmd::Dial {{ addr: {:?} }}", addr)
+            }
+            SwarmCmd::GetNetworkRecord {
+                key,
+                quorum,
+                expected_holders,
+                ..
+            } => {
+                write!(f, "SwarmCmd::GetNetworkRecord {{ key: {:?}, quorum: {:?}, expected_holders: {:?} }}", PrettyPrintRecordKey::from(key.clone()), quorum, expected_holders)
+            }
+            SwarmCmd::PutRecord { record, .. } => {
+                write!(
+                    f,
+                    "SwarmCmd::PutRecord {{ key: {:?} }}",
+                    PrettyPrintRecordKey::from(record.key.clone())
+                )
+            }
+            SwarmCmd::PutLocalRecord { record } => {
+                write!(
+                    f,
+                    "SwarmCmd::PutLocalRecord {{ key: {:?} }}",
+                    PrettyPrintRecordKey::from(record.key.clone())
+                )
+            }
+            SwarmCmd::RemoveFailedLocalRecord { key } => {
+                write!(
+                    f,
+                    "SwarmCmd::RemoveFailedLocalRecord {{ key: {:?} }}",
+                    PrettyPrintRecordKey::from(key.clone())
+                )
+            }
+            SwarmCmd::AddKeysToReplicationFetcher { holder, keys } => {
+                write!(
+                    f,
+                    "SwarmCmd::AddKeysToReplicationFetcher {{ holder: {:?}, keys_len: {:?} }}",
+                    holder,
+                    keys.len()
+                )
+            }
+            SwarmCmd::GossipsubSubscribe(topic) => {
+                write!(f, "SwarmCmd::GossipsubSubscribe({:?})", topic)
+            }
+            SwarmCmd::GossipsubUnsubscribe(topic) => {
+                write!(f, "SwarmCmd::GossipsubUnsubscribe({:?})", topic)
+            }
+            SwarmCmd::GossipsubPublish { topic_id, msg } => {
+                write!(
+                    f,
+                    "SwarmCmd::GossipsubPublish {{ topic_id: {:?}, msg len: {:?} }}",
+                    topic_id,
+                    msg.len()
+                )
+            }
+            SwarmCmd::DialWithOpts { opts, .. } => {
+                write!(f, "SwarmCmd::DialWithOpts {{ opts: {:?} }}", opts)
+            }
+            SwarmCmd::GetClosestPeers { key, .. } => {
+                write!(f, "SwarmCmd::GetClosestPeers {{ key: {:?} }}", key)
+            }
+            SwarmCmd::GetClosestLocalPeers { key, .. } => {
+                write!(f, "SwarmCmd::GetClosestLocalPeers {{ key: {:?} }}", key)
+            }
+            SwarmCmd::StopBootstrapping => {
+                write!(f, "SwarmCmd::StopBootstrapping")
+            }
+            SwarmCmd::GetLocalStoreCost { .. } => {
+                write!(f, "SwarmCmd::GetLocalStoreCost")
+            }
+            SwarmCmd::GetLocalRecord { key, .. } => {
+                write!(
+                    f,
+                    "SwarmCmd::GetLocalRecord {{ key: {:?} }}",
+                    PrettyPrintRecordKey::from(key.clone())
+                )
+            }
+            SwarmCmd::GetAllLocalRecordAddresses { .. } => {
+                write!(f, "SwarmCmd::GetAllLocalRecordAddresses")
+            }
+            SwarmCmd::GetAllLocalPeers { .. } => {
+                write!(f, "SwarmCmd::GetAllLocalPeers")
+            }
+            SwarmCmd::GetOurCloseGroup { .. } => {
+                write!(f, "SwarmCmd::GetOurCloseGroup")
+            }
+            SwarmCmd::GetSwarmLocalState { .. } => {
+                write!(f, "SwarmCmd::GetSwarmLocalState")
+            }
+            SwarmCmd::RecordStoreHasKey { key, .. } => {
+                write!(
+                    f,
+                    "SwarmCmd::RecordStoreHasKey {:?}",
+                    PrettyPrintRecordKey::from(key.clone())
+                )
+            }
+            SwarmCmd::SendResponse { resp, .. } => {
+                write!(f, "SwarmCmd::SendResponse resp: {:?}", resp)
+            }
+            SwarmCmd::SendRequest { req, peer, .. } => {
+                write!(f, "SwarmCmd::SendRequest req: {:?}, peer: {:?}", req, peer)
+            }
+        }
+    }
+}
 /// Snapshot of information kept in the Swarm's local state
 #[derive(Debug, Clone)]
 pub struct SwarmLocalState {

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -528,7 +528,7 @@ impl SwarmDriver {
                         if let Err(err) = self.handle_cmd(cmd) {
                             warn!("Error while handling cmd: {err}");
                         }
-                        debug!("SwarmCmd handled in {:?}: {cmd_string:?}", start.elapsed());
+                        trace!("SwarmCmd handled in {:?}: {cmd_string:?}", start.elapsed());
                     },
                     None =>  continue,
                 },

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -521,9 +521,12 @@ impl SwarmDriver {
                 },
                 some_cmd = self.cmd_receiver.recv() => match some_cmd {
                     Some(cmd) => {
+                        let start = std::time::Instant::now();
+                        let cmd_string = format!("{:?}", cmd);
                         if let Err(err) = self.handle_cmd(cmd) {
                             warn!("Error while handling cmd: {err}");
                         }
+                        debug!("SwarmCmd handled in {:?}: {cmd_string:?}", start.elapsed());
                     },
                     None =>  continue,
                 },

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -515,6 +515,8 @@ impl SwarmDriver {
         loop {
             tokio::select! {
                 swarm_event = self.swarm.select_next_some() => {
+                    // logging for handling events happens inside handle_swarm_events
+                    // otherwise we're rewriting match statements etc around this anwyay
                     if let Err(err) = self.handle_swarm_events(swarm_event) {
                         warn!("Error while handling swarm event: {err}");
                     }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -183,7 +183,14 @@ impl Node {
                             Some(event) => {
                                 let stateless_node_copy = self.clone();
                                 let _handle =
-                                    spawn(async move { stateless_node_copy.handle_network_event(event, peers_connected).await });
+                                    spawn(async move {
+                                        let start = std::time::Instant::now();
+                                        let event_string = format!("{:?}", event);
+
+                                        stateless_node_copy.handle_network_event(event, peers_connected).await ;
+                                        info!("Handled network event in {:?}: {:?}", start.elapsed(), event_string);
+
+                                    });
                             }
                             None => {
                                 error!("The `NetworkEvent` channel is closed");


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Oct 23 13:13 UTC
This pull request includes two patches. 

The first patch adds logging and debugging statements to the `sn_client`, `sn_networking`, and `sn_node` modules. It logs the handling of network events and measures the time it takes to handle them. It also improves the debug representation of the `SwarmCmd` enum.

The second patch improves the sorting algorithm in the `sort_peers_by_key` function in the `sn_networking` module. Instead of using indices and multiple computations of distances, it creates a vector of tuples where each tuple is a reference to a peer and its distance to the key. This vector is then sorted by distance, and the sorted peers are collected into a new vector.

Overall, these patches improve logging and debugging capabilities and optimize the sorting algorithm.
<!-- reviewpad:summarize:end --> 
