### PR TITLE
chore: expand replication range

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -110,7 +110,6 @@ jobs:
           TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
-          CHUNKS_ONLY: true
         timeout-minutes: 30
 
       - name: Verify restart of nodes using rg

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -392,7 +392,6 @@ jobs:
           TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
-          CHUNKS_ONLY: true
         timeout-minutes: 30
 
       - name: Verify restart of nodes using rg

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -10,6 +10,7 @@ use crate::{
     driver::SwarmDriver,
     error::{Error, Result},
     sort_peers_by_address, GetQuorum, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
+    REPLICATE_RANGE,
 };
 use libp2p::{
     kad::{store::RecordStore, Quorum, Record, RecordKey},
@@ -555,12 +556,12 @@ impl SwarmDriver {
     // Hence, the ilog2 calculation based on close_range cannot cover such case.
     // And have to sort all nodes to figure out whether self is among the close_group to the target.
     fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &[PeerId]) -> bool {
-        if all_peers.len() <= CLOSE_GROUP_SIZE + 2 {
+        if all_peers.len() <= REPLICATE_RANGE {
             return true;
         }
 
         // Margin of 2 to allow our RT being bit lagging.
-        match sort_peers_by_address(all_peers, target, CLOSE_GROUP_SIZE + 2) {
+        match sort_peers_by_address(all_peers, target, REPLICATE_RANGE) {
             Ok(close_group) => close_group.contains(&&self.self_peer_id),
             Err(err) => {
                 warn!("Could not get sorted peers for {target:?} with error {err:?}");

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -112,8 +112,11 @@ pub enum Error {
     #[error("Gossipsub subscribe Error: {0}")]
     GossipsubSubscriptionError(#[from] SubscriptionError),
 
-    #[error("Split Record: {0:?}")]
-    SplitRecord(HashMap<XorName, (Record, HashSet<PeerId>)>),
+    // Avoid logging the whole `Record` content by accident
+    #[error("Split Record has {} different copies", result_map.len())]
+    SplitRecord {
+        result_map: HashMap<XorName, (Record, HashSet<PeerId>)>,
+    },
 
     #[error("Record header is incorrect")]
     InCorrectRecordHeader,

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -114,6 +114,9 @@ pub enum Error {
 
     #[error("Split Record: {0:?}")]
     SplitRecord(HashMap<XorName, (Record, HashSet<PeerId>)>),
+
+    #[error("Record header is incorrect")]
+    InCorrectRecordHeader,
 }
 
 #[cfg(test)]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -1025,7 +1025,7 @@ impl SwarmDriver {
                     let _ = sender.send(result);
                 } else {
                     debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with split record");
-                    let _ = sender.send(Err(Error::SplitRecord(result_map)));
+                    let _ = sender.send(Err(Error::SplitRecord { result_map }));
                 }
             } else {
                 let _ = self

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -370,7 +370,8 @@ impl Network {
                     warn!("No holder of record '{pretty_key:?}' found. Retrying the fetch ...",);
                 }
                 Err(error) => {
-                    error!("{error:?}");
+                    error!("Getting record {pretty_key:?} attempts #{verification_attempts}/{total_attempts} , encountered {error:?}");
+
                     if verification_attempts >= total_attempts {
                         break;
                     }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -45,12 +45,12 @@ use libp2p::{
 };
 use sn_protocol::{
     messages::{Query, QueryResponse, Request, Response},
-    storage::{RecordHeader, RecordKind},
+    storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use sn_transfers::MainPubkey;
 use sn_transfers::NanoTokens;
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
@@ -526,7 +526,9 @@ impl Network {
     }
 
     /// Returns the Addresses of all the locally stored Records
-    pub async fn get_all_local_record_addresses(&self) -> Result<HashSet<NetworkAddress>> {
+    pub async fn get_all_local_record_addresses(
+        &self,
+    ) -> Result<HashMap<NetworkAddress, RecordType>> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetAllLocalRecordAddresses { sender })?;
 
@@ -539,7 +541,7 @@ impl Network {
     pub fn add_keys_to_replication_fetcher(
         &self,
         holder: PeerId,
-        keys: Vec<NetworkAddress>,
+        keys: Vec<(NetworkAddress, RecordType)>,
     ) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { holder, keys })
     }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -369,6 +369,14 @@ impl Network {
 
                     warn!("No holder of record '{pretty_key:?}' found. Retrying the fetch ...",);
                 }
+                Err(Error::SplitRecord { result_map }) => {
+                    error!("Getting record {pretty_key:?} attempts #{verification_attempts}/{total_attempts} , encountered split");
+
+                    if verification_attempts >= total_attempts {
+                        return Err(Error::SplitRecord { result_map });
+                    }
+                    warn!("Fetched split Record '{pretty_key:?}' from network!. Retrying...",);
+                }
                 Err(error) => {
                     error!("Getting record {pretty_key:?} attempts #{verification_attempts}/{total_attempts} , encountered {error:?}");
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -61,6 +61,10 @@ use tracing::warn;
 /// The size has been set to 5 for improved performance.
 pub const CLOSE_GROUP_SIZE: usize = 5;
 
+/// The range of peers that will be considered as close to a record target,
+/// that a replication of the record shall be sent/accepted to/by the peer.
+pub const REPLICATE_RANGE: usize = CLOSE_GROUP_SIZE * 2;
+
 /// Majority of a given group (i.e. > 1/2).
 #[inline]
 pub const fn close_group_majority() -> usize {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -16,16 +16,20 @@ use libp2p::{
 };
 #[cfg(feature = "open-metrics")]
 use prometheus_client::metrics::gauge::Gauge;
-use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
+use sn_protocol::{
+    storage::{RecordHeader, RecordKind, RecordType},
+    NetworkAddress, PrettyPrintRecordKey,
+};
 use sn_transfers::NanoTokens;
 use std::{
     borrow::Cow,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     vec,
 };
 use tokio::sync::mpsc;
+use xor_name::XorName;
 
 /// Max number of records a node can store
 const MAX_RECORDS_COUNT: usize = 2048;
@@ -37,7 +41,7 @@ pub struct NodeRecordStore {
     /// The configuration of the store.
     config: NodeRecordStoreConfig,
     /// A set of keys, each corresponding to a data `Record` stored on disk.
-    records: HashSet<Key>,
+    records: HashMap<Key, RecordType>,
     /// Currently only used to notify the record received via network put to be validated.
     event_sender: Option<mpsc::Sender<NetworkEvent>>,
     /// Distance range specify the acceptable range of record entry.
@@ -142,7 +146,7 @@ impl NodeRecordStore {
         // sort records by distance to our local key
         let furthest = self
             .records
-            .iter()
+            .keys()
             .max_by_key(|k| {
                 let kbucket_key = KBucketKey::from(k.to_vec());
                 self.local_key.distance(&kbucket_key)
@@ -185,28 +189,33 @@ impl NodeRecordStore {
 
 impl NodeRecordStore {
     /// Returns `true` if the `Key` is present locally
-    pub(crate) fn contains(&self, key: &Key) -> bool {
-        self.records.contains(key)
+    pub(crate) fn contains(&self, key: &Key) -> Option<&RecordType> {
+        self.records.get(key)
     }
 
     /// Returns the set of `NetworkAddress::RecordKey` held by the store
     /// Use `record_addresses_ref` to get a borrowed type
-    pub(crate) fn record_addresses(&self) -> HashSet<NetworkAddress> {
+    pub(crate) fn record_addresses(&self) -> HashMap<NetworkAddress, RecordType> {
         self.records
             .iter()
-            .map(NetworkAddress::from_record_key)
+            .map(|(record_key, record_type)| {
+                (
+                    NetworkAddress::from_record_key(record_key),
+                    record_type.clone(),
+                )
+            })
             .collect()
     }
 
     /// Returns the reference to the set of `NetworkAddress::RecordKey` held by the store
     #[allow(clippy::mutable_key_type)]
-    pub(crate) fn record_addresses_ref(&self) -> &HashSet<Key> {
+    pub(crate) fn record_addresses_ref(&self) -> &HashMap<Key, RecordType> {
         &self.records
     }
 
     /// Warning: PUTs a `Record` to the store without validation
     /// Should be used in context where the `Record` is trusted
-    pub(crate) fn put_verified(&mut self, r: Record) -> Result<()> {
+    pub(crate) fn put_verified(&mut self, r: Record, record_type: RecordType) -> Result<()> {
         let record_key = PrettyPrintRecordKey::from(&r.key).into_owned();
         trace!("PUT a verified Record: {record_key:?}");
 
@@ -214,7 +223,7 @@ impl NodeRecordStore {
 
         let filename = Self::key_to_hex(&r.key);
         let file_path = self.config.storage_dir.join(&filename);
-        let _ = self.records.insert(r.key.clone());
+        let _ = self.records.insert(r.key.clone(), record_type);
         #[cfg(feature = "open-metrics")]
         if let Some(metric) = &self.record_count_metric {
             let _ = metric.set(self.records.len() as i64);
@@ -249,9 +258,11 @@ impl NodeRecordStore {
     }
 
     /// Calculate the cost to store data for our current store state
+    #[allow(clippy::mutable_key_type)]
     pub(crate) fn store_cost(&self) -> NanoTokens {
         let relevant_records_len = if let Some(distance_range) = self.distance_range {
-            self.get_records_within_distance_range(&self.records, distance_range)
+            let record_keys: HashSet<_> = self.records.keys().cloned().collect();
+            self.get_records_within_distance_range(&record_keys, distance_range)
         } else {
             warn!("No distance range set on record store. Returning MAX_RECORDS_COUNT for relevant records in store cost calculation.");
             MAX_RECORDS_COUNT
@@ -302,7 +313,7 @@ impl RecordStore for NodeRecordStore {
         // with the record. Thus a node can be bombarded with GET reqs for random keys. These can be safely
         // ignored if we don't have the record locally.
         let key = PrettyPrintRecordKey::from(k);
-        if !self.records.contains(k) {
+        if !self.records.contains_key(k) {
             trace!("Record not found locally: {key}");
             return None;
         }
@@ -321,19 +332,45 @@ impl RecordStore for NodeRecordStore {
             return Err(Error::ValueTooLarge);
         }
 
-        if self.records.contains(&record.key) {
-            trace!(
-                "Unverified Record {:?} already exists.",
-                PrettyPrintRecordKey::from(&record.key)
-            );
+        let record_key = PrettyPrintRecordKey::from(&record.key);
 
-            // Blindly sent to validation to allow double spend can be detected.
-            // TODO: consider avoid throw duplicated chunk to validation.
+        // Record with payment shall always get passed further
+        // to allow the payment to be taken and credit into own wallet.
+        match RecordHeader::from_record(&record) {
+            Ok(record_header) => {
+                match record_header.kind {
+                    RecordKind::ChunkWithPayment | RecordKind::RegisterWithPayment => {
+                        trace!("Record {record_key:?} with payment shall always be processed.");
+                    }
+                    _ => {
+                        // Chunk with existing key do not to be stored again.
+                        // `Spend` or `Register` with same content_hash do not to be stored again,
+                        // otherwise shall be passed further to allow
+                        // double spend to be detected or register op update.
+                        match self.records.get(&record.key) {
+                            Some(RecordType::Chunk) => {
+                                trace!("Chunk {record_key:?} already exists.");
+                                return Ok(());
+                            }
+                            Some(RecordType::NonChunk(existing_content_hash)) => {
+                                let content_hash = XorName::from_content(&record.value);
+                                if content_hash == *existing_content_hash {
+                                    trace!("A non-chunk record {record_key:?} with same content_hash {content_hash:?} already exists.");
+                                    return Ok(());
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                error!("For record {record_key:?}, failed to parse record_header {err:?}");
+                return Ok(());
+            }
         }
-        trace!(
-            "Unverified Record {:?} try to validate and store",
-            PrettyPrintRecordKey::from(&record.key)
-        );
+
+        trace!("Unverified Record {record_key:?} try to validate and store");
         if let Some(event_sender) = self.event_sender.clone() {
             // push the event off thread so as to be non-blocking
             let _handle = tokio::spawn(async move {
@@ -400,24 +437,24 @@ impl RecordStore for NodeRecordStore {
 /// A place holder RecordStore impl for the client that does nothing
 #[derive(Default, Debug)]
 pub struct ClientRecordStore {
-    empty_record_addresses: HashSet<Key>,
+    empty_record_addresses: HashMap<Key, RecordType>,
 }
 
 impl ClientRecordStore {
-    pub(crate) fn contains(&self, _key: &Key) -> bool {
-        false
+    pub(crate) fn contains(&self, _key: &Key) -> Option<&RecordType> {
+        None
     }
 
-    pub(crate) fn record_addresses(&self) -> HashSet<NetworkAddress> {
-        HashSet::new()
+    pub(crate) fn record_addresses(&self) -> HashMap<NetworkAddress, RecordType> {
+        HashMap::new()
     }
 
     #[allow(clippy::mutable_key_type)]
-    pub(crate) fn record_addresses_ref(&self) -> &HashSet<Key> {
+    pub(crate) fn record_addresses_ref(&self) -> &HashMap<Key, RecordType> {
         &self.empty_record_addresses
     }
 
-    pub(crate) fn put_verified(&mut self, _r: Record) -> Result<()> {
+    pub(crate) fn put_verified(&mut self, _r: Record, _record_type: RecordType) -> Result<()> {
         Ok(())
     }
 
@@ -501,6 +538,7 @@ mod tests {
         kad::{KBucketKey, RecordKey},
     };
     use quickcheck::*;
+    use sn_protocol::storage::try_serialize_record;
     use tokio::runtime::Runtime;
 
     const MULITHASH_CODE: u64 = 0x12;
@@ -544,9 +582,16 @@ mod tests {
 
     impl Arbitrary for ArbitraryRecord {
         fn arbitrary(g: &mut Gen) -> ArbitraryRecord {
+            let value: Vec<u8> = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+                RecordKind::Chunk,
+            ) {
+                Ok(value) => value,
+                Err(err) => panic!("Cannot generate record value {:?}", err),
+            };
             let record = Record {
                 key: ArbitraryKey::arbitrary(g).0,
-                value: Vec::arbitrary(g),
+                value,
                 publisher: None,
                 expires: None,
             };
@@ -609,7 +654,9 @@ mod tests {
             panic!("Failed recevied the record for further verification");
         };
 
-        assert!(store.put_verified(returned_record).is_ok());
+        assert!(store
+            .put_verified(returned_record, RecordType::Chunk)
+            .is_ok());
 
         // loop over store.get max_iterations times to ensure async disk write had time to complete.
         let max_iterations = 10;
@@ -655,19 +702,25 @@ mod tests {
         };
         let self_id = PeerId::random();
         let mut store = NodeRecordStore::with_config(self_id, store_config.clone(), None);
-
         let mut stored_records: Vec<RecordKey> = vec![];
         let self_address = NetworkAddress::from_peer(self_id);
         for i in 0..100 {
             let record_key = NetworkAddress::from_peer(PeerId::random()).to_record_key();
+            let value: Vec<u8> = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+                RecordKind::Chunk,
+            ) {
+                Ok(value) => value,
+                Err(err) => panic!("Cannot generate record value {:?}", err),
+            };
             let record = Record {
                 key: record_key.clone(),
-                value: (0..50).map(|_| rand::random::<u8>()).collect(),
+                value,
                 publisher: None,
                 expires: None,
             };
             let retained_key = if i < max_records {
-                assert!(store.put_verified(record).is_ok());
+                assert!(store.put_verified(record, RecordType::Chunk).is_ok());
                 record_key
             } else {
                 // The list is already sorted by distance, hence always shall only prune the last one
@@ -678,11 +731,11 @@ mod tests {
                     > self_address.distance(&record_addr)
                 {
                     // The new entry is closer, it shall replace the existing one
-                    assert!(store.put_verified(record).is_ok());
+                    assert!(store.put_verified(record, RecordType::Chunk).is_ok());
                     (record_key, furthest_key)
                 } else {
                     // The new entry is farther away, it shall not replace the existing one
-                    assert!(store.put_verified(record).is_err());
+                    assert!(store.put_verified(record, RecordType::Chunk).is_err());
                     (furthest_key, record_key)
                 };
 
@@ -729,6 +782,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::mutable_key_type)]
     async fn get_records_within_distance_range() -> eyre::Result<()> {
         let max_records = 50;
 
@@ -747,14 +801,21 @@ mod tests {
         // minus one here as if we hit max, the store will fail
         for _ in 0..max_records - 1 {
             let record_key = NetworkAddress::from_peer(PeerId::random()).to_record_key();
+            let value: Vec<u8> = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+                RecordKind::Chunk,
+            ) {
+                Ok(value) => value,
+                Err(err) => panic!("Cannot generate record value {:?}", err),
+            };
             let record = Record {
                 key: record_key.clone(),
-                value: (0..50).map(|_| rand::random::<u8>()).collect(),
+                value,
                 publisher: None,
                 expires: None,
             };
             // The new entry is closer, it shall replace the existing one
-            assert!(store.put_verified(record).is_ok());
+            assert!(store.put_verified(record, RecordType::Chunk).is_ok());
 
             stored_records.push(record_key);
             stored_records.sort_by(|a, b| {
@@ -775,9 +836,11 @@ mod tests {
 
         store.set_distance_range(distance);
 
+        let record_keys: HashSet<_> = store.records.keys().cloned().collect();
+
         // check that the number of records returned is correct
         assert_eq!(
-            store.get_records_within_distance_range(&store.records, distance),
+            store.get_records_within_distance_range(&record_keys, distance),
             stored_records.len() / 2
         );
 

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -11,9 +11,9 @@ use libp2p::kad::{
     store::{RecordStore, Result},
     KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
 };
-use sn_protocol::NetworkAddress;
+use sn_protocol::{storage::RecordType, NetworkAddress};
 use sn_transfers::NanoTokens;
-use std::{borrow::Cow, collections::HashSet};
+use std::{borrow::Cow, collections::HashMap};
 
 pub enum UnifiedRecordStore {
     Client(ClientRecordStore),
@@ -82,14 +82,14 @@ impl RecordStore for UnifiedRecordStore {
 }
 
 impl UnifiedRecordStore {
-    pub(crate) fn contains(&self, key: &RecordKey) -> bool {
+    pub(crate) fn contains(&self, key: &RecordKey) -> Option<&RecordType> {
         match self {
             Self::Client(store) => store.contains(key),
             Self::Node(store) => store.contains(key),
         }
     }
 
-    pub(crate) fn record_addresses(&self) -> HashSet<NetworkAddress> {
+    pub(crate) fn record_addresses(&self) -> HashMap<NetworkAddress, RecordType> {
         match self {
             Self::Client(store) => store.record_addresses(),
             Self::Node(store) => store.record_addresses(),
@@ -97,17 +97,17 @@ impl UnifiedRecordStore {
     }
 
     #[allow(clippy::mutable_key_type)]
-    pub(crate) fn record_addresses_ref(&self) -> &HashSet<RecordKey> {
+    pub(crate) fn record_addresses_ref(&self) -> &HashMap<RecordKey, RecordType> {
         match self {
             Self::Client(store) => store.record_addresses_ref(),
             Self::Node(store) => store.record_addresses_ref(),
         }
     }
 
-    pub(crate) fn put_verified(&mut self, r: Record) -> Result<()> {
+    pub(crate) fn put_verified(&mut self, r: Record, record_type: RecordType) -> Result<()> {
         match self {
-            Self::Client(store) => store.put_verified(r),
-            Self::Node(store) => store.put_verified(r),
+            Self::Client(store) => store.put_verified(r, record_type),
+            Self::Node(store) => store.put_verified(r, record_type),
         }
     }
 

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -9,9 +9,9 @@
 
 use crate::CLOSE_GROUP_SIZE;
 use libp2p::{kad::RecordKey, PeerId};
-use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
+use sn_protocol::{storage::RecordType, NetworkAddress, PrettyPrintRecordKey};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     time::{Duration, Instant},
 };
 
@@ -27,9 +27,9 @@ type ReplicationRequestSentTime = Instant;
 
 #[derive(Default, Debug)]
 pub(crate) struct ReplicationFetcher {
-    to_be_fetched: HashMap<(RecordKey, PeerId), Option<ReplicationRequestSentTime>>,
+    to_be_fetched: HashMap<(RecordKey, RecordType, PeerId), Option<ReplicationRequestSentTime>>,
     // Avoid fetching same chunk from different nodes AND carry out too many parallel tasks.
-    on_going_fetches: HashMap<RecordKey, PeerId>,
+    on_going_fetches: HashMap<(RecordKey, RecordType), PeerId>,
 }
 
 impl ReplicationFetcher {
@@ -38,17 +38,23 @@ impl ReplicationFetcher {
     pub(crate) fn add_keys(
         &mut self,
         holder: PeerId,
-        incoming_keys: Vec<NetworkAddress>,
-        locally_stored_keys: &HashSet<RecordKey>,
+        incoming_keys: Vec<(NetworkAddress, RecordType)>,
+        locally_stored_keys: &HashMap<RecordKey, RecordType>,
     ) -> Vec<(PeerId, RecordKey)> {
         self.remove_stored_keys(locally_stored_keys);
 
         // add non existing keys to the fetcher
         incoming_keys
             .into_iter()
-            .filter_map(|incoming| incoming.as_record_key())
-            .filter(|incoming| !locally_stored_keys.contains(incoming))
-            .for_each(|incoming| self.add_key(holder, incoming));
+            .filter_map(|(addr, record_type)| {
+                let key = addr.to_record_key();
+                if Some(&record_type) == locally_stored_keys.get(&key) {
+                    None
+                } else {
+                    Some((key, record_type))
+                }
+            })
+            .for_each(|(key, record_type)| self.add_key(holder, key, record_type));
 
         self.next_keys_to_fetch()
     }
@@ -56,11 +62,16 @@ impl ReplicationFetcher {
     // Notify the replication fetcher about a newly added Record to the node.
     // The corresponding key can now be removed from the replication fetcher.
     // Also returns the next set of keys that has to be fetched from the peer/network.
-    pub(crate) fn notify_about_new_put(&mut self, new_put: &RecordKey) -> Vec<(PeerId, RecordKey)> {
-        self.to_be_fetched.retain(|(key, _), _| key != new_put);
+    pub(crate) fn notify_about_new_put(
+        &mut self,
+        new_put: RecordKey,
+        record_type: RecordType,
+    ) -> Vec<(PeerId, RecordKey)> {
+        self.to_be_fetched
+            .retain(|(key, t, _), _| key != &new_put || t != &record_type);
 
         // if we're actively fetching for the key, reduce the on_going_fetches
-        let _ = self.on_going_fetches.remove(new_put);
+        let _ = self.on_going_fetches.remove(&(new_put, record_type));
 
         self.next_keys_to_fetch()
     }
@@ -84,17 +95,21 @@ impl ReplicationFetcher {
         }
 
         let mut data_to_fetch = vec![];
-        for ((key, holder), is_fetching) in self.to_be_fetched.iter_mut() {
+        for ((key, t, holder), is_fetching) in self.to_be_fetched.iter_mut() {
             // Already carried out expiration pruning above.
             // Hence here only need to check whether is ongoing fetching.
             // Also avoid fetching same record from different nodes.
             if is_fetching.is_none()
                 && self.on_going_fetches.len() < MAX_PARALLEL_FETCH
-                && !self.on_going_fetches.contains_key(key)
+                && !self
+                    .on_going_fetches
+                    .contains_key(&(key.clone(), t.clone()))
             {
                 data_to_fetch.push((*holder, key.clone()));
                 *is_fetching = Some(Instant::now());
-                let _ = self.on_going_fetches.insert(key.clone(), *holder);
+                let _ = self
+                    .on_going_fetches
+                    .insert((key.clone(), t.clone()), *holder);
             }
         }
 
@@ -117,10 +132,10 @@ impl ReplicationFetcher {
     // Just remove outdated entries, which indicates a failure to fetch from network.
     // Leave it to to the next round of replication if triggered again.
     fn prune_expired_keys(&mut self) {
-        self.to_be_fetched.retain(|(key, holder), is_fetching| {
+        self.to_be_fetched.retain(|(key, t, holder), is_fetching| {
             let is_expired = if let Some(requested_time) = is_fetching {
                 if Instant::now() > *requested_time + FETCH_TIMEOUT {
-                    self.on_going_fetches.retain(|data, node| data != key || node != holder);
+                    self.on_going_fetches.retain(|(data, record_type), node| data != key || node != holder || record_type != t);
                     debug!(
                         "Prune record {:?} at {holder:?} from the replication_fetcher due to timeout.",
                         PrettyPrintRecordKey::from(key)
@@ -137,14 +152,17 @@ impl ReplicationFetcher {
     }
 
     /// Remove keys that we hold already and no longer need to be replicated.
-    fn remove_stored_keys(&mut self, existing_keys: &HashSet<RecordKey>) {
+    fn remove_stored_keys(&mut self, existing_keys: &HashMap<RecordKey, RecordType>) {
         self.to_be_fetched
-            .retain(|(key, _), _| !existing_keys.contains(key));
+            .retain(|(key, t, _), _| Some(t) != existing_keys.get(key));
     }
 
     /// Add the key if not present yet.
-    fn add_key(&mut self, holder: PeerId, key: RecordKey) {
-        let _ = self.to_be_fetched.entry((key, holder)).or_insert(None);
+    fn add_key(&mut self, holder: PeerId, key: RecordKey, record_type: RecordType) {
+        let _ = self
+            .to_be_fetched
+            .entry((key, record_type, holder))
+            .or_insert(None);
     }
 }
 
@@ -153,19 +171,19 @@ mod tests {
     use super::{ReplicationFetcher, FETCH_TIMEOUT, MAX_PARALLEL_FETCH};
     use eyre::Result;
     use libp2p::{kad::RecordKey, PeerId};
-    use sn_protocol::NetworkAddress;
-    use std::{collections::HashSet, time::Duration};
+    use sn_protocol::{storage::RecordType, NetworkAddress};
+    use std::{collections::HashMap, time::Duration};
 
     #[tokio::test]
     async fn verify_max_parallel_fetches() -> Result<()> {
         let mut replication_fetcher = ReplicationFetcher::default();
-        let locally_stored_keys = HashSet::new();
+        let locally_stored_keys = HashMap::new();
 
         let mut incoming_keys = Vec::new();
         (0..MAX_PARALLEL_FETCH * 2).for_each(|_| {
             let random_data: Vec<u8> = (0..50).map(|_| rand::random::<u8>()).collect();
             let key = NetworkAddress::from_record_key(&RecordKey::from(random_data));
-            incoming_keys.push(key);
+            incoming_keys.push((key, RecordType::Chunk));
         });
 
         let keys_to_fetch =
@@ -175,8 +193,11 @@ mod tests {
         // we should not fetch anymore keys
         let random_data: Vec<u8> = (0..50).map(|_| rand::random::<u8>()).collect();
         let key = NetworkAddress::from_record_key(&RecordKey::from(random_data));
-        let keys_to_fetch =
-            replication_fetcher.add_keys(PeerId::random(), vec![key], &locally_stored_keys);
+        let keys_to_fetch = replication_fetcher.add_keys(
+            PeerId::random(),
+            vec![(key, RecordType::Chunk)],
+            &locally_stored_keys,
+        );
         assert!(keys_to_fetch.is_empty());
 
         tokio::time::sleep(FETCH_TIMEOUT + Duration::from_secs(1)).await;

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -103,7 +103,13 @@ impl RunningNode {
 
     /// Returns the list of all the RecordKeys held by the node
     pub async fn get_all_record_addresses(&self) -> Result<HashSet<NetworkAddress>> {
-        let addresses = self.network.get_all_local_record_addresses().await?;
+        let addresses: HashSet<_> = self
+            .network
+            .get_all_local_record_addresses()
+            .await?
+            .keys()
+            .cloned()
+            .collect();
         Ok(addresses)
     }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -472,6 +472,8 @@ impl Node {
             .cash_notes_from_payment(&payment, &wallet, pretty_key.clone())
             .await?;
 
+        trace!("Received payment of {received_fee:?} for {pretty_key}");
+
         // deposit the CashNotes in our wallet
         wallet
             .deposit_and_store_to_disk(&cash_notes)

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -12,7 +12,7 @@ use libp2p::{
     kad::{Record, RecordKey, K_VALUE},
     PeerId,
 };
-use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
+use sn_networking::{sort_peers_by_address, GetQuorum, REPLICATE_RANGE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
@@ -74,8 +74,7 @@ impl Node {
         let all_peers: Vec<_> = all_peers_set.iter().cloned().collect();
 
         for key in all_records {
-            let sorted_based_on_key =
-                sort_peers_by_address(&all_peers, &key, CLOSE_GROUP_SIZE + 1)?;
+            let mut sorted_based_on_key = sort_peers_by_address(&all_peers, &key, REPLICATE_RANGE)?;
             let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
                 .iter()
                 .map(|&peer_id| {
@@ -88,29 +87,19 @@ impl Node {
 
             if sorted_based_on_key.contains(&&peer_id) {
                 trace!("replication: close for {key:?} are: {sorted_peers_pretty_print:?}");
-                let target_peer = if is_removal {
-                    // For dead peer, only replicate to farthest close_group peer,
-                    // when the dead peer was one of the close_group peers to the record.
-                    if let Some(&farthest_peer) = sorted_based_on_key.last() {
-                        if *farthest_peer != peer_id {
-                            *farthest_peer
-                        } else {
-                            continue;
-                        }
-                    } else {
-                        continue;
-                    }
+                let target_peers: Vec<_> = if is_removal {
+                    // For dead peer, replicate to close peers except the dead one.
+                    sorted_based_on_key.retain(|target| **target != peer_id);
+                    sorted_based_on_key.to_vec()
                 } else {
                     // For new peer, always replicate to it when it is close_group of the record.
-                    if Some(&&peer_id) != sorted_based_on_key.last() {
-                        peer_id
-                    } else {
-                        continue;
-                    }
+                    vec![&peer_id]
                 };
 
-                let keys_to_replicate = replicate_to.entry(target_peer).or_default();
-                keys_to_replicate.push(key.clone());
+                for target_peer in target_peers {
+                    let keys_to_replicate = replicate_to.entry(*target_peer).or_default();
+                    keys_to_replicate.push(key.clone());
+                }
             }
         }
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -47,12 +47,14 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
         chunks_dir.path().to_path_buf(),
     )?;
 
-    println!("Paying for {} random addresses...", chunks.len());
+    println!("Paying for {} random addresses... {chunks:?}", chunks.len());
     let prev_rewards_balance = current_rewards_balance()?;
 
     let (_file_addr, rewards_paid, _royalties_fees) = files_api
         .pay_and_upload_bytes_test(*content_addr.xorname(), chunks)
         .await?;
+
+    println!("Paid {rewards_paid:?} total rewards for the chunks");
 
     let expected_rewards_balance = prev_rewards_balance
         .checked_add(rewards_paid)
@@ -170,6 +172,7 @@ async fn verify_rewards(expected_rewards_balance: NanoTokens) -> Result<()> {
 
     while iteration < 15 {
         iteration += 1;
+        println!("Current iteration {iteration}");
         let new_rewards_balance = current_rewards_balance()?;
         if expected_rewards_balance == new_rewards_balance {
             return Ok(());
@@ -193,10 +196,13 @@ fn current_rewards_balance() -> Result<NanoTokens> {
         let path = entry?.path();
         let wallet = LocalWallet::try_load_from(&path)?;
         let balance = wallet.balance();
+        println!("Node's wallet {path:?} currentln have balance of {balance:?}");
         total_rewards = total_rewards
             .checked_add(balance)
             .ok_or_else(|| eyre!("Faied to sum up rewards balance"))?;
     }
+
+    println!("Current total balance is {total_rewards:?}");
 
     Ok(total_rewards)
 }

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -266,7 +266,6 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "registers dont currentlyt merge well. Ignoring until stable"]
 async fn storage_payment_register_creation_succeeds() -> Result<()> {
     let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::NetworkAddress;
+use crate::{storage::RecordType, NetworkAddress};
 use serde::{Deserialize, Serialize};
 // TODO: remove this dependency and define these types herein.
 pub use sn_transfers::{Hash, UniquePubkey};
@@ -28,7 +28,7 @@ pub enum Cmd {
         holder: NetworkAddress,
         /// Keys of copy that shall be replicated.
         #[debug(skip)]
-        keys: Vec<NetworkAddress>,
+        keys: Vec<(NetworkAddress, RecordType)>,
     },
 }
 

--- a/sn_protocol/src/storage/header.rs
+++ b/sn_protocol/src/storage/header.rs
@@ -11,6 +11,16 @@ use crate::PrettyPrintRecordKey;
 use libp2p::kad::Record;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use xor_name::XorName;
+
+/// Indicates the type of the record content.
+/// Note for `Spend` and `Register`, using its content_hash (in `XorName` format)
+/// to indicate different content body.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum RecordType {
+    Chunk,
+    NonChunk(XorName),
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecordHeader {

--- a/sn_protocol/src/storage/mod.rs
+++ b/sn_protocol/src/storage/mod.rs
@@ -13,5 +13,5 @@ mod header;
 pub use self::{
     address::{ChunkAddress, RegisterAddress, SpendAddress},
     chunks::Chunk,
-    header::{try_deserialize_record, try_serialize_record, RecordHeader, RecordKind},
+    header::{try_deserialize_record, try_serialize_record, RecordHeader, RecordKind, RecordType},
 };


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Oct 23 14:12 UTC
This pull request expands the replication range in the code. It modifies the `sn_networking/src/cmd.rs`, `sn_networking/src/lib.rs`, and `sn_node/src/replication.rs` files. The changes include updating the `REPLICATE_RANGE` constant to be twice the `CLOSE_GROUP_SIZE`, and using this new range in the code logic to determine whether a peer is in the close range. The patch also involves making adjustments to the replication process based on whether the target peer is a dead peer or a new peer.
<!-- reviewpad:summarize:end --> 
