### PR TITLE
feat(protocol)!: implement `PrettyPrintRecordKey` as a `Cow` type

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -284,7 +284,7 @@ impl Client {
 
         debug!(
             "Got record from the network, {:?}",
-            PrettyPrintRecordKey::from(record.key.clone())
+            PrettyPrintRecordKey::from(&record.key)
         );
 
         let register = get_register_from_record(record)
@@ -497,7 +497,7 @@ impl Client {
 
         trace!(
             "Getting spend {unique_pubkey:?} with record_key {:?}",
-            PrettyPrintRecordKey::from(key.clone())
+            PrettyPrintRecordKey::from(&key)
         );
         let record = self
             .network
@@ -510,7 +510,7 @@ impl Client {
             })?;
         debug!(
             "For spend {unique_pubkey:?} got record from the network, {:?}",
-            PrettyPrintRecordKey::from(record.key.clone())
+            PrettyPrintRecordKey::from(&record.key)
         );
 
         let header = RecordHeader::from_record(&record).map_err(|err| {
@@ -564,7 +564,7 @@ impl Client {
                     error!("Found double spend for {address:?}");
                     Err(Error::CouldNotVerifyTransfer(format!(
                 "Found double spend for the unique_pubkey {unique_pubkey:?} - {:?}: spend_one {:?} and spend_two {:?}",
-                PrettyPrintRecordKey::from(key), one.derived_key_sig, two.derived_key_sig
+                PrettyPrintRecordKey::from(&key), one.derived_key_sig, two.derived_key_sig
             )))
                 }
             }
@@ -615,15 +615,15 @@ fn merge_split_register_records(
     address: RegisterAddress,
     map: &HashMap<XorName, (Record, HashSet<PeerId>)>,
 ) -> Result<SignedRegister> {
-    let key =
-        PrettyPrintRecordKey::from(NetworkAddress::from_register_address(address).to_record_key());
-    debug!("Got multiple records from the network for key: {key:?}");
+    let key = NetworkAddress::from_register_address(address).to_record_key();
+    let pretty_key = PrettyPrintRecordKey::from(&key);
+    debug!("Got multiple records from the network for key: {pretty_key:?}");
     let mut all_registers = vec![];
     for (record, peers) in map.values() {
         match get_register_from_record(record.clone()) {
             Ok(r) => all_registers.push(r),
             Err(e) => {
-                warn!("Ignoring invalid register record found for {key:?} received from {peers:?}: {:?}", e);
+                warn!("Ignoring invalid register record found for {pretty_key:?} received from {peers:?}: {:?}", e);
                 continue;
             }
         }

--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -18,7 +18,7 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(missing_docs)]
 pub enum Error {
     #[error("Failed to get find payment for record: {0:?}")]
-    NoPaymentForRecord(PrettyPrintRecordKey),
+    NoPaymentForRecord(PrettyPrintRecordKey<'static>),
 
     #[error("Failed to get chunk permit")]
     CouldNotGetChunkPermit,

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -169,9 +169,9 @@ impl Files {
 
         if payment.is_empty() {
             warn!("Failed to get payment proof for chunk: {chunk_addr:?} it was not found in the local wallet");
-            return Err(ChunksError::NoPaymentForRecord(PrettyPrintRecordKey::from(
-                chunk_addr.to_record_key(),
-            )))?;
+            return Err(ChunksError::NoPaymentForRecord(
+                PrettyPrintRecordKey::from(&chunk_addr.to_record_key()).into_owned(),
+            ))?;
         }
 
         trace!(

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -186,7 +186,7 @@ impl SwarmDriver {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key.clone());
 
                 if !expected_holders.is_empty() {
-                    debug!("Record {:?} with task {query_id:?} expected to be held by {expected_holders:?}", PrettyPrintRecordKey::from(key));
+                    debug!("Record {:?} with task {query_id:?} expected to be held by {expected_holders:?}", PrettyPrintRecordKey::from(&key));
                 }
 
                 if self
@@ -225,7 +225,7 @@ impl SwarmDriver {
                 let _ = sender.send(record);
             }
             SwarmCmd::PutRecord { record, sender } => {
-                let record_key = PrettyPrintRecordKey::from(record.key.clone());
+                let record_key = PrettyPrintRecordKey::from(&record.key).into_owned();
                 trace!(
                     "Putting record sized: {:?} to network {:?}",
                     record.value.len(),

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -46,10 +46,10 @@ pub enum Error {
 
     /// No put_record attempts were successfully verified.
     #[error("Could not retrieve the record after storing it: {0:}")]
-    FailedToVerifyRecordWasStored(PrettyPrintRecordKey),
+    FailedToVerifyRecordWasStored(PrettyPrintRecordKey<'static>),
 
     #[error("Record retrieved from the network does not match the one we attempted to store {0:}")]
-    ReturnedRecordDoesNotMatch(PrettyPrintRecordKey),
+    ReturnedRecordDoesNotMatch(PrettyPrintRecordKey<'static>),
 
     #[error("Could not create storage dir: {path:?}, error: {source}")]
     FailedToCreateRecordStoreDir {
@@ -130,8 +130,7 @@ mod tests {
         let address = ChunkAddress::new(xor_name);
         let network_address = NetworkAddress::from_chunk_address(address);
         let record_key = network_address.to_record_key();
-        let pretty_record: PrettyPrintRecordKey = record_key.into();
-        let record_str = format!("{}", pretty_record);
+        let record_str = format!("{}", PrettyPrintRecordKey::from(&record_key));
         let xor_name_str = format!(
             "{:64x}({:?})",
             xor_name,

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -160,8 +160,8 @@ impl NodeRecordStore {
             {
                 trace!(
                     "{:?} will be pruned to make space for new record: {:?}",
-                    PrettyPrintRecordKey::from(furthest_record.clone()),
-                    PrettyPrintRecordKey::from(r.clone())
+                    PrettyPrintRecordKey::from(&furthest_record),
+                    PrettyPrintRecordKey::from(r)
                 );
                 // we should prune and make space
                 self.remove(&furthest_record);
@@ -207,7 +207,7 @@ impl NodeRecordStore {
     /// Warning: PUTs a `Record` to the store without validation
     /// Should be used in context where the `Record` is trusted
     pub(crate) fn put_verified(&mut self, r: Record) -> Result<()> {
-        let record_key = PrettyPrintRecordKey::from(r.key.clone());
+        let record_key = PrettyPrintRecordKey::from(&r.key).into_owned();
         trace!("PUT a verified Record: {record_key:?}");
 
         self.prune_storage_if_needed_for_record(&r.key)?;
@@ -301,7 +301,7 @@ impl RecordStore for NodeRecordStore {
         // When a client calls GET, the request is forwarded to the nodes until one node returns
         // with the record. Thus a node can be bombarded with GET reqs for random keys. These can be safely
         // ignored if we don't have the record locally.
-        let key = PrettyPrintRecordKey::from(k.clone());
+        let key = PrettyPrintRecordKey::from(k);
         if !self.records.contains(k) {
             trace!("Record not found locally: {key}");
             return None;
@@ -324,7 +324,7 @@ impl RecordStore for NodeRecordStore {
         if self.records.contains(&record.key) {
             trace!(
                 "Unverified Record {:?} already exists.",
-                PrettyPrintRecordKey::from(record.key.clone())
+                PrettyPrintRecordKey::from(&record.key)
             );
 
             // Blindly sent to validation to allow double spend can be detected.
@@ -332,7 +332,7 @@ impl RecordStore for NodeRecordStore {
         }
         trace!(
             "Unverified Record {:?} try to validate and store",
-            PrettyPrintRecordKey::from(record.key.clone())
+            PrettyPrintRecordKey::from(&record.key)
         );
         if let Some(event_sender) = self.event_sender.clone() {
             // push the event off thread so as to be non-blocking

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -100,7 +100,7 @@ impl ReplicationFetcher {
 
         let pretty_keys: Vec<_> = data_to_fetch
             .iter()
-            .map(|(holder, key)| (*holder, PrettyPrintRecordKey::from(key.clone())))
+            .map(|(holder, key)| (*holder, PrettyPrintRecordKey::from(key)))
             .collect();
 
         if !data_to_fetch.is_empty() {
@@ -123,7 +123,7 @@ impl ReplicationFetcher {
                     self.on_going_fetches.retain(|data, node| data != key || node != holder);
                     debug!(
                         "Prune record {:?} at {holder:?} from the replication_fetcher due to timeout.",
-                        PrettyPrintRecordKey::from(key.clone())
+                        PrettyPrintRecordKey::from(key)
                     );
                     true
                 } else {

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -29,7 +29,7 @@ impl Network {
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!(
             "Got record from the network, {:?}",
-            PrettyPrintRecordKey::from(record.key.clone())
+            PrettyPrintRecordKey::from(&record.key)
         );
         let header =
             RecordHeader::from_record(&record).map_err(|_| Error::SpendNotFound(address))?;

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -51,14 +51,14 @@ pub enum Marker<'a> {
     },
 
     /// Valid non-existing Chunk record PUT from the network received and stored
-    ValidChunkRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    ValidChunkRecordPutFromNetwork(&'a PrettyPrintRecordKey<'a>),
     /// Valid non-existing Register record PUT from the network received and stored
-    ValidRegisterRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    ValidRegisterRecordPutFromNetwork(&'a PrettyPrintRecordKey<'a>),
     /// Valid non-existing Spend record PUT from the network received and stored
-    ValidSpendRecordPutFromNetwork(&'a PrettyPrintRecordKey),
+    ValidSpendRecordPutFromNetwork(&'a PrettyPrintRecordKey<'a>),
 
     /// Record rejected
-    RecordRejected(&'a PrettyPrintRecordKey),
+    RecordRejected(&'a PrettyPrintRecordKey<'a>),
 }
 
 impl<'a> Marker<'a> {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -340,7 +340,7 @@ impl Node {
                 }
             }
             NetworkEvent::UnverifiedRecord(record) => {
-                let key = PrettyPrintRecordKey::from(record.key.clone());
+                let key = PrettyPrintRecordKey::from(&record.key).into_owned();
                 match self.validate_and_store_record(record).await {
                     Ok(cmdok) => trace!("UnverifiedRecord {key} stored with {cmdok:?}."),
                     Err(err) => {
@@ -420,9 +420,9 @@ impl Node {
 
                 if record_exists {
                     QueryResponse::GetStoreCost {
-                        store_cost: Err(ProtocolError::RecordExists(PrettyPrintRecordKey::from(
-                            address.to_record_key(),
-                        ))),
+                        store_cost: Err(ProtocolError::RecordExists(
+                            PrettyPrintRecordKey::from(&address.to_record_key()).into_owned(),
+                        )),
                         payment_address,
                     }
                 } else {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -148,7 +148,7 @@ impl Node {
             let node = self.clone();
             let requester = NetworkAddress::from_peer(self.network.peer_id);
             let _handle: JoinHandle<Result<()>> = tokio::spawn(async move {
-                let pretty_key = PrettyPrintRecordKey::from(key.clone());
+                let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
                 trace!("Fetching record {pretty_key:?} from node {holder:?}");
                 let req = Request::Query(Query::GetReplicatedRecord {
                     requester,

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -184,7 +184,7 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
     while verification_attempts < VERIFICATION_ATTEMPTS {
         failed.clear();
         for (key, actual_holders_idx) in record_holders.iter() {
-            println!("Verifying {:?}", PrettyPrintRecordKey::from(key.clone()));
+            println!("Verifying {:?}", PrettyPrintRecordKey::from(key));
             let record_key = KBucketKey::from(key.to_vec());
             let expected_holders = sort_peers_by_key(all_peers, &record_key, CLOSE_GROUP_SIZE)?
                 .into_iter()
@@ -215,11 +215,11 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
 
                 error!(
                     "Record {:?} is not stored by {missing_peers:?}",
-                    PrettyPrintRecordKey::from(key.clone()),
+                    PrettyPrintRecordKey::from(key),
                 );
                 println!(
                     "Record {:?} is not stored by {missing_peers:?}",
-                    PrettyPrintRecordKey::from(key.clone()),
+                    PrettyPrintRecordKey::from(key),
                 );
             }
 
@@ -230,7 +230,7 @@ async fn verify_location(record_holders: &RecordHolders, all_peers: &[PeerId]) -
                 .for_each(|expected| failed_peers.push(*expected));
 
             if !failed_peers.is_empty() {
-                failed.insert(PrettyPrintRecordKey::from(key.clone()), failed_peers);
+                failed.insert(PrettyPrintRecordKey::from(key), failed_peers);
             }
         }
 
@@ -325,7 +325,7 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
             random_bytes.len()
         );
 
-        let key = PrettyPrintRecordKey::from(RecordKey::new(&file_addr));
+        let key = PrettyPrintRecordKey::from(&RecordKey::new(&file_addr)).into_owned();
         file_api
             .pay_and_upload_bytes_test(file_addr, chunks)
             .await?;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -23,11 +23,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     // ---------- record layer + payment errors
     #[error("Record was not stored as no payment supplied: {0:?}")]
-    InvalidPutWithoutPayment(PrettyPrintRecordKey),
+    InvalidPutWithoutPayment(PrettyPrintRecordKey<'static>),
 
     /// At this point in replication flows, payment is unimportant and should not be supplied
     #[error("Record should not be a `WithPayment` type: {0:?}")]
-    UnexpectedRecordWithPayment(PrettyPrintRecordKey),
+    UnexpectedRecordWithPayment(PrettyPrintRecordKey<'static>),
 
     // ---------- register errors
     #[error("Register was not stored: {0}")]
@@ -69,7 +69,7 @@ pub enum Error {
     #[error(
         "Payment proof received with record:{0:?}. No payment for our node in its transaction"
     )]
-    NoPaymentToOurNode(PrettyPrintRecordKey),
+    NoPaymentToOurNode(PrettyPrintRecordKey<'static>),
     /// Payments received could not be stored on node's local wallet
     #[error("Payments received could not be stored on node's local wallet: {0}")]
     FailedToStorePaymentIntoNodeWallet(String),
@@ -94,7 +94,7 @@ pub enum Error {
 
     // ---------- record errors
     #[error("Record was not stored: {0:?}: {1:?}")]
-    RecordNotStored(PrettyPrintRecordKey, String),
+    RecordNotStored(PrettyPrintRecordKey<'static>, String),
     // Could not Serialize/Deserialize RecordHeader from Record
     #[error("Could not Serialize/Deserialize RecordHeader to/from Record")]
     RecordHeaderParsingFailed,
@@ -109,5 +109,5 @@ pub enum Error {
     RecordKindMismatch(RecordKind),
     // The record already exists at this node
     #[error("The record already exists, so do not charge for it: {0:?}")]
-    RecordExists(PrettyPrintRecordKey),
+    RecordExists(PrettyPrintRecordKey<'static>),
 }

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -24,7 +24,10 @@ use libp2p::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    borrow::Cow,
+    fmt::{self, Debug, Display, Formatter},
+};
 use xor_name::XorName;
 
 /// This is the address in the network by which proximity/distance
@@ -187,7 +190,7 @@ impl Debug for NetworkAddress {
             ),
             NetworkAddress::RecordKey(bytes) => format!(
                 "NetworkAddress::RecordKey({:?} - ",
-                PrettyPrintRecordKey::from(RecordKey::new(bytes))
+                PrettyPrintRecordKey::from(&RecordKey::new(bytes))
             ),
         };
         write!(
@@ -240,27 +243,30 @@ impl std::fmt::Debug for PrettyPrintKBucketKey {
     }
 }
 
-/// Pretty print a `kad::RecordKey` as a hex string.
-/// So clients can use the hex string for xorname and record keys interchangeably.
-/// This makes errors actionable for clients.
-/// The only cost is converting kad::RecordKey into it before sending it in errors: `record_key.into()`
+/// Provides a hex representation of a `kad::RecordKey`.
+///
+/// This internally stores the RecordKey as a `Cow` type. Use `PrettyPrintRecordKey::from(&RecordKey)` to create a
+/// borrowed version for printing/logging.
+/// To use in error messages, to pass to other functions, call `PrettyPrintRecordKey::from(&RecordKey).into_owned()` to
+///  obtain a cloned, non-referenced `RecordKey`.
 #[derive(Clone, Hash, Eq, PartialEq)]
-pub struct PrettyPrintRecordKey(RecordKey);
+pub struct PrettyPrintRecordKey<'a> {
+    key: Cow<'a, RecordKey>,
+}
 
-// Implementing Serialize for PrettyPrintRecordKey
-impl Serialize for PrettyPrintRecordKey {
+impl<'a> Serialize for PrettyPrintRecordKey<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         // Use the `to_vec` function of the inner RecordKey to get the bytes
         // and then serialize those bytes
-        self.0.to_vec().serialize(serializer)
+        self.key.to_vec().serialize(serializer)
     }
 }
 
 // Implementing Deserialize for PrettyPrintRecordKey
-impl<'de> Deserialize<'de> for PrettyPrintRecordKey {
+impl<'de> Deserialize<'de> for PrettyPrintRecordKey<'static> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -268,30 +274,51 @@ impl<'de> Deserialize<'de> for PrettyPrintRecordKey {
         // Deserialize to bytes first
         let bytes = Vec::<u8>::deserialize(deserializer)?;
         // Then use the bytes to create a RecordKey and wrap it in PrettyPrintRecordKey
-        Ok(PrettyPrintRecordKey(RecordKey::new(&bytes)))
+        Ok(PrettyPrintRecordKey {
+            key: Cow::Owned(RecordKey::new(&bytes)),
+        })
     }
 }
-// seamless conversion from `kad::RecordKey` to `PrettyPrintRecordKey`
-impl From<RecordKey> for PrettyPrintRecordKey {
-    fn from(key: RecordKey) -> Self {
-        PrettyPrintRecordKey(key)
+/// This is the only interface to create a PrettyPrintRecordKey.
+/// `.into_owned()` must be called explicitly if you want a Owned version to be used for errors/args.
+impl<'a> From<&'a RecordKey> for PrettyPrintRecordKey<'a> {
+    fn from(key: &'a RecordKey) -> Self {
+        PrettyPrintRecordKey {
+            key: Cow::Borrowed(key),
+        }
     }
 }
 
-impl std::fmt::Display for PrettyPrintRecordKey {
+impl<'a> PrettyPrintRecordKey<'a> {
+    /// Creates a owned version that can be then used to pass as error values.
+    /// Do not call this if you just want to print/log `PrettyPrintRecordKey`
+    pub fn into_owned(self) -> PrettyPrintRecordKey<'static> {
+        let cloned_key = match self.key {
+            Cow::Borrowed(key) => Cow::Owned(key.clone()),
+            Cow::Owned(key) => Cow::Owned(key),
+        };
+
+        PrettyPrintRecordKey { key: cloned_key }
+    }
+}
+
+impl<'a> std::fmt::Display for PrettyPrintRecordKey<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let b: Vec<u8> = self.0.as_ref().to_vec();
+        let b: Vec<u8> = self.key.as_ref().to_vec();
         let record_key_b = Bytes::from(b);
+        // to get the inner RecordKey
+        let key = self.key.clone().into_owned();
+
         write!(
             f,
             "{:64x}({:?})",
             record_key_b,
-            PrettyPrintKBucketKey(NetworkAddress::from_record_key(self.0.clone()).as_kbucket_key())
+            PrettyPrintKBucketKey(NetworkAddress::from_record_key(key).as_kbucket_key())
         )
     }
 }
 
-impl std::fmt::Debug for PrettyPrintRecordKey {
+impl<'a> std::fmt::Debug for PrettyPrintRecordKey<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self)
     }

--- a/sn_protocol/src/storage/header.rs
+++ b/sn_protocol/src/storage/header.rs
@@ -106,7 +106,7 @@ pub fn try_deserialize_record<T: serde::de::DeserializeOwned>(record: &Record) -
     rmp_serde::from_slice(bytes).map_err(|err| {
         error!(
             "Failed to deserialized record {} with error: {err:?}",
-            PrettyPrintRecordKey::from(record.key.clone())
+            PrettyPrintRecordKey::from(&record.key)
         );
         Error::RecordParsingFailed
     })


### PR DESCRIPTION
- this allows us to hold a reference to `RecordKey` when we just want to log things.
- We're still cloning while printing `KbucketKey`, will be fixed with an update to the libp2p API.

## Description

reviewpad:summary 
- this allows us to hold a reference to RecordKey when we just want to
  log things.