### PR TITLE
feat(client): do not retry verification GETs

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -307,9 +307,12 @@ async fn upload_files(
 
     // If we are not verifying, we can skip this
     if verify_store {
+        println!("**************************************");
+        println!("*            Verification            *");
+        println!("**************************************");
+
         let mut data_to_verify_or_repay = chunks_to_upload;
         while !data_to_verify_or_repay.is_empty() {
-            tokio::time::sleep(Duration::from_secs(3)).await;
             trace!(
                 "Verifying and potentially topping up payment of {:?} chunks",
                 data_to_verify_or_repay.len()
@@ -406,9 +409,6 @@ async fn verify_and_repay_if_needed(
 ) -> Result<Vec<(XorName, PathBuf)>> {
     let total_chunks = chunks_paths.len();
 
-    println!("**************************************");
-    println!("*            Verification            *");
-    println!("**************************************");
     println!("{total_chunks} chunks to be checked and repaid if required");
 
     let progress_bar = get_progress_bar(total_chunks as u64)?;
@@ -468,11 +468,6 @@ async fn verify_and_repay_if_needed(
 
     // If there were any failed chunks, we need to repay them
     for failed_chunks_batch in failed_chunks.chunks(batch_size) {
-        println!(
-            "Failed to fetch {} chunks. Attempting to repay them.",
-            failed_chunks_batch.len()
-        );
-
         let mut wallet = file_api.wallet()?;
 
         // Now we pay again or top up, depending on the new current store cost is
@@ -516,7 +511,11 @@ async fn verify_and_repay_if_needed(
     }
 
     let elapsed = now.elapsed();
-    println!("Repaid and re-uploaded {num_of_failed_chunks:?} chunks in {elapsed:?}");
+    println!(
+        "Repaid and re-uploaded {:?} chunks in {elapsed:?}",
+        chunks_paths.len()
+    );
+    println!("{total_failed_chunks:?} were not yet verified...");
 
     Ok(total_failed_chunks)
 }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -420,7 +420,7 @@ impl Client {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, true, Default::default())
+            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
             .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {
@@ -437,7 +437,7 @@ impl Client {
         let key = NetworkAddress::from_register_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, true, Default::default())
+            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
             .await?;
 
         let header = RecordHeader::from_record(&record)?;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -253,7 +253,8 @@ impl Network {
                 payment_address,
             }) = response
             {
-                all_costs.push((payment_address, cost));
+                let cost_with_tolerance = NanoTokens::from((cost.as_nano() as f32 * 1.1) as u64);
+                all_costs.push((payment_address, cost_with_tolerance));
             } else {
                 error!("Non store cost response received,  was {:?}", response);
             }


### PR DESCRIPTION
Either first attempt works, or we move on

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Oct 23 19:16 UTC
This pull request updates the client implementation in the `api.rs` file. Specifically, it modifies the `get_record_from_network` function calls by changing the last parameter from `true` to `false`. This change ensures that verification GETs are not retried and instead either the first attempt works or the process moves on.
<!-- reviewpad:summarize:end --> 
