### PR TITLE
reverse chg to line 340

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -336,7 +336,7 @@ async fn upload_files(
         .append(true)
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
-        println!("Uploaded {} to {:x}", file_name, addr);
+        println!(" {}  {:x}", file_name, addr);
         info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -337,7 +337,7 @@ async fn upload_files(
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
         println!(" {}  {:x}", file_name, addr);
-        info!("Uploaded {} to {:x}", file_name, addr);
+        info!("{} {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }
     file.flush()?;

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -337,7 +337,7 @@ async fn upload_files(
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
         println!(" {}  {:x}", file_name, addr);
-        info!("{} {:x}", file_name, addr);
+        info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }
     file.flush()?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 00:48 UTC
This pull request includes three patches to the files.rs file. 

The first patch makes a naive attempt to address an issue mentioned in the provided link. It updates the upload_files function to print the uploaded file name and address using the println! macro.

The second patch tries to make further improvements by modifying the info! macro to include the "Uploaded" prefix before the file name.

The third patch reverses the changes made in the second patch and restores the original behavior of the info! macro.

Overall, these patches involve changes in the upload_files function for better logging and output.
<!-- reviewpad:summarize:end --> 
