### PR TITLE
Make files upload output cut n paste friendly

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -336,7 +336,7 @@ async fn upload_files(
         .append(true)
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
-        println!(" {}  {:x}", file_name, addr);
+        println!("{}  {:x}", file_name, addr);
         info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -336,7 +336,7 @@ async fn upload_files(
         .append(true)
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
-        println!("{}  {:x}", file_name, addr);
+        println!("\"{}\" {:x}", file_name, addr);
         info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -336,7 +336,7 @@ async fn upload_files(
         .append(true)
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
-        println!("Uploaded {} to {:x}", file_name, addr);
+        println!(" {}  {:x}", file_name, addr);
         info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -337,7 +337,7 @@ async fn upload_files(
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
         println!(" {}  {:x}", file_name, addr);
-        info!("Uploaded {} to {:x}", file_name, addr);
+        info!("{} {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }
     file.flush()?;

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -337,7 +337,7 @@ async fn upload_files(
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
         println!(" {}  {:x}", file_name, addr);
-        info!("{} {:x}", file_name, addr);
+        info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }
     file.flush()?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Nov 23 09:40 UTC
This pull request includes multiple patches to update the files.rs file in the sn_cli subcommands. The changes primarily involve updating the print statements and log messages related to file uploads. Some changes attempt to address specific issues mentioned in a forum thread. The patches also include whitespace cleanup and formatting changes, such as surrounding the file names with double quotes in print statements for better readability and user-friendliness.
<!-- reviewpad:summarize:end --> 


https://github.com/maidsafe/safe_network/issues/890

Make sharing upload results as easy as possible and encourage others to test downloads.

Change

**************************************
*          Uploaded Files            *
**************************************
Uploaded History of Stuff 1980-2023.pdf to 1d1e081fbf7b37f2156f3f428ead2ecb31f7b91b0a4239564eb426cffca65e0f
to


**************************************
*          Uploaded Files            *
**************************************
"History of Stuff 1980-2023.pdf" 1d1e081fbf7b37f2156f3f428ead2ecb31f7b91b0a4239564eb426cffca65e0f

This output then can be pasted directly into safe files download for immediate testing or can be quickly posted to an Uploads wiki page on the forum.