### PR TITLE
feat(node): provide arg to set the maximum number of log files to store 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,6 +4367,8 @@ dependencies = [
 name = "sn_logging"
 version = "0.2.12"
 dependencies = [
+ "chrono",
+ "dirs-next",
  "file-rotate",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -9,7 +9,7 @@
 use crate::subcommands::SubCmd;
 use clap::Parser;
 use color_eyre::{eyre::eyre, Result};
-use sn_logging::{parse_log_format, LogFormat, LogOutputDest};
+use sn_logging::{LogFormat, LogOutputDest};
 use sn_peers_acquisition::PeersArgs;
 use std::{path::PathBuf, time::Duration};
 
@@ -59,7 +59,7 @@ pub(crate) struct Opt {
     /// Valid values are "default" or "json".
     ///
     /// If the argument is not used, the default format will be applied.
-    #[clap(long, value_parser = parse_log_format, verbatim_doc_comment)]
+    #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
     pub log_format: Option<LogFormat>,
 
     #[command(flatten)]

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -27,7 +27,7 @@ use clap::Parser;
 use color_eyre::Result;
 use sn_client::Client;
 #[cfg(feature = "metrics")]
-use sn_logging::{init_logging, metrics::init_metrics, LogFormat};
+use sn_logging::{metrics::init_metrics, LogBuilder, LogFormat};
 use sn_peers_acquisition::parse_peers_args;
 use sn_transfers::bls_secret_from_hex;
 use std::path::PathBuf;
@@ -53,11 +53,10 @@ async fn main() -> Result<()> {
             ("sn_registers".to_string(), Level::TRACE),
             ("sn_transfers".to_string(), Level::TRACE),
         ];
-        init_logging(
-            logging_targets,
-            log_output_dest,
-            opt.log_format.unwrap_or(LogFormat::Default),
-        )?
+        let mut log_builder = LogBuilder::new(logging_targets);
+        log_builder.output_dest(log_output_dest);
+        log_builder.format(opt.log_format.unwrap_or(LogFormat::Default));
+        log_builder.initialize()?
     } else {
         None
     };

--- a/sn_logging/Cargo.toml
+++ b/sn_logging/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.2.12"
 
 [dependencies]
+chrono = "~0.4.19"
+dirs-next = "~2.0.0"
 file-rotate = "0.7.3"
 opentelemetry = { version = "0.20", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.13", optional = true }

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -1,0 +1,270 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{
+    appender,
+    error::{Error, Result},
+    LogFormat, LogOutputDest,
+};
+use std::collections::BTreeMap;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_core::{Event, Level, Subscriber};
+use tracing_subscriber::{
+    filter::Targets,
+    fmt as tracing_fmt,
+    fmt::{
+        format::Writer,
+        time::{FormatTime, SystemTime},
+        FmtContext, FormatEvent, FormatFields,
+    },
+    layer::Filter,
+    registry::LookupSpan,
+    Layer, Registry,
+};
+
+const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
+const MAX_UNCOMPRESSED_LOG_FILES: usize = 100;
+const MAX_LOG_FILES: usize = 1000;
+// Everything is logged by default
+const ALL_SN_LOGS: &str = "all";
+// Trace at nodes, clients, debug at networking layer
+const VERBOSE_SN_LOGS: &str = "v";
+
+#[derive(Default)]
+/// Tracing log formatter setup for easier span viewing
+struct LogFormatter;
+
+impl<S, N> FormatEvent<S, N> for LogFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        // Write level and target
+        let level = *event.metadata().level();
+        let module = event.metadata().module_path().unwrap_or("<unknown module>");
+        let time = SystemTime;
+
+        write!(writer, "[")?;
+        time.format_time(&mut writer)?;
+        write!(writer, " {level} {module}")?;
+        ctx.visit_spans(|span| write!(writer, "/{}", span.name()))?;
+        write!(writer, "] ")?;
+
+        // Add the log message and any fields associated with the event
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+
+        writeln!(writer)
+    }
+}
+
+/// The different Subscribers composed into a list of layers
+#[derive(Default)]
+pub(crate) struct TracingLayers {
+    pub(crate) layers: Vec<Box<dyn Layer<Registry> + Send + Sync>>,
+    pub(crate) guard: Option<WorkerGuard>,
+}
+
+impl TracingLayers {
+    pub(crate) fn fmt_layer(
+        &mut self,
+        default_logging_targets: Vec<(String, Level)>,
+        output_dest: LogOutputDest,
+        format: LogFormat,
+        max_uncompressed_log_files: Option<usize>,
+        max_compressed_log_files: Option<usize>,
+    ) -> Result<()> {
+        let layer = match output_dest {
+            LogOutputDest::Stdout => {
+                println!("Logging to stdout");
+                tracing_fmt::layer()
+                    .with_ansi(false)
+                    .with_target(false)
+                    .event_format(LogFormatter)
+                    .boxed()
+            }
+            LogOutputDest::Path(ref path) => {
+                std::fs::create_dir_all(path)?;
+                println!("Logging to directory: {path:?}");
+
+                // the number of normal files
+                let max_uncompressed_log_files =
+                    max_uncompressed_log_files.unwrap_or(MAX_UNCOMPRESSED_LOG_FILES);
+                // the total number of files; should be greater than uncompressed
+                let max_log_files = if let Some(max_compressed_log_files) = max_compressed_log_files
+                {
+                    max_compressed_log_files + max_uncompressed_log_files
+                } else {
+                    std::cmp::max(max_uncompressed_log_files, MAX_LOG_FILES)
+                };
+                let (file_rotation, worker_guard) = appender::file_rotater(
+                    path,
+                    MAX_LOG_SIZE,
+                    max_uncompressed_log_files,
+                    max_log_files,
+                );
+                self.guard = Some(worker_guard);
+
+                match format {
+                    LogFormat::Json => tracing_fmt::layer()
+                        .json()
+                        .flatten_event(true)
+                        .with_writer(file_rotation)
+                        .boxed(),
+                    LogFormat::Default => tracing_fmt::layer()
+                        .with_ansi(false)
+                        .with_writer(file_rotation)
+                        .event_format(LogFormatter)
+                        .boxed(),
+                }
+            }
+        };
+        let targets = match std::env::var("SN_LOG") {
+            Ok(sn_log_val) => {
+                println!("Using SN_LOG={sn_log_val}");
+                get_logging_targets(&sn_log_val)?
+            }
+            Err(_) => default_logging_targets,
+        };
+
+        let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
+            Box::new(Targets::new().with_targets(targets));
+        let layer = layer.with_filter(target_filters);
+        self.layers.push(Box::new(layer));
+        Ok(())
+    }
+
+    #[cfg(feature = "otlp")]
+    pub(crate) fn otlp_layer(
+        &mut self,
+        default_logging_targets: Vec<(String, Level)>,
+    ) -> Result<()> {
+        use opentelemetry::{
+            sdk::{trace, Resource},
+            KeyValue,
+        };
+        use opentelemetry_otlp::WithExportConfig;
+        use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
+        use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+        let service_name = std::env::var("OTLP_SERVICE_NAME").unwrap_or_else(|_| {
+            let random_node_name: String = thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .map(char::from)
+                .collect();
+            random_node_name
+        });
+        println!("The opentelemetry traces are logged under the name: {service_name}");
+
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_env())
+            .with_trace_config(trace::config().with_resource(Resource::new(vec![
+                KeyValue::new(SERVICE_NAME, service_name),
+                KeyValue::new(SERVICE_INSTANCE_ID, std::process::id().to_string()),
+            ])))
+            .install_batch(opentelemetry::runtime::Tokio)?;
+
+        let targets = match std::env::var("SN_LOG_OTLP") {
+            Ok(sn_log_val) => {
+                println!("Using SN_LOG_OTLP={sn_log_val}");
+                get_logging_targets(&sn_log_val)?
+            }
+            Err(_) => default_logging_targets,
+        };
+
+        let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
+            Box::new(Targets::new().with_targets(targets));
+        let otlp_layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(target_filters)
+            .boxed();
+        self.layers.push(otlp_layer);
+        Ok(())
+    }
+}
+
+/// Parses the logging targets from the env variable (SN_LOG). The crates should be given as a CSV, for e.g.,
+/// `export SN_LOG = libp2p=DEBUG, tokio=INFO, all, sn_client=ERROR`
+/// If any custom keyword is encountered in the CSV, for e.g., VERBOSE_SN_LOGS ('all'), then they might override some
+/// of the value that you might have provided, `sn_client=ERROR` in the above example will be ignored and
+/// instead will be set to `TRACE` since `all` keyword is provided.
+fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> {
+    let mut targets = BTreeMap::new();
+    let mut contains_keyword_all_sn_logs = false;
+    let mut contains_keyword_verbose_sn_logs = false;
+
+    for crate_log_level in logging_env_value.split(',') {
+        // TODO: are there other default short-circuits wanted?
+        // Could we have a default set if NOT on a release commit?
+        if crate_log_level == ALL_SN_LOGS {
+            contains_keyword_all_sn_logs = true;
+            continue;
+        } else if crate_log_level == VERBOSE_SN_LOGS {
+            contains_keyword_verbose_sn_logs = true;
+            continue;
+        }
+
+        let mut split = crate_log_level.split('=');
+        let crate_name = split.next().ok_or_else(|| {
+            Error::LoggingConfigurationError(
+                "Could not obtain crate name in logging string".to_string(),
+            )
+        })?;
+        let log_level = split.next().unwrap_or("trace");
+        targets.insert(crate_name.to_string(), get_log_level_from_str(log_level)?);
+    }
+
+    // dealing with keywords
+    let networking_log_level = if contains_keyword_all_sn_logs {
+        ("sn_networking".to_string(), Level::TRACE)
+    } else {
+        ("sn_networking".to_string(), Level::DEBUG)
+    };
+    if contains_keyword_all_sn_logs || contains_keyword_verbose_sn_logs {
+        // extend will overwrite values inside `targets`
+        targets.extend(vec![
+            networking_log_level,
+            ("safenode".to_string(), Level::TRACE),
+            ("safe".to_string(), Level::TRACE),
+            ("sn_build_info".to_string(), Level::TRACE),
+            ("sn_cli".to_string(), Level::TRACE),
+            ("sn_client".to_string(), Level::TRACE),
+            ("sn_logging".to_string(), Level::TRACE),
+            ("sn_node".to_string(), Level::TRACE),
+            ("sn_peers_acquisition".to_string(), Level::TRACE),
+            ("sn_protocol".to_string(), Level::TRACE),
+            ("sn_registers".to_string(), Level::INFO),
+            ("sn_testnet".to_string(), Level::TRACE),
+            ("sn_transfers".to_string(), Level::TRACE),
+        ]);
+    }
+    Ok(targets
+        .into_iter()
+        .map(|(crate_name, level)| (crate_name, level))
+        .collect())
+}
+
+fn get_log_level_from_str(log_level: &str) -> Result<Level> {
+    match log_level.to_lowercase().as_str() {
+        "info" => Ok(Level::INFO),
+        "debug" => Ok(Level::DEBUG),
+        "trace" => Ok(Level::TRACE),
+        "warn" => Ok(Level::WARN),
+        "error" => Ok(Level::WARN),
+        _ => Err(Error::LoggingConfigurationError(format!(
+            "Log level {log_level} is not supported"
+        ))),
+    }
+}

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -6,38 +6,33 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub mod appender;
-pub mod error;
+mod appender;
+mod error;
+mod layers;
 #[cfg(feature = "process-metrics")]
 pub mod metrics;
 
-use self::error::{Error, Result};
+use crate::error::{Error, Result};
+use layers::TracingLayers;
 use std::path::PathBuf;
-use std::{collections::BTreeMap, fmt};
+use tracing::info;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_core::{Event, Level, Subscriber};
-use tracing_subscriber::{
-    filter::Targets,
-    fmt as tracing_fmt,
-    fmt::{
-        format::Writer,
-        time::{FormatTime, SystemTime},
-        FmtContext, FormatEvent, FormatFields,
-    },
-    layer::Filter,
-    prelude::*,
-    registry::LookupSpan,
-    Layer, Registry,
-};
-
-const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
-const MAX_UNCOMPRESSED_LOG_FILES: usize = 100;
-const MAX_LOG_FILES: usize = 1000;
+use tracing_core::{dispatcher::DefaultGuard, Level};
+use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, Clone)]
 pub enum LogOutputDest {
     Stdout,
     Path(PathBuf),
+}
+
+impl std::fmt::Display for LogOutputDest {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LogOutputDest::Stdout => write!(f, "stdout"),
+            LogOutputDest::Path(p) => write!(f, "{}", p.to_string_lossy()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -46,301 +41,168 @@ pub enum LogFormat {
     Json,
 }
 
-pub fn parse_log_format(val: &str) -> Result<LogFormat> {
-    match val {
-        "default" => Ok(LogFormat::Default),
-        "json" => Ok(LogFormat::Json),
-        _ => Err(Error::LoggingConfigurationError(
-            "The only valid values for this argument are \"default\" or \"json\"".to_string(),
-        )),
-    }
-}
-
-impl fmt::Display for LogOutputDest {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            LogOutputDest::Stdout => write!(f, "stdout"),
-            LogOutputDest::Path(p) => write!(f, "{}", p.to_string_lossy()),
+impl LogFormat {
+    pub fn parse_from_str(val: &str) -> Result<Self> {
+        match val {
+            "default" => Ok(LogFormat::Default),
+            "json" => Ok(LogFormat::Json),
+            _ => Err(Error::LoggingConfigurationError(
+                "The only valid values for this argument are \"default\" or \"json\"".to_string(),
+            )),
         }
     }
 }
 
-// Everything is logged by default
-const ALL_SN_LOGS: &str = "all";
-// Trace at nodes, clients, debug at networking layer
-const VERBOSE_SN_LOGS: &str = "v";
-
-#[derive(Default)]
-/// Tracing log formatter setup for easier span viewing
-pub struct LogFormatter;
-
-impl<S, N> FormatEvent<S, N> for LogFormatter
-where
-    S: Subscriber + for<'a> LookupSpan<'a>,
-    N: for<'a> FormatFields<'a> + 'static,
-{
-    fn format_event(
-        &self,
-        ctx: &FmtContext<'_, S, N>,
-        mut writer: Writer,
-        event: &Event<'_>,
-    ) -> std::fmt::Result {
-        // Write level and target
-        let level = *event.metadata().level();
-        let module = event.metadata().module_path().unwrap_or("<unknown module>");
-        let time = SystemTime;
-
-        write!(writer, "[")?;
-        time.format_time(&mut writer)?;
-        write!(writer, " {level} {module}")?;
-        ctx.visit_spans(|span| write!(writer, "/{}", span.name()))?;
-        write!(writer, "] ")?;
-
-        // Add the log message and any fields associated with the event
-        ctx.field_format().format_fields(writer.by_ref(), event)?;
-
-        writeln!(writer)
-    }
-}
-
-/// The different Subscribers composed into a list of layers
-#[derive(Default)]
-pub struct TracingLayers {
-    pub layers: Vec<Box<dyn Layer<Registry> + Send + Sync>>,
-    pub guard: Option<WorkerGuard>,
-}
-
-impl TracingLayers {
-    fn fmt_layer(
-        &mut self,
-        default_logging_targets: Vec<(String, Level)>,
-        output_dest: LogOutputDest,
-        format: LogFormat,
-    ) -> Result<()> {
-        let layer = match output_dest {
-            LogOutputDest::Stdout => {
-                println!("Logging to stdout");
-                tracing_fmt::layer()
-                    .with_ansi(false)
-                    .with_target(false)
-                    .event_format(LogFormatter)
-                    .boxed()
-            }
-            LogOutputDest::Path(ref path) => {
-                std::fs::create_dir_all(path)?;
-                println!("Logging to directory: {path:?}");
-
-                let (file_rotation, worker_guard) = appender::file_rotater(
-                    path,
-                    MAX_LOG_SIZE,
-                    MAX_UNCOMPRESSED_LOG_FILES,
-                    MAX_LOG_FILES,
-                );
-                self.guard = Some(worker_guard);
-
-                match format {
-                    LogFormat::Json => tracing_fmt::layer()
-                        .json()
-                        .flatten_event(true)
-                        .with_writer(file_rotation)
-                        .boxed(),
-                    LogFormat::Default => tracing_fmt::layer()
-                        .with_ansi(false)
-                        .with_writer(file_rotation)
-                        .event_format(LogFormatter)
-                        .boxed(),
-                }
-            }
-        };
-        let targets = match std::env::var("SN_LOG") {
-            Ok(sn_log_val) => {
-                println!("Using SN_LOG={sn_log_val}");
-                get_logging_targets(&sn_log_val)?
-            }
-            Err(_) => default_logging_targets,
-        };
-
-        let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
-            Box::new(Targets::new().with_targets(targets));
-        let layer = layer.with_filter(target_filters);
-        self.layers.push(Box::new(layer));
-        Ok(())
-    }
-
-    #[cfg(feature = "otlp")]
-    fn otlp_layer(&mut self, default_logging_targets: Vec<(String, Level)>) -> Result<()> {
-        use opentelemetry::{
-            sdk::{trace, Resource},
-            KeyValue,
-        };
-        use opentelemetry_otlp::WithExportConfig;
-        use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
-        use rand::{distributions::Alphanumeric, thread_rng, Rng};
-
-        let service_name = std::env::var("OTLP_SERVICE_NAME").unwrap_or_else(|_| {
-            let random_node_name: String = thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(10)
-                .map(char::from)
-                .collect();
-            random_node_name
-        });
-        println!("The opentelemetry traces are logged under the name: {service_name}");
-
-        let tracer = opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_env())
-            .with_trace_config(trace::config().with_resource(Resource::new(vec![
-                KeyValue::new(SERVICE_NAME, service_name),
-                KeyValue::new(SERVICE_INSTANCE_ID, std::process::id().to_string()),
-            ])))
-            .install_batch(opentelemetry::runtime::Tokio)?;
-
-        let targets = match std::env::var("SN_LOG_OTLP") {
-            Ok(sn_log_val) => {
-                println!("Using SN_LOG_OTLP={sn_log_val}");
-                get_logging_targets(&sn_log_val)?
-            }
-            Err(_) => default_logging_targets,
-        };
-
-        let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
-            Box::new(Targets::new().with_targets(targets));
-        let otlp_layer = tracing_opentelemetry::layer()
-            .with_tracer(tracer)
-            .with_filter(target_filters)
-            .boxed();
-        self.layers.push(otlp_layer);
-        Ok(())
-    }
-}
-
-/// Inits node logging, returning the NonBlocking guard if present.
-/// This guard should be held for the life of the program.
-///
-/// Logging should be instantiated only once.
-pub fn init_logging(
+pub struct LogBuilder {
     default_logging_targets: Vec<(String, Level)>,
     output_dest: LogOutputDest,
     format: LogFormat,
-) -> Result<Option<WorkerGuard>> {
-    let mut layers = TracingLayers::default();
+    max_uncompressed_log_files: Option<usize>,
+    max_compressed_log_files: Option<usize>,
+}
 
-    #[cfg(not(feature = "otlp"))]
-    layers.fmt_layer(default_logging_targets, output_dest, format)?;
+impl LogBuilder {
+    /// Create a new builder
+    /// Provide the default_logging_targets that are used if the `SN_LOG` env variable is not set.
+    ///
+    /// By default, we use log to the StdOut with the defualt format.
+    pub fn new(default_logging_targets: Vec<(String, Level)>) -> Self {
+        Self {
+            default_logging_targets,
+            output_dest: LogOutputDest::Stdout,
+            format: LogFormat::Default,
+            max_uncompressed_log_files: None,
+            max_compressed_log_files: None,
+        }
+    }
 
-    #[cfg(feature = "otlp")]
-    {
-        layers.fmt_layer(default_logging_targets.clone(), output_dest, format)?;
+    /// Set the logging output destination
+    pub fn output_dest(&mut self, output_dest: LogOutputDest) {
+        self.output_dest = output_dest;
+    }
 
-        match std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
-            Ok(_) => layers.otlp_layer(default_logging_targets)?,
-            Err(_) => println!(
+    /// Set the logging format
+    pub fn format(&mut self, format: LogFormat) {
+        self.format = format
+    }
+
+    /// The max number of uncompressed log files to store
+    pub fn max_uncompressed_log_files(&mut self, files: usize) {
+        self.max_uncompressed_log_files = Some(files);
+    }
+
+    /// The max number of compressed files to store
+    pub fn max_compressed_log_files(&mut self, files: usize) {
+        self.max_compressed_log_files = Some(files);
+    }
+
+    /// Inits node logging, returning the NonBlocking guard if present.
+    /// This guard should be held for the life of the program.
+    ///
+    /// Logging should be instantiated only once.
+    pub fn initialize(self) -> Result<Option<WorkerGuard>> {
+        let mut layers = TracingLayers::default();
+
+        #[cfg(not(feature = "otlp"))]
+        layers.fmt_layer(
+            self.default_logging_targets,
+            self.output_dest,
+            self.format,
+            self.max_uncompressed_log_files,
+            self.max_compressed_log_files,
+        )?;
+
+        #[cfg(feature = "otlp")]
+        {
+            layers.fmt_layer(
+                self.default_logging_targets.clone(),
+                self.output_dest,
+                self.format,
+                self.max_uncompressed_log_files,
+                self.max_compressed_log_files,
+            )?;
+
+            match std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+                Ok(_) => layers.otlp_layer(self.default_logging_targets)?,
+                Err(_) => println!(
                 "The OTLP feature is enabled but the OTEL_EXPORTER_OTLP_ENDPOINT variable is not \
                 set, so traces will not be submitted."
             ),
+            }
         }
+
+        if tracing_subscriber::registry()
+            .with(layers.layers)
+            .try_init()
+            .is_err()
+        {
+            println!("Tried to initialize and set global default subscriber more than once");
+        }
+
+        Ok(layers.guard)
     }
 
-    if tracing_subscriber::registry()
+    /// Logs to the data_dir. Should be called from a single threaded tokio/non-tokio context.
+    /// Provide the test file name to capture tracings from the test.
+    ///
+    /// subscriber.set_default() should be used if under a single threaded tokio / single threaded non-tokio context.
+    /// Refer here for more details: <https://github.com/tokio-rs/tracing/discussions/1626>
+    pub fn init_single_threaded_tokio_test(
+        test_file_name: &str,
+    ) -> (Option<WorkerGuard>, DefaultGuard) {
+        let layers = Self::get_test_layers(test_file_name);
+        let log_guard = tracing_subscriber::registry()
+            .with(layers.layers)
+            .set_default();
+        // this is the test_name and not the test_file_name
+        if let Some(test_name) = std::thread::current().name() {
+            info!("Running test: {test_name}");
+        }
+        (layers.guard, log_guard)
+    }
+
+    /// Logs to the data_dir. Should be called from a multi threaded tokio context.
+    /// Provide the test file name to capture tracings from the test.
+    ///
+    /// subscriber.init() should be used under multi threaded tokio context. If you have 1+ multithreaded tokio tests under
+    /// the same integration test, this might result in loss of logs. Hence use .init() (instead of .try_init()) to panic
+    /// if called more than once.
+    pub fn init_multi_threaded_tokio_test(test_file_name: &str) -> Option<WorkerGuard> {
+        let layers = Self::get_test_layers(test_file_name);
+        tracing_subscriber::registry()
         .with(layers.layers)
         .try_init()
-        .is_err()
-    {
-        println!("Tried to initialize and set global default subscriber more than once");
+        .expect("You have tried to init multi_threaded tokio logging twice\nRefer sn_logging::get_test_layers docs for more.");
+
+        layers.guard
     }
 
-    Ok(layers.guard)
-}
+    /// Initialize just the fmt_layer for testing purposes.
+    ///
+    /// Also overwrites the SN_LOG variable to log everything including the test_file_name
+    fn get_test_layers(test_file_name: &str) -> TracingLayers {
+        // overwrite SN_LOG
+        std::env::set_var("SN_LOG", format!("{test_file_name}=TRACE,all"));
 
-/// Initialize fmt_layers for testing purposes.
-///
-/// subscriber.set_default() should be used if under a single threaded tokio / single threaded non-tokio context.
-/// Refer here for more details: <https://github.com/tokio-rs/tracing/discussions/1626>
-///
-/// subscriber.init() should be used under multi threaded tokio context. If you have 1+ multithreaded tokio tests under
-/// the same integration test, this might result in loss of logs. Hence use .init() (instead of .try_init()) to panic
-/// if called more than once.
-pub fn get_test_layers(
-    default_logging_targets: Vec<(String, Level)>,
-    output_dest: LogOutputDest,
-    format: LogFormat,
-) -> Result<TracingLayers> {
-    let mut layers = TracingLayers::default();
-    layers.fmt_layer(default_logging_targets, output_dest, format)?;
-    Ok(layers)
-}
+        let output_dest = match dirs_next::data_dir() {
+            Some(dir) => {
+                // Get the current timestamp and format it to be human readable
+                let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+                let path = dir
+                    .join("safe")
+                    .join("client")
+                    .join("logs")
+                    .join(format!("log_{}", timestamp));
+                LogOutputDest::Path(path)
+            }
+            None => LogOutputDest::Stdout,
+        };
 
-/// Parses the logging targets from the env variable (SN_LOG). The crates should be given as a CSV, for e.g.,
-/// `export SN_LOG = libp2p=DEBUG, tokio=INFO, all, sn_client=ERROR`
-/// If any custom keyword is encountered in the CSV, for e.g., VERBOSE_SN_LOGS ('all'), then they might override some
-/// of the value that you might have provided, `sn_client=ERROR` in the above example will be ignored and
-/// instead will be set to `TRACE` since `all` keyword is provided.
-fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> {
-    let mut targets = BTreeMap::new();
-    let mut contains_keyword_all_sn_logs = false;
-    let mut contains_keyword_verbose_sn_logs = false;
+        let mut layers = TracingLayers::default();
 
-    for crate_log_level in logging_env_value.split(',') {
-        // TODO: are there other default short-circuits wanted?
-        // Could we have a default set if NOT on a release commit?
-        if crate_log_level == ALL_SN_LOGS {
-            contains_keyword_all_sn_logs = true;
-            continue;
-        } else if crate_log_level == VERBOSE_SN_LOGS {
-            contains_keyword_verbose_sn_logs = true;
-            continue;
-        }
-
-        let mut split = crate_log_level.split('=');
-        let crate_name = split.next().ok_or_else(|| {
-            Error::LoggingConfigurationError(
-                "Could not obtain crate name in logging string".to_string(),
-            )
-        })?;
-        let log_level = split.next().unwrap_or("trace");
-        targets.insert(crate_name.to_string(), get_log_level_from_str(log_level)?);
-    }
-
-    // dealing with keywords
-    let networking_log_level = if contains_keyword_all_sn_logs {
-        ("sn_networking".to_string(), Level::TRACE)
-    } else {
-        ("sn_networking".to_string(), Level::DEBUG)
-    };
-    if contains_keyword_all_sn_logs || contains_keyword_verbose_sn_logs {
-        // extend will overwrite values inside `targets`
-        targets.extend(vec![
-            networking_log_level,
-            ("safenode".to_string(), Level::TRACE),
-            ("safe".to_string(), Level::TRACE),
-            ("sn_build_info".to_string(), Level::TRACE),
-            ("sn_cli".to_string(), Level::TRACE),
-            ("sn_client".to_string(), Level::TRACE),
-            ("sn_logging".to_string(), Level::TRACE),
-            ("sn_node".to_string(), Level::TRACE),
-            ("sn_peers_acquisition".to_string(), Level::TRACE),
-            ("sn_protocol".to_string(), Level::TRACE),
-            ("sn_registers".to_string(), Level::INFO),
-            ("sn_testnet".to_string(), Level::TRACE),
-            ("sn_transfers".to_string(), Level::TRACE),
-        ]);
-    }
-    Ok(targets
-        .into_iter()
-        .map(|(crate_name, level)| (crate_name, level))
-        .collect())
-}
-
-fn get_log_level_from_str(log_level: &str) -> Result<Level> {
-    match log_level.to_lowercase().as_str() {
-        "info" => Ok(Level::INFO),
-        "debug" => Ok(Level::DEBUG),
-        "trace" => Ok(Level::TRACE),
-        "warn" => Ok(Level::WARN),
-        "error" => Ok(Level::WARN),
-        _ => Err(Error::LoggingConfigurationError(format!(
-            "Log level {log_level} is not supported"
-        ))),
+        layers
+            .fmt_layer(vec![], output_dest, LogFormat::Default, None, None)
+            .expect("Failed to get TracingLayers");
+        layers
     }
 }

--- a/sn_node/examples/safenode_rpc_client.rs
+++ b/sn_node/examples/safenode_rpc_client.rs
@@ -15,7 +15,7 @@ use safenode_proto::{
     NetworkInfoRequest, NodeEventsRequest, NodeInfoRequest, RecordAddressesRequest, RestartRequest,
     StopRequest, UpdateRequest,
 };
-use sn_logging::{init_logging, LogFormat, LogOutputDest};
+use sn_logging::LogBuilder;
 use sn_node::NodeEvent;
 use std::str::FromStr;
 use std::{net::SocketAddr, time::Duration};
@@ -106,8 +106,7 @@ async fn main() -> Result<()> {
         ("sn_networking".to_string(), Level::INFO),
         ("sn_node".to_string(), Level::INFO),
     ];
-    let _log_appender_guard =
-        init_logging(logging_targets, LogOutputDest::Stdout, LogFormat::Default)?;
+    let _log_appender_guard = LogBuilder::new(logging_targets).initialize()?;
 
     let opt = Opt::parse();
     let addr = opt.addr;

--- a/sn_node/src/bin/faucet/main.rs
+++ b/sn_node/src/bin/faucet/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, Subcommand};
 use eyre::{bail, eyre, Result};
 use faucet_server::run_faucet_server;
 use sn_client::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet, Client};
-use sn_logging::{init_logging, LogFormat, LogOutputDest};
+use sn_logging::{LogBuilder, LogOutputDest};
 use sn_peers_acquisition::{parse_peers_args, PeersArgs};
 use sn_transfers::{parse_main_pubkey, NanoTokens, Transfer};
 use std::path::PathBuf;
@@ -45,7 +45,9 @@ async fn main() -> Result<()> {
             ("sn_testnet".to_string(), Level::TRACE),
             ("sn_transfers".to_string(), Level::TRACE),
         ];
-        init_logging(logging_targets, log_output_dest, LogFormat::Default)?
+        let mut log_builder = LogBuilder::new(logging_targets);
+        log_builder.output_dest(log_output_dest);
+        log_builder.initialize()?
     } else {
         None
     };

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -89,6 +89,23 @@ struct Opt {
     #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
     log_format: Option<LogFormat>,
 
+    /// Specify the maximum number of uncompressed log files to store.
+    ///
+    /// This argument is ignored if `log_output_dest` is set to "stdout"
+    ///
+    /// After reaching this limit, the older files are archived to save space.
+    /// You can also specify the maximum number of archived log files to keep.
+    #[clap(long = "max_log_files", verbatim_doc_comment)]
+    max_uncompressed_log_files: Option<usize>,
+
+    /// Specify the maximum number of archived log files to store.
+    ///
+    /// This argument is ignored if `log_output_dest` is set to "stdout"
+    ///
+    /// After reaching this limit, the older archived files are deleted.
+    #[clap(long = "max_archived_log_files", verbatim_doc_comment)]
+    max_compressed_log_files: Option<usize>,
+
     /// Specify the node's data directory.
     ///
     /// If not provided, the default location is platform specific:
@@ -151,13 +168,9 @@ fn main() -> Result<()> {
     let opt = Opt::parse();
 
     let node_socket_addr = SocketAddr::new(opt.ip, opt.port);
-    let (root_dir, keypair) = get_root_dir_and_keypair(opt.root_dir)?;
+    let (root_dir, keypair) = get_root_dir_and_keypair(&opt.root_dir)?;
 
-    let (log_output_dest, _log_appender_guard) = init_logging(
-        opt.log_output_dest,
-        keypair.public().to_peer_id(),
-        opt.log_format,
-    )?;
+    let (log_output_dest, _log_appender_guard) = init_logging(&opt, keypair.public().to_peer_id())?;
 
     let rt = Runtime::new()?;
     // bootstrap peers can be empty for the genesis node.
@@ -329,11 +342,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
     });
 }
 
-fn init_logging(
-    log_output_dest: LogOutputDestArg,
-    peer_id: PeerId,
-    format: Option<LogFormat>,
-) -> Result<(String, Option<WorkerGuard>)> {
+fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, Option<WorkerGuard>)> {
     let logging_targets = vec![
         // TODO: Reset to nice and clean defaults once we have a better idea of what we want
         ("sn_networking".to_string(), Level::DEBUG),
@@ -348,20 +357,27 @@ fn init_logging(
         ("sn_transfers".to_string(), Level::TRACE),
     ];
 
-    let output_dest = match log_output_dest {
+    let output_dest = match &opt.log_output_dest {
         LogOutputDestArg::Stdout => LogOutputDest::Stdout,
         LogOutputDestArg::DataDir => {
             let path = get_root_dir(peer_id)?.join("logs");
             LogOutputDest::Path(path)
         }
-        LogOutputDestArg::Path(path) => LogOutputDest::Path(path),
+        LogOutputDestArg::Path(path) => LogOutputDest::Path(path.clone()),
     };
 
     #[cfg(not(feature = "otlp"))]
     let log_appender_guard = {
         let mut log_builder = sn_logging::LogBuilder::new(logging_targets);
         log_builder.output_dest(output_dest.clone());
-        log_builder.format(format.unwrap_or(LogFormat::Default));
+        log_builder.format(opt.log_format.clone().unwrap_or(LogFormat::Default));
+        if let Some(files) = opt.max_uncompressed_log_files {
+            log_builder.max_uncompressed_log_files(files);
+        }
+        if let Some(files) = opt.max_compressed_log_files {
+            log_builder.max_compressed_log_files(files);
+        }
+
         log_builder.initialize()?
     };
 
@@ -372,7 +388,13 @@ fn init_logging(
         let guard = rt.block_on(async {
             let mut log_builder = sn_logging::LogBuilder::new(logging_targets);
             log_builder.output_dest(output_dest.clone());
-            log_builder.format(format.unwrap_or(LogFormat::Default));
+            log_builder.format(opt.log_format.clone().unwrap_or(LogFormat::Default));
+            if let Some(files) = opt.max_uncompressed_log_files {
+                log_builder.max_uncompressed_log_files(files);
+            }
+            if let Some(files) = opt.max_compressed_log_files {
+                log_builder.max_compressed_log_files(files);
+            }
             log_builder.initialize()
         })?;
         (rt, guard)
@@ -437,13 +459,13 @@ fn get_root_dir(peer_id: PeerId) -> Result<PathBuf> {
 
 /// The keypair is located inside the root directory. At the same time, when no dir is specified,
 /// the dir name is derived from the keypair used in the application: the peer ID is used as the directory name.
-fn get_root_dir_and_keypair(root_dir: Option<PathBuf>) -> Result<(PathBuf, Keypair)> {
+fn get_root_dir_and_keypair(root_dir: &Option<PathBuf>) -> Result<(PathBuf, Keypair)> {
     match root_dir {
         Some(dir) => {
-            std::fs::create_dir_all(&dir)?;
+            std::fs::create_dir_all(dir)?;
 
             let secret_key_path = dir.join("secret-key");
-            Ok((dir, keypair_from_path(secret_key_path)?))
+            Ok((dir.clone(), keypair_from_path(secret_key_path)?))
         }
         None => {
             let secret_key = libp2p::identity::ed25519::SecretKey::generate();

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -8,7 +8,6 @@
 
 mod common;
 
-use crate::common::init_logging_multi_threaded_tokio;
 use assert_fs::TempDir;
 use common::{
     get_client_and_wallet, get_funded_wallet, get_wallet, node_restart,
@@ -17,6 +16,7 @@ use common::{
 use eyre::{bail, Result};
 use rand::{rngs::OsRng, Rng};
 use sn_client::{Client, Error, Files, WalletClient};
+use sn_logging::LogBuilder;
 use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress, SpendAddress},
     NetworkAddress,
@@ -80,7 +80,7 @@ type ContentErredList = Arc<RwLock<BTreeMap<NetworkAddress, ContentError>>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn data_availability_during_churn() -> Result<()> {
-    let _log_appender_guard = init_logging_multi_threaded_tokio("data_with_churn");
+    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("data_with_churn");
 
     let test_duration = if let Ok(str) = std::env::var("TEST_DURATION_MINS") {
         Duration::from_secs(60 * str.parse::<u64>()?)

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -8,14 +8,12 @@
 
 mod common;
 
-use crate::common::{
-    init_logging_single_threaded_tokio,
-    safenode_proto::{
-        safe_node_client::SafeNodeClient, GossipsubPublishRequest, GossipsubSubscribeRequest,
-        GossipsubUnsubscribeRequest, NodeEventsRequest,
-    },
+use crate::common::safenode_proto::{
+    safe_node_client::SafeNodeClient, GossipsubPublishRequest, GossipsubSubscribeRequest,
+    GossipsubUnsubscribeRequest, NodeEventsRequest,
 };
 use eyre::Result;
+use sn_logging::LogBuilder;
 use sn_node::NodeEvent;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -31,7 +29,7 @@ const TEST_CYCLES: u8 = 20;
 
 #[tokio::test]
 async fn msgs_over_gossipsub() -> Result<()> {
-    let _guard = init_logging_single_threaded_tokio("msgs_over_gossipsub");
+    let _guard = LogBuilder::init_single_threaded_tokio_test("msgs_over_gossipsub");
     let all_nodes_addrs: Vec<_> = (0..NODE_COUNT)
         .map(|i| {
             (

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -9,12 +9,13 @@
 mod common;
 
 use crate::common::{
-    get_client_and_wallet, init_logging_single_threaded_tokio, random_content,
+    get_client_and_wallet, random_content,
     safenode_proto::{safe_node_client::SafeNodeClient, NodeEventsRequest},
 };
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use sn_client::WalletClient;
+use sn_logging::LogBuilder;
 use sn_networking::CLOSE_GROUP_SIZE;
 use sn_node::NodeEvent;
 use sn_transfers::{LocalWallet, NanoTokens};
@@ -28,7 +29,7 @@ use xor_name::XorName;
 
 #[tokio::test]
 async fn nodes_rewards_for_storing_chunks() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("nodes_rewards");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("nodes_rewards");
 
     let paying_wallet_balance = 10_000_000_000_333;
     let paying_wallet_dir = TempDir::new()?;
@@ -62,7 +63,7 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
 
 #[tokio::test]
 async fn nodes_rewards_for_storing_registers() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("nodes_rewards");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("nodes_rewards");
 
     let paying_wallet_balance = 10_000_000_000_444;
     let paying_wallet_dir = TempDir::new()?;
@@ -94,7 +95,7 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
 
 #[tokio::test]
 async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("nodes_rewards");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("nodes_rewards");
 
     let paying_wallet_balance = 10_000_000_111_000;
     let paying_wallet_dir = TempDir::new()?;
@@ -128,7 +129,7 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
 
 #[tokio::test]
 async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("nodes_rewards");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("nodes_rewards");
 
     let paying_wallet_balance = 10_000_000_222_000;
     let paying_wallet_dir = TempDir::new()?;

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -9,14 +9,15 @@
 mod common;
 
 use assert_fs::TempDir;
-use common::{get_client_and_wallet, get_wallet, init_logging_single_threaded_tokio};
+use common::{get_client_and_wallet, get_wallet};
 use eyre::Result;
 use sn_client::send;
+use sn_logging::LogBuilder;
 use sn_transfers::{create_offline_transfer, rng, Hash, NanoTokens, UniquePubkey};
 
 #[tokio::test]
 async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("sequential_transfer");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("sequential_transfer");
 
     let first_wallet_balance = 1_000_000_000;
     let first_wallet_dir = TempDir::new()?;
@@ -53,7 +54,7 @@ async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
 
 #[tokio::test]
 async fn cash_note_transfer_double_spend_fail() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("sequential_transfer");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("sequential_transfer");
 
     // create 1 wallet add money from faucet
     let first_wallet_balance = 1_000_000_000;

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -8,11 +8,12 @@
 
 mod common;
 
-use crate::common::{get_client_and_wallet, init_logging_single_threaded_tokio, random_content};
+use crate::common::{get_client_and_wallet, random_content};
 use assert_fs::TempDir;
 use eyre::Result;
 use rand::Rng;
 use sn_client::{Error as ClientError, WalletClient};
+use sn_logging::LogBuilder;
 use sn_networking::Error as NetworkError;
 use sn_protocol::{
     error::Error as ProtocolError,
@@ -26,7 +27,7 @@ use xor_name::XorName;
 
 #[tokio::test]
 async fn storage_payment_succeeds() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let paying_wallet_balance = 50_000_000_000_000_001;
     let paying_wallet_dir = TempDir::new()?;
@@ -66,7 +67,7 @@ async fn storage_payment_succeeds() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let wallet_original_balance = 100_000_000_000;
     let paying_wallet_dir: TempDir = TempDir::new()?;
@@ -109,7 +110,7 @@ async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
 #[ignore = "Currently we do not cache the proofs in the wallet"]
 #[tokio::test]
 async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let wallet_original_balance = 100_000_000_000_000_000;
     let paying_wallet_dir: TempDir = TempDir::new()?;
@@ -171,7 +172,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let paying_wallet_balance = 50_000_000_000_002;
     let paying_wallet_dir = TempDir::new()?;
@@ -208,7 +209,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let paying_wallet_balance = 50_000_000_000_003;
     let paying_wallet_dir = TempDir::new()?;
@@ -267,7 +268,7 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_register_creation_succeeds() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let paying_wallet_balance = 65_000_000_000;
     let paying_wallet_dir = TempDir::new()?;
@@ -309,7 +310,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
 #[tokio::test]
 #[ignore = "Test currently invalid as we always try to pay and upload registers if none found... need to check if this test is valid"]
 async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
-    let _log_guards = init_logging_single_threaded_tokio("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
 
     let paying_wallet_balance = 55_000_000_005;
     let paying_wallet_dir = TempDir::new()?;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use crate::common::{
-    get_client_and_wallet, init_logging_multi_threaded_tokio, node_restart,
+    get_client_and_wallet, node_restart,
     safenode_proto::{safe_node_client::SafeNodeClient, NodeInfoRequest, RecordAddressesRequest},
     PAYING_WALLET_INITIAL_BALANCE,
 };
@@ -22,6 +22,7 @@ use libp2p::{
 };
 use rand::{rngs::OsRng, Rng};
 use sn_client::{Client, Files};
+use sn_logging::LogBuilder;
 use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{NetworkAddress, PrettyPrintRecordKey};
 use std::{
@@ -62,7 +63,7 @@ type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
-    let _log_appender_guard = init_logging_multi_threaded_tokio("verify_data_location");
+    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("verify_data_location");
 
     let churn_count = if let Ok(str) = std::env::var("CHURN_COUNT") {
         str.parse::<u8>()?


### PR DESCRIPTION
- Also refactors `init_logging` into `LogBuilder::initialize()`
- Also move the test logging setup into `LogBuilder`
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 06:12 UTC
This pull request includes changes in multiple files. Here is a summary of the changes made:

1. The file `nodes_rewards.rs`:
- Removed the import of `init_logging_single_threaded_tokio` from the `common` module.
- Updated the use of `LogBuilder` from the `sn_logging` module.
- Updated the values of `paying_wallet_balance` in multiple test functions.

2. The file `verify_data_location.rs`:
- Modified the import statement by removing `init_logging_multi_threaded_tokio` from the `common` module.
- Added `use sn_logging::LogBuilder`.
- Modified the test function `verify_data_location` by replacing `init_logging_multi_threaded_tokio` with `LogBuilder::init_multi_threaded_tokio_test`.

3. The file `main.rs` in the `faucet` directory:
- Removed the import statement for `LogFormat`.
- Added the import statement for `LogBuilder`.
- Removed the import statement for `LogOutputDest`.
- Modified the initialization of logging using the new `LogBuilder` API.

4. The file `safenode/src/main.rs`:
- Removing the import and use of the `parse_log_format` and `LogOutputDest` functions from `sn_logging`.
- Modifying the `Opt` struct to include new fields `max_uncompressed_log_files` and `max_compressed_log_files`.
- Modifying the `init_logging` function to use the `LogFormat` enum's `parse_from_str` function for argument parsing and to handle the new fields of `Opt`.
- Modifying the `get_root_dir_and_keypair` function to use a reference to `root_dir` instead of a `PathBuf` value.

5. The file `storage_payments.rs`:
- Removed the import statement for `init_logging_single_threaded_tokio` from the `common` module.
- Added an import statement for `sn_logging::LogBuilder`.
- Modified multiple test functions to use the `LogBuilder` to initialize logging.

6. The file `cli.rs`:
- Removed the import statement for `parse_log_format` and `LogOutputDest` from the `sn_logging` module.
- Modified the `value_parser` for the `log_format` field to use the `LogFormat::parse_from_str` function.

7. The file `sequential_transfers.rs`:
- Updated import statements, specifically the removal of the `init_logging_single_threaded_tokio` import.
- Updated usage of the `LogBuilder` struct for initializing logging in the test functions.

8. The file `layers.rs`:
- Added a new file called `layers.rs` in the `sn_logging` directory, which contains logging layers implementation for the SAFE Network Software.

9. The file `sn_node/tests/common/mod.rs`:
- Removed the import statement for the `sn_logging` module.
- Removed log-related functions and lazy_static declaration.

10. The file `msgs_over_gossipsub.rs`:
- Refactored imports and replaced `init_logging_single_threaded_tokio` with `LogBuilder::init_single_threaded_tokio_test` for logging initialization in tests.

11. The file `Cargo.lock`:
- Added two dependencies: "chrono" and "dirs-next".

12. The `Cargo.toml` file:
- Added a new dependency `chrono` and `dirs-next`.
- Updated existing dependencies.

13. The file `safenode_rpc_client.rs`:
- Replaced `use sn_logging::{init_logging, LogFormat, LogOutputDest};` with `use sn_logging::LogBuilder`.
- Updated logging configuration in the `main` function.

14. The file `data_with_churn.rs`:
- Removed the usage of `crate::common::init_logging_multi_threaded_tokio` function and used `sn_logging::LogBuilder::init_multi_threaded_tokio_test` instead.
- Modified imports and type definitions.

Please review the specific changes in the diffs provided for more details. Let me know if you need any further assistance.
<!-- reviewpad:summarize:end --> 
