### PR TITLE
fix(node): dont try and replicate to non existent peers

### DIFF
--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -223,6 +223,12 @@ impl Node {
                                 }
                             };
 
+                            // early return to avoid panic on gen_range
+                            if closest_peers.is_empty() {
+                                info!("No peers to replicate to");
+                                return;
+                            }
+
                             let peer_id =
                                 closest_peers[rand::thread_rng().gen_range(0..closest_peers.len())];
                             Marker::ForcedReplication(peer_id).log();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 08:34 UTC
This pull request fixes a bug in the `node.rs` file of the `sn_node` project. The fix ensures that the code does not attempt to replicate to non-existent peers. It adds a check to prevent a panic and logs a message if there are no peers available for replication.
<!-- reviewpad:summarize:end --> 
