### PR TITLE
fix: return with majority

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -71,7 +71,13 @@ impl Files {
         downloaded_file_path: Option<PathBuf>,
         show_holders: bool,
     ) -> Result<Option<Bytes>> {
-        let chunk = self.client.get_chunk(address, show_holders).await?;
+        let chunk = match self.client.get_chunk(address, show_holders).await {
+            Ok(chunk) => chunk,
+            Err(err) => {
+                error!("Failed to fetch head chunk {address:?}");
+                return Err(err);
+            }
+        };
 
         // first try to deserialize a LargeFile, if it works, we go and seek it
         if let Ok(data_map) = self.unpack_chunk(chunk.clone()).await {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -34,7 +34,7 @@ use libp2p_metrics::Recorder;
 
 use sn_protocol::{
     messages::{Request, Response},
-    storage::{try_deserialize_record, Chunk, RecordHeader},
+    storage::RecordHeader,
     NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
@@ -1006,24 +1006,18 @@ impl SwarmDriver {
                 GetQuorum::One => 1,
             };
 
-            trace!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {} so far", peer_list.len());
-            let result = if peer_list.len() >= expected_answers {
-                Some(Ok(peer_record.record.clone()))
-            } else if usize::from(count) >= CLOSE_GROUP_SIZE {
-                Some(Err(Error::RecordNotFound))
-            } else {
-                None
-            };
+            let responded_peers = peer_list.len();
+            trace!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
 
-            let _ = result_map.insert(record_content_hash, (peer_record.record, peer_list));
+            let _ = result_map.insert(record_content_hash, (peer_record.record.clone(), peer_list));
 
-            if let Some(result) = result {
+            if responded_peers >= expected_answers {
                 if !expected_holders.is_empty() {
                     debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with non-responded expected holders {expected_holders:?}");
                 }
 
                 if result_map.len() == 1 {
-                    let _ = sender.send(result);
+                    let _ = sender.send(Ok(peer_record.record));
                 } else {
                     debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with split record");
                     let _ = sender.send(Err(Error::SplitRecord { result_map }));
@@ -1034,6 +1028,11 @@ impl SwarmDriver {
                     query.finish();
                 }
             } else {
+                if usize::from(count) >= CLOSE_GROUP_SIZE {
+                    debug!("For record {pretty_key:?} task {query_id:?}, got {count:?} with {} versions so far.",
+                        result_map.len());
+                }
+
                 let _ = self
                     .pending_get_record
                     .insert(query_id, (sender, result_map, quorum, expected_holders));
@@ -1061,24 +1060,15 @@ impl SwarmDriver {
                // Ensure that we only exit early if quorum is indeed for only one match
                matches!(quorum, GetQuorum::One)
             {
-                if let Ok(chunk) = try_deserialize_record::<Chunk>(&peer_record.record) {
-                    if chunk.network_address().to_record_key() == peer_record.record.key {
-                        debug!(
-                            "Early completion with the first copy of chunk {:?}",
-                            chunk.name()
-                        );
-                        let _ = sender.send(Ok(peer_record.record.clone()));
-
-                        // Stop the query; possibly stops more nodes from being queried.
-                        if let Some(mut query) =
-                            self.swarm.behaviour_mut().kademlia.query_mut(query_id)
-                        {
-                            query.finish();
-                        }
-
-                        return true;
-                    }
+                // Stop the query; possibly stops more nodes from being queried.
+                if let Some(mut query) = self.swarm.behaviour_mut().kademlia.query_mut(query_id) {
+                    query.finish();
                 }
+                // A claimed Chunk type record can be trusted.
+                // Punishment of peer that sending corrupted Chunk type record
+                // maybe carried out by other verification mechanism.
+                let _ = sender.send(Ok(peer_record.record.clone()));
+                return true;
             }
 
             let _ = self

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -318,10 +318,10 @@ impl Network {
                 expected_holders: expected_holders.clone(),
             })?;
 
-            match receiver
-                .await
-                .map_err(|_e| Error::InternalMsgChannelDropped)?
-            {
+            match receiver.await.map_err(|e| {
+                error!("When fetching record {pretty_key:?} , encountered a channel error {e:?}.");
+                Error::InternalMsgChannelDropped
+            })? {
                 Ok(returned_record) => {
                     let header = RecordHeader::from_record(&returned_record)?;
                     let is_chunk = matches!(header.kind, RecordKind::Chunk);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 15:15 UTC
This pull request fixes the issue of returning with the majority in the code. The changes include modifications in the `api.rs`, `error.rs`, and `event.rs` files. The patch ensures that when encountering a split record, the code returns with the majority copy instead of logging the whole `Record` content.
<!-- reviewpad:summarize:end --> 
