### PR TITLE
feat(cli): chunk files in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,7 @@ dependencies = [
  "hex",
  "indicatif",
  "libp2p",
+ "rayon",
  "reqwest",
  "sn_build_info",
  "sn_client",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -37,6 +37,7 @@ dirs-next = "~2.0.0"
 hex = "~0.4.3"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = { version="0.52", features = ["identify", "kad"] }
+rayon = "1.8.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.95.4" }

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -25,7 +25,6 @@ use std::{
     io::prelude::*,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    sync::Arc,
     time::{Duration, Instant},
 };
 use tempfile::tempdir;
@@ -363,7 +362,7 @@ fn upload_chunks_in_parallel(
     file_api: Files,
     chunks_paths: Vec<(XorName, PathBuf)>,
     verify_store: bool,
-    progress_bar: Arc<ProgressBar>,
+    progress_bar: ProgressBar,
     show_holders: bool,
 ) -> Vec<JoinHandle<Result<()>>> {
     let mut upload_handles = Vec::new();
@@ -392,7 +391,7 @@ async fn upload_chunk(
     file_api: Files,
     chunk: (XorName, PathBuf),
     verify_store: bool,
-    progress_bar: Arc<ProgressBar>,
+    progress_bar: ProgressBar,
     show_holders: bool,
 ) -> Result<()> {
     let (_, path) = chunk;
@@ -607,9 +606,8 @@ async fn download_file(
     }
 }
 
-fn get_progress_bar(length: u64) -> Result<Arc<ProgressBar>> {
+fn get_progress_bar(length: u64) -> Result<ProgressBar> {
     let progress_bar = ProgressBar::new(length);
-    let progress_bar = Arc::new(progress_bar);
     progress_bar.set_style(
         ProgressStyle::default_bar()
             .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len}")?

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -15,6 +15,7 @@ use color_eyre::{
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use libp2p::futures::future::join_all;
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use sn_client::{Client, Files};
 use sn_protocol::storage::{Chunk, ChunkAddress};
 use sn_transfers::NanoTokens;
@@ -137,6 +138,8 @@ pub(crate) async fn files_cmds(
     Ok(())
 }
 
+/// Chunk all the files in the provided `files_path`
+/// `chunks_dir` is used to store the results of the self-encryption process
 pub(super) async fn chunk_path(
     file_api: &Files,
     files_path: &Path,
@@ -145,32 +148,37 @@ pub(super) async fn chunk_path(
     trace!("Starting to chunk {files_path:?} now.");
     let now = Instant::now();
 
-    let total_files = WalkDir::new(files_path)
+    let files_to_chunk = WalkDir::new(files_path)
         .into_iter()
         .flatten()
-        .filter(|entry| entry.file_type().is_file())
-        .count();
-    let progress_bar = get_progress_bar(total_files as u64)?;
-    progress_bar.println(format!("Chunking {total_files} files..."));
+        .filter_map(|entry| {
+            if !entry.file_type().is_file() {
+                return None;
+            }
 
-    // Get the list of Chunks addresses from the files found at 'files_path'
-    let mut chunked_files = BTreeMap::new();
-    for entry in WalkDir::new(files_path).into_iter().flatten() {
-        if entry.file_type().is_file() {
-            let file_name = if let Some(file_name) = entry.file_name().to_str() {
-                file_name.to_string()
+            if let Some(file_name) = entry.file_name().to_str() {
+                Some((file_name.to_string(), entry.into_path()))
             } else {
                 println!(
                     "Skipping file {:?} as it is not valid UTF-8.",
                     entry.file_name()
                 );
-                continue;
-            };
+                None
+            }
+        })
+        .collect::<Vec<_>>();
 
+    let total_files = files_to_chunk.len();
+    let progress_bar = get_progress_bar(total_files as u64)?;
+    progress_bar.println(format!("Chunking {total_files} files..."));
+
+    let chunked_files = files_to_chunk
+        .par_iter()
+        .filter_map(|(file_name, path)| {
             // Each file using individual dir for temp SE chunks.
             let file_chunks_dir = {
-                let file_chunks_dir = chunks_dir.join(file_name.clone());
-                match fs::create_dir_all(file_chunks_dir.clone()) {
+                let file_chunks_dir = chunks_dir.join(file_name);
+                match fs::create_dir_all(&file_chunks_dir) {
                     Ok(_) => file_chunks_dir,
                     Err(err) => {
                         trace!("Failed to create temp folder {file_chunks_dir:?} for SE chunks with error {err:?}!");
@@ -179,22 +187,18 @@ pub(super) async fn chunk_path(
                 }
             };
 
-            let (file_addr, _size, chunks) =
-                match file_api.chunk_file(entry.path(), &file_chunks_dir) {
-                    Ok((file_addr, size, chunks)) => (file_addr, size, chunks),
-                    Err(err) => {
-                        println!(
-                            "Skipping file {:?} as it could not be chunked: {:?}",
-                            entry.path(),
-                            err
-                        );
-                        continue;
-                    }
-                };
-            progress_bar.inc(1);
-            chunked_files.insert(file_addr, ChunkedFile { file_name, chunks });
-        }
-    }
+            match file_api.chunk_file(path, &file_chunks_dir) {
+                Ok((file_addr, _size, chunks)) => {
+                    progress_bar.clone().inc(1);
+                    Some((file_addr, ChunkedFile {file_name: file_name.clone(), chunks}))
+                }
+                Err(err) => {
+                    println!("Skipping file {path:?} as it could not be chunked: {err:?}");
+                    None
+                }
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
 
     if chunked_files.is_empty() {
         bail!("The provided path does not contain any file. Please check your path!\nExiting...");

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -143,6 +143,7 @@ pub(super) async fn chunk_path(
     chunks_dir: &Path,
 ) -> Result<BTreeMap<XorName, ChunkedFile>> {
     trace!("Starting to chunk {files_path:?} now.");
+    let now = Instant::now();
 
     let total_files = WalkDir::new(files_path)
         .into_iter()
@@ -200,6 +201,7 @@ pub(super) async fn chunk_path(
     }
 
     progress_bar.finish_and_clear();
+    debug!("It took {:?} to chunk all the files", now.elapsed());
 
     Ok(chunked_files)
 }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "~0.11.0"
 libp2p = { version="0.52", features = ["identify"] }
 prometheus-client = { version = "0.21.2", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
-rayon = "1.7.0"
+rayon = "1.8.0"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_networking = { path = "../sn_networking", version = "0.9.4" }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -54,7 +54,7 @@ prost = { version = "0.9" }
 tonic = { version = "0.6.2" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
-rayon = "1.7.0"
+rayon = "1.8.0"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Oct 23 12:07 UTC
This pull request includes three patches:

1. `chore(cli): add logs to indicate the time spent on chunking the files`
   - Adds logging to indicate the time spent on chunking the files in the CLI.
   - Inserts logs at the start and end of the chunking process.
   - Prints the time taken to chunk all the files.
   
2. `feat(cli): chunk files in parallel`
   - Adds parallel chunking of files in the CLI.
   - Adds `rayon` as a dependency.
   - Uses `rayon` to parallelize the chunking process.
   - Improves the performance of file chunking.

3. `fix(cli): remove Arc from ProgressBar as it is Arc internally`
   - Removes `Arc` from `ProgressBar` as it is `Arc` internally.
   - Updates the function signature of `get_progress_bar()` to return a `ProgressBar` directly.

Please review the patches and provide feedback.
<!-- reviewpad:summarize:end --> 
