### PR TITLE
refactor: pass RecordKey by reference

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -194,7 +194,7 @@ impl NodeRecordStore {
     pub(crate) fn record_addresses(&self) -> HashSet<NetworkAddress> {
         self.records
             .iter()
-            .map(|record_key| NetworkAddress::from_record_key(record_key.clone()))
+            .map(NetworkAddress::from_record_key)
             .collect()
     }
 
@@ -672,8 +672,8 @@ mod tests {
             } else {
                 // The list is already sorted by distance, hence always shall only prune the last one
                 let furthest_key = stored_records.remove(stored_records.len() - 1);
-                let furthest_addr = NetworkAddress::from_record_key(furthest_key.clone());
-                let record_addr = NetworkAddress::from_record_key(record_key.clone());
+                let furthest_addr = NetworkAddress::from_record_key(&furthest_key);
+                let record_addr = NetworkAddress::from_record_key(&record_key);
                 let (retained_key, pruned_key) = if self_address.distance(&furthest_addr)
                     > self_address.distance(&record_addr)
                 {
@@ -719,8 +719,8 @@ mod tests {
 
             stored_records.push(retained_key);
             stored_records.sort_by(|a, b| {
-                let a = NetworkAddress::from_record_key(a.clone());
-                let b = NetworkAddress::from_record_key(b.clone());
+                let a = NetworkAddress::from_record_key(a);
+                let b = NetworkAddress::from_record_key(b);
                 self_address.distance(&a).cmp(&self_address.distance(&b))
             });
         }
@@ -758,8 +758,8 @@ mod tests {
 
             stored_records.push(record_key);
             stored_records.sort_by(|a, b| {
-                let a = NetworkAddress::from_record_key(a.clone());
-                let b = NetworkAddress::from_record_key(b.clone());
+                let a = NetworkAddress::from_record_key(a);
+                let b = NetworkAddress::from_record_key(b);
                 self_address.distance(&a).cmp(&self_address.distance(&b))
             });
         }
@@ -768,8 +768,7 @@ mod tests {
         let halfway_record_address = NetworkAddress::from_record_key(
             stored_records
                 .get((stored_records.len() / 2) - 1)
-                .wrap_err("Could not parse record store key")?
-                .clone(),
+                .wrap_err("Could not parse record store key")?,
         );
         // get the distance to this record from our local key
         let distance = self_address.distance(&halfway_record_address);

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -164,7 +164,7 @@ mod tests {
         let mut incoming_keys = Vec::new();
         (0..MAX_PARALLEL_FETCH * 2).for_each(|_| {
             let random_data: Vec<u8> = (0..50).map(|_| rand::random::<u8>()).collect();
-            let key = NetworkAddress::from_record_key(RecordKey::from(random_data));
+            let key = NetworkAddress::from_record_key(&RecordKey::from(random_data));
             incoming_keys.push(key);
         });
 
@@ -174,7 +174,7 @@ mod tests {
 
         // we should not fetch anymore keys
         let random_data: Vec<u8> = (0..50).map(|_| rand::random::<u8>()).collect();
-        let key = NetworkAddress::from_record_key(RecordKey::from(random_data));
+        let key = NetworkAddress::from_record_key(&RecordKey::from(random_data));
         let keys_to_fetch =
             replication_fetcher.add_keys(PeerId::random(), vec![key], &locally_stored_keys);
         assert!(keys_to_fetch.is_empty());

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -152,7 +152,7 @@ impl Node {
                 trace!("Fetching record {pretty_key:?} from node {holder:?}");
                 let req = Request::Query(Query::GetReplicatedRecord {
                     requester,
-                    key: NetworkAddress::from_record_key(key.clone()),
+                    key: NetworkAddress::from_record_key(&key),
                 });
                 let record_opt = if let Ok(resp) = node.network.send_request(req, holder).await {
                     match resp {

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -73,7 +73,7 @@ impl NetworkAddress {
     }
 
     /// Return a `NetworkAddress` representation of the `RecordKey` by encapsulating its bytes.
-    pub fn from_record_key(record_key: RecordKey) -> Self {
+    pub fn from_record_key(record_key: &RecordKey) -> Self {
         NetworkAddress::RecordKey(record_key.to_vec())
     }
 
@@ -313,12 +313,10 @@ impl<'a> std::fmt::Display for PrettyPrintRecordKey<'a> {
             f.write_fmt(format_args!("{:02x}", byte))?;
         }
 
-        // to get the inner RecordKey
-        let key = self.key.clone().into_owned();
         write!(
             f,
             "({:?})",
-            PrettyPrintKBucketKey(NetworkAddress::from_record_key(key).as_kbucket_key())
+            PrettyPrintKBucketKey(NetworkAddress::from_record_key(&self.key).as_kbucket_key())
         )
     }
 }
@@ -349,9 +347,7 @@ mod tests {
                 f,
                 "{:64x}({:?})",
                 record_key_b,
-                OldKBucketKeyPrint(
-                    NetworkAddress::from_record_key(self.0.clone()).as_kbucket_key()
-                )
+                OldKBucketKeyPrint(NetworkAddress::from_record_key(&self.0).as_kbucket_key())
             )
         }
     }


### PR DESCRIPTION
This prevents cloning in many places this is called, as the RecordKey is
copied into a Vec anyway.
