### PR TITLE
Anonymous gossip

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -394,12 +394,14 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .validation_mode(libp2p::gossipsub::ValidationMode::Anonymous)
+            .build()
+            .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.
-        let message_authenticity =
-            libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
+        let message_authenticity = libp2p::gossipsub::MessageAuthenticity::Anonymous;
 
         // build a gossipsub network behaviour
         let gossipsub: libp2p::gossipsub::Behaviour =

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -106,6 +106,9 @@ pub enum Error {
     #[error("Network Metric error")]
     NetworkMetricError,
 
+    #[error("Gossipsub config Error: {0}")]
+    GossipsubConfigError(String),
+
     #[error("Gossipsub publish Error: {0}")]
     GossipsubPublishError(#[from] PublishError),
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 13:18 UTC
This pull request fixes a bug related to anonymous gossip messages. It modifies the `driver.rs` file by setting the validation mode for gossipsub messages to be anonymous instead of using a signed message authenticity. Additionally, it adds error handling for the gossipsub configuration. The `error.rs` file is also modified to include a new error variant for gossipsub configuration errors.
<!-- reviewpad:summarize:end --> 
