### PR TITLE
debuggg + send transfers over gossip

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -394,12 +394,14 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .validation_mode(libp2p::gossipsub::ValidationMode::Anonymous)
+            .build()
+            .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.
-        let message_authenticity =
-            libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
+        let message_authenticity = libp2p::gossipsub::MessageAuthenticity::Anonymous;
 
         // build a gossipsub network behaviour
         let gossipsub: libp2p::gossipsub::Behaviour =

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -106,6 +106,9 @@ pub enum Error {
     #[error("Network Metric error")]
     NetworkMetricError,
 
+    #[error("Gossipsub config Error: {0}")]
+    GossipsubConfigError(String),
+
     #[error("Gossipsub publish Error: {0}")]
     GossipsubPublishError(#[from] PublishError),
 

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::{CashNote, UniquePubkey};
+use sn_transfers::{CashNote, UniquePubkey, Transfer};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
@@ -71,8 +71,8 @@ pub enum NodeEvent {
     TransferNotif {
         /// Public key the transfer notification is about
         key: PublicKey,
-        /// The cash notes
-        cash_notes: Vec<CashNote>,
+        /// The transfers
+        transfers: Vec<Transfer>,
     },
 }
 

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -513,7 +513,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<NodeEvent> {
     );
     let key = PublicKey::from_bytes(key_bytes)?;
 
-    let cash_notes: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let transfers: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
 
-    Ok(NodeEvent::TransferNotif { key, cash_notes })
+    Ok(NodeEvent::TransferNotif { key, transfers })
 }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -23,7 +23,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey};
+use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey, Transfer};
 use std::{
     net::SocketAddr,
     path::PathBuf,
@@ -513,7 +513,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<NodeEvent> {
     );
     let key = PublicKey::from_bytes(key_bytes)?;
 
-    let cash_notes: Vec<CashNote> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let cash_notes: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
 
     Ok(NodeEvent::TransferNotif { key, cash_notes })
 }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -215,7 +215,7 @@ fn spawn_royalties_payment_listener(endpoint: String) -> JoinHandle<Result<usize
         println!("Awaiting transfers notifs...");
         while let Some(Ok(e)) = stream.next().await {
             match NodeEvent::from_bytes(&e.event) {
-                Ok(NodeEvent::TransferNotif { key, cash_notes: _ }) => {
+                Ok(NodeEvent::TransferNotif { key, transfers: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     if key == royalties_pk {
                         count += 1;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -82,6 +82,8 @@ pub enum Error {
     // ---------- transfer errors
     #[error("Failed to decypher transfer, we probably are not the recipient")]
     FailedToDecypherTransfer,
+    #[error("Failed to encrypt transfer")]
+    FailedToEncryptTransfer,
     #[error("Failed to get transfer parent spend")]
     FailedToGetTransferParentSpend,
     #[error("Transfer is invalid: {0}")]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 11:56 UTC
This pull request includes the following changes:
- In `sn_networking/src/driver.rs`, the `message_authenticity` variable is set to `libp2p::gossipsub::MessageAuthenticity::Anonymous`.
- In `sn_node/examples/safenode_rpc_client.rs`, there are changes related to handling transfer notifications. The variable `cash_notes` has been renamed to `transfers`, and there are additional logic and error handling related to encrypted and network royalties transfers.
- In `sn_node/src/event.rs`, the `TransferNotif` enum variant has been updated to include `transfers` instead of `cash_notes`.
- In `sn_node/src/node.rs`, there are changes related to processing transfer notifications. The method `cash_notes_from_payment` has been updated to handle transfers instead of cash notes, and the variable `royalties_cash_notes` has been renamed to `royalties_transfers`. There are also changes related to publishing a transfer notification over the `gossipsub` topic for network royalties payments.
- In `sn_node/src/put_validation.rs`, there are changes related to processing transfers. The method `cash_notes_from_payment` has been updated to handle transfers instead of cash notes, and the variable `royalties_cash_notes` has been renamed to `royalties_transfers`. There are also changes related to publishing a transfer notification over the `gossipsub` topic for network royalties payments.
- In `sn_node/tests/nodes_rewards.rs`, there are changes related to handling transfer notifications. The variable `cash_notes` has been renamed to `transfers`.
- In `sn_protocol/src/error.rs`, a new error variant `FailedToEncryptTransfer` has been added.
<!-- reviewpad:summarize:end --> 
