### PR TITLE
fix: sn_testnet build check was missing rand dep

### DIFF
--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -39,6 +39,8 @@ tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = "~0.3.1"
 walkdir = "~2.4.0"
+# add rand to libp2p
+libp2p-identity = { version="0.2.7", features = ["rand"] }
 
 [dependencies.tokio]
 version = "1.17.0"
@@ -53,5 +55,3 @@ tonic-build = { version = "~0.6.2" }
 assert_fs = "~1.0"
 mockall = "0.11.3"
 predicates = "3.0"
-# add rand to libp2p
-libp2p-identity = { version="0.2.7", features = ["rand"] }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 13:10 UTC
This pull request fixes an issue where the sn_testnet build check was missing the rand dependency. The patch adds the rand dependency to the libp2p in the Cargo.toml file.
<!-- reviewpad:summarize:end --> 
