### PR TITLE
feat(rpc-client): be able to decrpyt received Transfers by providing a secret key

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -393,12 +393,14 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .validation_mode(libp2p::gossipsub::ValidationMode::Anonymous)
+            .build()
+            .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.
-        let message_authenticity =
-            libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
+        let message_authenticity = libp2p::gossipsub::MessageAuthenticity::Anonymous;
 
         // build a gossipsub network behaviour
         let gossipsub: libp2p::gossipsub::Behaviour =

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -393,14 +393,12 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
-            .validation_mode(libp2p::gossipsub::ValidationMode::Anonymous)
-            .build()
-            .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
+        let gossipsub_config = libp2p::gossipsub::Config::default();
 
         // Set the message authenticity - Here we expect the publisher
         // to sign the message with their key.
-        let message_authenticity = libp2p::gossipsub::MessageAuthenticity::Anonymous;
+        let message_authenticity =
+            libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
 
         // build a gossipsub network behaviour
         let gossipsub: libp2p::gossipsub::Behaviour =

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -106,6 +106,9 @@ pub enum Error {
     #[error("Network Metric error")]
     NetworkMetricError,
 
+    #[error("Gossipsub config Error: {0}")]
+    GossipsubConfigError(String),
+
     #[error("Gossipsub publish Error: {0}")]
     GossipsubPublishError(#[from] PublishError),
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -31,6 +31,7 @@ open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 quic=["sn_networking/quic"]
 
 [dependencies]
+assert_fs = "1.0.0"
 async-trait = "0.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -81,7 +82,6 @@ tiny_http = { version="0.12", features = ["ssl-rustls"] }
 color-eyre = "0.6.2"
 
 [dev-dependencies]
-assert_fs = "1.0.0"
 tempfile = "3.6.0"
 
 [build-dependencies]

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::{CashNote, UniquePubkey};
+use sn_transfers::{CashNote, UniquePubkey, Transfer};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
@@ -71,8 +71,8 @@ pub enum NodeEvent {
     TransferNotif {
         /// Public key the transfer notification is about
         key: PublicKey,
-        /// The cash notes
-        cash_notes: Vec<CashNote>,
+        /// The transfers
+        transfers: Vec<Transfer>,
     },
 }
 

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::{CashNote, UniquePubkey, Transfer};
+use sn_transfers::{Transfer, UniquePubkey};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -23,7 +23,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey};
+use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey, Transfer};
 use std::{
     net::SocketAddr,
     path::PathBuf,
@@ -520,7 +520,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<NodeEvent> {
     );
     let key = PublicKey::from_bytes(key_bytes)?;
 
-    let cash_notes: Vec<CashNote> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let cash_notes: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
 
     Ok(NodeEvent::TransferNotif { key, cash_notes })
 }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -23,7 +23,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey, Transfer};
+use sn_transfers::{LocalWallet, MainPubkey, MainSecretKey, Transfer};
 use std::{
     net::SocketAddr,
     path::PathBuf,

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -520,7 +520,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<NodeEvent> {
     );
     let key = PublicKey::from_bytes(key_bytes)?;
 
-    let cash_notes: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let transfers: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
 
-    Ok(NodeEvent::TransferNotif { key, cash_notes })
+    Ok(NodeEvent::TransferNotif { key, transfers })
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -477,7 +477,7 @@ impl Node {
 
         // unpack transfer
         trace!("Unpacking incoming Transfers for record {pretty_key}");
-        let (received_fee, cash_notes, royalties_cash_notes) = self
+        let (received_fee, cash_notes, royalties_transfers) = self
             .cash_notes_from_payment(&payment, &wallet, pretty_key.clone())
             .await?;
 
@@ -493,14 +493,14 @@ impl Node {
             .reward_wallet_balance
             .set(wallet.balance().as_nano() as i64);
 
-        if royalties_cash_notes.is_empty() {
+        if royalties_transfers.is_empty() {
             return Err(ProtocolError::NoNetworkRoyaltiesPayment(
                 pretty_key.into_owned(),
             ));
         }
 
         // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for the network royalties payment.
-        match bincode::serialize(&royalties_cash_notes) {
+        match bincode::serialize(&royalties_transfers) {
             Ok(serialised) => {
                 let royalties_pk = *NETWORK_ROYALTIES_PK;
                 trace!("Publishing a royalties transfer notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}");

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -221,7 +221,7 @@ fn spawn_royalties_payment_listener(endpoint: String) -> JoinHandle<Result<usize
         println!("Awaiting transfers notifs...");
         while let Some(Ok(e)) = stream.next().await {
             match NodeEvent::from_bytes(&e.event) {
-                Ok(NodeEvent::TransferNotif { key, cash_notes: _ }) => {
+                Ok(NodeEvent::TransferNotif { key, transfers: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     if key == royalties_pk {
                         count += 1;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -82,6 +82,8 @@ pub enum Error {
     // ---------- transfer errors
     #[error("Failed to decypher transfer, we probably are not the recipient")]
     FailedToDecypherTransfer,
+    #[error("Failed to encrypt transfer")]
+    FailedToEncryptTransfer,
     #[error("Failed to get transfer parent spend")]
     FailedToGetTransferParentSpend,
     #[error("Transfer is invalid: {0}")]

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -428,6 +428,28 @@ impl LocalWallet {
         Ok(())
     }
 
+    /// Store the given cash_notes on the wallet (without storing them to disk).
+    pub fn deposit(&mut self, received_cash_notes: &Vec<CashNote>) -> Result<()> {
+        for cash_note in received_cash_notes {
+            let id = cash_note.unique_pubkey();
+
+            if self.wallet.spent_cash_notes.contains(&id) {
+                debug!("skipping: cash_note is spent");
+                continue;
+            }
+
+            if cash_note.derived_key(&self.key).is_err() {
+                debug!("skipping: cash_note is not our key");
+                continue;
+            }
+
+            let value = cash_note.value()?;
+            self.wallet.available_cash_notes.insert(id, value);
+        }
+
+        Ok(())
+    }
+
     /// Store the given cash_notes to the `cash_notes` dir in the wallet dir.
     /// Update and store the updated wallet to disk
     /// This function locks the wallet to prevent concurrent processes from writing to it


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 14:36 UTC
This pull request includes the following changes:

1. The implementation of the `cash_notes_from_payment` function has been modified in the `impl Node` block. It now returns a tuple containing three values: `NanoTokens`, `Vec<CashNote>`, and `Vec<Transfer>`, instead of just `Vec<CashNote>`. The third value represents the transfers corresponding to network royalties payment. Variable names have been renamed and types have been updated accordingly. Royalty transfers are generated from cash notes and added to the `royalties_transfers` vector. The code now handles the case where there are no network royalties payments by checking if the `royalties_transfers` vector is empty. A notification is published over the gossipsub topic `TRANSFER_NOTIF_TOPIC` for the network royalties payment, using the `royalties_transfers` vector for serialization.

2. Several changes have been made to the dependencies in the file diff of a different file. The changes include adding dependencies such as `assert_fs::TempDir` and `bls::SecretKey`, and removing the `eyre::Result` import and replacing it with `eyre::{eyre, Result}`. Additionally, the `sn_client::Client` and `sn_transfers::{LocalWallet, MainSecretKey, Transfer}` dependencies have been added. The `tracing::warn` dependency has also been added. The signature of the `node_events` function has been updated to remove the `only_transfers` and `log_cash_notes` parameters. A new function `transfers_events` has been added to handle transfer events. The `main` function has been modified to use the `transfers_events` function when the `Cmd::TransfersEvents` variant is selected. The `node_events` function has been modified to handle both node events and transfer notifications. Logic has been added to verify and unpack transfers, and store the resulting cash notes. Print statements have been updated to reflect the changes.

3. In the file `error.rs`, a new variant `GossipsubConfigError` has been added to the `Error` enum. Additionally, the `GossipsubPublishError` variant now includes a parameter of type `PublishError`.

4. The file `nodes_rewards.rs` has a single change, which is a simple renaming of the variable `cash_notes` to `transfers` in the pattern matching arm of the function `spawn_royalties_payment_listener`.

5. In the file `event.rs`, the usage of `CashNote` has been replaced with `Transfer` and associated variable names and types have been updated accordingly. The `TransferNotif` variant of the `NodeEvent` enum now contains a `transfers` field of type `Vec<Transfer>` instead of a `cash_notes` field of type `Vec<CashNote>`.

6. In the file `driver.rs`, the default parameters for gossipsub have been modified using the `ConfigBuilder`. The message authenticity has been changed to `Anonymous` instead of being signed with the keypair.

7. The file `sn_node/src/node.rs` has undergone changes including import statement changes and code changes. The import statement now includes the `Transfer` module from `sn_transfers` and excludes the `CashNote` module. Variable `cash_notes` has been renamed to `transfers`. The deserialization of `msg[PK_SIZE..]` has been changed from `Vec<CashNote>` to `Vec<Transfer>`. The `NodeEvent::TransferNotif` struct now contains the field `transfers` instead of `cash_notes`.

8. The diff of the `error.rs` file includes the addition of an error variant called `FailedToEncryptTransfer`.

9. The diff of the `Cargo.toml` file includes changes such as added and updated dependencies. These changes include adding a dependency on `assert_fs` version 1.0.0 and updating dependencies such as `async-trait`, `bincode`, `bls`, `tiny_http`, and `color-eyre`. Some dev-dependencies have also been updated or removed.

10. The file `api.rs` has been modified with changes including importing various modules such as `CashNote`, `LocalWallet`, `NanoTokens`, `SignedSpend`, `Transfer`, and `UniquePubkey` from the `sn_transfers` module. A new function `verify_and_unpack_transfer` has been added to the `Client` struct. The existing function `publish_on_topic` has been modified to include a missing semicolon. A helper function `get_register_from_record` has been added.

Please review these changes and ensure that they are correct and fulfill the requirements. Let me know if you need further clarification or assistance with anything else.
<!-- reviewpad:summarize:end --> 
