### PR TITLE
feat: encrypt network royalty to Transfer for gossip msg

### DIFF
--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -31,6 +31,7 @@ open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 quic=["sn_networking/quic"]
 
 [dependencies]
+assert_fs = "1.0.0"
 async-trait = "0.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -81,7 +82,6 @@ tiny_http = { version="0.12", features = ["ssl-rustls"] }
 color-eyre = "0.6.2"
 
 [dev-dependencies]
-assert_fs = "1.0.0"
 tempfile = "3.6.0"
 
 [build-dependencies]

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::{CashNote, UniquePubkey};
+use sn_transfers::{CashNote, UniquePubkey, Transfer};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
@@ -71,8 +71,8 @@ pub enum NodeEvent {
     TransferNotif {
         /// Public key the transfer notification is about
         key: PublicKey,
-        /// The cash notes
-        cash_notes: Vec<CashNote>,
+        /// The transfers
+        transfers: Vec<Transfer>,
     },
 }
 

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
-use sn_transfers::{CashNote, UniquePubkey, Transfer};
+use sn_transfers::{Transfer, UniquePubkey};
 use tokio::sync::broadcast;
 
 const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -23,7 +23,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey, Transfer};
+use sn_transfers::{LocalWallet, MainPubkey, MainSecretKey, Transfer};
 use std::{
     net::SocketAddr,
     path::PathBuf,

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -23,7 +23,7 @@ use sn_protocol::{
     messages::{Cmd, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey};
+use sn_transfers::{CashNote, LocalWallet, MainPubkey, MainSecretKey, Transfer};
 use std::{
     net::SocketAddr,
     path::PathBuf,
@@ -520,7 +520,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<NodeEvent> {
     );
     let key = PublicKey::from_bytes(key_bytes)?;
 
-    let cash_notes: Vec<CashNote> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let transfers: Vec<Transfer> = bincode::deserialize(&msg[PK_SIZE..])?;
 
-    Ok(NodeEvent::TransferNotif { key, cash_notes })
+    Ok(NodeEvent::TransferNotif { key, transfers })
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -477,7 +477,7 @@ impl Node {
 
         // unpack transfer
         trace!("Unpacking incoming Transfers for record {pretty_key}");
-        let (received_fee, cash_notes, royalties_cash_notes) = self
+        let (received_fee, cash_notes, royalties_transfers) = self
             .cash_notes_from_payment(&payment, &wallet, pretty_key.clone())
             .await?;
 
@@ -493,14 +493,14 @@ impl Node {
             .reward_wallet_balance
             .set(wallet.balance().as_nano() as i64);
 
-        if royalties_cash_notes.is_empty() {
+        if royalties_transfers.is_empty() {
             return Err(ProtocolError::NoNetworkRoyaltiesPayment(
                 pretty_key.into_owned(),
             ));
         }
 
         // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for the network royalties payment.
-        match bincode::serialize(&royalties_cash_notes) {
+        match bincode::serialize(&royalties_transfers) {
             Ok(serialised) => {
                 let royalties_pk = *NETWORK_ROYALTIES_PK;
                 trace!("Publishing a royalties transfer notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}");

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -221,7 +221,7 @@ fn spawn_royalties_payment_listener(endpoint: String) -> JoinHandle<Result<usize
         println!("Awaiting transfers notifs...");
         while let Some(Ok(e)) = stream.next().await {
             match NodeEvent::from_bytes(&e.event) {
-                Ok(NodeEvent::TransferNotif { key, cash_notes: _ }) => {
+                Ok(NodeEvent::TransferNotif { key, transfers: _ }) => {
                     println!("Transfer notif received for key {key:?}");
                     if key == royalties_pk {
                         count += 1;

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -82,6 +82,8 @@ pub enum Error {
     // ---------- transfer errors
     #[error("Failed to decypher transfer, we probably are not the recipient")]
     FailedToDecypherTransfer,
+    #[error("Failed to encrypt transfer")]
+    FailedToEncryptTransfer,
     #[error("Failed to get transfer parent spend")]
     FailedToGetTransferParentSpend,
     #[error("Transfer is invalid: {0}")]

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -428,6 +428,28 @@ impl LocalWallet {
         Ok(())
     }
 
+    /// Store the given cash_notes on the wallet (without storing them to disk).
+    pub fn deposit(&mut self, received_cash_notes: &Vec<CashNote>) -> Result<()> {
+        for cash_note in received_cash_notes {
+            let id = cash_note.unique_pubkey();
+
+            if self.wallet.spent_cash_notes.contains(&id) {
+                debug!("skipping: cash_note is spent");
+                continue;
+            }
+
+            if cash_note.derived_key(&self.key).is_err() {
+                debug!("skipping: cash_note is not our key");
+                continue;
+            }
+
+            let value = cash_note.value()?;
+            self.wallet.available_cash_notes.insert(id, value);
+        }
+
+        Ok(())
+    }
+
     /// Store the given cash_notes to the `cash_notes` dir in the wallet dir.
     /// Update and store the updated wallet to disk
     /// This function locks the wallet to prevent concurrent processes from writing to it


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Oct 23 05:38 UTC
This pull request includes the following changes:
- The import statement for `CashNote` from `sn_transfers` has been removed.
- The import statement for `Transfer` from `sn_transfers` has been added.
- The variable `cash_notes` has been renamed to `transfers` and its type has been changed to `Vec<Transfer>` in the function `try_decode_transfer_notif` in `api.rs`.
- The file `api.rs` adds a new function `verify_and_unpack_transfer` to the `Client` struct. This function is used to receive a transfer and turn it back into spendable cash notes. It verifies the transfer and rebuilds the spendable currency from it. If the transfer cannot be deciphered or is invalid, it returns an error. Otherwise, it returns a list of cash notes that can be deposited to the wallet and spent.
- The file `local_store.rs` adds a new function called `deposit` that takes a vector of `CashNote` objects as input and stores them in the wallet without writing to disk. It performs checks on each cash note before storing it, skipping any that are marked as spent or not associated with the current wallet key. It inserts valid cash notes into the `available_cash_notes` map in the wallet.
- The changes in `local_store.rs` allow for the deposit of cash notes into the wallet without immediately persisting them to disk.
- The changes in `sn_node/src/put_validation.rs` involve modifying the return type and variable names related to network royalties transfers.
- The file `error.rs` adds a new error variant `FailedToEncryptTransfer` to the `Error` enum.
- The function `spawn_royalties_payment_listener` in `nodes_rewards.rs` renames the variable "cash_notes" to "transfers" in the match pattern of the `NodeEvent::TransferNotif` case.
- Several changes are made in different functions and variants in the Rust codebase, including added imports, updated function logic, and log statements related to listening to and processing transfer notifications.

Let me know if there's anything else I can help you with!
<!-- reviewpad:summarize:end --> 
