### PR TITLE
handle_cmd and gossip mem tweaks

### DIFF
--- a/sn_cli/src/subcommands/gossipsub.rs
+++ b/sn_cli/src/subcommands/gossipsub.rs
@@ -44,7 +44,7 @@ pub(crate) async fn gossipsub_cmds(cmds: GossipsubCmds, client: &Client) -> Resu
             let mut events_channel = client.events_channel();
             while let Ok(event) = events_channel.recv().await {
                 if let ClientEvent::GossipsubMsg { msg, .. } = event {
-                    let msg = String::from_utf8(msg)?;
+                    let msg = String::from_utf8(msg.to_vec())?;
                     println!("New message published: {msg}");
                 }
             }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -11,6 +11,7 @@ use super::{
     Client, ClientEvent, ClientEventsChannel, ClientEventsReceiver, ClientRegister, WalletClient,
 };
 use bls::{PublicKey, SecretKey, Signature};
+use bytes::Bytes;
 use indicatif::ProgressBar;
 use libp2p::{
     identity::Keypair,
@@ -585,7 +586,7 @@ impl Client {
     }
 
     /// Publish message on given topic
-    pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
+    pub fn publish_on_topic(&self, topic_id: String, msg: Bytes) -> Result<()> {
         info!("Publishing msg on topic id: {topic_id}");
         self.network.publish_on_topic(topic_id, msg)?;
         Ok(())

--- a/sn_client/src/event.rs
+++ b/sn_client/src/event.rs
@@ -8,6 +8,7 @@
 
 use super::error::Result;
 
+use bytes::Bytes;
 use serde::Serialize;
 use tokio::sync::broadcast;
 
@@ -49,7 +50,7 @@ pub enum ClientEvent {
         topic: String,
         /// The raw bytes of the received message
         #[debug(skip)]
-        msg: Vec<u8>,
+        msg: Bytes,
     },
 }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -12,6 +12,7 @@ use crate::{
     sort_peers_by_address, GetQuorum, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
     REPLICATE_RANGE,
 };
+use bytes::Bytes;
 use libp2p::{
     kad::{store::RecordStore, Quorum, Record, RecordKey},
     swarm::dial_opts::DialOpts,
@@ -139,7 +140,7 @@ pub enum SwarmCmd {
         /// Topic to publish on
         topic_id: String,
         /// Raw bytes of the message to publish
-        msg: Vec<u8>,
+        msg: Bytes,
     },
 }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -276,9 +276,8 @@ impl SwarmDriver {
                 // Only store record from Replication that close enough to us.
                 let all_peers = self.get_all_local_peers();
                 let keys_to_store = keys
-                    .iter()
+                    .into_iter()
                     .filter(|(key, _)| self.is_in_close_range(key, &all_peers))
-                    .cloned()
                     .collect();
                 #[allow(clippy::mutable_key_type)]
                 let all_keys = self
@@ -558,7 +557,6 @@ impl SwarmDriver {
                 // Hence push an event to notify that we've published a message
                 self.send_event(NetworkEvent::GossipsubMsgPublished {
                     topic: topic_id.clone(),
-                    msg: msg.clone(),
                 });
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -558,6 +558,7 @@ impl SwarmDriver {
                 // Hence push an event to notify that we've published a message
                 self.send_event(NetworkEvent::GossipsubMsgPublished {
                     topic: topic_id.clone(),
+                    msg: msg.clone(),
                 });
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -12,6 +12,7 @@ use crate::{
     error::{Error, Result},
     multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE,
 };
+use bytes::Bytes;
 use core::fmt;
 use custom_debug::Debug as CustomDebug;
 use itertools::Itertools;
@@ -143,14 +144,14 @@ pub enum NetworkEvent {
         /// Topic the message was published on
         topic: String,
         /// The raw bytes of the received message
-        msg: Vec<u8>,
+        msg: Bytes,
     },
     /// The Gossipsub message that we published
     GossipsubMsgPublished {
         /// Topic the message was published on
         topic: String,
         /// The raw bytes of the sent message
-        msg: Vec<u8>,
+        msg: Bytes,
     },
 }
 
@@ -349,7 +350,7 @@ impl SwarmDriver {
                 match event {
                     libp2p::gossipsub::Event::Message { message, .. } => {
                         let topic = message.topic.into_string();
-                        let msg = message.data;
+                        let msg = Bytes::from(message.data);
                         self.send_event(NetworkEvent::GossipsubMsgReceived { topic, msg });
                     }
                     other => trace!("Gossipsub Event has been ignored: {other:?}"),

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -35,6 +35,7 @@ pub use self::{
 };
 
 use self::{cmd::SwarmCmd, driver::ExpectedHoldersList, error::Result};
+use bytes::Bytes;
 use futures::future::select_all;
 use itertools::Itertools;
 use libp2p::{
@@ -282,7 +283,7 @@ impl Network {
     }
 
     /// Publish a msg on a given topic
-    pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
+    pub fn publish_on_topic(&self, topic_id: String, msg: Bytes) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::GossipsubPublish { topic_id, msg })?;
         Ok(())
     }

--- a/sn_node/src/bin/safenode/rpc.rs
+++ b/sn_node/src/bin/safenode/rpc.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use bytes::Bytes;
 use sn_node::RunningNode;
 
 use super::NodeCtrl;
@@ -208,7 +209,8 @@ impl SafeNode for SafeNodeRpcService {
         );
 
         let topic = &request.get_ref().topic;
-        let msg = &request.get_ref().msg;
+        // Convert the message from Vec<u8> to Bytes
+        let msg = Bytes::from(request.get_ref().msg.clone());
 
         match self
             .running_node

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -8,6 +8,7 @@
 
 use crate::error::{Error, Result};
 use bls::PublicKey;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
 use sn_transfers::{Transfer, UniquePubkey};
@@ -65,7 +66,7 @@ pub enum NodeEvent {
         /// Topic the message was published on
         topic: String,
         /// The raw bytes of the received message
-        msg: Vec<u8>,
+        msg: Bytes,
     },
     /// Transfer notification message received for a public key
     TransferNotif {

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -59,6 +59,7 @@ pub use self::{
 };
 
 use crate::error::Result;
+use bytes::Bytes;
 use libp2p::PeerId;
 use sn_networking::{Network, SwarmLocalState};
 use sn_protocol::NetworkAddress;
@@ -126,7 +127,7 @@ impl RunningNode {
     }
 
     /// Publish a message on a given gossipsub topic
-    pub fn publish_on_topic(&self, topic_id: String, msg: Vec<u8>) -> Result<()> {
+    pub fn publish_on_topic(&self, topic_id: String, msg: Bytes) -> Result<()> {
         self.network.publish_on_topic(topic_id, msg)?;
         Ok(())
     }

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -74,7 +74,7 @@ async fn msgs_over_gossipsub() -> Result<()> {
                             Ok(NodeEvent::GossipsubMsg { topic, msg }) => {
                                 println!(
                                     "Msg received on node #{node_index} '{topic}': {}",
-                                    String::from_utf8(msg).unwrap()
+                                    String::from_utf8(msg.to_vec()).unwrap()
                                 );
                                 count += 1;
                                 if count == NODE_COUNT - NODES_SUBSCRIBED {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Oct 23 11:03 UTC
This pull request includes three patches:

1. The first patch in the pull request is titled "chore(networking): avoid a replication keys clone". It modifies the `cmd.rs` file in the `sn_networking` directory. The changes involve avoiding the cloning of replication keys by using `into_iter()` instead of `iter()`.

2. The second patch is titled "chore(networking): reduce GossipsubPub event weight, don't send useless bytes". It contains modifications to the `api.rs`, `event.rs`, and `node.rs` files. The changes reduce the weight of the `GossipsubPub` event and eliminate the sending of unnecessary bytes.

3. The third patch with the title "chore(node): make gossipsubpublish take Bytes" modifies the `api.rs`, `cmd.rs`, `lib.rs`, `node.rs`, `put_validation.rs` files. It changes the `msg` parameter in the `publish_on_topic` function from `Vec<u8>` to `Bytes`.
<!-- reviewpad:summarize:end --> 
