### PR TITLE
feat: bincode::serialize into `Bytes` without intermediate allocation 

### DIFF
--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -6,13 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{CashNote, SignedSpend, SpendAddress, UniquePubkey};
-
 use super::{
     error::{Error, Result},
     KeyLessWallet,
 };
-
+use crate::{CashNote, SignedSpend, SpendAddress, UniquePubkey};
 use std::{
     collections::BTreeSet,
     fs,
@@ -28,8 +26,8 @@ const UNCONFRIMED_TX_NAME: &str = "unconfirmed_spend_requests";
 /// Writes the `KeyLessWallet` to the specified path.
 pub(super) fn store_wallet(wallet_dir: &Path, wallet: &KeyLessWallet) -> Result<()> {
     let wallet_path = wallet_dir.join(WALLET_FILE_NAME);
-    let bytes = bincode::serialize(&wallet)?;
-    fs::write(wallet_path, bytes)?;
+    let mut file = fs::File::create(wallet_path)?;
+    bincode::serialize_into(&mut file, &wallet)?;
     Ok(())
 }
 
@@ -62,8 +60,9 @@ pub(super) fn store_unconfirmed_spend_requests(
     unconfirmed_spend_requests: &BTreeSet<SignedSpend>,
 ) -> Result<()> {
     let unconfirmed_spend_requests_path = wallet_dir.join(UNCONFRIMED_TX_NAME);
-    let bytes = bincode::serialize(&unconfirmed_spend_requests)?;
-    fs::write(unconfirmed_spend_requests_path, bytes)?;
+
+    let mut file = fs::File::create(unconfirmed_spend_requests_path)?;
+    bincode::serialize_into(&mut file, &unconfirmed_spend_requests)?;
     Ok(())
 }
 
@@ -76,8 +75,8 @@ pub(super) fn get_unconfirmed_spend_requests(
         return Ok(None);
     }
 
-    let bytes = fs::read(&path)?;
-    let unconfirmed_spend_requests = bincode::deserialize(&bytes)?;
+    let reader = fs::File::open(&path)?;
+    let unconfirmed_spend_requests = bincode::deserialize_from(&reader)?;
 
     Ok(Some(unconfirmed_spend_requests))
 }


### PR DESCRIPTION

## Description
- `bincode::serialize` calls `bincode::serialized_size` internally while creating a `Vec::with_capacity`, so we are not doing extra work here.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 07:04 UTC
This pull request includes the following file changes:

1. Modifications to the `sn_node/src/put_validation.rs` file.
   - Added imports for `bytes::BufMut` and `BytesMut`.
   - Updated the implementation of the `publish_network_royalties_transfer` method.
   - Refactored and reorganized the code within the method.
   - Added error handling and logging statements.
   These changes improve the serialization and publishing of a royalties transfer notification over the gossipsub topic.

2. Changes in the `pac_man.rs` file.
   - Imports: Removed the `serialize` import and added `BufMut`, `Bytes`, and `BytesMut` imports from the `bytes` crate.
   - Serialization Logic: Replaced `Bytes::from(serialize(&chunk)?)` with more efficient serialization using `BytesMut`. Calculated the serialized chunk size with `bincode::serialized_size(&chunk)?` and serialized it into a `BytesMut` writer using `bincode::serialize_into(&mut bytes, &chunk)?`. Obtained the serialized chunk using `bytes.into_inner().freeze()`.
   These changes aim to improve serialization performance and reduce memory overhead.

3. Modifications to the `sn_client/src/api.rs` file.
   - Added an import statement for the `Bytes` type from the `bytes` crate.
   - Modified the `publish_on_topic` method to use the `Bytes` type for the `msg` parameter instead of a `Vec<u8>`.

4. Changes in the `sn_transfers/src/wallet/wallet_file.rs` file.
   - Reordered imports.
   - Replaced `serialize` and `deserialize` with `serialize_into` and `deserialize_from` from the `bincode` crate.
   - Replaced `fs::write` with `File::create` and `fs::File::write` with `File::open` for storing and retrieving the wallet.
   These changes are related to how the wallet is stored and retrieved.

5. Modifications to the `gossipsub.rs` file.
   - Updated line 48 to convert `msg` from a byte slice to a `String` using `String::from_utf8(msg.to_vec())?`.

6. Changes in the `event.rs` file.
   - Added an import statement for the `bytes::Bytes` module.
   - Modified the `msg` field of the `NetworkEvent` enum to use `Bytes` instead of `Vec<u8>`.
   - Modified the `msg` value assignment in the `SwarmDriver`'s `Event::Message` handling to use `Bytes::from()` instead of direct assignment.

7. Modifications to the `msgs_over_gossipsub.rs` file.
   - Updated code to convert a byte slice to a vector before converting it to a UTF-8 string for improved handling of invalid UTF-8 bytes.

8. Changes in the `rpc.rs` file in the `safenode` directory.
   - Added an import statement for `bytes::Bytes`.
   - Modified the implementation of the `SafeNode` trait to convert the message from `Vec<u8>` to `Bytes`.

9. Modifications to the `lib.rs` file in the `sn_node` directory.
   - Added an import statement for the `bytes` crate.
   - Updated the `publish_on_topic` method to accept a `Bytes` parameter instead of a `Vec<u8>`.

10. Changes in the `event.rs` file related to the `NodeEvent` enum.
   - Imported the `bytes::Bytes` module.
   - Replaced the `msg` field type from `Vec<u8>` to `Bytes`.

These changes aim to improve code efficiency, handle serialization better, and enhance message handling.
<!-- reviewpad:summarize:end --> 
