### PR TITLE
feat(cli): error out if we do not have enough balance

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -225,6 +225,9 @@ async fn upload_files(
     );
 
     let file_api: Files = Files::new(client.clone(), wallet_dir_path.to_path_buf());
+    if file_api.wallet()?.balance().is_zero() {
+        bail!("The wallet is empty. Cannot upload any files! Please transfer some funds into the wallet");
+    }
 
     // Temp folder to hold SE chunks, which is cleaned up automatically once out of scope.
     let temp_dir = tempdir()?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 11:29 UTC
This pull request adds a new feature to the command-line interface (CLI). Specifically, it introduces an error-checking mechanism that ensures the user has enough balance before executing a certain action. The patch modifies the `files.rs` file, adding error handling code and error messages for insufficient balance situations.
<!-- reviewpad:summarize:end --> 
