### PR TITLE
Serialize direct to Bytes

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -356,7 +356,8 @@ impl Client {
 
         let record = Record {
             key: key.clone(),
-            value: try_serialize_record(&(payment, chunk.clone()), RecordKind::ChunkWithPayment)?,
+            value: try_serialize_record(&(payment, chunk.clone()), RecordKind::ChunkWithPayment)?
+                .to_vec(),
             publisher: None,
             expires: None,
         };
@@ -378,7 +379,7 @@ impl Client {
             // Hence the fetched copies shall only be a `Chunk`
             Some(Record {
                 key,
-                value: try_serialize_record(&chunk, RecordKind::Chunk)?,
+                value: try_serialize_record(&chunk, RecordKind::Chunk)?.to_vec(),
                 publisher: None,
                 expires: None,
             })
@@ -460,7 +461,7 @@ impl Client {
         let key = network_address.to_record_key();
         let record = Record {
             key,
-            value: try_serialize_record(&[spend], RecordKind::Spend)?,
+            value: try_serialize_record(&[spend], RecordKind::Spend)?.to_vec(),
             publisher: None,
             expires: None,
         };
@@ -710,21 +711,21 @@ mod tests {
         // prepare records
         let record1 = Record {
             key: NetworkAddress::from_register_address(address).to_record_key(),
-            value: try_serialize_record(&signed_register1, RecordKind::Register)?,
+            value: try_serialize_record(&signed_register1, RecordKind::Register)?.to_vec(),
             publisher: None,
             expires: None,
         };
         let xorname1 = XorName::from_content(&record1.value);
         let record2 = Record {
             key: NetworkAddress::from_register_address(address).to_record_key(),
-            value: try_serialize_record(&signed_register2, RecordKind::Register)?,
+            value: try_serialize_record(&signed_register2, RecordKind::Register)?.to_vec(),
             publisher: None,
             expires: None,
         };
         let xorname2 = XorName::from_content(&record2.value);
         let record_bad = Record {
             key: NetworkAddress::from_register_address(address).to_record_key(),
-            value: try_serialize_record(&signed_register_bad, RecordKind::Register)?,
+            value: try_serialize_record(&signed_register_bad, RecordKind::Register)?.to_vec(),
             publisher: None,
             expires: None,
         };

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -350,7 +350,8 @@ impl ClientRegister {
         let key = network_address.to_record_key();
         let record = Record {
             key: key.clone(),
-            value: try_serialize_record(&(payment, &register), RecordKind::RegisterWithPayment)?,
+            value: try_serialize_record(&(payment, &register), RecordKind::RegisterWithPayment)?
+                .to_vec(),
             publisher: None,
             expires: None,
         };
@@ -367,7 +368,7 @@ impl ClientRegister {
             (
                 Some(Record {
                     key,
-                    value: try_serialize_record(&register, RecordKind::Register)?,
+                    value: try_serialize_record(&register, RecordKind::Register)?.to_vec(),
                     publisher: None,
                     expires: None,
                 }),

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -532,6 +532,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use bytes::Bytes;
     use eyre::ContextCompat;
     use libp2p::{
         core::multihash::Multihash,
@@ -582,11 +583,11 @@ mod tests {
 
     impl Arbitrary for ArbitraryRecord {
         fn arbitrary(g: &mut Gen) -> ArbitraryRecord {
-            let value: Vec<u8> = match try_serialize_record(
-                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+            let value = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Bytes>(),
                 RecordKind::Chunk,
             ) {
-                Ok(value) => value,
+                Ok(value) => value.to_vec(),
                 Err(err) => panic!("Cannot generate record value {:?}", err),
             };
             let record = Record {
@@ -706,11 +707,11 @@ mod tests {
         let self_address = NetworkAddress::from_peer(self_id);
         for i in 0..100 {
             let record_key = NetworkAddress::from_peer(PeerId::random()).to_record_key();
-            let value: Vec<u8> = match try_serialize_record(
-                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+            let value = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Bytes>(),
                 RecordKind::Chunk,
             ) {
-                Ok(value) => value,
+                Ok(value) => value.to_vec(),
                 Err(err) => panic!("Cannot generate record value {:?}", err),
             };
             let record = Record {
@@ -801,11 +802,11 @@ mod tests {
         // minus one here as if we hit max, the store will fail
         for _ in 0..max_records - 1 {
             let record_key = NetworkAddress::from_peer(PeerId::random()).to_record_key();
-            let value: Vec<u8> = match try_serialize_record(
-                &(0..50).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+            let value = match try_serialize_record(
+                &(0..50).map(|_| rand::random::<u8>()).collect::<Bytes>(),
                 RecordKind::Chunk,
             ) {
-                Ok(value) => value,
+                Ok(value) => value.to_vec(),
                 Err(err) => panic!("Cannot generate record value {:?}", err),
             };
             let record = Record {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -11,6 +11,7 @@ use super::{error::Result, event::NodeEventsChannel, Marker, NodeEvent};
 use crate::metrics::NodeMetrics;
 use crate::RunningNode;
 use bls::{PublicKey, PK_SIZE};
+use bytes::Bytes;
 use libp2p::{autonat::NatStatus, identity::Keypair, Multiaddr};
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
@@ -469,7 +470,7 @@ impl Node {
 
                 if let Some(record_key) = record_key {
                     if let Ok(Some(record)) = self.network.get_local_record(&record_key).await {
-                        result = Ok((our_address, record.value));
+                        result = Ok((our_address, Bytes::from(record.value)));
                     }
                 }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -219,7 +219,7 @@ impl Node {
 
         let record = Record {
             key,
-            value: try_serialize_record(&chunk, RecordKind::Chunk)?,
+            value: try_serialize_record(&chunk, RecordKind::Chunk)?.to_vec(),
             publisher: None,
             expires: None,
         };
@@ -272,7 +272,7 @@ impl Node {
         // store in kad
         let record = Record {
             key: key.clone(),
-            value: try_serialize_record(&updated_register, RecordKind::Register)?,
+            value: try_serialize_record(&updated_register, RecordKind::Register)?.to_vec(),
             publisher: None,
             expires: None,
         };
@@ -358,7 +358,7 @@ impl Node {
         // store the record into the local storage
         let record = Record {
             key: key.clone(),
-            value: try_serialize_record(&validated_spends, RecordKind::Spend)?,
+            value: try_serialize_record(&validated_spends, RecordKind::Spend)?.to_vec(),
             publisher: None,
             expires: None,
         };

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -165,7 +165,7 @@ impl Node {
                 };
 
                 let record = if let Some(record_content) = record_opt {
-                    Record::new(key, record_content)
+                    Record::new(key, record_content.to_vec())
                 } else {
                     trace!(
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -8,6 +8,7 @@
 
 use crate::{error::Result, NetworkAddress};
 
+use bytes::Bytes;
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use sn_transfers::{MainPubkey, NanoTokens};
@@ -28,7 +29,7 @@ pub enum QueryResponse {
     /// Response to [`GetReplicatedRecord`]
     ///
     /// [`GetReplicatedRecord`]: crate::messages::Query::GetReplicatedRecord
-    GetReplicatedRecord(Result<(NetworkAddress, Vec<u8>)>),
+    GetReplicatedRecord(Result<(NetworkAddress, Bytes)>),
 }
 
 // Debug implementation for QueryResponse, to avoid printing Vec<u8>


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 11:30 UTC
This pull request updates the code related to networking in several files. 

Here is a brief summary of the changes:
- In the `api.rs` file, the serialization and deserialization of records are modified to directly convert the results to a byte array (`Vec<u8>`).
- In the `register.rs` file, the serialization and deserialization of register records are modified similarly.
- In the `node.rs` file, the value of fetched records is converted to `Bytes` instead of a `Vec<u8>`.
- In the `put_validation.rs` file, the serialization and deserialization of chunk and register records are modified similarly.
- In the `replication.rs` file, the value of retrieved records is passed as a `Bytes` object.
- In the `response.rs` file, the response to the `GetReplicatedRecord` query now contains a `Bytes` object instead of a `Vec<u8>`.
- In the `header.rs` file, the serialization and deserialization of record headers are modified to return the result as a `Bytes` object.

Overall, these changes optimize the serialization and deserialization process by directly using `Bytes` instead of `Vec<u8>`.
<!-- reviewpad:summarize:end --> 
