### PR TITLE
feat: try to replicate paid record immediately

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -171,6 +171,10 @@ async fn verify_rewards(expected_rewards_balance: NanoTokens) -> Result<()> {
     let mut iteration = 0;
     let mut cur_rewards_history = Vec::new();
 
+    // An initial sleep to avoid access to the wallet file synced with the node operations.
+    // Ideally, there shall be wallet file locker to prevent handle multiple processes access.
+    sleep(Duration::from_secs(5)).await;
+
     while iteration < 15 {
         iteration += 1;
         println!("Current iteration {iteration}");

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -47,8 +47,8 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
         chunks_dir.path().to_path_buf(),
     )?;
 
-    println!("Paying for {} random addresses... {chunks:?}", chunks.len());
     let prev_rewards_balance = current_rewards_balance()?;
+    println!("With {prev_rewards_balance:?} current balance, paying for {} random addresses... {chunks:?}", chunks.len());
 
     let (_file_addr, rewards_paid, _royalties_fees) = files_api
         .pay_and_upload_bytes_test(*content_addr.xorname(), chunks)
@@ -78,10 +78,11 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
 
     let rb = current_rewards_balance()?;
 
-    println!("Paying for random Register address... rb {rb:?}");
     let mut rng = rand::thread_rng();
     let register_addr = XorName::random(&mut rng);
     let expected_royalties_fees = NETWORK_ROYALTIES_AMOUNT_PER_ADDR; // fee for a single address
+
+    println!("Paying for random Register address {register_addr:?} with current balance {rb:?}");
 
     let prev_rewards_balance = current_rewards_balance()?;
 
@@ -150,7 +151,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let mut rng = rand::thread_rng();
     let register_addr = XorName::random(&mut rng);
 
-    println!("Paying for random Register address...");
+    println!("Paying for random Register address {register_addr:?} ...");
 
     let handle = spawn_royalties_payment_listener("https://127.0.0.1:12001".to_string());
 
@@ -196,7 +197,7 @@ fn current_rewards_balance() -> Result<NanoTokens> {
         let path = entry?.path();
         let wallet = LocalWallet::try_load_from(&path)?;
         let balance = wallet.balance();
-        println!("Node's wallet {path:?} currentln have balance of {balance:?}");
+        println!("Node's wallet {path:?} currently have balance of {balance:?}");
         total_rewards = total_rewards
             .checked_add(balance)
             .ok_or_else(|| eyre!("Faied to sum up rewards balance"))?;

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -276,11 +276,11 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
         get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
-    println!("Paying for random Register address...");
     let mut rng = rand::thread_rng();
     let xor_name = XorName::random(&mut rng);
     let address = RegisterAddress::new(xor_name, client.signer_pk());
     let net_addr = NetworkAddress::from_register_address(address);
+    println!("Paying for random Register address {net_addr:?} ...");
 
     let _cost = wallet_client
         .pay_for_storage(std::iter::once(net_addr))


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 13:12 UTC
This pull request adds a new feature to immediately replicate paid records. It includes changes to the `put_validation.rs` and `replication.rs` files. In `put_validation.rs`, the `store_chunk()` method is called before replicating the paid record to increase the chance of a timely response to replicate requests. Additionally, a new method `replicate_paid_record()` is implemented in `replication.rs` to replicate paid records to close group peers.
<!-- reviewpad:summarize:end --> 
