### PR TITLE
refactor(node): using unsigned gossipsub msgs

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -393,12 +393,13 @@ impl NetworkBuilder {
 
         // Gossipsub behaviour
         // set default parameters for gossipsub
-        let gossipsub_config = libp2p::gossipsub::Config::default();
+        let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+            .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
+            .build()
+            .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
 
-        // Set the message authenticity - Here we expect the publisher
-        // to sign the message with their key.
-        let message_authenticity =
-            libp2p::gossipsub::MessageAuthenticity::Signed(self.keypair.clone());
+        // Set the message authenticity
+        let message_authenticity = libp2p::gossipsub::MessageAuthenticity::Author(peer_id);
 
         // build a gossipsub network behaviour
         let gossipsub: libp2p::gossipsub::Behaviour =

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     #[error("Close group size must be a non-zero usize")]
     InvalidCloseGroupSize,
 
+    #[error("Could ont build the gossipsub config: {0}")]
+    GossipsubConfigError(String),
+
     #[error("Internal messaging channel was dropped")]
     InternalMsgChannelDropped,
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 13:58 UTC
This pull request refactors the `node` module by using unsigned gossipsub messages. The `driver.rs` file has been modified to replace the default gossipsub configuration with a custom configuration. The message authenticity is now set to be the author instead of expecting the publisher to sign the message with their key. Additionally, the `error.rs` file has been updated to include an error for failing to build the gossipsub configuration.
<!-- reviewpad:summarize:end --> 
