### PR TITLE
[WIP] Transfers opti with pay one

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -15,7 +15,7 @@ use bytes::Bytes;
 use indicatif::ProgressBar;
 use libp2p::{
     identity::Keypair,
-    kad::{Record, K_VALUE},
+    kad::{Quorum, Record, K_VALUE},
     Multiaddr, PeerId,
 };
 #[cfg(feature = "open-metrics")]
@@ -389,7 +389,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::One)
             .await?)
     }
 
@@ -430,7 +430,7 @@ impl Client {
         let key = NetworkAddress::from_chunk_address(address).to_record_key();
         let record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
+            .get_record_from_network(key, None, GetQuorum::One, false, Default::default())
             .await?;
         let header = RecordHeader::from_record(&record)?;
         if let RecordKind::Chunk = header.kind {
@@ -481,7 +481,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
             .await?)
     }
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -278,7 +278,7 @@ impl Client {
 
         let maybe_record = self
             .network
-            .get_record_from_network(key, None, GetQuorum::All, false, Default::default())
+            .get_record_from_network(key, None, GetQuorum::One, true, Default::default())
             .await;
         let record = match maybe_record {
             Ok(r) => r,

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -26,7 +26,7 @@ use std::{
     fs::{self, create_dir_all, File},
     io::{Read, Write},
     path::{Path, PathBuf},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tempfile::tempdir;
 use tokio::task;
@@ -304,6 +304,9 @@ impl Files {
                 .await?;
         }
 
+        // small wait before we verify
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         let mut failed_chunks = self.verify_uploaded_chunks(chunks, BATCH_SIZE).await?;
         warn!("Failed chunks: {:?}", failed_chunks.len());
 
@@ -337,6 +340,9 @@ impl Files {
                 self.get_local_payment_and_upload_chunk(chunk, false, false)
                     .await?;
             }
+
+            // small wait before we verify
+            tokio::time::sleep(Duration::from_secs(1)).await;
 
             trace!("Chunks uploaded again....");
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -382,7 +382,7 @@ impl ClientRegister {
         Ok(self
             .client
             .network
-            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
+            .put_record(record, record_to_verify, expected_holders, Quorum::One)
             .await?)
     }
 

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -9,7 +9,7 @@
 use crate::{Client, Error, Result, WalletClient};
 
 use bls::PublicKey;
-use libp2p::kad::Record;
+use libp2p::kad::{Quorum, Record};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::RegisterCmd,
@@ -382,7 +382,7 @@ impl ClientRegister {
         Ok(self
             .client
             .network
-            .put_record(record, record_to_verify, expected_holders)
+            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
             .await?)
     }
 

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -59,13 +59,13 @@ impl WalletClient {
     pub fn get_payment_transfers(&self, address: &NetworkAddress) -> WalletResult<Vec<Transfer>> {
         match &address.as_xorname() {
             Some(xorname) => {
-                let cash_notes = self.wallet.get_payment_cash_notes(xorname);
+                let transfers = self.wallet.get_payment_transfers(xorname);
 
                 info!(
-                    "Payment cash notes retrieved from wallet: {:?}",
-                    cash_notes.len()
+                    "Payment transfers retrieved for {xorname:?} from wallet: {:?}",
+                    transfers.len()
                 );
-                Ok(Transfer::transfers_from_cash_notes(cash_notes)?)
+                Ok(transfers)
             }
             None => Err(WalletError::InvalidAddressType),
         }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -130,7 +130,7 @@ pub enum SwarmCmd {
     /// The keys added to the replication fetcher are later used to fetch the Record from network
     AddKeysToReplicationFetcher {
         holder: PeerId,
-        keys: Vec<(NetworkAddress, RecordType)>,
+        keys: HashMap<NetworkAddress, RecordType>,
     },
     /// Subscribe to a given Gossipsub topic
     GossipsubSubscribe(String),

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -116,6 +116,7 @@ pub enum SwarmCmd {
     PutRecord {
         record: Record,
         sender: oneshot::Sender<Result<()>>,
+        quorum: Quorum,
     },
     /// Put record to the local RecordStore
     PutLocalRecord {
@@ -341,7 +342,11 @@ impl SwarmDriver {
                     .map(|rec| rec.into_owned());
                 let _ = sender.send(record);
             }
-            SwarmCmd::PutRecord { record, sender } => {
+            SwarmCmd::PutRecord {
+                record,
+                sender,
+                quorum,
+            } => {
                 let record_key = PrettyPrintRecordKey::from(&record.key).into_owned();
                 trace!(
                     "Putting record sized: {:?} to network {:?}",
@@ -352,7 +357,7 @@ impl SwarmDriver {
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .put_record(record, Quorum::All)
+                    .put_record(record, quorum)
                 {
                     Ok(request_id) => {
                         trace!("Sent record {record_key:?} to network. Request id: {request_id:?} to network");

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -454,7 +454,7 @@ impl NetworkBuilder {
             is_client,
             bootstrap: ContinuousBootstrap::new(),
             close_group: Default::default(),
-            replication_fetcher: Default::default(),
+            replication_fetcher: ReplicationFetcher::new(peer_id),
             #[cfg(feature = "open-metrics")]
             network_metrics,
             cmd_receiver: swarm_cmd_receiver,

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -571,7 +571,7 @@ impl Network {
     pub fn add_keys_to_replication_fetcher(
         &self,
         holder: PeerId,
-        keys: Vec<(NetworkAddress, RecordType)>,
+        keys: HashMap<NetworkAddress, RecordType>,
     ) -> Result<()> {
         self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { holder, keys })
     }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -46,6 +46,7 @@ use libp2p::{
 };
 use rand::Rng;
 use sn_protocol::{
+    error::Error as ProtocolError,
     messages::{Query, QueryResponse, Request, Response},
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
@@ -262,6 +263,12 @@ impl Network {
             {
                 let cost_with_tolerance = NanoTokens::from((cost.as_nano() as f32 * 1.1) as u64);
                 all_costs.push((payment_address, cost_with_tolerance));
+            } else if let Response::Query(QueryResponse::GetStoreCost {
+                store_cost: Err(ProtocolError::RecordExists(_)),
+                payment_address,
+            }) = response
+            {
+                all_costs.push((payment_address, NanoTokens::zero()));
             } else {
                 error!("Non store cost response received,  was {:?}", response);
             }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -242,7 +242,7 @@ impl Network {
                 .cmp(&record_address.distance(&b))
         });
 
-        close_nodes.truncate(CLOSE_GROUP_SIZE);
+        close_nodes.truncate(close_group_majority());
 
         let request = Request::Query(Query::GetStoreCost(record_address.clone()));
         let responses = self

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -25,6 +25,7 @@ mod record_store_api;
 mod replication_fetcher;
 mod transfers;
 
+use self::{cmd::SwarmCmd, driver::ExpectedHoldersList, error::Result};
 pub use self::{
     cmd::SwarmLocalState,
     driver::{NetworkBuilder, SwarmDriver},
@@ -34,7 +35,6 @@ pub use self::{
     record_store::NodeRecordStore,
 };
 
-use self::{cmd::SwarmCmd, driver::ExpectedHoldersList, error::Result};
 use bytes::Bytes;
 use futures::future::select_all;
 use itertools::Itertools;
@@ -393,7 +393,10 @@ impl Network {
 
             // wait for a bit before re-trying
             if re_attempt {
-                tokio::time::sleep(MAX_REVERIFICATION_WAIT_TIME_S).await;
+                // Generate a random duration between MAX_REVERIFICATION_WAIT_TIME_S and MIN_REVERIFICATION_WAIT_TIME_S
+                let wait_duration = rand::thread_rng()
+                    .gen_range(MIN_REVERIFICATION_WAIT_TIME_S..MAX_REVERIFICATION_WAIT_TIME_S);
+                tokio::time::sleep(wait_duration).await;
             }
         }
 

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -22,7 +22,7 @@ const MAX_PARALLEL_FETCH: usize = K_VALUE.get() * 4;
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.
-const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
 // The time at which the key was sent to be fetched from the peer.
 type ReplicationRequestSentTime = Instant;

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 // Max parallel fetches that can be undertaken at the same time.
-const MAX_PARALLEL_FETCH: usize = K_VALUE.get() * 2;
+const MAX_PARALLEL_FETCH: usize = K_VALUE.get() * 4;
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -200,7 +200,7 @@ mod tests {
     use eyre::Result;
     use libp2p::{kad::RecordKey, PeerId};
     use sn_protocol::{storage::RecordType, NetworkAddress};
-    use std::{collections::HashSet, time::Duration};
+    use std::{collections::HashMap, time::Duration};
 
     #[tokio::test]
     async fn verify_max_parallel_fetches() -> Result<()> {

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -207,7 +207,7 @@ mod tests {
         //random peer_id
         let peer_id = PeerId::random();
         let mut replication_fetcher = ReplicationFetcher::new(peer_id);
-        let locally_stored_keys = HashSet::new();
+        let locally_stored_keys = HashMap::new();
 
         let mut incoming_keys = Vec::new();
         (0..MAX_PARALLEL_FETCH * 2).for_each(|_| {

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 // Max parallel fetches that can be undertaken at the same time.
-const MAX_PARALLEL_FETCH: usize = K_VALUE.get();
+const MAX_PARALLEL_FETCH: usize = K_VALUE.get() * 2;
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.
@@ -27,14 +27,24 @@ const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
 // The time at which the key was sent to be fetched from the peer.
 type ReplicationRequestSentTime = Instant;
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct ReplicationFetcher {
+    self_peer_id: PeerId,
     to_be_fetched: HashMap<(RecordKey, RecordType, PeerId), Option<ReplicationRequestSentTime>>,
     // Avoid fetching same chunk from different nodes AND carry out too many parallel tasks.
     on_going_fetches: HashMap<(RecordKey, RecordType), PeerId>,
 }
 
 impl ReplicationFetcher {
+    /// Instantiate a new replication fetcher with passed PeerId.
+    pub(crate) fn new(self_peer_id: PeerId) -> Self {
+        Self {
+            self_peer_id,
+            to_be_fetched: HashMap::new(),
+            on_going_fetches: HashMap::new(),
+        }
+    }
+
     // Adds the non existing incoming keys from the peer to the fetcher. Returns the next set of keys that has to be
     // fetched from the peer/network.
     pub(crate) fn add_keys(
@@ -97,7 +107,18 @@ impl ReplicationFetcher {
         }
 
         let mut data_to_fetch = vec![];
-        for ((key, t, holder), is_fetching) in self.to_be_fetched.iter_mut() {
+        // Sort to_be_fetched by key closeness to our PeerId
+        let mut to_be_fetched_sorted: Vec<_> = self.to_be_fetched.iter_mut().collect();
+
+        let self_address = NetworkAddress::from_peer(self.self_peer_id);
+
+        to_be_fetched_sorted.sort_by(|((a, _, _), _), ((b, _, _), _)| {
+            let a = NetworkAddress::from_record_key(a);
+            let b = NetworkAddress::from_record_key(b);
+            self_address.distance(&a).cmp(&self_address.distance(&b))
+        });
+
+        for ((key, t, holder), is_fetching) in to_be_fetched_sorted {
             // Already carried out expiration pruning above.
             // Hence here only need to check whether is ongoing fetching.
             // Also avoid fetching same record from different nodes.
@@ -112,6 +133,11 @@ impl ReplicationFetcher {
                 let _ = self
                     .on_going_fetches
                     .insert((key.clone(), t.clone()), *holder);
+            }
+
+            // break out the loop early if we can do no more now
+            if self.on_going_fetches.len() >= MAX_PARALLEL_FETCH {
+                break;
             }
         }
 

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -200,12 +200,14 @@ mod tests {
     use eyre::Result;
     use libp2p::{kad::RecordKey, PeerId};
     use sn_protocol::{storage::RecordType, NetworkAddress};
-    use std::{collections::HashMap, time::Duration};
+    use std::{collections::HashSet, time::Duration};
 
     #[tokio::test]
     async fn verify_max_parallel_fetches() -> Result<()> {
-        let mut replication_fetcher = ReplicationFetcher::default();
-        let locally_stored_keys = HashMap::new();
+        //random peer_id
+        let peer_id = PeerId::random();
+        let mut replication_fetcher = ReplicationFetcher::new(peer_id);
+        let locally_stored_keys = HashSet::new();
 
         let mut incoming_keys = Vec::new();
         (0..MAX_PARALLEL_FETCH * 2).for_each(|_| {

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -7,8 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 #![allow(clippy::mutable_key_type)]
 
-use crate::CLOSE_GROUP_SIZE;
-use libp2p::{kad::RecordKey, PeerId};
+use libp2p::{
+    kad::{RecordKey, K_VALUE},
+    PeerId,
+};
 use sn_protocol::{storage::RecordType, NetworkAddress, PrettyPrintRecordKey};
 use std::{
     collections::HashMap,
@@ -16,11 +18,11 @@ use std::{
 };
 
 // Max parallel fetches that can be undertaken at the same time.
-const MAX_PARALLEL_FETCH: usize = CLOSE_GROUP_SIZE * 2;
+const MAX_PARALLEL_FETCH: usize = K_VALUE.get();
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.
-const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
 
 // The time at which the key was sent to be fetched from the peer.
 type ReplicationRequestSentTime = Instant;

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -27,7 +27,7 @@ pub enum Marker<'a> {
     NoNetworkActivity(Duration),
 
     /// Forced Replication by simulating a churned out node within close range.
-    ForcedReplication(PeerId),
+    ForcedReplication,
 
     /// Network Cmd message received
     NodeCmdReceived(&'a Cmd),
@@ -43,6 +43,8 @@ pub enum Marker<'a> {
 
     /// Replication trigger was fired
     ReplicationTriggered,
+    /// Interval based replication
+    IntervalReplicationTriggered,
 
     /// Keys of Records we are fetching to replicate locally
     FetchingKeysForReplication {

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -414,8 +414,7 @@ impl Node {
         Ok(CmdOk::StoredSuccessfully)
     }
 
-    /// Gets CashNotes out of a Payment, this includes network verifications of the Transfer.
-    /// Return the CashNotes corresponding to our wallet and the trasfers corresponding to network royalties payment.
+    /// Gets CashNotes out of a Payment, this includes network verifications of the Transfers
     async fn cash_notes_from_payment(
         &self,
         payment: &Vec<Transfer>,
@@ -439,7 +438,7 @@ impl Node {
                     // transfer invalid
                     Err(e) => return Err(e),
                     // transfer ok
-                    Ok(cns) => cash_notes = cns,
+                    Ok(cns) => cash_notes.extend(cns),
                 },
                 Transfer::NetworkRoyalties(cashnote_redemptions) => {
                     if let Ok(cash_notes) = self

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -438,34 +438,41 @@ impl Node {
                     Err(ProtocolError::FailedToDecypherTransfer) => continue,
                     // transfer invalid
                     Err(e) => return Err(e),
-                    // transfer ok
+                    // transfer ok, add to cash_notes and continue as more transfers might be ours
                     Ok(cns) => cash_notes.extend(cns),
                 },
                 Transfer::NetworkRoyalties(cashnote_redemptions) => {
-                    if let Ok(cash_notes) = self
+                    match self
                         .network
                         .verify_cash_notes_redemptions(royalties_pk, cashnote_redemptions)
                         .await
                     {
-                        let received_royalties =
-                            total_cash_notes_amount(&cash_notes, pretty_key.clone())?;
-                        trace!(
-                            "{} network royalties payment cash notes found for record {pretty_key} for a total value of {received_royalties:?}",
-                            cash_notes.len()
-                        );
-                        let rewraped_transfers = cash_notes
-                            .into_iter()
-                            .map(Transfer::transfers_from_cash_note)
-                            .collect::<Result<Vec<Transfer>, sn_transfers::Error>>()
-                            .map_err(|err| {
-                                error!("Error generating royalty transfer: {err:?}");
-                                ProtocolError::FailedToEncryptTransfer
-                            })?;
+                        Ok(cash_notes) => {
+                            let received_royalties =
+                                total_cash_notes_amount(&cash_notes, pretty_key.clone())?;
+                            trace!(
+                                "{} network royalties payment cash notes found for record {pretty_key} for a total value of {received_royalties:?}",
+                                cash_notes.len()
+                            );
+                            let rewraped_transfers = cash_notes
+                                .into_iter()
+                                .map(Transfer::transfers_from_cash_note)
+                                .collect::<Result<Vec<Transfer>, sn_transfers::Error>>()
+                                .map_err(|err| {
+                                    error!("Error generating royalty transfer: {err:?}");
+                                    ProtocolError::FailedToEncryptTransfer
+                                })?;
 
-                        royalties_transfers.extend(rewraped_transfers);
-                        received_fee = received_fee
-                            .checked_add(received_royalties)
-                            .ok_or_else(|| ProtocolError::PaymentExceedsTotalTokens)?;
+                            royalties_transfers.extend(rewraped_transfers);
+                            received_fee = received_fee
+                                .checked_add(received_royalties)
+                                .ok_or_else(|| ProtocolError::PaymentExceedsTotalTokens)?;
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Invalid network royalties payment for record {pretty_key}: {e:?}"
+                            );
+                        }
                     }
                 }
             }
@@ -522,9 +529,9 @@ impl Node {
 
         if royalties_transfers.is_empty() {
             warn!("No network royalties payment found for record {pretty_key}");
-            // return Err(ProtocolError::NoNetworkRoyaltiesPayment(
-            //     pretty_key.into_owned(),
-            // ));
+            return Err(ProtocolError::NoNetworkRoyaltiesPayment(
+                pretty_key.into_owned(),
+            ));
         }
 
         // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for the network royalties payment.

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -174,7 +174,7 @@ impl Node {
                         .get_record_from_network(
                             key,
                             None,
-                            GetQuorum::Majority,
+                            GetQuorum::One,
                             false,
                             Default::default(),
                         )

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -12,7 +12,7 @@ use libp2p::{
     kad::{Record, RecordKey, K_VALUE},
     PeerId,
 };
-use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE, REPLICATE_RANGE};
+use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     storage::RecordType,
@@ -176,7 +176,7 @@ impl Node {
                     trace!("Replicating paid record {pretty_key:?} to {peer_id:?}");
                     let request = Request::Cmd(Cmd::Replicate {
                         holder: our_address.clone(),
-                        keys: vec![(addr.clone(), record_type.clone())],
+                        keys: HashMap::from_iter([(addr.clone(), record_type.clone())]),
                     });
 
                     let _ = network.send_req_ignore_reply(request, *peer_id);

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -16,106 +16,39 @@ use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE, REPLICAT
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     storage::RecordType,
-    NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
+    NetworkAddress, PrettyPrintRecordKey,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::HashMap;
 use tokio::task::{spawn, JoinHandle};
 
-// To reduce the number of messages exchanged, patch max 500 replication keys into one request.
-const MAX_REPLICATION_KEYS_PER_REQUEST: usize = 500;
-
 impl Node {
-    /// When there is PeerAdded or PeerRemoved, trigger replication, and replication target to be:
-    /// 1, For PeerAdded(X), replicate any record that is now having X in its close_group
-    ///    (from our knowledge) to that X
-    /// 2, For PeerRemoved(X), replicate any record that previously having X in its close_group,
-    ///    to that record's new close_group's farthest peer
-    pub(crate) async fn try_trigger_targetted_replication(
-        &self,
-        peer_id: PeerId,
-        is_removal: bool,
-    ) -> Result<()> {
+    /// Sends _all_ record keys every interval to all peers.
+    pub(crate) async fn try_interval_replication(&self) -> Result<()> {
         let start = std::time::Instant::now();
-        info!("Try trigger start");
         // Already contains self_peer_id
-        let mut all_peers_set: BTreeSet<_> = self
-            .network
-            .get_all_local_peers()
-            .await?
-            .iter()
-            .cloned()
-            .collect();
+        let all_peers = self.network.get_all_local_peers().await?;
 
         // Do not carry out replication if not many peers present.
-        if all_peers_set.len() < K_VALUE.into() {
+        if all_peers.len() < K_VALUE.into() {
             trace!(
                 "Not having enough peers to start replication: {:?}/{K_VALUE:?}",
-                all_peers_set.len()
+                all_peers.len()
             );
             return Ok(());
         }
 
-        self.record_metrics(Marker::ReplicationTriggered);
+        self.record_metrics(Marker::IntervalReplicationTriggered);
 
         let our_peer_id = self.network.peer_id;
         let our_address = NetworkAddress::from_peer(our_peer_id);
 
         let all_records = self.network.get_all_local_record_addresses().await?;
 
-        trace!(
-            "Replication triggered by the churning of {peer_id:?}, we have #{:?} records",
-            all_records.len()
-        );
-
-        let mut replicate_to: BTreeMap<PeerId, Vec<(NetworkAddress, RecordType)>> =
-            Default::default();
-
-        if is_removal {
-            let _ = all_peers_set.insert(peer_id);
-        }
-        let all_peers: Vec<_> = all_peers_set.iter().cloned().collect();
-
-        for (key, record_type) in all_records {
-            let mut sorted_based_on_key = sort_peers_by_address(&all_peers, &key, REPLICATE_RANGE)?;
-            let sorted_peers_pretty_print: Vec<_> = sorted_based_on_key
-                .iter()
-                .map(|&peer_id| {
-                    format!(
-                        "{peer_id:?}({:?})",
-                        PrettyPrintKBucketKey(NetworkAddress::from_peer(*peer_id).as_kbucket_key())
-                    )
-                })
-                .collect();
-
-            if sorted_based_on_key.contains(&&peer_id) {
-                trace!("replication: close for {key:?} are: {sorted_peers_pretty_print:?}");
-                let target_peers: Vec<_> = if is_removal {
-                    // For dead peer, replicate to close peers except the dead one.
-                    sorted_based_on_key.retain(|target| **target != peer_id);
-                    sorted_based_on_key.to_vec()
-                } else {
-                    // For new peer, always replicate to it when it is close_group of the record.
-                    vec![&peer_id]
-                };
-
-                for target_peer in target_peers {
-                    let keys_to_replicate = replicate_to.entry(*target_peer).or_default();
-                    keys_to_replicate.push((key.clone(), record_type.clone()));
-                }
-            }
+        for peer_id in all_peers {
+            self.send_replicate_cmd_without_wait(&our_address, &peer_id, all_records.clone())?;
         }
 
-        for (peer_id, keys) in replicate_to {
-            let (_left, mut remaining_keys) = keys.split_at(0);
-            while remaining_keys.len() > MAX_REPLICATION_KEYS_PER_REQUEST {
-                let (left, right) = remaining_keys.split_at(MAX_REPLICATION_KEYS_PER_REQUEST);
-                remaining_keys = right;
-                self.send_replicate_cmd_without_wait(&our_address, &peer_id, left.to_vec())?;
-            }
-            self.send_replicate_cmd_without_wait(&our_address, &peer_id, remaining_keys.to_vec())?;
-        }
-
-        info!("Try trigger end, took {:?}", start.elapsed());
+        info!("Try trigger interval, took {:?}", start.elapsed());
         Ok(())
     }
 
@@ -124,7 +57,7 @@ impl Node {
     pub(crate) fn add_keys_to_replication_fetcher(
         &self,
         holder: PeerId,
-        keys: Vec<(NetworkAddress, RecordType)>,
+        keys: HashMap<NetworkAddress, RecordType>,
     ) -> Result<()> {
         self.network.add_keys_to_replication_fetcher(holder, keys)?;
         Ok(())
@@ -261,7 +194,7 @@ impl Node {
         &self,
         our_address: &NetworkAddress,
         peer_id: &PeerId,
-        keys: Vec<(NetworkAddress, RecordType)>,
+        keys: HashMap<NetworkAddress, RecordType>,
     ) -> Result<()> {
         trace!(
             "Sending a replication list of {} keys to {peer_id:?} keys: {keys:?}",

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -306,7 +306,7 @@ fn create_cash_note_task(
 
             let dest_pk = MainSecretKey::random().main_pubkey();
             let cash_note = wallet_client
-                .send_cash_note(NanoTokens::from(10), dest_pk, false)
+                .send_cash_note(NanoTokens::from(10), dest_pk, true)
                 .await
                 .expect("Failed to send CashNote to {dest_pk}");
 
@@ -421,9 +421,8 @@ fn store_chunks_task(
             };
 
             println!(
-                "Storing ({}) Chunk/s at cost: {cost:?} of file ({} bytes) at {addr:?} in {delay:?}",
-                chunks_len,
-                chunk_size
+                "Storws ({}) Chunk/s at cost: {cost:?} of file ({} bytes) at {addr:?} in {delay:?}",
+                chunks_len, chunk_size
             );
             sleep(delay).await;
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -14,7 +14,7 @@ use crate::common::{
 };
 use sn_client::WalletClient;
 use sn_logging::LogBuilder;
-use sn_networking::CLOSE_GROUP_SIZE;
+
 use sn_node::NodeEvent;
 use sn_transfers::{
     LocalWallet, NanoTokens, NETWORK_ROYALTIES_AMOUNT_PER_ADDR, NETWORK_ROYALTIES_PK,
@@ -132,7 +132,7 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(count, 1, "Not enough notifications received");
 
     Ok(())
 }
@@ -162,7 +162,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     let count = handle.await??;
     println!("Number of notifications received by node: {count}");
-    assert_eq!(count, CLOSE_GROUP_SIZE, "Not enough notifications received");
+    assert_eq!(count, 1, "Not enough notifications received");
 
     Ok(())
 }
@@ -230,7 +230,7 @@ fn spawn_royalties_payment_listener(endpoint: String) -> JoinHandle<Result<usize
                     println!("Transfer notif received for key {key:?}");
                     if key == royalties_pk {
                         count += 1;
-                        if count == CLOSE_GROUP_SIZE {
+                        if count == 1 {
                             break;
                         }
                     }

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -44,7 +44,7 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(90);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(120);
 
 // Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 3;
@@ -113,7 +113,6 @@ async fn verify_data_location() -> Result<()> {
 
         // wait for the dead peer to be removed from the RT and the replication flow to finish
         println!("\nNode {node_index} has been restarted, waiting for {VERIFICATION_DELAY:?} before verification");
-
         tokio::time::sleep(VERIFICATION_DELAY).await;
 
         // get the new PeerId for the current NodeIndex

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -10,6 +10,7 @@ use crate::{storage::RecordType, NetworkAddress};
 use serde::{Deserialize, Serialize};
 // TODO: remove this dependency and define these types herein.
 pub use sn_transfers::{Hash, UniquePubkey};
+use std::collections::HashMap;
 
 /// Data and CashNote cmds - recording spends or creating, updating, and removing data.
 ///
@@ -28,7 +29,7 @@ pub enum Cmd {
         holder: NetworkAddress,
         /// Keys of copy that shall be replicated.
         #[debug(skip)]
-        keys: Vec<(NetworkAddress, RecordType)>,
+        keys: HashMap<NetworkAddress, RecordType>,
     },
 }
 

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     rng, CashNote, DerivationIndex, DerivedSecretKey, Hash, Input, MainPubkey, NanoTokens,
-    SignedSpend, Transaction, TransactionBuilder, UniquePubkey,
+    SignedSpend, Transaction, TransactionBuilder, Transfer, UniquePubkey,
 };
 use crate::{Error, Result};
 
@@ -36,7 +36,7 @@ pub struct OfflineTransfer {
     pub all_spend_requests: Vec<SignedSpend>,
 }
 
-pub type PaymentDetails = (UniquePubkey, MainPubkey, NanoTokens);
+pub type PaymentDetails = (Transfer, MainPubkey, NanoTokens);
 
 /// Xorname of data from which the content was fetched, mapping to the CashNote UniquePubkey (its id on disk)
 /// the main key for that CashNote and the value

--- a/sn_transfers/src/transfers/transfer.rs
+++ b/sn_transfers/src/transfers/transfer.rs
@@ -12,7 +12,6 @@ use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 use crate::error::{Error, Result};
 
@@ -28,50 +27,6 @@ pub enum Transfer {
 }
 
 impl Transfer {
-    /// This function is used to create Transfer from CashNotes, can be done offline, and sent to the recipient.
-    /// Creates Transfers from the given cash_notes
-    /// Grouping CashNotes by recipient into different transfers
-    /// This Transfer can be sent safely to the recipients as all data in it is encrypted
-    /// The recipients can then decrypt the data and use it to verify and reconstruct the CashNotes
-    pub fn transfers_from_cash_notes(cash_notes: Vec<CashNote>) -> Result<Vec<Transfer>> {
-        let mut cashnote_redemptions_map: BTreeMap<MainPubkey, Vec<CashNoteRedemption>> =
-            BTreeMap::new();
-        for cash_note in cash_notes {
-            let recipient = cash_note.main_pubkey;
-            let derivation_index = cash_note.derivation_index();
-            let parent_spend_addr = match cash_note.signed_spends.iter().next() {
-                Some(s) => SpendAddress::from_unique_pubkey(s.unique_pubkey()),
-                None => {
-                    warn!(
-                        "Skipping CashNote {cash_note:?} while creating Transfer as it has no parent spends."
-                    );
-                    continue;
-                }
-            };
-
-            info!("Creating Transfer for CashNote {cash_note:?} with recipient {recipient:?} of value {:?}", cash_note.value()?);
-            let u = CashNoteRedemption::new(derivation_index, parent_spend_addr);
-            cashnote_redemptions_map
-                .entry(recipient)
-                .or_default()
-                .push(u);
-        }
-
-        let mut transfers = Vec::new();
-        for (recipient, cashnote_redemptions) in cashnote_redemptions_map {
-            let t = if recipient == *crate::NETWORK_ROYALTIES_PK {
-                // create a network royalties transfer type
-                Self::NetworkRoyalties(cashnote_redemptions.clone())
-            } else {
-                Self::create(cashnote_redemptions, recipient)
-                    .map_err(|_| Error::CashNoteRedemptionEncryptionFailed)?
-            };
-
-            transfers.push(t);
-        }
-        Ok(transfers)
-    }
-
     /// This function is used to create a Transfer from a CashNote, can be done offline, and sent to the recipient.
     /// Creates a Transfer from the given cash_note
     /// This Transfer can be sent safely to the recipients as all data in it is encrypted
@@ -90,6 +45,21 @@ impl Transfer {
         let t = Transfer::create(vec![u], recipient)
             .map_err(|_| Error::CashNoteRedemptionEncryptionFailed)?;
         Ok(t)
+    }
+
+    /// This function is used to create a Network Royalties Transfer from a CashNote
+    /// can be done offline, and should be sent along with a data payment
+    pub(crate) fn royalties_transfers_from_cash_note(cash_note: CashNote) -> Result<Transfer> {
+        let derivation_index = cash_note.derivation_index();
+        let parent_spend_addr = match cash_note.signed_spends.iter().next() {
+            Some(s) => SpendAddress::from_unique_pubkey(s.unique_pubkey()),
+            None => {
+                return Err(Error::CashNoteHasNoParentSpends);
+            }
+        };
+
+        let u = CashNoteRedemption::new(derivation_index, parent_spend_addr);
+        Ok(Self::NetworkRoyalties(vec![u]))
     }
 
     /// Create a new transfer

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -227,24 +227,17 @@ impl LocalWallet {
     }
 
     /// Return the payment cash_note ids for the given content address name if cached.
-    pub fn get_payment_cash_notes(&self, name: &XorName) -> Vec<CashNote> {
-        let ids = self.get_payment_unique_pubkeys_and_values(name);
-        // now grab all those cash_notes
-        let mut cash_notes: Vec<CashNote> = vec![];
+    pub fn get_payment_transfers(&self, name: &XorName) -> Vec<Transfer> {
+        let mut transfers: Vec<Transfer> = vec![];
 
-        if let Some(ids) = ids {
-            for (id, _main_pub_key, _value) in ids {
-                if let Some(cash_note) = load_created_cash_note(id, &self.wallet_dir) {
-                    trace!(
-                        "Current cash_note of chunk {name:?} is paying {:?} tokens.",
-                        cash_note.value()
-                    );
-                    cash_notes.push(cash_note);
-                }
+        if let Some(payment) = self.get_payment_unique_pubkeys_and_values(name) {
+            for (trans, _main_pub_key, value) in payment {
+                trace!("Current transfer for chunk {name:?} is of {value:?} tokens.");
+                transfers.push(trans.to_owned());
             }
         }
 
-        cash_notes
+        transfers
     }
 
     /// Make a transfer and return all created cash_notes
@@ -350,7 +343,7 @@ impl LocalWallet {
         for (content_addr, payees) in all_data_payments {
             for (payee, token) in payees {
                 if let Some(cash_note) =
-                    &offline_transfer
+                    offline_transfer
                         .created_cash_notes
                         .iter()
                         .find(|cash_note| {
@@ -364,7 +357,7 @@ impl LocalWallet {
                     let cash_notes_for_content: &mut Vec<PaymentDetails> =
                         all_transfers_per_address.entry(content_addr).or_default();
                     cash_notes_for_content.push((
-                        cash_note.unique_pubkey(),
+                        Transfer::transfers_from_cash_note(cash_note.to_owned())?,
                         *cash_note.main_pubkey(),
                         cash_note.value()?,
                     ));
@@ -506,17 +499,17 @@ impl LocalWallet {
         // For each target address
         for (xor, payments) in payment_map.iter_mut() {
             // All payments done for an address, should be multiple nodes.
-            if let Some(notes) = self.get_payment_unique_pubkeys_and_values(xor) {
-                for (_note_main_key, main_pub_key, note_value) in notes {
-                    // Find new payment to a node, for which we have a cashnote already
+            if let Some(prev_payment) = self.get_payment_unique_pubkeys_and_values(xor) {
+                for (_transfer, prev_payment_pub_key, prev_payment_value) in prev_payment {
+                    // Find new payment to a node, for which we have a transfer already
                     if let Some((_main_pub_key, payment_tokens)) = payments
                         .iter_mut()
-                        .find(|(pubkey, _)| pubkey.public_key() == main_pub_key.public_key())
+                        .find(|(pubkey, _)| pubkey == prev_payment_pub_key)
                     {
                         // Subtract what we already paid from what we're about to pay.
                         // `checked_sub` overflows if would be negative, so we set it to 0.
                         *payment_tokens = payment_tokens
-                            .checked_sub(*note_value)
+                            .checked_sub(*prev_payment_value)
                             .unwrap_or(NanoTokens::zero());
                     }
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Nov 23 08:57 UTC
This pull request includes the following changes across multiple files:
1. The `LocalWallet` struct in `sn_transfers/src/wallet/local_store.rs`:
   - Renamed `get_payment_cash_notes` to `get_payment_transfers`.
   - Now returns a vector of `Transfer` objects instead of `CashNote` objects.
   - Simplified logic in the `get_payment_transfers` function for fetching payment transfers and appending them to the `transfers` vector.
   - Renamed the `adjust_payment_map` function in the `local_send_storage_payment` function to `take_previous_payments_into_account`.
   - Minor changes in variable names, comments, and formatting throughout the file.
   
2. The `WalletClient` implementation in the `wallet.rs` file:
   - Replaced `get_payment_cash_notes` with `get_payment_transfers` in the `get_payment_transfers` method.
   - Updated the logging statement to reflect this change.
   - Moved the line declaring `payment_map` inside the `get_store_costs` method, with added comments to explain the purpose.
   - Updated the code for collecting store costs from the network.
   - Replaced the line to adjust the payment map with a `take_previous_payments_into_account` method call in the `pay_for_records` method.
   - Overall improvements to functionality and reliability of the WalletClient.

3. The `driver.rs` file in `sn_networking/src`:
   - Modification of the `replication_fetcher` field in line 454. It was previously set to `Default::default()`, but now it is set to `ReplicationFetcher::new(peer_id)`.

4. Changes in the `verify_data_location.rs` file:
   - Line 47: Updated the `VERIFICATION_DELAY` constant from 90 seconds to 120 seconds.
   - Line 116: Removed an empty line of code.

5. Modifications in the `cmd.rs` file:
   - Added an import statement for `std::collections::HashMap`.
   - Changed the type of the `keys` field in the `Cmd::Put` variant from `Vec<(NetworkAddress, RecordType)>` to `HashMap<NetworkAddress, RecordType>`.
   
6. Changes in the `data_with_churn.rs` file:
   - Line 306: Modified the `send_cash_note` function call by changing the third argument from `false` to `true`.
   - Line 421: Corrected a typo in the `println!` statement. "Storws" was changed to "Storing" for proper output.

7. Modifications to the `ReplicationFetcher` struct and its implementation in `replication_fetcher.rs`:
   - Updated the import statements for `RecordKey` and `PeerId`.
   - Changed `MAX_PARALLEL_FETCH` from using `CLOSE_GROUP_SIZE` to `K_VALUE` multiplied by 4.
   - Updated `FETCH_TIMEOUT` to a duration of 15 seconds instead of 10.
   - Added a `self_peer_id` field of type `PeerId` to the `ReplicationFetcher` struct.
   - Added the `new` associated function to instantiate a new `ReplicationFetcher` instance with a provided `PeerId`.
   - Updated the `add_keys` method to take an additional `self_peer_id` parameter and store it in the `ReplicationFetcher` struct.
   - Modified the `fetch_from_peer` method to sort the `to_be_fetched` hashmap by key closeness to the `self_peer_id`.
   - Created a new `NetworkAddress` using the `PeerId` for the `self_peer_id` to calculate key closeness distances.
   - Updated the `verify_max_parallel_fetches` test function to create a random `PeerId` and pass it to the `new` function of `ReplicationFetcher`.

8. Changes to the `log_markers.rs` file:
   - Modified the `ForcedReplication` variant of the `Marker` enum by removing the `PeerId` parameter.
   - Added a new variant called `IntervalReplicationTriggered` to the `Marker` enum.

9. Modifications in the `nodes_rewards.rs` file:
   - Removed the import statement for `CLOSE_GROUP_SIZE` from the `sn_networking` module.
   - Modified the `assert_eq!` macro in the `async fn nodes_rewards_for_chunks_notifs_over_gossipsub()` to expect a count of 1 instead of `CLOSE_GROUP_SIZE`.
   - Modified the `assert_eq!` macro in the `async fn nodes_rewards_for_register_notifs_over_gossipsub()` to expect a count of 1 instead of `CLOSE_GROUP_SIZE`.
   - Modified the `if` condition in the `fn spawn_royalties_payment_listener()` to break when the count reaches 1 instead of `CLOSE_GROUP_SIZE`.

10. Changes to the `cmd.rs` file:
    - Changes made to the `SwarmCmd` enum and the `impl SwarmDriver` struct.
    - Added a new variant `PutRecord` to the `SwarmCmd` enum, which includes a `quorum` field of type `Quorum`.
    - Handling of the `PutRecord` variant in the `impl SwarmDriver` struct, passing the `quorum` field to the `put_record` function of the `kademlia` module.

11. Changes to the `Node` struct implementation in the `node.rs` file:
    - Simplified the code related to periodic replication, removing the logic for fetching closest peers and selecting a random peer for replication.
    - Instead, directly logged the `Marker::ForcedReplication` and triggered replication using the `try_interval_replication` method.
    - Replaced the `try_trigger_targetted_replication` method with `try_interval_replication`.
    - Modified the error message for replication triggering failure.
    - Similar changes made for the `try_trigger_targetted_replication` method when a peer is removed.
    - These changes simplify the replication logic by removing the complexity of selecting closest peers and directly triggering replication using the `Marker` enum.

12. Modifications to the `Replication` code in several files:
    - Removed the constant `MAX_REPLICATION_KEYS_PER_REQUEST`.
    - Renamed the `try_trigger_targetted_replication` function to `try_interval_replication`.
    - Removed the `is_removal` parameter from the `try_interval_replication` function.
    - Renamed the `all_peers_set` variable to `all_peers`.
    - Updated the check for the number of peers before replication to use `all_peers.len()` instead of `all_peers_set.len()`.
    - Changed the marker for recording replication from `ReplicationTriggered` to `IntervalReplication
<!-- reviewpad:summarize:end --> 
