### PR TITLE
refactor(node): short-circuit transfers verification once the first o…

### DIFF
--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use sn_protocol::storage::{ChunkAddress, RegisterAddress};
 use sn_transfers::{Transfer, UniquePubkey};
 use tokio::sync::broadcast;
-const NODE_EVENT_CHANNEL_SIZE: usize = 10_000;
+
+const NODE_EVENT_CHANNEL_SIZE: usize = 500;
 
 /// Channel where users of the public API can listen to events broadcasted by the node.
 #[derive(Clone)]

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -41,6 +41,11 @@ impl NodeEventsChannel {
             trace!("Error occurred when trying to broadcast a node event ({event:?}): {err}");
         }
     }
+
+    /// Returns the number of active receivers
+    pub fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
 }
 
 /// Type of events broadcasted by the node to the public API.

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -371,16 +371,18 @@ impl Node {
             }
             NetworkEvent::GossipsubMsgReceived { topic, msg }
             | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
-                if topic == TRANSFER_NOTIF_TOPIC {
-                    // this is expected to be a notification of a transfer which we treat specially
-                    match try_decode_transfer_notif(&msg) {
-                        Ok(notif_event) => return self.events_channel.broadcast(notif_event),
-                        Err(err) => warn!("GossipsubMsg matching the transfer notif. topic name, couldn't be decoded as such: {:?}", err),
+                if self.events_channel.receiver_count() > 0 {
+                    if topic == TRANSFER_NOTIF_TOPIC {
+                        // this is expected to be a notification of a transfer which we treat specially
+                        match try_decode_transfer_notif(&msg) {
+                            Ok(notif_event) => return self.events_channel.broadcast(notif_event),
+                            Err(err) => warn!("GossipsubMsg matching the transfer notif. topic name, couldn't be decoded as such: {:?}", err),
+                        }
                     }
-                }
 
-                self.events_channel
-                    .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                    self.events_channel
+                        .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                }
             }
         }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -429,7 +429,7 @@ impl Node {
 
         for transfer in payment {
             match transfer {
-                Transfer::Encrypted(_) => match self
+                Transfer::Encrypted(_) if cash_notes.is_empty() => match self
                     .network
                     .verify_and_unpack_transfer(transfer, wallet)
                     .await
@@ -441,6 +441,7 @@ impl Node {
                     // transfer ok
                     Ok(cns) => cash_notes = cns,
                 },
+                Transfer::Encrypted(_) => continue, // we already have our cash notes, so we can skip this one
                 Transfer::NetworkRoyalties(cashnote_redemptions) => {
                     if let Ok(cash_notes) = self
                         .network


### PR DESCRIPTION
…ne belonging to itself is found

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Nov 23 13:12 UTC
This pull request refactors the `put_validation.rs` file in the `sn_node` project. The change introduces a short-circuit mechanism that skips further verification once the first transfer belonging to itself is found. This improves the overall efficiency of the code.
<!-- reviewpad:summarize:end --> 
