### PR TITLE
feat(node): allow to set a filter for transfer notifications based on targeted pk

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -49,8 +49,7 @@ use sn_protocol::{
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
-use sn_transfers::MainPubkey;
-use sn_transfers::NanoTokens;
+use sn_transfers::{MainPubkey, NanoTokens};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,

--- a/sn_node/src/error.rs
+++ b/sn_node/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     #[error("Failed to parse NodeEvent")]
     NodeEventParsingFailed,
 
+    #[error("Failed to send a cmd to the node: {0}")]
+    NodeCmdFailed(String),
+
     #[error("Node's rewards wallet error {0}")]
     RewardsWallet(#[from] WalletError),
 }

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -67,6 +67,13 @@ message GossipsubPublishRequest {
 
 message GossipsubPublishResponse {}
 
+// Set a PublicKey to start decoding and accepting Transfer notifications received over gossipsub.
+message TransferNotifsFilterRequest {
+  bytes pk = 1;
+}
+
+message TransferNotifsFilterResponse {}
+
 // Stop the safenode app
 message StopRequest {
   uint64 delay_millis = 1;

--- a/sn_node/src/protocol/safenode_proto/safenode.proto
+++ b/sn_node/src/protocol/safenode_proto/safenode.proto
@@ -31,6 +31,9 @@ service SafeNode {
   // Returns a stream of events as triggered by this node
   rpc NodeEvents (NodeEventsRequest) returns (stream NodeEvent);
 
+  // Set a PublicKey to start decoding and accepting Transfer notifications received over gossipsub.
+  rpc TransferNotifsFilter (TransferNotifsFilterRequest) returns (TransferNotifsFilterResponse);
+
   // Returns the Addresses of all the Records stored by this node
   rpc RecordAddresses (RecordAddressesRequest) returns (RecordAddressesResponse);
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Nov 23 17:35 UTC
This pull request adds a new feature to the codebase. It allows setting a filter for transfer notifications based on the targeted public key. The changes include additions to the `sn_networking` and `sn_node` modules, including modifications to their respective files. The `NetworkBuilder` struct now includes a `transfer_notifs_filter` field that can be set to a specific public key. The `Network` struct in the `sn_networking` module includes a new field `transfer_notifs_filter` of type `Option<PublicKey>`, which represents the transfer notification filter. The `Network` struct also includes a new method `transfer_notifs_filter` that can be used to set the filter. The `Node` struct in the `sn_node` module has been modified to handle the decoding of transfer notifications based on the filter. The `try_decode_transfer_notif` function now takes an additional parameter `filter` of type `PublicKey` and returns an `Option<NodeEvent>`. If the decoded key matches the filter, the function returns `Some(NodeEvent::TransferNotif)` containing the key and transfers. Otherwise, it returns `None`. The code changes also include appropriate handling and broadcasting of transfer notifications in the `Node` struct.
<!-- reviewpad:summarize:end --> 
