### PR TITLE
chore(log): log the connected peers during peer add

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -200,7 +200,7 @@ impl Client {
 
     fn handle_network_event(&mut self, event: NetworkEvent) -> Result<()> {
         match event {
-            NetworkEvent::PeerAdded(peer_id) => {
+            NetworkEvent::PeerAdded(peer_id, _connected_peer) => {
                 self.peers_added += 1;
                 debug!("PeerAdded: {peer_id}");
 

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -29,11 +29,9 @@ impl SwarmDriver {
         &mut self,
         current_bootstrap_interval: Duration,
     ) -> Option<Interval> {
-        let peers_in_rt = self.swarm.connected_peers().count() as u32;
-
         let (should_bootstrap, new_interval) = self
             .bootstrap
-            .should_we_bootstrap(peers_in_rt, current_bootstrap_interval)
+            .should_we_bootstrap(self.connected_peers as u32, current_bootstrap_interval)
             .await;
         if should_bootstrap {
             self.initiate_bootstrap();

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -451,6 +451,7 @@ impl NetworkBuilder {
             self_peer_id: peer_id,
             local: self.local,
             is_client,
+            connected_peers: 0,
             bootstrap: ContinuousBootstrap::new(),
             close_group: Default::default(),
             replication_fetcher: Default::default(),
@@ -486,6 +487,7 @@ pub struct SwarmDriver {
     pub(crate) self_peer_id: PeerId,
     pub(crate) local: bool,
     pub(crate) is_client: bool,
+    pub(crate) connected_peers: usize,
     pub(crate) bootstrap: ContinuousBootstrap,
     /// The peers that are closer to our PeerId. Includes self.
     pub(crate) close_group: Vec<PeerId>,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -831,9 +831,9 @@ impl SwarmDriver {
             } => {
                 event_string = "kad_event::RoutingUpdated";
                 if is_new_peer {
-                    // todo: cache the count as it is frequently used during replication as well.
-                    let connected_peers = self.swarm.connected_peers().count();
-                    info!("New peer added to routing table: {peer:?}, now we have #{connected_peers} connected peers");
+                    self.connected_peers += 1;
+
+                    info!("New peer added to routing table: {peer:?}, now we have #{} connected peers", self.connected_peers);
                     self.log_kbuckets(&peer);
 
                     if self.bootstrap.notify_new_peer() {
@@ -844,6 +844,8 @@ impl SwarmDriver {
                 }
 
                 if old_peer.is_some() {
+                    self.connected_peers -= 1;
+
                     info!("Evicted old peer on new peer join: {old_peer:?}");
                     self.send_event(NetworkEvent::PeerRemoved(peer));
                     self.log_kbuckets(&peer);

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -831,7 +831,9 @@ impl SwarmDriver {
             } => {
                 event_string = "kad_event::RoutingUpdated";
                 if is_new_peer {
-                    info!("New peer added to routing table: {peer:?}");
+                    // todo: cache the count as it is frequently used during replication as well.
+                    let connected_peers = self.swarm.connected_peers().count();
+                    info!("New peer added to routing table: {peer:?}, now we have #{connected_peers} connected peers");
                     self.log_kbuckets(&peer);
 
                     if self.bootstrap.notify_new_peer() {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -428,7 +428,7 @@ impl SwarmDriver {
                     .kademlia
                     .remove_peer(&failed_peer_id)
                 {
-                    self.connected_peers -= 1;
+                    self.connected_peers = self.connected_peers.saturating_sub(1);
                     self.send_event(NetworkEvent::PeerRemoved(
                         *dead_peer.node.key.preimage(),
                         self.connected_peers,
@@ -838,7 +838,7 @@ impl SwarmDriver {
             } => {
                 event_string = "kad_event::RoutingUpdated";
                 if is_new_peer {
-                    self.connected_peers += 1;
+                    self.connected_peers = self.connected_peers.saturating_add(1);
 
                     info!("New peer added to routing table: {peer:?}, now we have #{} connected peers", self.connected_peers);
                     self.log_kbuckets(&peer);
@@ -851,7 +851,7 @@ impl SwarmDriver {
                 }
 
                 if old_peer.is_some() {
-                    self.connected_peers -= 1;
+                    self.connected_peers = self.connected_peers.saturating_sub(1);
 
                     info!("Evicted old peer on new peer join: {old_peer:?}");
                     self.send_event(NetworkEvent::PeerRemoved(peer, self.connected_peers));

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -41,6 +41,9 @@ pub enum Marker<'a> {
     /// Peer was removed from the routing table
     PeerRemovedFromRoutingTable(PeerId),
 
+    /// The number of peers in the routing table
+    PeersInRoutingTable(usize),
+
     /// Replication trigger was fired
     ReplicationTriggered,
 


### PR DESCRIPTION
- used by vdash
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Nov 23 18:03 UTC
This pull request adds logging of the connected peers when a new peer is added to the routing table in the `chore(log)` module. The patch includes changes to the `event.rs` file, where the count of connected peers is cached and logged along with the new peer information.
<!-- reviewpad:summarize:end --> 
