### PR TITLE
feat: keep transfers in mem instead of heavy cashnotes

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -59,13 +59,13 @@ impl WalletClient {
     pub fn get_payment_transfers(&self, address: &NetworkAddress) -> WalletResult<Vec<Transfer>> {
         match &address.as_xorname() {
             Some(xorname) => {
-                let cash_notes = self.wallet.get_payment_cash_notes(xorname);
+                let transfers = self.wallet.get_payment_transfers(xorname);
 
                 info!(
-                    "Payment cash notes retrieved from wallet: {:?}",
-                    cash_notes.len()
+                    "Payment transfers retrieved for {xorname:?} from wallet: {:?}",
+                    transfers.len()
                 );
-                Ok(Transfer::transfers_from_cash_notes(cash_notes)?)
+                Ok(transfers)
             }
             None => Err(WalletError::InvalidAddressType),
         }
@@ -139,10 +139,9 @@ impl WalletClient {
         content_addrs: impl Iterator<Item = NetworkAddress>,
     ) -> WalletResult<(NanoTokens, NanoTokens)> {
         let verify_store = true;
-        let mut payment_map = BTreeMap::default();
 
+        // get store cost from network in parrallel
         let mut tasks = JoinSet::new();
-        // we can collate all the payments together into one transfer
         for content_addr in content_addrs {
             let client = self.client.clone();
             tasks.spawn(async move {
@@ -156,8 +155,10 @@ impl WalletClient {
                 (content_addr, costs)
             });
         }
-
         debug!("Pending store cost tasks: {:?}", tasks.len());
+
+        // collect store costs
+        let mut payment_map = BTreeMap::default();
         while let Some(res) = tasks.join_next().await {
             // In case of cann't fetch cost from network for a content,
             // just skip it as it will then get verification failure,
@@ -179,13 +180,14 @@ impl WalletClient {
                 }
             }
         }
-
         info!("Storecosts retrieved");
 
+        // pay for records
         if payment_map.is_empty() {
             Ok((NanoTokens::zero(), NanoTokens::zero()))
         } else {
-            self.wallet.adjust_payment_map(&mut payment_map);
+            self.wallet
+                .take_previous_payments_into_account(&mut payment_map);
             self.pay_for_records(payment_map, verify_store).await
         }
     }
@@ -200,16 +202,12 @@ impl WalletClient {
         all_data_payments: BTreeMap<XorName, Vec<(MainPubkey, NanoTokens)>>,
         verify_store: bool,
     ) -> WalletResult<(NanoTokens, NanoTokens)> {
-        // TODO:
-        // Check for any existing payment CashNotes, and use them if they exist, only topping up if needs be
-
         let total_cost = self
             .wallet
             .local_send_storage_payment(all_data_payments, None)?;
 
         // send to network
         trace!("Sending storage payment transfer to the network");
-
         let spend_attempt_result = self
             .client
             .send(

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     rng, CashNote, DerivationIndex, DerivedSecretKey, Hash, Input, MainPubkey, NanoTokens,
-    SignedSpend, Transaction, TransactionBuilder, UniquePubkey,
+    SignedSpend, Transaction, TransactionBuilder, Transfer, UniquePubkey,
 };
 use crate::{Error, Result};
 
@@ -36,7 +36,7 @@ pub struct OfflineTransfer {
     pub all_spend_requests: Vec<SignedSpend>,
 }
 
-pub type PaymentDetails = (UniquePubkey, MainPubkey, NanoTokens);
+pub type PaymentDetails = (Transfer, MainPubkey, NanoTokens);
 
 /// Xorname of data from which the content was fetched, mapping to the CashNote UniquePubkey (its id on disk)
 /// the main key for that CashNote and the value


### PR DESCRIPTION
## Description

Gets rid of unnecessary `CashNote` disk I/O by turning them into `Transfers` (very small) as soon as possible. This should also help alleviate the memory because `CashNotes` are very big to work with unlike `Transfers` which are very small. 

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Nov 23 06:47 UTC
This pull request includes the following changes:

1. In the `offline_transfer.rs` file:
- Replaced `UniquePubkey` with `Transfer` in the type `PaymentDetails`.

2. In the file diff of `transfer.rs`:
- Rewrapped the `Transfers` into encrypted Transfers ready to be sent directly to the beneficiary.
- Added logging and error handling for invalid and missing network royalties payments.

3. In the file diff of `wallet.rs`:
- Modified the `get_payment_transfers` function to retrieve payment transfers instead of payment cash notes from the wallet and updated the corresponding log message.
- Updated the `store_content` function to use a JoinSet instead of a BTreeMap for storing payment information, and updated the log message for pending store cost tasks.
- Updated the `store_content` function to handle payment adjustment and taking into account previous payments instead of storing payment cash notes.
- Updated the `pay_for_records` function to consider existing payment CashNotes and top up if necessary.

4. In the file diff of a separate file:
- Renamed the function `get_payment_cash_notes` to `get_payment_transfers` and updated its logic to return `Transfer` objects instead of `CashNote` objects.
- Refactored the logic in the `get_payment_transfers` function for simplification and readability.
- Renamed the function `adjust_payment_map` to `take_previous_payments_into_account`.
- Updated the logic in the `take_previous_payments_into_account` function to subtract previous payments from the payments about to be made.
- Fixed a typo in a log message.
- Updated the test case to reflect the code changes.

These changes aim to improve the handling, processing, and clarity of the code related to payments, transfers, and network royalties. Let me know if you need more information.
<!-- reviewpad:summarize:end --> 
