### PR TITLE
chore(cli): make file upload output cut n paste friendly

### DIFF
--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -356,7 +356,7 @@ async fn upload_files(
         .append(true)
         .open(file_names_path)?;
     for (addr, file_name) in uploaded_file_info.iter() {
-        println!("Uploaded {} to {:x}", file_name, addr);
+        println!("\"{}\" {:x}", file_name, addr);
         info!("Uploaded {} to {:x}", file_name, addr);
         writeln!(file, "{:x}: {}", addr, file_name)?;
     }


### PR DESCRIPTION
naive attempt to address issue from https://safenetforum.org/t/heapnet2-testnet-12-10-23/38749/460?u=southside

rebased version of https://github.com/maidsafe/safe_network/pull/891

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Nov 23 08:49 UTC
This pull request modifies the `upload_files` function in the `files.rs` file of the `sn_cli` project. The change replaces the output message when uploading a file, making it more friendly for cutting and pasting. Previously, the message included the word "Uploaded" before the filename and address, but now it only includes the filename and address within double quotes. This change was made in response to an issue reported on the Safe Network forum.
<!-- reviewpad:summarize:end --> 
