### PR TITLE
feat: for royalty transfer, subscribe and publish to sub-group only

### DIFF
--- a/sn_node/src/bin/safenode_rpc_client.rs
+++ b/sn_node/src/bin/safenode_rpc_client.rs
@@ -245,6 +245,15 @@ pub async fn transfers_events(
     };
     let endpoint = format!("https://{addr}");
     let mut node_client = SafeNodeClient::connect(endpoint).await?;
+
+    for group_index in 0..256 {
+        let royalty_topic: &str = "ROYALTY_TRANSFER";
+        let topic = format!("{royalty_topic}_GROUP_{group_index}");
+        let _response = node_client
+            .subscribe_to_topic(Request::new(GossipsubSubscribeRequest { topic }))
+            .await?;
+    }
+
     let response = node_client
         .node_events(Request::new(NodeEventsRequest {}))
         .await?;

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -148,7 +148,7 @@ impl NodeBuilder {
             #[cfg(feature = "open-metrics")]
             node_metrics,
         };
-        let topic_string = royalty_topic_group(&network.peer_id);
+
         let running_node = RunningNode {
             network,
             node_events_channel,
@@ -156,10 +156,6 @@ impl NodeBuilder {
 
         // Run the node
         node.run(swarm_driver, network_event_receiver);
-        // subscribe to receive transfer notifications over gossipsub topic
-        running_node
-            .subscribe_to_topic(topic_string.clone())
-            .map(|()| info!("Node has been subscribed to gossipsub topic '{topic_string}' to receive network royalties payments notifications."))?;
 
         Ok(running_node)
     }
@@ -393,6 +389,8 @@ impl Node {
             }
             NetworkEvent::GossipsubMsgReceived { topic, msg }
             | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
+                trace!("Received a gossip msg for the topic of {topic}");
+
                 if self.events_channel.receiver_count() > 0 {
                     // TODO: shall record which topics this network instance subscribed.
                     //       currently just using a wild match

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
+    node::royalty_topic_group,
     node::Node,
-    node::TRANSFER_NOTIF_TOPIC,
     spends::{aggregate_spends, check_parent_spends},
     Marker,
 };
@@ -534,7 +534,7 @@ impl Node {
             ));
         }
 
-        // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for the network royalties payment.
+        // publish a notification over gossipsub topic for the network royalties payment.
         let royalties_pk = *NETWORK_ROYALTIES_PK;
         trace!("Publishing a royalties transfer notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}");
         let royalties_pk_bytes = royalties_pk.to_bytes();
@@ -547,7 +547,7 @@ impl Node {
             match bincode::serialize_into(&mut msg, &royalties_transfers) {
                 Ok(_) => {
                     let msg = msg.into_inner().freeze();
-                    if let Err(err) = self.network.publish_on_topic(TRANSFER_NOTIF_TOPIC.to_string(), msg) {
+                    if let Err(err) = self.network.publish_on_topic(royalty_topic_group(&self.network.peer_id), msg) {
                         debug!("Failed to publish a network royalties payment notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}: {err:?}");
                     }
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Nov 23 14:51 UTC
This pull request adds a new feature for royalty transfer by subscribing and publishing to a sub-group only. It also modifies the logic for subscribing and publishing transfer notifications using gossipsub. This change improves the efficiency and specificity of notifications for royalty payments.
<!-- reviewpad:summarize:end --> 
