### PR TITLE
feat(node): allow to set/change the rewards address both from the API and RPC service

### DIFF
--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -59,7 +59,7 @@ pub use self::{
 };
 
 use crate::error::{Error, Result};
-use bls::PublicKey;
+use bls::{PublicKey, SecretKey};
 use bytes::Bytes;
 use libp2p::PeerId;
 use sn_networking::{Network, SwarmLocalState};
@@ -143,6 +143,15 @@ impl RunningNode {
         let _ = self
             .node_cmds
             .send(NodeCmd::TransferNotifsFilter(filter))
+            .map_err(|err| Error::NodeCmdFailed(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Set address the node shall request its rewards to be sent/paid to.
+    pub fn set_rewards_address(&self, sk: SecretKey) -> Result<()> {
+        let _ = self
+            .node_cmds
+            .send(NodeCmd::RewardsAddress(sk))
             .map_err(|err| Error::NodeCmdFailed(err.to_string()))?;
         Ok(())
     }

--- a/sn_node/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_node/src/protocol/safenode_proto/req_resp_types.proto
@@ -79,6 +79,13 @@ message StopRequest {
   uint64 delay_millis = 1;
 }
 
+// Set the address the node shall request its rewards to be sent/paid to.
+message SetRewardsAddressRequest {
+  bytes sk = 1;
+}
+
+message SetRewardsAddressResponse {}
+
 message StopResponse {}
 
 // Restart the safenode app

--- a/sn_node/src/protocol/safenode_proto/safenode.proto
+++ b/sn_node/src/protocol/safenode_proto/safenode.proto
@@ -46,6 +46,9 @@ service SafeNode {
   // Publish a msg on a Gossipsub topic
   rpc PublishOnTopic (GossipsubPublishRequest) returns (GossipsubPublishResponse);
 
+  // Set the address the node shall request its rewards to be sent/paid to.
+  rpc SetRewardsAddress (SetRewardsAddressRequest) returns (SetRewardsAddressResponse);
+
   // Stop the execution of this node
   rpc Stop (StopRequest) returns (StopResponse);
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -506,7 +506,8 @@ impl Node {
         trace!("Validating record payment for {pretty_key}");
 
         // load wallet
-        let mut wallet = LocalWallet::load_from(&self.network.root_dir_path)
+        let mut wallet = self
+            .load_wallet()
             .map_err(|err| ProtocolError::FailedToStorePaymentIntoNodeWallet(err.to_string()))?;
 
         // unpack transfer

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -257,12 +257,16 @@ fn current_rewards_balance() -> Result<NanoTokens> {
 
     for entry in std::fs::read_dir(node_dir_path)? {
         let path = entry?.path();
-        let wallet = LocalWallet::try_load_from(&path)?;
-        let balance = wallet.balance();
-        println!("Node's wallet {path:?} currently have balance of {balance:?}");
-        total_rewards = total_rewards
-            .checked_add(balance)
-            .ok_or_else(|| eyre!("Faied to sum up rewards balance"))?;
+        let wallets_dir_path = path.join("rewards_wallets");
+        for entry in std::fs::read_dir(wallets_dir_path)? {
+            let path = entry?.path();
+            let wallet = LocalWallet::load_from_path(&path, None)?;
+            let balance = wallet.balance();
+            println!("Node's wallet {path:?} currently have balance of {balance:?}");
+            total_rewards = total_rewards
+                .checked_add(balance)
+                .ok_or_else(|| eyre!("Failed to sum up rewards balance"))?;
+        }
     }
 
     println!("Current total balance is {total_rewards:?}");

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -136,8 +136,12 @@ impl LocalWallet {
     /// Loads a serialized wallet from a path.
     pub fn load_from(root_dir: &Path) -> Result<Self> {
         let wallet_dir = root_dir.join(WALLET_DIR_NAME);
-        // This creates the received_cash_notes dir if it doesn't exist.
-        std::fs::create_dir_all(&wallet_dir)?;
+        Self::load_from_path(&wallet_dir, None)
+    }
+
+    /// Tries to loads a serialized wallet from a path, bailing out if it doesn't exist.
+    pub fn try_load_from(root_dir: &Path) -> Result<Self> {
+        let wallet_dir = root_dir.join(WALLET_DIR_NAME);
         let (key, wallet, unconfirmed_spend_requests) = load_from_path(&wallet_dir, None)?;
         Ok(Self {
             key,
@@ -147,10 +151,11 @@ impl LocalWallet {
         })
     }
 
-    /// Tries to loads a serialized wallet from a path, bailing out if it doesn't exist.
-    pub fn try_load_from(root_dir: &Path) -> Result<Self> {
-        let wallet_dir = root_dir.join(WALLET_DIR_NAME);
-        let (key, wallet, unconfirmed_spend_requests) = load_from_path(&wallet_dir, None)?;
+    /// Loads a serialized wallet from a given path, no additional element will
+    /// be added to the provided path and strictly taken as the wallet files location.
+    pub fn load_from_path(wallet_dir: &Path, main_key: Option<MainSecretKey>) -> Result<Self> {
+        std::fs::create_dir_all(wallet_dir)?;
+        let (key, wallet, unconfirmed_spend_requests) = load_from_path(wallet_dir, main_key)?;
         Ok(Self {
             key,
             wallet,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Nov 23 14:55 UTC
This pull request includes the following changes:

1. The file `safenode.proto` has added two new RPC methods, `TransferNotifsFilter` and `SetRewardsAddress`. These methods allow setting a PublicKey for decoding and accepting transfer notifications, as well as setting the rewards address for the node.

2. The file `safenode_proto` has added imports for `TransferNotifsFilterRequest` and `bls::{PublicKey, SecretKey}`.

3. The test module has added imports for `bls::{PublicKey, SecretKey}`.

4. The test module has added a new test function `nodes_rewards_transfer_notifs_filter`.

5. The test module has added a new helper function `spawn_royalties_payment_listener`.

6. The test module has created additional handles for royalties payment listeners in the new test function.

7. The `spawn_royalties_payment_listener` function has added logic to set filters for transfer notifications.

8. The `spawn_royalties_payment_listener` function has added logic to count transfer notifications received.

9. The new test function has added assertions for expected counts of received notifications.

10. The diff includes several changes in the file `rpc.rs`. These changes involve imports, the implementation of new RPC methods, and updates to the `stop` RPC method.

11. The diff includes several changes in the file `error.rs`. The changes involve adding a new variant to the `Error` enum.

12. The diff includes several changes in the file `lib.rs`. The changes involve modifying an import statement.

Let me know if you need further assistance.
<!-- reviewpad:summarize:end --> 
