### PR TITLE
feat: publish to non-subscribed topic

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -22,7 +22,7 @@ use std::{
 use url::Url;
 
 const DEFAULT_RECEIVE_ONLINE_WALLET_DIR: &str = "receive_online";
-const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
+const ROYALTY_TRANSFER_NOTIF_TOPIC: &str = "ROYALTY_TRANSFER_NOTIFICATION";
 
 // Please do not remove the blank lines in these doc comments.
 // They are used for inserting line breaks when the help menu is rendered in the UI.
@@ -407,7 +407,7 @@ async fn listen_notifs_and_deposit(root_dir: &Path, client: &Client, sk: String)
     let main_pk = wallet.address();
     let pk = main_pk.public_key();
 
-    client.subscribe_to_topic(TRANSFER_NOTIF_TOPIC.to_string())?;
+    client.subscribe_to_topic(ROYALTY_TRANSFER_NOTIF_TOPIC.to_string())?;
     let mut events_receiver = client.events_channel();
 
     println!("Current balance in local wallet: {}", wallet.balance());

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -56,7 +56,7 @@ mod spends;
 pub use self::{
     event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
     log_markers::Marker,
-    node::{NodeBuilder, NodeCmd, TRANSFER_NOTIF_TOPIC},
+    node::{NodeBuilder, NodeCmd, ROYALTY_TRANSFER_NOTIF_TOPIC},
 };
 
 use crate::error::{Error, Result};

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     node::Node,
-    node::TRANSFER_NOTIF_TOPIC,
+    node::ROYALTY_TRANSFER_NOTIF_TOPIC,
     spends::{aggregate_spends, check_parent_spends},
     Marker,
 };
@@ -538,7 +538,8 @@ impl Node {
             ));
         }
 
-        // publish a notification over gossipsub topic TRANSFER_NOTIF_TOPIC for the network royalties payment.
+        // publish a notification over gossipsub topic ROYALTY_TRANSFER_NOTIF_TOPIC
+        // for the network royalties payment.
         let royalties_pk = *NETWORK_ROYALTIES_PK;
         trace!("Publishing a royalties transfer notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}");
         let royalties_pk_bytes = royalties_pk.to_bytes();
@@ -550,7 +551,7 @@ impl Node {
         match royalties_cash_notes_r.serialize(&mut serialiser) {
             Ok(()) => {
                 let msg = msg.into_inner().freeze();
-                if let Err(err) = self.network.publish_on_topic(TRANSFER_NOTIF_TOPIC.to_string(), msg) {
+                if let Err(err) = self.network.publish_on_topic(ROYALTY_TRANSFER_NOTIF_TOPIC.to_string(), msg) {
                     debug!("Failed to publish a network royalties payment notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}: {err:?}");
                 }
             }

--- a/sn_node_rpc_client/src/main.rs
+++ b/sn_node_rpc_client/src/main.rs
@@ -16,10 +16,11 @@ use color_eyre::eyre::{eyre, Result};
 use libp2p::Multiaddr;
 use sn_client::Client;
 use sn_logging::LogBuilder;
-use sn_node::NodeEvent;
+use sn_node::{NodeEvent, ROYALTY_TRANSFER_NOTIF_TOPIC};
 use sn_peers_acquisition::{parse_peers_args, PeersArgs};
 use sn_protocol::safenode_proto::{
-    safe_node_client::SafeNodeClient, NodeEventsRequest, TransferNotifsFilterRequest,
+    safe_node_client::SafeNodeClient, GossipsubSubscribeRequest, NodeEventsRequest,
+    TransferNotifsFilterRequest,
 };
 use sn_protocol::storage::SpendAddress;
 use sn_transfers::{LocalWallet, MainPubkey, MainSecretKey};
@@ -236,6 +237,13 @@ pub async fn transfers_events(
             pk: pk.to_bytes().to_vec(),
         }))
         .await?;
+
+    let _ = node_client
+        .subscribe_to_topic(Request::new(GossipsubSubscribeRequest {
+            topic: ROYALTY_TRANSFER_NOTIF_TOPIC.to_string(),
+        }))
+        .await?;
+
     let response = node_client
         .node_events(Request::new(NodeEventsRequest {}))
         .await?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Nov 23 16:12 UTC
This pull request adds a new feature where most of the nodes do not subscribe to the "TRANSFER_NOTIFICATION" topic. The patch modifies several files including `sn_cli/src/subcommands/wallet.rs`, `sn_node/src/lib.rs`, `sn_node/src/node.rs`, `sn_node/src/put_validation.rs`, `sn_node/tests/nodes_rewards.rs`, and `sn_node_rpc_client/src/main.rs`. The changes include renaming the constant `TRANSFER_NOTIF_TOPIC` to `ROYALTY_TRANSFER_NOTIF_TOPIC`, updating the subscription to the new topic in the `listen_notifs_and_deposit` function, and handling messages for the new topic in the `process_event` function. Additionally, the patch introduces a new constant `FORWARDER_CHOOSING_FACTOR` which determines the number of nodes acting as forwarders for the subscription.
<!-- reviewpad:summarize:end --> 
