### PR TITLE
WIP chore: log gossipsub msg separately

### DIFF
--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -38,6 +38,7 @@ use tokio::{
     sync::{broadcast, mpsc::Receiver},
     task::spawn,
 };
+use xor_name::XorName;
 
 /// Expected topic name where notifications of transfers are sent on.
 /// The notification msg is expected to contain the serialised public key, followed by the
@@ -397,8 +398,37 @@ impl Node {
                     error!("Failed to remove local record: {e:?}");
                 }
             }
-            NetworkEvent::GossipsubMsgReceived { topic, msg }
-            | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
+            NetworkEvent::GossipsubMsgReceived { topic, msg } => {
+                trace!(
+                    "Received GossipsubMsgReceived with content_hash {:?}",
+                    XorName::from_content(&msg)
+                );
+                if self.events_channel.receiver_count() > 0 {
+                    if topic == TRANSFER_NOTIF_TOPIC {
+                        // this is expected to be a notification of a transfer which we treat specially,
+                        // and we try to decode it only if it's referring to a PK the user is interested in
+                        if let Some(filter_pk) = self.transfer_notifs_filter {
+                            match try_decode_transfer_notif(&msg, filter_pk) {
+                                Ok(Some(notif_event)) => self.events_channel.broadcast(notif_event),
+                                Ok(None) => { /* transfer notif filered out */ }
+                                Err(err) => {
+                                    warn!("GossipsubMsg matching the transfer notif. topic name, couldn't be decoded as such: {:?}", err);
+                                    self.events_channel
+                                        .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                                }
+                            }
+                        }
+                    } else {
+                        self.events_channel
+                            .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                    }
+                }
+            }
+            NetworkEvent::GossipsubMsgPublished { topic, msg } => {
+                trace!(
+                    "Received GossipsubMsgPublished with content_hash {:?}",
+                    XorName::from_content(&msg)
+                );
                 if self.events_channel.receiver_count() > 0 {
                     if topic == TRANSFER_NOTIF_TOPIC {
                         // this is expected to be a notification of a transfer which we treat specially,

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -291,7 +291,7 @@ fn spawn_royalties_payment_listener(
         let mut count = 0;
         let mut stream = response.into_inner();
 
-        let duration = Duration::from_secs(120);
+        let duration = Duration::from_secs(60);
         println!("Awaiting transfers notifs for at most {duration:?}...");
         if timeout(duration, async {
             while let Some(Ok(e)) = stream.next().await {
@@ -300,9 +300,6 @@ fn spawn_royalties_payment_listener(
                         println!("Transfer notif received for key {key:?}");
                         if key == royalties_pk {
                             count += 1;
-                            if count == CLOSE_GROUP_SIZE {
-                                break;
-                            }
                         }
                     }
                     Ok(_) => { /* ignored */ }
@@ -317,6 +314,8 @@ fn spawn_royalties_payment_listener(
         {
             println!("Timeout after {duration:?}.");
         }
+
+        println!("Received {count} royalty transfer notifs");
 
         Ok(count)
     })


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Nov 23 11:10 UTC
This pull request adds logging for gossipsub messages separately. It modifies the `node.rs` file to handle `GossipsubMsgReceived` and `GossipsubMsgPublished` events differently. It also adjusts the duration in the `nodes_rewards.rs` test file.
<!-- reviewpad:summarize:end --> 
