### PR TITLE
chore(ci): use latest cargo udeps

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,12 +27,8 @@ jobs:
           toolchain: nightly
           # we need rustfmt here while we have a build step
           components: rustfmt
-
       - name: Install cargo-udeps
-        # TODO: (2023-07-03) This is a non-released version from udeps, which includes a bug fix:
-        # https://github.com/est31/cargo-udeps/issues/180
-        # Change this when this is released.
-        run: cargo install --git=https://github.com/est31/cargo-udeps.git --rev=f7a4705 --locked
+        run: cargo install cargo-udeps --locked
       - name: Run cargo-udeps
         run: cargo +nightly udeps --all-targets
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Nov 23 17:07 UTC
This pull request updates the CI workflow to use the latest version of cargo udeps. It removes the dependency on a non-released version and replaces it with the released version.
<!-- reviewpad:summarize:end --> 
