### PR TITLE
chore: ensure replication flow handled with spawned thread

### DIFF
--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::SwarmDriver;
+use libp2p::kad::K_VALUE;
 use std::time::{Duration, Instant};
 use tokio::time::Interval;
 
@@ -114,8 +115,8 @@ impl ContinuousBootstrap {
         current_interval: Duration,
     ) -> (bool, Option<Interval>) {
         // stop bootstrapping if flag is set
-        if self.stop_bootstrapping {
-            info!("stop_bootstrapping flag has been set to true. Disabling further bootstrapping");
+        if self.stop_bootstrapping || peers_in_rt as usize > K_VALUE.into() {
+            info!("We got {peers_in_rt} peers connected, stop_bootstrapping flag is {}. Disabling further bootstrapping", self.stop_bootstrapping);
             let mut new_interval = tokio::time::interval(Duration::from_secs(86400));
             new_interval.tick().await; // the first tick completes immediately
             return (false, Some(new_interval));

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -615,19 +615,15 @@ impl Network {
 
     // Helper to send SwarmCmd
     fn send_swarm_cmd(&self, cmd: SwarmCmd) -> Result<()> {
-        let capacity = self.swarm_cmd_sender.capacity();
-
-        if capacity == 0 {
-            error!("SwarmCmd channel is full. Dropping SwarmCmd: {:?}", cmd);
-
-            // Lets error out just now.
-            return Err(Error::NoSwarmCmdChannelCapacity);
-        }
         let cmd_sender = self.swarm_cmd_sender.clone();
 
         // Spawn a task to send the SwarmCmd and keep this fn sync
         let _handle = tokio::spawn(async move {
-            if let Err(error) = cmd_sender.send(cmd).await {
+            let capacity = cmd_sender.capacity();
+
+            if capacity == 0 {
+                error!("SwarmCmd channel is full. Dropping SwarmCmd: {:?}", cmd);
+            } else if let Err(error) = cmd_sender.send(cmd).await {
                 error!("Failed to send SwarmCmd: {}", error);
             }
         });


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Nov 23 14:30 UTC
This pull request ensures that the replication flow is handled with a spawned thread. It includes changes to both `sn_networking/src/lib.rs` and `sn_node/src/node.rs` files. The `send_swarm_cmd` function in `sn_networking/src/lib.rs` now spawns a task to send the `SwarmCmd` and keeps the function synchronous. The `try_trigger_targetted_replication` function in `sn_node/src/node.rs` is now executed in a spawned thread for both `PeerAdded` and `PeerRemoved` events.
<!-- reviewpad:summarize:end --> 
