### PR TITLE
fix: stop bootstrap once connected to enough peers

### DIFF
--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -15,7 +15,7 @@ pub(crate) const BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Every BOOTSTRAP_CONNECTED_PEERS_STEP connected peer, we step up the BOOTSTRAP_INTERVAL to slow down bootstrapping
 /// process
-const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 50;
+const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 5;
 
 /// If the previously added peer has been before LAST_PEER_ADDED_TIME_LIMIT, then we should slowdown the bootstrapping
 /// process. This is to make sure we don't flood the network with `FindNode` msgs.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Nov 23 17:19 UTC
This pull request fixes an issue where the bootstrap process would continue even after connecting to enough peers. The fix introduces a check to stop the bootstrap if the `stop_bootstrapping` flag is set or if the number of connected peers is greater than a predefined value (`K_VALUE`). Additionally, the logging message has been updated to include the number of peers connected and the status of the `stop_bootstrapping` flag.
<!-- reviewpad:summarize:end --> 
