### PR TITLE
feat: chunk put retry taking repayment into account

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -175,12 +175,6 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 5
 
-      - name: Start a client to pay for files storage
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir wallet pay "./resources"
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 10
-
       - name: Start a client to upload files
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./resources"
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,12 +53,6 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Start a client to pay for files storage
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir wallet pay "./resources"
-        env:
-          SN_LOG: "all"
-        timeout-minutes: 2
-    
       - name: Start a client to carry out chunk actions
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources"
         env:

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -34,7 +34,7 @@ use tokio::task::JoinHandle;
 use xor_name::XorName;
 
 /// Max amount of times to retry uploading a chunk
-const MAX_CHUNK_PUT_RETRIES: usize = 3;
+const MAX_CHUNK_PUT_RETRIES: usize = 10;
 
 #[derive(Parser, Debug)]
 pub enum FilesCmds {

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -35,6 +35,7 @@ use xor_name::XorName;
 
 /// Max amount of times to retry uploading a chunk
 const MAX_CHUNK_PUT_RETRIES: usize = 10;
+const CHUNK_PUT_RETRY_WAIT_S: u64 = 2;
 
 #[derive(Parser, Debug)]
 pub enum FilesCmds {
@@ -362,7 +363,7 @@ async fn verify_and_repay_if_needed(
             println!(
                 "Retrying chunk upload and payment verification in 2s (retry attempt {retries})"
             );
-            tokio::time::sleep(Duration::from_secs(2)).await;
+            tokio::time::sleep(Duration::from_secs(CHUNK_PUT_RETRY_WAIT_S)).await;
         }
         retries += 1;
 

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -34,7 +34,7 @@ pub enum WalletCmds {
         #[clap(long)]
         peer_id: Vec<String>,
     },
-    /// [DEPRECATED] will be removed in future versions.
+    /// DEPRECATED will be removed in future versions.
     /// Prefer using the send and receive commands instead.
     ///
     /// Deposit CashNotes from the received directory to the local wallet.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 08:38 UTC
This pull request introduces a new feature that adds retry functionality to the chunk put process, taking repayment into account. It modifies the `verify_and_repay_if_needed` function to retry uploading and payment verification up to a specified number of times or until all chunks are verified. It also adds a new function `verify_and_repay_if_needed_once` to handle a single verification and repayment attempt. Additionally, the deprecated `Pay` command in the `WalletCmds` enum is removed. Some code cleanup and refactoring is also performed. Overall, this patch improves the reliability of chunk put and payment verification processes.
<!-- reviewpad:summarize:end --> 
