### PR TITLE
WIP chore: log gossipsub message hash

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -568,6 +568,8 @@ impl SwarmDriver {
                     msg: msg.clone(),
                 });
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
+                let content_hash = XorName::from_content(&msg);
+                trace!("Publishing a gossipsub msg {content_hash:?} with topic_id {topic_id:}");
                 self.swarm
                     .behaviour_mut()
                     .gossipsub


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 12:25 UTC
This pull request adds logging of gossipsub message hash in the Node module. It includes the change of adding a trace log for received gossipsub messages along with their content hash and topic. Additionally, there is a trace log for handling gossipsub messages with their content hash.
<!-- reviewpad:summarize:end --> 
