### PR TITLE
feat: no throwing up if not a gossip listener

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -578,6 +578,7 @@ impl Client {
     pub fn subscribe_to_topic(&self, topic_id: String) -> Result<()> {
         info!("Subscribing to topic id: {topic_id}");
         self.network.subscribe_to_topic(topic_id)?;
+        self.network.start_listen_gossip()?;
         Ok(())
     }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -143,6 +143,7 @@ pub enum SwarmCmd {
         /// Raw bytes of the message to publish
         msg: Bytes,
     },
+    GossipListener,
 }
 
 /// Debug impl for SwarmCmd to avoid printing full Record, instead only RecodKey
@@ -256,6 +257,9 @@ impl Debug for SwarmCmd {
             }
             SwarmCmd::SendRequest { req, peer, .. } => {
                 write!(f, "SwarmCmd::SendRequest req: {:?}, peer: {:?}", req, peer)
+            }
+            SwarmCmd::GossipListener => {
+                write!(f, "SwarmCmd::GossipListener")
             }
         }
     }
@@ -563,15 +567,20 @@ impl SwarmDriver {
             SwarmCmd::GossipsubPublish { topic_id, msg } => {
                 // If we publish a Gossipsub message, we might not receive the same message on our side.
                 // Hence push an event to notify that we've published a message
-                self.send_event(NetworkEvent::GossipsubMsgPublished {
-                    topic: topic_id.clone(),
-                    msg: msg.clone(),
-                });
+                if self.is_gossip_listener {
+                    self.send_event(NetworkEvent::GossipsubMsgPublished {
+                        topic: topic_id.clone(),
+                        msg: msg.clone(),
+                    });
+                }
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
                 self.swarm
                     .behaviour_mut()
                     .gossipsub
                     .publish(topic_id, msg)?;
+            }
+            SwarmCmd::GossipListener => {
+                self.is_gossip_listener = true;
             }
         }
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -476,6 +476,7 @@ impl NetworkBuilder {
             // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
+            is_gossip_listener: false,
         };
 
         Ok((
@@ -514,6 +515,7 @@ pub struct SwarmDriver {
     pub(crate) pending_get_record: PendingGetRecord,
     /// A list of the most recent peers we have dialed ourselves.
     pub(crate) dialed_peers: CircularVec<PeerId>,
+    pub(crate) is_gossip_listener: bool,
 }
 
 impl SwarmDriver {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -347,13 +347,15 @@ impl SwarmDriver {
 
                 #[cfg(feature = "open-metrics")]
                 self.network_metrics.record(&event);
-                match event {
-                    libp2p::gossipsub::Event::Message { message, .. } => {
-                        let topic = message.topic.into_string();
-                        let msg = Bytes::from(message.data);
-                        self.send_event(NetworkEvent::GossipsubMsgReceived { topic, msg });
+                if self.is_gossip_listener {
+                    match event {
+                        libp2p::gossipsub::Event::Message { message, .. } => {
+                            let topic = message.topic.into_string();
+                            let msg = Bytes::from(message.data);
+                            self.send_event(NetworkEvent::GossipsubMsgReceived { topic, msg });
+                        }
+                        other => trace!("Gossipsub Event has been ignored: {other:?}"),
                     }
-                    other => trace!("Gossipsub Event has been ignored: {other:?}"),
                 }
             }
             SwarmEvent::NewListenAddr { address, .. } => {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -602,6 +602,10 @@ impl Network {
         Ok(state)
     }
 
+    pub fn start_listen_gossip(&self) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::GossipListener)
+    }
+
     // Helper to send SwarmCmd
     fn send_swarm_cmd(&self, cmd: SwarmCmd) -> Result<()> {
         let capacity = self.swarm_cmd_sender.capacity();

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -121,6 +121,7 @@ impl RunningNode {
     /// Subscribe to given gossipsub topic
     pub fn subscribe_to_topic(&self, topic_id: String) -> Result<()> {
         self.network.subscribe_to_topic(topic_id)?;
+        self.network.start_listen_gossip()?;
         Ok(())
     }
 

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -267,7 +267,10 @@ impl Node {
                     }
                     node_cmd = cmds_receiver.recv() => {
                         match node_cmd {
-                            Ok(NodeCmd::TransferNotifsFilter(filter)) => self.transfer_notifs_filter = filter,
+                            Ok(NodeCmd::TransferNotifsFilter(filter)) => {
+                                self.transfer_notifs_filter = filter;
+                                let _ = self.network.start_listen_gossip();
+                            }
                             Err(err) => error!("When trying to read from the NodeCmds channel/receiver: {err:?}")
                         }
                     }

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -325,6 +325,7 @@ fn spawn_royalties_payment_client_listener(
 ) -> Result<JoinHandle<Result<usize, eyre::Report>>> {
     let royalties_pk = NETWORK_ROYALTIES_PK.public_key();
     client.subscribe_to_topic(TRANSFER_NOTIF_TOPIC.to_string())?;
+
     let mut events_receiver = client.events_channel();
 
     let handle = tokio::spawn(async move {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 14:08 UTC
This pull request adds a new feature that prevents throwing up if not a gossip listener. It includes changes to multiple files, such as `cmd.rs`, `driver.rs`, `event.rs`, `lib.rs`, `node.rs`, and `nodes_rewards.rs`. The changes involve adding a new variant to `SwarmCmd` enum called `GossipListener`, updating the `SwarmDriver` struct to include a boolean field `is_gossip_listener`, adding logic to handle the `GossipListener` command in `SwarmDriver`, and making necessary changes in other files to interact with the new feature.
<!-- reviewpad:summarize:end --> 
