### PR TITLE
feat(cli): new cmd to listen to royalties payments and deposit them i…

### DIFF
--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -97,8 +97,10 @@ pub enum WalletCmds {
         #[clap(name = "transfer")]
         transfer: String,
     },
-    /// Listen for transfer notifications from the network over gossipsub protocol,
-    /// depositing them onto a local wallet.
+    /// Listen for transfer notifications from the network over gossipsub protocol.
+    ///
+    /// Transfers will be deposited to a local wallet.
+    ///
     /// Only cash notes owned by the public key corresponding to the provided SK will be accepted,
     /// verified to be valid against the network, and deposited onto a locally stored wallet.
     ReceiveOnline {

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -76,6 +76,16 @@ impl LocalWallet {
         Ok(())
     }
 
+    /// Attempts to reload the wallet from disk.
+    pub fn reload_from_disk(&mut self) -> Result<()> {
+        std::fs::create_dir_all(&self.wallet_dir)?;
+        // lock and load from disk to make sure we're up to date and others can't modify the wallet concurrently
+        trace!("Trying to lock wallet to get available cash_notes...");
+        let exclusive_access = self.lock()?;
+        self.reload()?;
+        self.store(exclusive_access)
+    }
+
     /// Locks the wallet and returns exclusive access to the wallet
     /// This lock prevents any other process from locking the wallet dir, effectively acts as a mutex for the wallet
     pub fn lock(&self) -> Result<WalletExclusiveAccess> {


### PR DESCRIPTION
…nto a local wallet

Resolves #958.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 17:34 UTC
This pull request adds a new command to the CLI that allows listening to royalties payments and depositing them into a local wallet. It modifies the `wallet.rs` file, adding 103 lines of code and removing 13 lines of code. The new command is called `DepositFromNotifs` and requires a hex-encoded main secret key as an argument. The command subscribes to transfer notifications, verifies the received cash note redemptions, and deposits them into the wallet. It also prints information about the received cash notes and the wallet balance.
<!-- reviewpad:summarize:end --> 
