### PR TITLE
test(royalties): verify royalties fees amounts

### DIFF
--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -88,18 +88,18 @@ async fn create_register(
     let mut wallet_client = WalletClient::new(client.clone(), wallet);
 
     let meta = XorName::from_content(name.as_bytes());
-    let (register, cost) = client
+    let (register, storage_cost, royalties_fees) = client
         .create_and_pay_for_register(meta, &mut wallet_client, verify_store)
         .await?;
 
-    if cost.is_zero() {
+    if storage_cost.is_zero() {
         println!(
             "Register '{name}' already exists at {}!",
             register.address()
         );
     } else {
         println!(
-            "Successfully created register '{name}' at {} for {cost:?}!",
+            "Successfully created register '{name}' at {} for {storage_cost:?} (royalties fees: {royalties_fees:?})!",
             register.address()
         );
     }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -194,7 +194,10 @@ impl Files {
     /// Pay for a given set of chunks.
     ///
     /// Returns the cost and the resulting new balance of the local wallet.
-    pub async fn pay_for_chunks(&self, chunks: Vec<XorName>) -> Result<(NanoTokens, NanoTokens)> {
+    pub async fn pay_for_chunks(
+        &self,
+        chunks: Vec<XorName>,
+    ) -> Result<(NanoTokens, NanoTokens, NanoTokens)> {
         let mut wallet_client = self.wallet()?;
         info!("Paying for and uploading {:?} chunks", chunks.len());
 
@@ -205,13 +208,9 @@ impl Files {
                 }))
                 .await?;
 
-        let cost = storage_cost
-            .checked_add(royalties_fees)
-            .ok_or(Error::TotalPriceTooHigh)?;
-
         wallet_client.store_local_wallet()?;
         let new_balance = wallet_client.balance();
-        Ok((cost, new_balance))
+        Ok((storage_cost, royalties_fees, new_balance))
     }
 
     /// Verify that chunks were uploaded

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -922,7 +922,7 @@ impl SwarmDriver {
                 CLOSE_GROUP_SIZE,
             ) {
                 Err(error) => {
-                    error!("Failed to sort peers by address: {error:?}");
+                    debug!("Failed to sort peers by address: {error:?}");
                     return false;
                 }
                 Ok(closest_k_peers) => closest_k_peers,

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Register '{reg_nickname}' not found, creating it at {address}");
-            let (register, _cost) = client
+            let (register, _cost, _royalties_fees) = client
                 .create_and_pay_for_register(meta, &mut wallet_client, true)
                 .await?;
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -286,7 +286,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
         .pay_for_storage(std::iter::once(net_addr))
         .await?;
 
-    let (mut register, _cost) = client
+    let (mut register, _cost, _royalties_fees) = client
         .create_and_pay_for_register(xor_name, &mut wallet_client, true)
         .await?;
 
@@ -340,7 +340,7 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
         .local_send_storage_payment(no_data_payments, None)?;
 
     // this should fail to store as the amount paid is not enough
-    let (mut register, _cost) = client
+    let (mut register, _cost, _royalties_fees) = client
         .create_and_pay_for_register(xor_name, &mut wallet_client, false)
         .await?;
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -37,7 +37,7 @@ pub const TOTAL_SUPPLY: u64 = u32::MAX as u64 * u64::pow(10, 9);
 ///
 /// This key is public for auditing purposes. Hard coding its value means all nodes will be able to
 /// validate it.
-const GENESIS_CASHNOTE_SK: &str =
+pub const GENESIS_CASHNOTE_SK: &str =
     "5f15ae2ea589007e1474e049bbc32904d583265f12ce1f8153f955076a9af49b";
 
 /// Main error type for the crate.

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -31,8 +31,8 @@ pub use genesis::{
     load_genesis_wallet,
 };
 pub use genesis::{
-    Error as GenesisError, GENESIS_CASHNOTE, NETWORK_ROYALTIES_AMOUNT_PER_ADDR,
-    NETWORK_ROYALTIES_PK,
+    Error as GenesisError, GENESIS_CASHNOTE, GENESIS_CASHNOTE_SK,
+    NETWORK_ROYALTIES_AMOUNT_PER_ADDR, NETWORK_ROYALTIES_PK,
 };
 pub use transfers::create_offline_transfer;
 pub use wallet::{bls_secret_from_hex, parse_main_pubkey};


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Nov 23 14:03 UTC
This pull request contains changes to the codebase that aim to verify and track the fees associated with royalties when uploading files. The patch modifies several files in order to add functionality related to calculating and recording the royalties fees. Specifically, the changes include:
- Adding variables to track the total royalties fees and total cost of payments.
- Modifying the `pay_for_chunks` function to return the storage cost, royalties fees, and new balance of the wallet.
- Modifying the code to handle the storage cost and royalties fees when making payments for chunks.
- Updating the print statements and log messages to include information about the royalties fees.
- Adding new code to handle and verify the cash note redemptions related to royalties fees.
- Modifying the tests to check the amount of royalties fees received and the new balance after the deposit of cash notes.

These changes aim to improve the accuracy and transparency of the fees associated with royalties during file uploads.
<!-- reviewpad:summarize:end --> 
