### PR TITLE
fix(client): ensure we store spends at CLOSE_GROUP nodes.

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -523,7 +523,7 @@ impl Client {
 
         Ok(self
             .network
-            .put_record(record, record_to_verify, expected_holders, Quorum::Majority)
+            .put_record(record, record_to_verify, expected_holders, Quorum::All)
             .await?)
     }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -78,9 +78,9 @@ pub const fn close_group_majority() -> usize {
 }
 
 /// Max duration to wait for verification
-const MAX_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(2000);
+const MAX_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(5000);
 /// Min duration to wait for verification
-const MIN_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(500);
+const MIN_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(1500);
 /// Number of attempts to verify a record
 const VERIFICATION_ATTEMPTS: usize = 3;
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -342,7 +342,7 @@ fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        let duration = Duration::from_secs(10);
+        let duration = Duration::from_secs(20);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
             while let Ok(event) = events_receiver.recv().await {


### PR DESCRIPTION
We later expect spends to be on ALL, so we should send to all

## Description

reviewpad:summary 
