### PR TITLE
feat(networking): allow port reuse

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -378,14 +378,15 @@ impl NetworkBuilder {
 
         // Transport
         #[cfg(not(feature = "quic"))]
-        let mut transport = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default())
-            .upgrade(libp2p::core::upgrade::Version::V1)
-            .authenticate(
-                libp2p::noise::Config::new(&self.keypair)
-                    .expect("Signing libp2p-noise static DH keypair failed."),
-            )
-            .multiplex(libp2p::yamux::Config::default())
-            .boxed();
+        let mut transport =
+            libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::new().port_reuse(true))
+                .upgrade(libp2p::core::upgrade::Version::V1)
+                .authenticate(
+                    libp2p::noise::Config::new(&self.keypair)
+                        .expect("Signing libp2p-noise static DH keypair failed."),
+                )
+                .multiplex(libp2p::yamux::Config::default())
+                .boxed();
 
         #[cfg(feature = "quic")]
         let mut transport = libp2p::quic::tokio::Transport::new(quic::Config::new(&self.keypair))


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Nov 23 06:49 UTC
This pull request adds a new feature to the networking module by allowing port reuse. It modifies the `driver.rs` file by updating the `transport` configuration to enable port reuse for TCP connections. This change ensures that the same port can be reused for multiple connections, improving efficiency and resource utilization.
<!-- reviewpad:summarize:end --> 
