### PR TITLE
Reduce unhandled NetworkEvents

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -545,6 +545,8 @@ impl SwarmDriver {
                             channel: MsgResponder::FromSelf(sender),
                         });
                     } else {
+                        // We should never receive a Replicate request from ourselves.
+                        // we already hold this data if we do... so we can ignore
                         trace!("Replicate cmd to self received, ignoring");
                     }
                 } else {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -498,7 +498,7 @@ impl SwarmDriver {
                     // if the request is replication, we can handle it and send the OK response here,
                     // as we send that regardless of how we handle the request as its unimportant to the sender.
                     match request {
-                        Request::Cmd(cmd) => {
+                        Request::Cmd(sn_protocol::messages::Cmd::Replicate { holder, keys }) => {
                             trace!("Short circuit ReplicateOk response to peer {peer:?}");
                             let response = Response::Cmd(
                                 sn_protocol::messages::CmdResponse::Replicate(Ok(())),
@@ -509,7 +509,9 @@ impl SwarmDriver {
                                 .send_response(channel, response)
                                 .map_err(|_| Error::InternalMsgChannelDropped)?;
 
-                            self.send_event(NetworkEvent::CmdRequestReceived { cmd });
+                            self.send_event(NetworkEvent::CmdRequestReceived {
+                                cmd: sn_protocol::messages::Cmd::Replicate { holder, keys },
+                            });
                         }
                         Request::Query(query) => {
                             self.send_event(NetworkEvent::QueryRequestReceived {

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -7,10 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use libp2p::{kad::RecordKey, PeerId};
-use sn_protocol::{
-    messages::{Cmd, CmdResponse},
-    PrettyPrintRecordKey,
-};
+use sn_protocol::{messages::Cmd, PrettyPrintRecordKey};
 use std::time::Duration;
 // this gets us to_string easily enough
 use strum::Display;
@@ -31,9 +28,6 @@ pub enum Marker<'a> {
 
     /// Network Cmd message received
     NodeCmdReceived(&'a Cmd),
-
-    /// Network Cmd message response was generated
-    NodeCmdResponded(&'a CmdResponse),
 
     /// Peer was added to the routing table
     PeerAddedToRoutingTable(PeerId),

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -104,7 +104,7 @@ impl std::hash::Hash for SignedSpend {
 }
 
 /// Represents the data to be signed by the DerivedSecretKey of the CashNote being spent.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(custom_debug::Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Spend {
     /// UniquePubkey of input CashNote that this SignedSpend is proving to be spent.
     pub unique_pubkey: UniquePubkey,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Nov 23 10:37 UTC
This pull request includes the following changes:

1. In `sn_networking/src/cmd.rs`:
   - Modified the handling of a request sent to itself by the swarm driver. If the request is a `Query` type, it sends a `NetworkEvent::QueryRequestReceived`. Otherwise, it logs a message stating that a replicate command to self was received and it is ignored.

2. In `sn_networking/src/driver.rs`:
   - Updated the configuration of the gossipsub behavior to disable sending to all peers subscribed to a topic (`flood_publish(false)`).

3. In `sn_networking/src/event.rs`:
   - Renamed `RequestReceived` to `CmdRequestReceived` and added a new variant `QueryRequestReceived` in the `NetworkEvent` enum.

4. In `sn_networking/src/swarm_driver.rs`:
   - Modified the handling of a request received from a peer. If the request is a `Cmd` type, it sends a replicate OK response to the peer and handles the command separately. If the request is a `Query` type, it sends a `NetworkEvent::QueryRequestReceived`.

5. In `sn_node/src/node.rs`:
   - Updated the handling of network events in the `handle_response` function. If the response is a replicate OK response, it logs a warning as it should have been handled earlier.
   - Updated the handling of network events in the `handle_query` and `handle_node_cmd` functions. Instead of returning a response, it now directly sends the response using the `send_response` function.

6. In `sn_transfers/src/cashnotes/signed_spend.rs`:
   - Added the `custom_debug` attribute to the `Spend` struct.

These changes improve the handling of requests and responses in the code.
<!-- reviewpad:summarize:end --> 
