### PR TITLE
chore: increase default batch size

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="300" # mb
-          client_avg_mem_limit_mb="200" # mb
+          client_peak_mem_limit_mb="700" # mb
+          client_avg_mem_limit_mb="350" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -236,8 +236,8 @@ jobs:
         shell: bash
         # limits here are lower that benchmark tests as there is less going on.
         run: |
-          client_peak_mem_limit_mb="300" # mb
-          client_avg_mem_limit_mb="180" # mb
+          client_peak_mem_limit_mb="700" # mb
+          client_avg_mem_limit_mb="350" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -10,7 +10,6 @@ mod chunk_manager;
 
 pub(crate) use chunk_manager::ChunkManager;
 
-use super::wallet::BATCH_SIZE;
 use bytes::Bytes;
 use clap::Parser;
 use color_eyre::{
@@ -19,7 +18,7 @@ use color_eyre::{
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use libp2p::futures::future::join_all;
-use sn_client::{Client, Error as ClientError, Files};
+use sn_client::{Client, Error as ClientError, Files, BATCH_SIZE};
 use sn_protocol::storage::{Chunk, ChunkAddress};
 use sn_transfers::{Error as TransfersError, NanoTokens, WalletError};
 use std::{
@@ -49,7 +48,7 @@ pub enum FilesCmds {
         path: PathBuf,
         /// The batch_size to split chunks into parallely handling batches
         /// during payment and upload processing.
-        #[clap(long, default_value_t = BATCH_SIZE)]
+        #[clap(long, default_value_t = BATCH_SIZE, short='b')]
         batch_size: usize,
         /// Flagging whether to show the holders of the uploaded chunks.
         /// Default to be not showing.

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -21,9 +21,6 @@ use std::{
 };
 use url::Url;
 
-// Defines the size of batch for the parallel uploading of chunks and correspondent payments.
-pub(crate) const BATCH_SIZE: usize = 20;
-
 const DEFAULT_RECEIVE_ONLINE_WALLET_DIR: &str = "receive_online";
 const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
 

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -42,8 +42,8 @@ pub struct Files {
 
 type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
 
-// Defines the size of batch for the parallel downloading of chunks.
-const BATCH_SIZE: usize = 20;
+// Defines the size of batch for the parallel downloading of data.
+pub const BATCH_SIZE: usize = 100;
 
 impl Files {
     /// Create file apis instance.

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
     faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
-    file_apis::Files,
+    file_apis::{Files, BATCH_SIZE},
     register::ClientRegister,
     wallet::{send, WalletClient},
 };


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Nov 23 12:40 UTC
This pull request increases the default batch size for chunk processing in the "files" subcommand. It modifies the "sn_cli/src/subcommands/files/mod.rs" file by removing the reference to the BATCH_SIZE constant from the wallet module and adds a reference to the BATCH_SIZE constant from the client module. It also modifies the "sn_client/src/file_apis.rs" file by changing the BATCH_SIZE constant value from 20 to 100.
<!-- reviewpad:summarize:end --> 
