### PR TITLE
no flood sub

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -401,6 +401,8 @@ impl NetworkBuilder {
         let gossipsub = if self.enable_gossip {
             // Gossipsub behaviour
             let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
+                // disable sending to ALL_PEERS subscribed to a topic, which is the default behaviour
+                .flood_publish(false)
                 // we don't currently require source peer id and/or signing
                 .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
                 // we use the hash of the msg content as the msg id to deduplicate them

--- a/sn_node/tests/msgs_over_gossipsub.rs
+++ b/sn_node/tests/msgs_over_gossipsub.rs
@@ -67,7 +67,7 @@ async fn msgs_over_gossipsub() -> Result<()> {
 
                 let mut count = 0;
 
-                let _ = timeout(Duration::from_secs(10), async {
+                let _ = timeout(Duration::from_secs(40), async {
                     let mut stream = response.into_inner();
                     while let Some(Ok(e)) = stream.next().await {
                         match NodeEvent::from_bytes(&e.event) {

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -342,7 +342,7 @@ fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        let duration = Duration::from_secs(40);
+        let duration = Duration::from_secs(80);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
             while let Ok(event) = events_receiver.recv().await {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Nov 23 13:38 UTC
This pull request includes several changes. Here is a summary of the diff:

- In the `SwarmDriver` implementation, some changes were made to handle requests and responses. The handling of self-requesting has been modified to differentiate between query requests and replicate requests.
- A configuration change was made in the `NetworkBuilder` implementation to disable sending to all peers subscribed to a topic by default.
- In the `NetworkEvent` enum, new variants were added for `CmdRequestReceived` and `QueryRequestReceived` to handle incoming command and query requests.
- In the `SwarmDriver` implementation, the handling of response messages was modified. Replicate responses are now handled separately to ensure they are not dropped.
- Changes were made in the `Node` implementation to handle command and query requests. The `handle_request` method was removed and the logic was moved to separate methods for command and query handling.
- The `handle_node_cmd` method in the `Node` implementation was modified to remove unnecessary response generation and logging.
- In the `SignedSpend` struct in the `signed_spend.rs` file, the `Debug` attribute was changed to `custom_debug::Debug` for improved debugging.

Overall, these changes improve the handling of requests and responses, as well as make some configuration updates.
<!-- reviewpad:summarize:end --> 
