### PR TITLE
Make gossip optional at clients

### DIFF
--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.98.8"
 
 [features]
 default=[]
+gossip=["sn_networking/gossip"]
 local-discovery=["sn_networking/local-discovery"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -27,18 +27,15 @@ pub async fn get_tokens_from_faucet(
 /// With all balance transferred from the genesis_wallet to the faucet_wallet.
 pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<LocalWallet> {
     println!("Loading faucet...");
-    info!("Loading faucet...");
     let mut faucet_wallet = create_faucet_wallet();
 
     let faucet_balance = faucet_wallet.balance();
     if !faucet_balance.is_zero() {
         println!("Faucet wallet balance: {faucet_balance}");
-        debug!("Faucet wallet balance: {faucet_balance}");
         return Ok(faucet_wallet);
     }
 
     println!("Loading genesis...");
-    debug!("Loading genesis...");
     let genesis_wallet = load_genesis_wallet()?;
 
     // Transfer to faucet. We will transfer almost all of the genesis wallet's
@@ -46,7 +43,6 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
 
     let faucet_balance = genesis_wallet.balance();
     println!("Sending {faucet_balance} from genesis to faucet wallet..");
-    debug!("Sending {faucet_balance} from genesis to faucet wallet..");
     let cash_note = send(
         genesis_wallet,
         faucet_balance,
@@ -60,16 +56,12 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
         .deposit_and_store_to_disk(&vec![cash_note.clone()])
         .expect("Faucet wallet shall be stored successfully.");
     println!("Faucet wallet balance: {}", faucet_wallet.balance());
-    debug!("Faucet wallet balance: {}", faucet_wallet.balance());
 
     println!("Verifying the transfer from genesis...");
-    debug!("Verifying the transfer from genesis...");
     if let Err(error) = client.verify(&cash_note).await {
-        error!("Could not verify the transfer from genesis: {error:?}. Panicking.");
         panic!("Could not verify the transfer from genesis: {error:?}");
     } else {
         println!("Successfully verified the transfer from genesis on the second try.");
-        info!("Successfully verified the transfer from genesis on the second try.");
     }
 
     Ok(faucet_wallet)

--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -11,7 +11,6 @@ use color_eyre::eyre::{eyre, Result};
 use sn_client::Client;
 use std::path;
 use tiny_http::{Response, Server};
-use tracing::{debug, error, trace};
 
 /// Run the faucet server.
 ///
@@ -34,23 +33,15 @@ use tracing::{debug, error, trace};
 
 pub async fn run_faucet_server(client: &Client) -> Result<()> {
     let server =
-        Server::http("0.0.0.0:8000").map_err(|err| eyre!("Failed to start server: {err}"))?;
-    claim_genesis(client).await.map_err(|err| {
+        Server::http("0.0.0.0:8000").map_err(|e| eyre!("Failed to start server: {}", e))?;
+    claim_genesis(client).await.map_err(|e| {
         eprintln!("Faucet Server couldn't start as we failed to claim Genesis");
-        error!("Faucet Server couldn't start as we failed to claim Genesis");
-        err
+        e
     })?;
 
     println!("Starting http server listening on port 8000...");
-    debug!("Starting http server listening on port 8000...");
     for request in server.incoming_requests() {
         println!(
-            "received request! method: {:?}, url: {:?}, headers: {:?}",
-            request.method(),
-            request.url(),
-            request.headers()
-        );
-        trace!(
             "received request! method: {:?}, url: {:?}, headers: {:?}",
             request.method(),
             request.url(),
@@ -60,21 +51,18 @@ pub async fn run_faucet_server(client: &Client) -> Result<()> {
 
         match send_tokens(client, "100", key).await {
             Ok(transfer) => {
-                println!("Sent tokens to {key}");
-                debug!("Sent tokens to {key}");
+                println!("Sent tokens to {}", key);
                 let response = Response::from_string(transfer);
-                let _ = request.respond(response).map_err(|err| {
-                    eprintln!("Failed to send response: {err}");
-                    error!("Failed to send response: {err}");
-                });
+                let _ = request
+                    .respond(response)
+                    .map_err(|e| eprintln!("Failed to send response: {}", e));
             }
-            Err(err) => {
-                eprintln!("Failed to send tokens to {key}: {err}");
-                error!("Failed to send tokens to {key}: {err}");
-                let response = Response::from_string(format!("Failed to send tokens: {err}"));
+            Err(e) => {
+                eprintln!("Failed to send tokens to {}: {}", key, e);
+                let response = Response::from_string(format!("Failed to send tokens: {}", e));
                 let _ = request
                     .respond(response.with_status_code(500))
-                    .map_err(|err| eprintln!("Failed to send response: {err}"));
+                    .map_err(|e| eprintln!("Failed to send response: {}", e));
             }
         }
     }

--- a/sn_faucet/src/main.rs
+++ b/sn_faucet/src/main.rs
@@ -16,7 +16,7 @@ use sn_logging::{LogBuilder, LogOutputDest};
 use sn_peers_acquisition::{parse_peers_args, PeersArgs};
 use sn_transfers::{parse_main_pubkey, NanoTokens, Transfer};
 use std::path::PathBuf;
-use tracing::{error, info};
+use tracing::info;
 use tracing_core::Level;
 
 #[tokio::main]
@@ -34,11 +34,11 @@ async fn main() -> Result<()> {
     let _log_appender_guard = if let Some(log_output_dest) = opt.log_output_dest {
         let logging_targets = vec![
             // TODO: Reset to nice and clean defaults once we have a better idea of what we want
-            ("faucet".to_string(), Level::TRACE),
-            ("sn_faucet".to_string(), Level::TRACE),
             ("sn_networking".to_string(), Level::DEBUG),
+            ("safenode".to_string(), Level::TRACE),
             ("sn_build_info".to_string(), Level::TRACE),
             ("sn_logging".to_string(), Level::TRACE),
+            ("sn_node".to_string(), Level::TRACE),
             ("sn_peers_acquisition".to_string(), Level::TRACE),
             ("sn_protocol".to_string(), Level::TRACE),
             ("sn_registers".to_string(), Level::TRACE),
@@ -55,14 +55,9 @@ async fn main() -> Result<()> {
     info!("Instantiating a SAFE Test Faucet...");
 
     let secret_key = bls::SecretKey::random();
-    match Client::new(secret_key, bootstrap_peers, None).await {
-        Ok(client) => {
-            if let Err(err) = faucet_cmds(opt.cmd.clone(), &client).await {
-                error!("Failed to run faucet cmd {:?} with err {err:?}", opt.cmd)
-            }
-        }
-        Err(err) => error!("Failed to get Client with err {err:?}"),
-    }
+    let client = Client::new(secret_key, bootstrap_peers, None).await?;
+
+    faucet_cmds(opt.cmd, &client).await?;
 
     Ok(())
 }
@@ -92,7 +87,7 @@ struct Opt {
     pub cmd: SubCmd,
 }
 
-#[derive(Subcommand, Debug, Clone)]
+#[derive(Subcommand, Debug)]
 enum SubCmd {
     /// Claim the amount in the genesis CashNote and deposit it to the faucet local wallet.
     /// This needs to be run before a testnet is opened to the public, as to not have

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -248,6 +248,8 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
             ("sn_registers".to_string(), Level::INFO),
             ("sn_testnet".to_string(), Level::TRACE),
             ("sn_transfers".to_string(), Level::TRACE),
+            ("libp2p".to_string(), Level::TRACE),
+            ("libp2p_gossipsub".to_string(), Level::TRACE),
         ]);
     }
     Ok(targets

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -236,19 +236,13 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
         // extend will overwrite values inside `targets`
         targets.extend(vec![
             networking_log_level,
-            // bins
-            ("faucet".to_string(), Level::TRACE),
             ("safenode".to_string(), Level::TRACE),
-            ("safenode_rpc_client".to_string(), Level::TRACE),
             ("safe".to_string(), Level::TRACE),
-            // libs
             ("sn_build_info".to_string(), Level::TRACE),
             ("sn_cli".to_string(), Level::TRACE),
             ("sn_client".to_string(), Level::TRACE),
-            ("sn_faucet".to_string(), Level::TRACE),
             ("sn_logging".to_string(), Level::TRACE),
             ("sn_node".to_string(), Level::TRACE),
-            ("sn_node_rpc_client".to_string(), Level::TRACE),
             ("sn_peers_acquisition".to_string(), Level::TRACE),
             ("sn_protocol".to_string(), Level::TRACE),
             ("sn_registers".to_string(), Level::INFO),

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.10.13"
 
 [features]
 default=[]
+gossip=["libp2p/gossipsub"]
 local-discovery=["libp2p/mdns"]
 quic=["libp2p/quic"]
 open-metrics=["libp2p/metrics", "prometheus-client", "hyper", "sysinfo"]
@@ -23,7 +24,7 @@ futures = "~0.3.13"
 hyper = { version = "0.14", features = ["server", "tcp", "http1"], optional = true}
 itertools = "~0.11.0"
 custom_debug = "~0.5.0"
-libp2p = {   version="0.53" ,  features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux", "gossipsub"] }
+libp2p = {   version="0.53" ,  features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux"] }
 prometheus-client = { version = "0.22", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -14,7 +14,7 @@ name = "safenode"
 path = "src/bin/safenode/main.rs"
 
 [features]
-default=["metrics"]
+default=["metrics", "sn_networking/gossip"]
 local-discovery=["sn_networking/local-discovery"]
 otlp = ["sn_logging/otlp"]
 metrics = ["sn_logging/process-metrics"]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Nov 23 09:08 UTC
This pull request contains several file diffs. Here's a summary of the changes:

1. The `Cargo.toml` file:
   - Added new features related to gossip, local discovery, and open metrics to the `sn_client` crate.
   - Modified and added features to the `sn_networking` crate.

2. A file diff involving import statements, error handling, logging, and print statements:
   - Removed unnecessary import statements and logging messages.
   - Updated error handling and fixed formatting of printed messages.

3. Another `Cargo.toml` file diff:
   - Modified and added features to the `default` and `metrics` sections.
   - Added new features related to local discovery and OTLP.

4. A file diff in the `layers.rs` file:
   - Modified the `targets` vector, removing some items and adding new ones.

5. Another `Cargo.toml` file diff:
   - Added new features related to gossip, local discovery, and open metrics.
   - Updated features related to the `libp2p` dependency.

6. A file diff in the `sn_client/src/faucet/mod.rs` file:
   - Removed log statements and improved code formatting.

7. Another file diff involving the `driver.rs` file:
   - Added new code related to the `gossipsub` network behavior.

8. The `main.rs` file:
   - Modified import statements and logging targets related to the `tracing` module.

These changes involve adding or modifying features, updating logging configurations, improving code formatting, and handling errors. Let me know if you need more assistance.
<!-- reviewpad:summarize:end --> 
