### PR TITLE
feat(sn_networking): no gossip for clients via Toggle

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -98,7 +98,14 @@ async fn main() -> Result<()> {
         Some(bootstrap_peers)
     };
 
-    let client = Client::new(secret_key, bootstrap_peers, opt.connection_timeout).await?;
+    let joins_gossip = false;
+    let client = Client::new(
+        secret_key,
+        bootstrap_peers,
+        joins_gossip,
+        opt.connection_timeout,
+    )
+    .await?;
 
     // default to verifying storage
     let should_verify_store = !opt.no_verify;

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -59,6 +59,7 @@ impl Client {
     pub async fn new(
         signer: SecretKey,
         peers: Option<Vec<Multiaddr>>,
+        joins_gossip: bool,
         connection_timeout: Option<Duration>,
     ) -> Result<Self> {
         // If any of our contact peers has a global address, we'll assume we're in a global network.
@@ -78,7 +79,8 @@ impl Client {
         #[cfg(feature = "open-metrics")]
         network_builder.metrics_registry(Registry::default());
 
-        let (network, mut network_event_receiver, swarm_driver) = network_builder.build_client()?;
+        let (network, mut network_event_receiver, swarm_driver) =
+            network_builder.build_client(joins_gossip)?;
         info!("Client constructed network and swarm_driver");
         let events_channel = ClientEventsChannel::default();
 

--- a/sn_faucet/src/main.rs
+++ b/sn_faucet/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     info!("Instantiating a SAFE Test Faucet...");
 
     let secret_key = bls::SecretKey::random();
-    match Client::new(secret_key, bootstrap_peers, None).await {
+    match Client::new(secret_key, bootstrap_peers, false, None).await {
         Ok(client) => {
             if let Err(err) = faucet_cmds(opt.cmd.clone(), &client).await {
                 error!("Failed to run faucet cmd {:?} with err {err:?}", opt.cmd)

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -602,14 +602,16 @@ impl SwarmDriver {
             }
             SwarmCmd::GossipsubSubscribe(topic_id) => {
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
-                self.swarm.behaviour_mut().gossipsub.subscribe(&topic_id)?;
+                if let Some(gossip) = self.swarm.behaviour_mut().gossipsub.as_mut() {
+                    gossip.subscribe(&topic_id)?;
+                }
             }
             SwarmCmd::GossipsubUnsubscribe(topic_id) => {
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
-                self.swarm
-                    .behaviour_mut()
-                    .gossipsub
-                    .unsubscribe(&topic_id)?;
+
+                if let Some(gossip) = self.swarm.behaviour_mut().gossipsub.as_mut() {
+                    gossip.unsubscribe(&topic_id)?;
+                }
             }
             SwarmCmd::GossipsubPublish { topic_id, msg } => {
                 // If we publish a Gossipsub message, we might not receive the same message on our side.
@@ -621,10 +623,9 @@ impl SwarmDriver {
                     });
                 }
                 let topic_id = libp2p::gossipsub::IdentTopic::new(topic_id);
-                self.swarm
-                    .behaviour_mut()
-                    .gossipsub
-                    .publish(topic_id, msg)?;
+                if let Some(gossip) = self.swarm.behaviour_mut().gossipsub.as_mut() {
+                    gossip.publish(topic_id, msg)?;
+                }
             }
             SwarmCmd::GossipListener => {
                 self.is_gossip_listener = true;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -872,7 +872,7 @@ mod tests {
     fn test_network_sign_verify() -> eyre::Result<()> {
         let (network, _, _) =
             NetworkBuilder::new(Keypair::generate_ed25519(), false, std::env::temp_dir())
-                .build_client(false)?;
+                .build_client()?;
         let msg = b"test message";
         let sig = network.sign(msg)?;
         assert!(network.verify(msg, &sig));

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -872,7 +872,7 @@ mod tests {
     fn test_network_sign_verify() -> eyre::Result<()> {
         let (network, _, _) =
             NetworkBuilder::new(Keypair::generate_ed25519(), false, std::env::temp_dir())
-                .build_client()?;
+                .build_client(false)?;
         let msg = b"test message";
         let sig = network.sign(msg)?;
         assert!(network.verify(msg, &sig));

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     let signer = SecretKey::random();
 
     println!("Starting SAFE client...");
-    let client = Client::new(signer, None, None).await?;
+    let client = Client::new(signer, None, false, None).await?;
     println!("SAFE client signer public key: {:?}", client.signer_pk());
 
     let root_dir = dirs_next::data_dir()

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -113,6 +113,8 @@ impl NodeBuilder {
         };
 
         let mut network_builder = NetworkBuilder::new(self.keypair, self.local, self.root_dir);
+
+        network_builder.enable_gossip();
         network_builder.listen_addr(self.addr);
         #[cfg(feature = "open-metrics")]
         network_builder.metrics_registry(metrics_registry);

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -45,7 +45,7 @@ lazy_static! {
 }
 
 ///  Get a new Client for testing
-pub async fn get_client() -> Client {
+pub async fn get_gossip_client() -> Client {
     let secret_key = bls::SecretKey::random();
 
     let bootstrap_peers = if !cfg!(feature = "local-discovery") {
@@ -61,7 +61,7 @@ pub async fn get_client() -> Client {
     };
 
     println!("Client bootstrap with peer {bootstrap_peers:?}");
-    Client::new(secret_key, bootstrap_peers, None)
+    Client::new(secret_key, bootstrap_peers, true, None)
         .await
         .expect("Client shall be successfully created.")
 }
@@ -91,10 +91,14 @@ pub async fn get_funded_wallet(
     Ok(local_wallet)
 }
 
-pub async fn get_client_and_wallet(root_dir: &Path, amount: u64) -> Result<(Client, LocalWallet)> {
+/// Retrieve a client that is also listening for gossip
+pub async fn get_gossip_client_and_wallet(
+    root_dir: &Path,
+    amount: u64,
+) -> Result<(Client, LocalWallet)> {
     let _guard = FAUCET_WALLET_MUTEX.lock().await;
 
-    let client = get_client().await;
+    let client = get_gossip_client().await;
     let faucet = load_faucet_wallet_from_genesis_wallet(&client).await?;
     let local_wallet = get_funded_wallet(&client, faucet, root_dir, amount).await?;
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -10,7 +10,7 @@ mod common;
 
 use assert_fs::TempDir;
 use common::{
-    get_client_and_wallet, get_funded_wallet, get_wallet, node_restart,
+    get_funded_wallet, get_gossip_client_and_wallet, get_wallet, node_restart,
     PAYING_WALLET_INITIAL_BALANCE,
 };
 use eyre::{bail, eyre, Result};
@@ -117,7 +117,8 @@ async fn data_availability_during_churn() -> Result<()> {
     println!("Creating a client and paying wallet...");
     let paying_wallet_dir = TempDir::new()?;
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), PAYING_WALLET_INITIAL_BALANCE).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), PAYING_WALLET_INITIAL_BALANCE)
+            .await?;
 
     // Waiting for the paying_wallet funded.
     sleep(std::time::Duration::from_secs(10)).await;

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use crate::common::{get_client_and_wallet, random_content};
+use crate::common::{get_gossip_client_and_wallet, random_content};
 use sn_client::{Client, ClientEvent, WalletClient};
 use sn_logging::LogBuilder;
 use sn_node::{NodeEvent, TRANSFER_NOTIF_TOPIC};
@@ -39,7 +39,7 @@ async fn nodes_rewards_for_storing_chunks() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, _paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
 
     let (files_api, _content_bytes, content_addr, chunks) = random_content(
         &client,
@@ -73,7 +73,7 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let rb = current_rewards_balance()?;
@@ -108,7 +108,7 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, _paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
 
     let (files_api, _content_bytes, content_addr, chunks) = random_content(
         &client,
@@ -150,7 +150,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let mut rng = rand::thread_rng();
@@ -188,7 +188,7 @@ async fn nodes_rewards_transfer_notifs_filter() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, _paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
 
     let (files_api, _content_bytes, content_addr, chunks) = random_content(
         &client,

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use assert_fs::TempDir;
-use common::{get_client_and_wallet, get_wallet};
+use common::{get_gossip_client_and_wallet, get_wallet};
 use eyre::Result;
 use sn_client::send;
 use sn_logging::LogBuilder;
@@ -23,7 +23,7 @@ async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
     let first_wallet_dir = TempDir::new()?;
 
     let (client, first_wallet) =
-        get_client_and_wallet(first_wallet_dir.path(), first_wallet_balance).await?;
+        get_gossip_client_and_wallet(first_wallet_dir.path(), first_wallet_balance).await?;
 
     let second_wallet_balance = NanoTokens::from(first_wallet_balance / 2);
     println!("Transferring from first wallet to second wallet: {second_wallet_balance}.");
@@ -61,7 +61,7 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     let first_wallet_dir = TempDir::new()?;
 
     let (client, mut first_wallet) =
-        get_client_and_wallet(first_wallet_dir.path(), first_wallet_balance).await?;
+        get_gossip_client_and_wallet(first_wallet_dir.path(), first_wallet_balance).await?;
 
     // create wallet 2 and 3 to receive money from 1
     let second_wallet_dir = TempDir::new()?;

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use crate::common::{get_client_and_wallet, random_content};
+use crate::common::{get_gossip_client_and_wallet, random_content};
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use rand::Rng;
@@ -33,7 +33,7 @@ async fn storage_payment_succeeds() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
 
     let balance_before = paying_wallet.balance();
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
@@ -74,7 +74,7 @@ async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), wallet_original_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), wallet_original_balance).await?;
 
     let (files_api, content_bytes, _random_content_addrs, chunks) = random_content(
         &client,
@@ -116,7 +116,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
     let paying_wallet_dir: TempDir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), wallet_original_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), wallet_original_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     // generate a random number (between 50 and 100) of random addresses
@@ -186,7 +186,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let (files_api, _content_bytes, file_addr, chunks) = random_content(
@@ -223,7 +223,7 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
     let chunks_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let (files_api, content_bytes, content_addr, chunks) = random_content(
@@ -273,7 +273,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let mut rng = rand::thread_rng();
@@ -315,7 +315,7 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), paying_wallet_balance).await?;
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
 
     let mut rng = rand::thread_rng();

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::mutable_key_type)]
 mod common;
 
-use crate::common::{get_client_and_wallet, node_restart, PAYING_WALLET_INITIAL_BALANCE};
+use crate::common::{get_gossip_client_and_wallet, node_restart, PAYING_WALLET_INITIAL_BALANCE};
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use libp2p::{
@@ -86,7 +86,8 @@ async fn verify_data_location() -> Result<()> {
     let paying_wallet_dir = TempDir::new()?;
 
     let (client, _paying_wallet) =
-        get_client_and_wallet(paying_wallet_dir.path(), PAYING_WALLET_INITIAL_BALANCE).await?;
+        get_gossip_client_and_wallet(paying_wallet_dir.path(), PAYING_WALLET_INITIAL_BALANCE)
+            .await?;
 
     store_chunks(client, chunk_count, paying_wallet_dir.to_path_buf()).await?;
 

--- a/sn_node_rpc_client/src/main.rs
+++ b/sn_node_rpc_client/src/main.rs
@@ -231,7 +231,7 @@ pub async fn transfers_events(
     let (client, mut wallet, pk) = match SecretKey::from_hex(&sk) {
         Ok(sk) => {
             let pk = sk.public_key();
-            let client = Client::new(sk.clone(), bootstrap_peers, None).await?;
+            let client = Client::new(sk.clone(), bootstrap_peers, true, None).await?;
             let main_sk = MainSecretKey::new(sk);
             let wallet_dir = TempDir::new()?;
             let wallet = LocalWallet::load_from_main_key(&wallet_dir, main_sk)?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Nov 23 09:26 UTC
This pull request adds a feature to the sn_networking module. Specifically, it modifies the behavior of the Gossipsub protocol for clients. Gossiping is now disabled for clients via a Toggle. Additionally, the patch refactors the code related to the Gossipsub behavior and adds conditionals to handle different scenarios. The patch also includes various code cleanups and optimizations.
<!-- reviewpad:summarize:end --> 
