### PR TITLE
feat: retry at the record level, remove all other retries, report errors

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Check client memory usage
         shell: bash
         run: |
-          client_peak_mem_limit_mb="700" # mb
+          client_peak_mem_limit_mb="1024" # mb
           client_avg_mem_limit_mb="450" # mb
 
           peak_mem_usage=$(

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           client_peak_mem_limit_mb="1024" # mb
-          client_avg_mem_limit_mb="450" # mb
+          client_avg_mem_limit_mb="512" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -30,16 +30,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
-          
+
       - name: install ripgrep
         shell: bash
         run: sudo apt-get install -y ripgrep
 
       - name: Build binaries
-        run: cargo build --release --bins 
+        run: cargo build --release --bins
         timeout-minutes: 30
 
-      - name: Build churn tests 
+      - name: Build churn tests
         run: cargo test --release -p sn_node --test data_with_churn --no-run
         timeout-minutes: 30
 
@@ -136,14 +136,14 @@ jobs:
         #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
         #   exit 1
         # fi
-          
+
       - name: Verify data replication using rg
         shell: bash
         timeout-minutes: 1
         # get the counts, then the specific line, and then the digit count only
         # then check we have an expected level of replication
         # TODO: make this use an env var, or relate to testnet size
-        # As the bootstrap_node using separate folder for logging, 
+        # As the bootstrap_node using separate folder for logging,
         # hence the folder input to rg needs to cover that as well.
         run : |
           sending_list_count=$(rg "Sending a replication list" $NODE_DATA_PATH -c --stats | \
@@ -204,13 +204,13 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_memcheck
           platform: ubuntu-latest
-     
+
       - name: Check node memory usage
         shell: bash
         # The resources file and churning chunk_size we upload may change, and with it mem consumption.
-        # This is set to a value high enough to allow for some variation depending on 
-        # resources and node location in the network, but hopefully low enough to catch 
-        # any wild memory issues 
+        # This is set to a value high enough to allow for some variation depending on
+        # resources and node location in the network, but hopefully low enough to catch
+        # any wild memory issues
         # Any changes to this value should be carefully considered and tested!
         # As we have a bootstrap node acting as an access point for churning nodes and client,
         # The memory usage here will be significantly higher here than in the benchmark test,
@@ -219,9 +219,9 @@ jobs:
           node_peak_mem_limit_mb="300" # mb
 
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $NODE_DATA_PATH/*/logs/* -o --no-line-number --no-filename | 
-            awk -F':' '/"memory_used_mb":/{print $2}' | 
-            sort -n | 
+            rg '"memory_used_mb":[^,]*' $NODE_DATA_PATH/*/logs/* -o --no-line-number --no-filename |
+            awk -F':' '/"memory_used_mb":/{print $2}' |
+            sort -n |
             tail -n 1
           )
           echo "Node memory usage: $peak_mem_usage MB"
@@ -236,13 +236,13 @@ jobs:
         shell: bash
         # limits here are lower that benchmark tests as there is less going on.
         run: |
-          client_peak_mem_limit_mb="800" # mb
+          client_peak_mem_limit_mb="1024" # mb
           client_avg_mem_limit_mb="450" # mb
           
           peak_mem_usage=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
-            awk -F':' '/"memory_used_mb":/{print $2}' | 
-            sort -n | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |
+            awk -F':' '/"memory_used_mb":/{print $2}' |
+            sort -n |
             tail -n 1
           )
           echo "Peak memory usage: $peak_mem_usage MB"
@@ -252,7 +252,7 @@ jobs:
           fi
 
           total_mem=$(
-            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 
+            rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |
             awk -F':' '/"memory_used_mb":/ {sum += $2} END {printf "%.0f\n", sum}'
           )
           num_of_times=$(

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -237,7 +237,7 @@ jobs:
         # limits here are lower that benchmark tests as there is less going on.
         run: |
           client_peak_mem_limit_mb="1024" # mb
-          client_avg_mem_limit_mb="450" # mb
+          client_avg_mem_limit_mb="512" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -46,7 +46,7 @@ sn_logging = { path = "../sn_logging", version = "0.2.15" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.10" }
 sn_protocol = { path = "../sn_protocol", version = "0.8.28" }
 tempfile = "3.6.0"
-tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
+tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time", "fs"] }
 tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"
 url = "2.4.0"

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -352,7 +352,7 @@ impl ChunkManager {
 
     /// Mark all the unpaid chunks as paid and move them from the UNPAID_DIR to PAID_DIR
     /// Also removes the dir from UNPAID_DIR
-    pub(crate) fn mark_paid_all(&mut self) {
+    pub(crate) fn _mark_paid_all(&mut self) {
         let all_chunks = self
             .unpaid_chunks
             .values()
@@ -488,7 +488,7 @@ impl ChunkManager {
 
     /// Mark all the paid chunks as verified and remove them from PAID_DIR
     /// Retains the folder and metadata file
-    pub(crate) fn mark_verified_all(&mut self) {
+    pub(crate) fn _mark_verified_all(&mut self) {
         let all_chunks = self
             .paid_chunks
             .values()
@@ -861,7 +861,7 @@ mod tests {
             .count();
         assert_eq!(n_folders, 5);
 
-        manager.mark_paid_all();
+        manager._mark_paid_all();
 
         let n_folders = WalkDir::new(&manager.unpaid_dir)
             .into_iter()
@@ -942,8 +942,8 @@ mod tests {
             .count();
         assert_eq!(n_folders, 5);
 
-        manager.mark_paid_all();
-        manager.mark_verified_all();
+        manager._mark_paid_all();
+        manager._mark_verified_all();
 
         // all 5 files should be marked as verified
         assert_eq!(manager.verified_files.len(), 5);
@@ -983,9 +983,9 @@ mod tests {
 
         // marking all as verified should not do anything
         let manager_clone = manager.clone();
-        manager.mark_verified_all();
+        manager._mark_verified_all();
 
-        // 1. mark_verified_all() directly does nothing
+        // 1. _mark_verified_all() directly does nothing
         assert_eq!(manager, manager_clone);
 
         // get all the chunks and then mark as verified. This should trigger mark_paid
@@ -1160,7 +1160,7 @@ mod tests {
             .count();
 
         // mark all as paid
-        manager.mark_paid_all();
+        manager._mark_paid_all();
         let mut new_manager = ChunkManager::new(&root_dir);
         new_manager.chunk_path(&random_files_dir)?;
 
@@ -1225,8 +1225,8 @@ mod tests {
 
         let _ = create_random_files(&random_files_dir, 5, 5)?;
         manager.chunk_path(&random_files_dir)?;
-        manager.mark_paid_all();
-        manager.mark_verified_all();
+        manager._mark_paid_all();
+        manager._mark_verified_all();
 
         let mut new_manager = ChunkManager::new(&root_dir);
         new_manager.chunk_path(&random_files_dir)?;

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -238,7 +238,6 @@ impl Files {
             for result in verify_results {
                 if let ((chunk_addr, path), true) = result?? {
                     warn!("Failed to fetch a chunk {chunk_addr:?}");
-                    // This needs to be NetAddr to allow for repayment
                     failed_chunks.push((chunk_addr, path));
                 }
             }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -43,7 +43,7 @@ pub struct Files {
 type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
 
 // Defines the size of batch for the parallel downloading of data.
-pub const BATCH_SIZE: usize = 100;
+pub const BATCH_SIZE: usize = 64;
 
 impl Files {
     /// Create file apis instance.


### PR DESCRIPTION
## Description

Leverage the benefits of `PaymentQuote` for the client side. 

- retry at the record put level
    - they work for all records types (Chunks, Spends, Registers)
    - retries can be done asynchronously instead of after as they happen during parallel async upload routines
- retry at the data address payment
    - they work for all records types (Chunks, Spends, Registers)
- remove unclear retries for each record kind, and at multiple levels
- report all errors as some where swallowed or not used
    - print them at the end in the cli so users have more actionable failures (they know if it's network, fs, or wallet related)

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Nov 23 10:25 UTC
This pull request introduces a new constant `PUT_RECORD_RETRIES` which specifies the number of attempts to put a record. The `put_record` method has been updated to retry putting the record `PUT_RECORD_RETRIES` times if verification is enabled. Each retry is accompanied by a random wait duration between 1.5 seconds and 5 seconds. This change aims to improve the reliability of storing records in the network.
<!-- reviewpad:summarize:end --> 
