### PR TITLE
feat(cli): add download batch-size option

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           client_peak_mem_limit_mb="700" # mb
-          client_avg_mem_limit_mb="400" # mb
+          client_avg_mem_limit_mb="450" # mb
 
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename |

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -237,7 +237,7 @@ jobs:
         # limits here are lower that benchmark tests as there is less going on.
         run: |
           client_peak_mem_limit_mb="700" # mb
-          client_avg_mem_limit_mb="400" # mb
+          client_avg_mem_limit_mb="450" # mb
           
           peak_mem_usage=$(
             rg '"memory_used_mb":[^,]*' $CLIENT_DATA_PATH/logs --glob safe.* -o --no-line-number --no-filename | 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -15,7 +15,7 @@ use common::{
 };
 use eyre::{bail, eyre, Result};
 use rand::{rngs::OsRng, Rng};
-use sn_client::{Client, Error, Files, WalletClient};
+use sn_client::{Client, Error, Files, WalletClient, BATCH_SIZE};
 use sn_logging::LogBuilder;
 use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress, SpendAddress},
@@ -632,7 +632,7 @@ async fn query_content(
         }
         NetworkAddress::ChunkAddress(addr) => {
             let file_api = Files::new(client.clone(), wallet_dir.to_path_buf());
-            let _ = file_api.read_bytes(*addr, None, false).await?;
+            let _ = file_api.read_bytes(*addr, None, false, BATCH_SIZE).await?;
             Ok(())
         }
         _other => Ok(()), // we don't create/store any other type of content in this test yet

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -12,7 +12,7 @@ use crate::common::{get_gossip_client_and_wallet, random_content};
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use rand::Rng;
-use sn_client::{Error as ClientError, WalletClient};
+use sn_client::{Error as ClientError, WalletClient, BATCH_SIZE};
 use sn_logging::LogBuilder;
 use sn_networking::Error as NetworkError;
 use sn_protocol::{
@@ -209,7 +209,9 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         .pay_and_upload_bytes_test(*file_addr.xorname(), chunks, true)
         .await?;
 
-    files_api.read_bytes(file_addr, None, false).await?;
+    files_api
+        .read_bytes(file_addr, None, false, BATCH_SIZE)
+        .await?;
 
     Ok(())
 }
@@ -256,7 +258,9 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
     println!("Reading {content_addr:?} expected to fail");
     assert!(
         matches!(
-            files_api.read_bytes(content_addr, None, false).await,
+            files_api
+                .read_bytes(content_addr, None, false, BATCH_SIZE)
+                .await,
             Err(ClientError::Network(NetworkError::RecordNotFound))
         ),
         "read bytes should fail as we didn't store them"


### PR DESCRIPTION
Sets default to 1/4 of upload

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Nov 23 09:07 UTC
This pull request adds a new option for the batch size in the command line interface (CLI) for parallel handling of chunks during payment and upload processing. Additionally, it also adds a batch size option for parallel downloading. The default value for the download batch size is set to one-fourth of the upload batch size. The changes are made in the `sn_cli/src/subcommands/files/mod.rs` and `sn_client/src/file_apis.rs` files. The patch adds new command line options and modifies the `files_cmds` function to handle the new batch size options. It also adds new functions `download_files`, `download_file`, and modifies the `verify_and_repay_if_needed_once` function to accommodate the new batch size option for parallel downloading.
<!-- reviewpad:summarize:end --> 
