### PR TITLE
feat(peers_acq): shuffle peers before we return.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,6 +4748,7 @@ dependencies = [
  "clap 4.4.7",
  "color-eyre",
  "libp2p 0.53.0",
+ "rand",
  "reqwest",
  "tokio",
  "tracing",

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -19,6 +19,7 @@ network-contacts = ["reqwest", "tokio", "url"]
 clap = { version = "4.2.1", features = ["derive", "env"] }
 color-eyre = "~0.6"
 libp2p = {   version="0.53" ,  features = [] }
+rand = "0.8.5"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls-tls"], optional = true }
 tokio = { version = "1.32.0", optional = true}
 tracing = { version = "~0.1.26" }

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -11,6 +11,7 @@ use clap::Args;
 use color_eyre::eyre::Context;
 use color_eyre::{eyre::eyre, Result};
 use libp2p::{multiaddr::Protocol, Multiaddr};
+use rand::{seq::SliceRandom, thread_rng};
 use tracing::*;
 #[cfg(feature = "network-contacts")]
 use url::Url;
@@ -88,6 +89,10 @@ pub async fn parse_peers_args(args: PeersArgs) -> Result<Vec<Multiaddr>> {
         error!("{err_str}");
         return Err(color_eyre::eyre::eyre!("{err_str}"));
     };
+
+    // Randomly sort peers before we return them to avoid overly hitting any one peer
+    let mut rng = thread_rng();
+    peers.shuffle(&mut rng);
 
     Ok(peers)
 }


### PR DESCRIPTION
This shoulf help prevent any one peer from being hammered more than any other in the list

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Nov 23 09:23 UTC
This pull request adds a new feature to shuffle peers before returning them. This will help prevent any one peer from being hammered more than any other in the list.
<!-- reviewpad:summarize:end --> 
