### PR TITLE
feat: move derivation index random method to itself

### DIFF
--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -13,7 +13,7 @@ use common::{get_gossip_client_and_wallet, get_wallet};
 use eyre::Result;
 use sn_client::send;
 use sn_logging::LogBuilder;
-use sn_transfers::{create_offline_transfer, rng, Hash, NanoTokens, UniquePubkey};
+use sn_transfers::{create_offline_transfer, rng, DerivationIndex, Hash, NanoTokens};
 
 #[tokio::test]
 async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
@@ -82,8 +82,8 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
 
     let mut rng = rng::thread_rng();
 
-    let to2_unique_key = (amount, to2, UniquePubkey::random_derivation_index(&mut rng));
-    let to3_unique_key = (amount, to3, UniquePubkey::random_derivation_index(&mut rng));
+    let to2_unique_key = (amount, to2, DerivationIndex::random(&mut rng));
+    let to3_unique_key = (amount, to3, DerivationIndex::random(&mut rng));
     let reason_hash = Hash::default();
 
     let transfer_to_2 =

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -11,7 +11,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use sn_transfers::{
     create_first_cash_note_from_key, create_offline_transfer, rng, CashNote, DerivationIndex, Hash,
-    MainSecretKey, NanoTokens, UniquePubkey,
+    MainSecretKey, NanoTokens,
 };
 use std::collections::BTreeSet;
 
@@ -27,7 +27,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
             (
                 NanoTokens::from(1),
                 main_key.main_pubkey(),
-                UniquePubkey::random_derivation_index(&mut rng),
+                DerivationIndex::random(&mut rng),
             )
         })
         .collect::<Vec<_>>();
@@ -82,7 +82,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
             (
                 NanoTokens::from(1),
                 recipient_of_100_mainkey.main_pubkey(),
-                UniquePubkey::random_derivation_index(&mut rng),
+                DerivationIndex::random(&mut rng),
             )
         })
         .collect::<Vec<_>>();
@@ -128,7 +128,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let one_single_recipient = vec![(
         NanoTokens::from(total_amount),
         starting_main_key.main_pubkey(),
-        UniquePubkey::random_derivation_index(&mut rng),
+        DerivationIndex::random(&mut rng),
     )];
 
     // create transfer to merge all of the cashnotes into one

--- a/sn_transfers/src/cashnotes/mod.rs
+++ b/sn_transfers/src/cashnotes/mod.rs
@@ -37,7 +37,7 @@ pub(crate) mod tests {
         let mut rng = crate::rng::from_seed([0u8; 32]);
         let amount = 1_530_000_000;
         let main_key = MainSecretKey::random_from_rng(&mut rng);
-        let derivation_index = UniquePubkey::random_derivation_index(&mut rng);
+        let derivation_index = DerivationIndex::random(&mut rng);
         let derived_key = main_key.derive_key(&derivation_index);
         let tx = Transaction {
             inputs: vec![],
@@ -64,7 +64,7 @@ pub(crate) mod tests {
         let mut rng = crate::rng::from_seed([0u8; 32]);
         let amount = 100;
         let main_key = MainSecretKey::random_from_rng(&mut rng);
-        let derivation_index = UniquePubkey::random_derivation_index(&mut rng);
+        let derivation_index = DerivationIndex::random(&mut rng);
         let derived_key = main_key.derive_key(&derivation_index);
         let tx = Transaction {
             inputs: vec![],
@@ -92,7 +92,7 @@ pub(crate) mod tests {
         let amount = 100;
 
         let main_key = MainSecretKey::random_from_rng(&mut rng);
-        let derivation_index = UniquePubkey::random_derivation_index(&mut rng);
+        let derivation_index = DerivationIndex::random(&mut rng);
         let derived_key = main_key.derive_key(&derivation_index);
 
         let tx = Transaction {
@@ -123,7 +123,7 @@ pub(crate) mod tests {
         let amount = 100;
 
         let main_key = MainSecretKey::random_from_rng(&mut rng);
-        let derivation_index = UniquePubkey::random_derivation_index(&mut rng);
+        let derivation_index = DerivationIndex::random(&mut rng);
         let derived_key = main_key.derive_key(&derivation_index);
 
         let tx = Transaction {

--- a/sn_transfers/src/cashnotes/unique_keys.rs
+++ b/sn_transfers/src/cashnotes/unique_keys.rs
@@ -27,6 +27,15 @@ impl fmt::Debug for DerivationIndex {
     }
 }
 
+impl DerivationIndex {
+    // generates a random derivation index
+    pub fn random(rng: &mut impl RngCore) -> DerivationIndex {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        DerivationIndex(bytes)
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct UniquePubkey(PublicKey);
 
@@ -42,13 +51,6 @@ impl UniquePubkey {
     /// Returns `true` if the signature matches the message.
     pub fn verify<M: AsRef<[u8]>>(&self, sig: &bls::Signature, msg: M) -> bool {
         self.0.verify(sig, msg)
-    }
-
-    // generates a random derivation index
-    pub fn random_derivation_index(rng: &mut impl RngCore) -> DerivationIndex {
-        let mut bytes = [0u8; 32];
-        rng.fill_bytes(&mut bytes);
-        DerivationIndex(bytes)
     }
 
     pub fn public_key(&self) -> PublicKey {
@@ -199,6 +201,6 @@ impl MainSecretKey {
     }
 
     pub fn random_derived_key(&self, rng: &mut impl RngCore) -> DerivedSecretKey {
-        self.derive_key(&UniquePubkey::random_derivation_index(rng))
+        self.derive_key(&DerivationIndex::random(rng))
     }
 }

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     rng, CashNote, DerivationIndex, DerivedSecretKey, Hash, Input, MainPubkey, NanoTokens,
-    SignedSpend, Transaction, TransactionBuilder, UniquePubkey,
+    SignedSpend, Transaction, TransactionBuilder,
 };
 use crate::{Error, Result};
 
@@ -188,7 +188,7 @@ fn create_offline_transfer_with(
         .add_outputs(selected_inputs.recipients);
 
     let mut rng = rng::thread_rng();
-    let derivation_index = UniquePubkey::random_derivation_index(&mut rng);
+    let derivation_index = DerivationIndex::random(&mut rng);
     let change_id = change_to.new_unique_pubkey(&derivation_index);
     if !change.is_zero() {
         tx_builder = tx_builder.add_output(change, change_to, derivation_index);

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -250,13 +250,7 @@ impl LocalWallet {
         // create a unique key for each output
         let to_unique_keys: Vec<_> = to
             .into_iter()
-            .map(|(amount, address)| {
-                (
-                    amount,
-                    address,
-                    UniquePubkey::random_derivation_index(&mut rng),
-                )
-            })
+            .map(|(amount, address)| (amount, address, DerivationIndex::random(&mut rng)))
             .collect();
 
         let (available_cash_notes, exclusive_access) = self.available_cash_notes()?;
@@ -296,16 +290,12 @@ impl LocalWallet {
         // create random derivation indexes for recipients
         let mut recipients_by_xor = BTreeMap::new();
         for (xorname, (main_pubkey, quote)) in price_map.iter() {
-            let storage_payee = (
-                quote.cost,
-                *main_pubkey,
-                UniquePubkey::random_derivation_index(&mut rng),
-            );
+            let storage_payee = (quote.cost, *main_pubkey, DerivationIndex::random(&mut rng));
             let royalties_fee = calculate_royalties_fee(quote.cost);
             let royalties_payee = (
                 royalties_fee,
                 *NETWORK_ROYALTIES_PK,
-                UniquePubkey::random_derivation_index(&mut rng),
+                DerivationIndex::random(&mut rng),
             );
 
             storage_cost = storage_cost


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Nov 23 10:56 UTC
This pull request includes several changes. 

In the `sn_node/tests/sequential_transfers.rs` file, the `UniquePubkey::random_derivation_index` method is replaced with the `DerivationIndex::random` method in two places.

In the `sn_transfers/benches/reissue.rs` file, the same replacement is made in four places.

In the `sn_transfers/src/cashnotes/mod.rs` file, the `UniquePubkey::random_derivation_index` method is replaced with the `DerivationIndex::random` method in four places.

In the `sn_transfers/src/transfers/offline_transfer.rs` file, the same replacement is made in one place.

In the `sn_transfers/src/wallet/local_store.rs` file, the `UniquePubkey::random_derivation_index` method is replaced with the `DerivationIndex::random` method in one place.

Overall, these changes involve replacing the usage of the `UniquePubkey::random_derivation_index` method with the `DerivationIndex::random` method.
<!-- reviewpad:summarize:end --> 
