### PR TITLE
WIP feat: query specific kbuckets for bootstrap

### DIFF
--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -57,6 +57,18 @@ impl SwarmDriver {
             }
         };
     }
+
+    pub(crate) fn trigger_network_discovery(&mut self) {
+        // The query is just to trigger the network discovery,
+        // hence no need to wait for a result.
+        for addr in &self.network_discovery_candidates {
+            let _ = self
+                .swarm
+                .behaviour_mut()
+                .kademlia
+                .get_closest_peers(addr.as_bytes());
+        }
+    }
 }
 
 /// Tracks and helps with the continuous kad::bootstrapping process

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -622,10 +622,6 @@ impl SwarmDriver {
                     if let Some(new_interval) = self.run_bootstrap_continuously(bootstrap_interval.period()).await {
                         bootstrap_interval = new_interval;
                     }
-                    // execute extra `kbucket targeted query` to make RT filled up more accurately
-                    let start = std::time::Instant::now();
-                    self.query_specific_kbucket();
-                    trace!("Query specific kbuckets handled in {:?}", start.elapsed());
                 }
             }
         }

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -860,6 +860,7 @@ impl SwarmDriver {
                         .map_err(|_| Error::InternalMsgChannelDropped)?;
                 }
             }
+            // Shall no longer receive this event
             kad::Event::OutboundQueryProgressed {
                 id,
                 result: QueryResult::Bootstrap(bootstrap_result),
@@ -870,10 +871,6 @@ impl SwarmDriver {
                 // here BootstrapOk::num_remaining refers to the remaining random peer IDs to query, one per
                 // bucket that still needs refreshing.
                 trace!("Kademlia Bootstrap with {id:?} progressed with {bootstrap_result:?} and step {step:?}");
-                if step.last {
-                    // inform the bootstrap process about the completion.
-                    self.bootstrap.completed();
-                }
             }
             kad::Event::RoutingUpdated {
                 peer,
@@ -890,7 +887,7 @@ impl SwarmDriver {
 
                     if self.bootstrap.notify_new_peer() {
                         info!("Performing the first bootstrap");
-                        self.initiate_bootstrap();
+                        self.trigger_network_discovery();
                     }
                     self.send_event(NetworkEvent::PeerAdded(peer, self.connected_peers));
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Nov 23 13:23 UTC
This pull request consists of two patches. 

In the first patch, the code is modified to query specific k-buckets for bootstrap. A new function `trigger_network_discovery` is added to initiate the network discovery process. This function triggers the network discovery by querying the closest peers for the given addresses. The function is called for each address in the `network_discovery_candidates` list. This change aims to improve network discovery accuracy.

In the second patch, the code is refactored to replace the bootstrap process with querying specific k-buckets. The `initiate_bootstrap` function is removed, and the `trigger_network_discovery` function is called instead. The `ContinuousBootstrap` struct is modified to remove the `is_ongoing` field and replace it with `last_bootstrap_triggered` field to track the time of the last bootstrap trigger. The `completed` method is also removed. Additionally, the code related to informing the bootstrap process about completion is removed, as it is no longer needed.

Overall, these patches aim to improve the bootstrap process by replacing it with querying specific k-buckets, which results in more accurate network discovery.

<!-- reviewpad:summarize:end --> 
