### PR TITLE
chore(networking): bootstrap more frequently, and take buncket count/…

### DIFF
--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::SwarmDriver;
+use libp2p::kad::K_VALUE;
 use std::time::{Duration, Instant};
 use tokio::time::Interval;
 
@@ -15,23 +16,34 @@ pub(crate) const BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Every BOOTSTRAP_CONNECTED_PEERS_STEP connected peer, we step up the BOOTSTRAP_INTERVAL to slow down bootstrapping
 /// process
-const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 5;
+const BOOTSTRAP_CONNECTED_PEERS_STEP: usize = 5;
 
-/// If the previously added peer has been before LAST_PEER_ADDED_TIME_LIMIT, then we should slowdown the bootstrapping
-/// process. This is to make sure we don't flood the network with `FindNode` msgs.
-const LAST_PEER_ADDED_TIME_LIMIT: Duration = Duration::from_secs(180);
+/// If the previously added peer has been before LAST_PEER_ADDED_TIME_LIMIT, then we should increase the bootstrapping
+/// process.
+const LAST_PEER_ADDED_TIME_LIMIT: Duration = Duration::from_secs(360);
 
-/// The bootstrap interval to use if we haven't added any new peers in a while.
-const NO_PEER_ADDED_SLOWDOWN_INTERVAL: Duration = Duration::from_secs(300);
+/// Number of kad buckets we deem desireable
+const DESIRABLE_BUCKET_COUNT: usize = 10;
+
+/// Number of peers we want in the avg bucket
+const DESIRED_AVG_BUCKET_SIZE: usize = K_VALUE.get() / 3;
 
 impl SwarmDriver {
     pub(crate) async fn run_bootstrap_continuously(
         &mut self,
         current_bootstrap_interval: Duration,
     ) -> Option<Interval> {
+        let all_buckets = self.swarm.behaviour_mut().kademlia.kbuckets();
+        let mut bucket_stats = vec![];
+        // lets see how many peers we know of
+        for kbucket in all_buckets {
+            let peers_in_bucket = kbucket.num_entries();
+            bucket_stats.push(peers_in_bucket)
+        }
+
         let (should_bootstrap, new_interval) = self
             .bootstrap
-            .should_we_bootstrap(self.connected_peers as u32, current_bootstrap_interval)
+            .should_we_bootstrap(bucket_stats, current_bootstrap_interval)
             .await;
         if should_bootstrap {
             self.initiate_bootstrap();
@@ -110,9 +122,11 @@ impl ContinuousBootstrap {
     /// Also optionally returns the new interval to re-bootstrap.
     pub(crate) async fn should_we_bootstrap(
         &mut self,
-        peers_in_rt: u32,
+        bucket_stats: Vec<usize>,
         current_interval: Duration,
     ) -> (bool, Option<Interval>) {
+        let peers_in_rt = bucket_stats.iter().sum::<usize>();
+
         // stop bootstrapping if flag is set
         if self.stop_bootstrapping {
             info!("stop_bootstrapping flag has been set to true. Disabling further bootstrapping");
@@ -124,23 +138,39 @@ impl ContinuousBootstrap {
         // kad bootstrap process needs at least one peer in the RT be carried out.
         let should_bootstrap = !self.is_ongoing && peers_in_rt >= 1;
 
+        // if we have less than DESIRABLE_BUCKET_COUNT buckets, then we should bootstrap
+        if bucket_stats.len() < DESIRABLE_BUCKET_COUNT {
+            info!("We have less than {DESIRABLE_BUCKET_COUNT} buckets. Continuing to bootstrap.");
+            return (should_bootstrap, None);
+        }
+
+        // If we're at a DESIRABLE_BUCKET_COUNT, we can think about slowing down the bootstrapping process
         // if it has been a while (LAST_PEER_ADDED_TIME_LIMIT) since we have added a new peer to our RT, then, slowdown
         // the bootstrapping process.
         // Don't slow down if we haven't even added one peer to our RT.
-        if self.last_peer_added_instant.elapsed() > LAST_PEER_ADDED_TIME_LIMIT && peers_in_rt != 0 {
+        if self.last_peer_added_instant.elapsed() > LAST_PEER_ADDED_TIME_LIMIT {
             info!(
-                "It has been {LAST_PEER_ADDED_TIME_LIMIT:?} since we last added a peer to RT. Slowing down the continuous bootstrapping process"
+                "It has been {LAST_PEER_ADDED_TIME_LIMIT:?} since we last added a peer to RT. Increasing the rate of continuous bootstrapping"
             );
 
-            let mut new_interval = tokio::time::interval(NO_PEER_ADDED_SLOWDOWN_INTERVAL);
+            let mut new_interval = tokio::time::interval(BOOTSTRAP_INTERVAL * 2);
             new_interval.tick().await; // the first tick completes immediately
             return (should_bootstrap, Some(new_interval));
+        }
+
+        // We want to aim for a decent average bucket size.
+        // we want the average bucket size to be at least K_VALUE / 3
+        if (peers_in_rt / bucket_stats.len()) < DESIRED_AVG_BUCKET_SIZE {
+            info!(
+                "The average bucket is < {DESIRED_AVG_BUCKET_SIZE} peers. Continuing to bootstrap."
+            );
+            return (should_bootstrap, None);
         }
 
         // increment bootstrap_interval in steps of BOOTSTRAP_INTERVAL every BOOTSTRAP_CONNECTED_PEERS_STEP
         let step = peers_in_rt / BOOTSTRAP_CONNECTED_PEERS_STEP;
         let step = std::cmp::max(1, step);
-        let new_interval = BOOTSTRAP_INTERVAL * step;
+        let new_interval = BOOTSTRAP_INTERVAL * step as u32;
         let new_interval = if new_interval > current_interval {
             info!("More peers have been added to our RT!. Slowing down the continuous bootstrapping process");
             let mut interval = tokio::time::interval(new_interval);

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -167,7 +167,7 @@ impl NodeRecordStore {
             if incoming_record_key.distance(&self.local_key)
                 < furthest_record_key.distance(&self.local_key)
             {
-                trace!(
+                info!(
                     "{:?} will be pruned to make space for new record: {:?}",
                     PrettyPrintRecordKey::from(&furthest_record),
                     PrettyPrintRecordKey::from(r)


### PR DESCRIPTION
…densisty into account

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Nov 23 12:18 UTC
This pull request includes changes to the networking module. It improves the bootstrapping process by bootstrapping more frequently and taking into account the count and density of buckets. It also adds information about the number of peers in each bucket and uses these statistics to determine whether to continue bootstrapping or slow down the process. Additionally, it sets desirable bucket count and desired average bucket size to improve the efficiency of the bootstrapping process. The patch also includes some code refactoring and logging improvements.
<!-- reviewpad:summarize:end --> 
