### PR TITLE
chore(networking): improve logs around replication

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -183,11 +183,8 @@ impl Debug for NetworkEvent {
                 )
             }
             NetworkEvent::KeysForReplication(list) => {
-                let pretty_list: Vec<_> = list
-                    .iter()
-                    .map(|(holder, key)| (*holder, PrettyPrintRecordKey::from(key)))
-                    .collect();
-                write!(f, "NetworkEvent::KeysForReplication({pretty_list:?})")
+                let keys_len = list.len();
+                write!(f, "NetworkEvent::KeysForReplication({keys_len:?})")
             }
             NetworkEvent::NewListenAddr(addr) => {
                 write!(f, "NetworkEvent::NewListenAddr({addr:?})")

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -183,7 +183,7 @@ impl NodeRecordStore {
                 }
             } else {
                 // we should not prune, but warn as we're at max capacity
-                warn!("Record not stored. Maximum number of records reached. Current num_records: {num_records}");
+                warn!("Record not stored (key: {r:?}). Maximum number of records reached. Current num_records: {num_records}");
                 return Err(Error::MaxRecords);
             }
         }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Nov 23 12:26 UTC
This pull request improves the logs around replication in the networking module. It updates the Debug implementation for NetworkEvent to print the length of the list of keys for replication instead of the keys themselves. It also adds additional information to the warning message in the NodeRecordStore when a record is not stored due to reaching the maximum capacity.
<!-- reviewpad:summarize:end --> 
