### PR TITLE
feat(test): impl routing table test

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -81,7 +81,9 @@ jobs:
 
       - name: Verify the routing tables of the nodes
         run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
-        timeout-minutes: 5
+        env:
+          SLEEP_BEFORE_VERIFICATION: 120
+        timeout-minutes: 10
 
       - name: Create and fund a wallet to pay for files storage
         run: |
@@ -118,7 +120,9 @@ jobs:
 
       - name: Verify the routing tables of the nodes
         run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
-        timeout-minutes: 5
+        env:
+          SLEEP_BEFORE_VERIFICATION: 120
+        timeout-minutes: 10
 
       - name: Verify restart of nodes using rg
         shell: bash

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Verify the routing tables of the nodes
         run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
         env:
-          SLEEP_BEFORE_VERIFICATION: 220
+          SLEEP_BEFORE_VERIFICATION: 300
         timeout-minutes: 10
 
       - name: Verify restart of nodes using rg

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -79,12 +79,6 @@ jobs:
         shell: bash
         run: echo "The SAFE_PEERS variable has been set to ${SAFE_PEERS}"
 
-      - name: Verify the routing tables of the nodes
-        run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
-        env:
-          SLEEP_BEFORE_VERIFICATION: 120
-        timeout-minutes: 10
-
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- --log-output-dest=data-dir send 5000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
@@ -121,7 +115,7 @@ jobs:
       - name: Verify the routing tables of the nodes
         run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
         env:
-          SLEEP_BEFORE_VERIFICATION: 120
+          SLEEP_BEFORE_VERIFICATION: 220
         timeout-minutes: 10
 
       - name: Verify restart of nodes using rg

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -39,8 +39,8 @@ jobs:
         run: cargo build --release --bins
         timeout-minutes: 30
 
-      - name: Build churn tests
-        run: cargo test --release -p sn_node --test data_with_churn --no-run
+      - name: Build tests
+        run: cargo test --release -p sn_node --test data_with_churn --test verify_routing_table --no-run
         timeout-minutes: 30
 
       - name: Start a node instance that does not undergo churn
@@ -79,6 +79,10 @@ jobs:
         shell: bash
         run: echo "The SAFE_PEERS variable has been set to ${SAFE_PEERS}"
 
+      - name: Verify the routing tables of the nodes
+        run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
+        timeout-minutes: 5
+
       - name: Create and fund a wallet to pay for files storage
         run: |
           cargo run --bin faucet --release -- --log-output-dest=data-dir send 5000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet.txt
@@ -111,6 +115,10 @@ jobs:
           TEST_TOTAL_CHURN_CYCLES: 15
           SN_LOG: "all"
         timeout-minutes: 30
+
+      - name: Verify the routing tables of the nodes
+        run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
+        timeout-minutes: 5
 
       - name: Verify restart of nodes using rg
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -438,9 +438,9 @@ jobs:
           log_file_prefix: safe_test_logs_churn
           platform: ${{ matrix.os }}
 
-  verify_data_location:
+  verify_data_location_routing_table:
       if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-      name: Verify data location
+      name: Verify data location and Routing Table
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
@@ -464,8 +464,8 @@ jobs:
           run: cargo build --release --features local-discovery --bin safenode --bin faucet
           timeout-minutes: 30
 
-        - name: Build data location test
-          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run  
+        - name: Build data location and routing table tests
+          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run  
           timeout-minutes: 30
 
         - name: Start a local network
@@ -487,12 +487,20 @@ jobs:
               echo "SAFE_PEERS has been set to $SAFE_PEERS"
             fi
 
+        - name: Verify the routing tables of the nodes
+          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
+          timeout-minutes: 5
+      
         - name: Verify the location of the data on the network (4 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture 
           env:
             CHURN_COUNT: 3
             SN_LOG: "all"
           timeout-minutes: 30
+
+        - name: Verify the routing tables of the nodes
+          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
+          timeout-minutes: 5
 
         - name: Verify restart of nodes using rg
           shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -383,8 +383,8 @@ jobs:
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Nightly Churn Test Run Failed"
 
-  verify_data_location:
-      name: Verify data location
+  verify_data_location_routing_table:
+      name: Verify data location and Routing Table
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
@@ -410,8 +410,8 @@ jobs:
           run: cargo build --release --features local-discovery --bin safenode --bin faucet
           timeout-minutes: 30
 
-        - name: Build data location test
-          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --no-run
+        - name: Build data location and routing table tests
+          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run
           timeout-minutes: 30
 
         - name: Start a local network
@@ -423,12 +423,20 @@ jobs:
             faucet-path: target/release/faucet
             platform: ${{ matrix.os }}
 
+        - name: Verify the Routing table of the nodes
+          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
+          timeout-minutes: 5
+
         - name: Verify the location of the data on the network (approx 12 * 5 mins)
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
           env:
             CHURN_COUNT: 12
             SN_LOG: "all"
           timeout-minutes: 90
+
+        - name: Verify the routing tables of the nodes
+          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
+          timeout-minutes: 5
         
         - name: Verify restart of nodes using rg
           shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,6 +4653,7 @@ dependencies = [
  "prometheus-client 0.22.0",
  "quickcheck",
  "rand",
+ "rayon",
  "rmp-serde",
  "serde",
  "sn_protocol",

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -26,6 +26,7 @@ custom_debug = "~0.5.0"
 libp2p = {   version="0.53" ,  features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux", "gossipsub"] }
 prometheus-client = { version = "0.22", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
+rayon = "1.8.0"
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_protocol = { path = "../sn_protocol", version = "0.8.29" }

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -50,9 +50,10 @@ impl SwarmDriver {
 
     pub(crate) fn trigger_network_discovery(&mut self) {
         let now = Instant::now();
-        // The query is just to trigger the network discovery,
-        // hence no need to wait for a result.
+        // Fetches the candidates and also generates new candidates
         for addr in self.network_discovery.candidates() {
+            // The query_id is tracked here. This is to update the candidate list of network_discovery with the newly
+            // found closest peers. It may fill up the candidate list of closer buckets which are harder to generate.
             let query_id = self
                 .swarm
                 .behaviour_mut()
@@ -63,8 +64,7 @@ impl SwarmDriver {
                 (PendingGetClosestType::NetworkDiscovery, Default::default()),
             );
         }
-        // Refresh the candidate list to not query the same candidates over and over again.
-        self.network_discovery.try_refresh_candidates();
+
         self.bootstrap.initiated();
         debug!("Trigger network discovery took {:?}", now.elapsed());
     }

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -49,16 +49,20 @@ impl SwarmDriver {
     }
 
     pub(crate) fn trigger_network_discovery(&mut self) {
+        let now = Instant::now();
         // The query is just to trigger the network discovery,
         // hence no need to wait for a result.
-        for addr in &self.network_discovery_candidates {
+        for addr in self.network_discovery_candidates.candidates() {
             let _ = self
                 .swarm
                 .behaviour_mut()
                 .kademlia
                 .get_closest_peers(addr.as_bytes());
         }
+        self.network_discovery_candidates
+            .try_generate_new_candidates();
         self.bootstrap.initiated();
+        debug!("Trigger network discovery took {:?}", now.elapsed());
     }
 }
 

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::SwarmDriver;
+use crate::{driver::PendingGetClosestType, SwarmDriver};
 use std::time::{Duration, Instant};
 use tokio::time::Interval;
 
@@ -53,11 +53,15 @@ impl SwarmDriver {
         // The query is just to trigger the network discovery,
         // hence no need to wait for a result.
         for addr in self.network_discovery_candidates.candidates() {
-            let _ = self
+            let query_id = self
                 .swarm
                 .behaviour_mut()
                 .kademlia
                 .get_closest_peers(addr.as_bytes());
+            let _ = self.pending_get_closest_peers.insert(
+                query_id,
+                (PendingGetClosestType::NetworkDiscovery, Default::default()),
+            );
         }
         self.network_discovery_candidates
             .try_generate_new_candidates();

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -52,7 +52,7 @@ impl SwarmDriver {
         let now = Instant::now();
         // The query is just to trigger the network discovery,
         // hence no need to wait for a result.
-        for addr in self.network_discovery_candidates.candidates() {
+        for addr in self.network_discovery.candidates() {
             let query_id = self
                 .swarm
                 .behaviour_mut()
@@ -63,8 +63,8 @@ impl SwarmDriver {
                 (PendingGetClosestType::NetworkDiscovery, Default::default()),
             );
         }
-        self.network_discovery_candidates
-            .try_generate_new_candidates();
+        // Refresh the candidate list to not query the same candidates over and over again.
+        self.network_discovery.try_refresh_candidates();
         self.bootstrap.initiated();
         debug!("Trigger network discovery took {:?}", now.elapsed());
     }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -25,7 +25,7 @@ use sn_protocol::{
 };
 use sn_transfers::NanoTokens;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
 };
 use tokio::sync::oneshot;
@@ -53,9 +53,10 @@ pub enum SwarmCmd {
     GetAllLocalPeers {
         sender: oneshot::Sender<Vec<PeerId>>,
     },
-    // Get the map of ilog2 distance of the Kbucket to the peers in that bucket
+    /// Get a map where each key is the ilog2 distance of that Kbucket and each value is a vector of peers in that
+    /// bucket.
     GetKBuckets {
-        sender: oneshot::Sender<HashMap<u32, Vec<PeerId>>>,
+        sender: oneshot::Sender<BTreeMap<u32, Vec<PeerId>>>,
     },
     // Returns up to K_VALUE peers from all the k-buckets from the local Routing Table.
     // And our PeerId as well.
@@ -524,7 +525,7 @@ impl SwarmDriver {
                 let _ = sender.send(self.get_all_local_peers());
             }
             SwarmCmd::GetKBuckets { sender } => {
-                let mut ilog2_kbuckets = HashMap::new();
+                let mut ilog2_kbuckets = BTreeMap::new();
                 for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
                     let range = kbucket.range();
                     if let Some(distance) = range.0.ilog2() {

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    driver::SwarmDriver,
+    driver::{PendingGetClosestType, SwarmDriver},
     error::{Error, Result},
     sort_peers_by_address, GetQuorum, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
     REPLICATE_RANGE,
@@ -512,9 +512,13 @@ impl SwarmDriver {
                     .behaviour_mut()
                     .kademlia
                     .get_closest_peers(key.as_bytes());
-                let _ = self
-                    .pending_get_closest_peers
-                    .insert(query_id, (sender, Default::default()));
+                let _ = self.pending_get_closest_peers.insert(
+                    query_id,
+                    (
+                        PendingGetClosestType::FunctionCall(sender),
+                        Default::default(),
+                    ),
+                );
             }
             SwarmCmd::GetAllLocalPeers { sender } => {
                 let _ = sender.send(self.get_all_local_peers());

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -64,7 +64,15 @@ use tracing::warn;
 /// List of expected record holders to be verified.
 pub(super) type ExpectedHoldersList = HashSet<PeerId>;
 
-type PendingGetClosest = HashMap<QueryId, (oneshot::Sender<HashSet<PeerId>>, HashSet<PeerId>)>;
+/// The ways in which the Get Closest queries are used.
+pub(crate) enum PendingGetClosestType {
+    /// The network discovery method is present at the networking layer
+    /// Thus we can just process the queries made by NetworkDiscovery without using any channels
+    NetworkDiscovery,
+    /// These are queries made by a function at the upper layers and contains a channel to send the result back.
+    FunctionCall(oneshot::Sender<HashSet<PeerId>>),
+}
+type PendingGetClosest = HashMap<QueryId, (PendingGetClosestType, HashSet<PeerId>)>;
 type PendingGetRecord = HashMap<
     QueryId,
     (

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -18,7 +18,7 @@ use crate::{
     event::NetworkEvent,
     event::{GetRecordResultMap, NodeEvent},
     multiaddr_pop_p2p,
-    network_discovery::NetworkDiscoveryCandidates,
+    network_discovery::NetworkDiscovery,
     record_store::{ClientRecordStore, NodeRecordStore, NodeRecordStoreConfig},
     record_store_api::UnifiedRecordStore,
     replication_fetcher::ReplicationFetcher,
@@ -504,7 +504,7 @@ impl NetworkBuilder {
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
             is_gossip_handler: false,
-            network_discovery_candidates: NetworkDiscoveryCandidates::new(&peer_id),
+            network_discovery: NetworkDiscovery::new(&peer_id),
         };
 
         Ok((
@@ -549,7 +549,7 @@ pub struct SwarmDriver {
     pub(crate) is_gossip_handler: bool,
     // A list of random `PeerId` candidates that falls into kbuckets,
     // This is to ensure a more accurate network discovery.
-    pub(crate) network_discovery_candidates: NetworkDiscoveryCandidates,
+    pub(crate) network_discovery: NetworkDiscovery,
 }
 
 impl SwarmDriver {

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -18,6 +18,7 @@ use crate::{
     event::NetworkEvent,
     event::{GetRecordResultMap, NodeEvent},
     multiaddr_pop_p2p,
+    network_discovery::NetworkDiscoveryCandidates,
     record_store::{ClientRecordStore, NodeRecordStore, NodeRecordStoreConfig},
     record_store_api::UnifiedRecordStore,
     replication_fetcher::ReplicationFetcher,
@@ -50,7 +51,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintKBucketKey,
 };
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
@@ -495,7 +496,7 @@ impl NetworkBuilder {
             // `identify` protocol to kick in and get them in the routing table.
             dialed_peers: CircularVec::new(63),
             is_gossip_handler: false,
-            network_discovery_candidates: generate_kbucket_specific_candidates(&peer_id),
+            network_discovery_candidates: NetworkDiscoveryCandidates::new(&peer_id),
         };
 
         Ok((
@@ -509,51 +510,6 @@ impl NetworkBuilder {
             swarm_driver,
         ))
     }
-}
-
-fn generate_kbucket_specific_candidates(self_peer_id: &PeerId) -> Vec<NetworkAddress> {
-    let mut candidates: BTreeMap<usize, NetworkAddress> = BTreeMap::new();
-    // To avoid deadlock or taking too much time, currently set a fixed generation attempts
-    let mut attempts = 0;
-    // Also an early return when got the first 20 furthest kBuckets covered.
-    let mut buckets_covered: BTreeSet<_> = (0..21).map(|index| index as usize).collect();
-
-    let local_key = NetworkAddress::from_peer(*self_peer_id).as_kbucket_key();
-    let local_key_bytes_len = local_key.hashed_bytes().len();
-    while attempts < 10000 && !buckets_covered.is_empty() {
-        let candiate = NetworkAddress::from_peer(PeerId::random());
-        let candidate_key = candiate.as_kbucket_key();
-        let candidate_key_bytes_len = candidate_key.hashed_bytes().len();
-
-        if local_key_bytes_len != candidate_key_bytes_len {
-            panic!("kBucketKey has different key length, {candiate:?} has {candidate_key_bytes_len:?}, {self_peer_id:?} has {local_key_bytes_len:?}");
-        }
-
-        let common_leading_bits =
-            common_leading_bits(local_key.hashed_bytes(), candidate_key.hashed_bytes());
-
-        let _ = candidates.insert(common_leading_bits, candiate);
-        let _ = buckets_covered.remove(&common_leading_bits);
-
-        attempts += 1;
-    }
-
-    let generated_buckets: Vec<_> = candidates.keys().copied().collect();
-    let generated_candidates: Vec<_> = candidates.values().cloned().collect();
-    trace!("Generated targets covering kbuckets {generated_buckets:?}");
-    generated_candidates
-}
-
-/// Returns the length of the common leading bits.
-/// e.g. when `11110000` and `11111111`, return as 4.
-/// Note: the length of two shall be the same
-fn common_leading_bits(one: &[u8], two: &[u8]) -> usize {
-    for byte_index in 0..one.len() {
-        if one[byte_index] != two[byte_index] {
-            return (byte_index * 8) + (one[byte_index] ^ two[byte_index]).leading_zeros() as usize;
-        }
-    }
-    8 * one.len()
 }
 
 pub struct SwarmDriver {
@@ -584,9 +540,8 @@ pub struct SwarmDriver {
     // they are not supposed to process the gossip msg that received from libp2p.
     pub(crate) is_gossip_handler: bool,
     // A list of random `PeerId` candidates that falls into kbuckets,
-    // one for each furthest 30 kbuckets.
     // This is to ensure a more accurate network discovery.
-    pub(crate) network_discovery_candidates: Vec<NetworkAddress>,
+    pub(crate) network_discovery_candidates: NetworkDiscoveryCandidates,
 }
 
 impl SwarmDriver {

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -623,7 +623,7 @@ impl SwarmDriver {
                 if current_closest.len() >= usize::from(K_VALUE) || step.last {
                     match get_closest_type {
                         PendingGetClosestType::NetworkDiscovery => self
-                            .network_discovery_candidates
+                            .network_discovery
                             .handle_get_closest_query(current_closest),
                         PendingGetClosestType::FunctionCall(sender) => {
                             sender
@@ -666,7 +666,7 @@ impl SwarmDriver {
 
                 match get_closest_type {
                     PendingGetClosestType::NetworkDiscovery => self
-                        .network_discovery_candidates
+                        .network_discovery
                         .handle_get_closest_query(current_closest),
                     PendingGetClosestType::FunctionCall(sender) => {
                         sender

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -183,6 +183,16 @@ impl Network {
         self.get_closest_peers(key, false).await
     }
 
+    /// Returns the map of ilog2 distance of the Kbucket to the peers in that bucket
+    /// Does not include self
+    pub async fn get_kbuckets(&self) -> Result<HashMap<u32, Vec<PeerId>>> {
+        let (sender, receiver) = oneshot::channel();
+        self.send_swarm_cmd(SwarmCmd::GetKBuckets { sender })?;
+        receiver
+            .await
+            .map_err(|_e| Error::InternalMsgChannelDropped)
+    }
+
     /// Returns the closest peers to the given `NetworkAddress` that is fetched from the local
     /// Routing Table. It is ordered by increasing distance of the peers
     /// Note self peer_id is not included in the result.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -53,7 +53,7 @@ use sn_protocol::{
 };
 use sn_transfers::{MainPubkey, NanoTokens, PaymentQuote};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::PathBuf,
 };
 use tokio::sync::{mpsc, oneshot};
@@ -184,9 +184,10 @@ impl Network {
         self.get_closest_peers(key, false).await
     }
 
-    /// Returns the map of ilog2 distance of the Kbucket to the peers in that bucket
+    /// Returns a map where each key is the ilog2 distance of that Kbucket and each value is a vector of peers in that
+    /// bucket.
     /// Does not include self
-    pub async fn get_kbuckets(&self) -> Result<HashMap<u32, Vec<PeerId>>> {
+    pub async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetKBuckets { sender })?;
         receiver

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -19,6 +19,7 @@ mod event;
 mod metrics;
 #[cfg(feature = "open-metrics")]
 mod metrics_service;
+mod network_discovery;
 mod quorum;
 mod record_store;
 mod record_store_api;

--- a/sn_networking/src/network_discovery.rs
+++ b/sn_networking/src/network_discovery.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::{kad::KBucketKey, PeerId};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use sn_protocol::NetworkAddress;
+use std::{
+    collections::{hash_map::Entry, HashMap, VecDeque},
+    time::Instant,
+};
+
+const INITIAL_GENERATION_ATTEMPTS: usize = 10_000;
+const GENERATION_ATTEMPTS: usize = 1_000;
+const MAX_PEERS_PER_BUCKET: usize = 5;
+
+#[derive(Debug, Clone)]
+pub(crate) struct NetworkDiscoveryCandidates {
+    self_key: KBucketKey<PeerId>,
+    candidates: HashMap<u32, VecDeque<NetworkAddress>>,
+}
+
+impl NetworkDiscoveryCandidates {
+    pub(crate) fn new(self_peer_id: &PeerId) -> Self {
+        let start = Instant::now();
+        let self_key = KBucketKey::from(*self_peer_id);
+        let candidates_vec = Self::generate_candidates(&self_key, INITIAL_GENERATION_ATTEMPTS);
+
+        let mut candidates: HashMap<u32, VecDeque<NetworkAddress>> = HashMap::new();
+        for (ilog2, candidate) in candidates_vec {
+            match candidates.entry(ilog2) {
+                Entry::Occupied(mut entry) => {
+                    let entry = entry.get_mut();
+                    if entry.len() >= MAX_PEERS_PER_BUCKET {
+                        continue;
+                    } else {
+                        entry.push_back(candidate);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = entry.insert(VecDeque::from([candidate]));
+                }
+            }
+        }
+
+        info!(
+            "Time to generate NetworkDiscoveryCandidates: {:?}",
+            start.elapsed()
+        );
+        let mut buckets_covered = candidates
+            .iter()
+            .map(|(ilog2, candidates)| (*ilog2, candidates.len()))
+            .collect::<Vec<_>>();
+        buckets_covered.sort_by_key(|(ilog2, _)| *ilog2);
+        info!("The generated network discovery candidates currently cover these ilog2 buckets: {buckets_covered:?}");
+
+        Self {
+            self_key,
+            candidates,
+        }
+    }
+
+    pub(crate) fn try_generate_new_candidates(&mut self) {
+        let candidates_vec = Self::generate_candidates(&self.self_key, GENERATION_ATTEMPTS);
+        for (ilog2, candidate) in candidates_vec {
+            match self.candidates.entry(ilog2) {
+                Entry::Occupied(mut entry) => {
+                    let entry = entry.get_mut();
+                    if entry.len() >= MAX_PEERS_PER_BUCKET {
+                        // pop the front (as it might have been already used for querying and insert the new one at the back
+                        let _ = entry.pop_front();
+                        entry.push_back(candidate);
+                    } else {
+                        entry.push_back(candidate);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = entry.insert(VecDeque::from([candidate]));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn candidates(&self) -> impl Iterator<Item = &NetworkAddress> {
+        self.candidates
+            .values()
+            .filter_map(|candidates| candidates.front())
+    }
+
+    fn generate_candidates(
+        self_key: &KBucketKey<PeerId>,
+        num_to_generate: usize,
+    ) -> Vec<(u32, NetworkAddress)> {
+        (0..num_to_generate)
+            .into_par_iter()
+            .filter_map(|_| {
+                let candidate = NetworkAddress::from_peer(PeerId::random());
+                let candidate_key = candidate.as_kbucket_key();
+                let ilog2_distance = candidate_key.distance(&self_key).ilog2()?;
+                Some((ilog2_distance, candidate))
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/sn_networking/src/network_discovery.rs
+++ b/sn_networking/src/network_discovery.rs
@@ -7,10 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use libp2p::{kad::KBucketKey, PeerId};
+use rand::{thread_rng, Rng};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sn_protocol::NetworkAddress;
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    collections::{hash_map::Entry, HashMap, HashSet},
     time::Instant,
 };
 
@@ -26,7 +27,7 @@ const MAX_PEERS_PER_BUCKET: usize = 5;
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkDiscovery {
     self_key: KBucketKey<PeerId>,
-    candidates: HashMap<u32, VecDeque<NetworkAddress>>,
+    candidates: HashMap<u32, Vec<NetworkAddress>>,
 }
 
 impl NetworkDiscovery {
@@ -34,24 +35,7 @@ impl NetworkDiscovery {
     pub(crate) fn new(self_peer_id: &PeerId) -> Self {
         let start = Instant::now();
         let self_key = KBucketKey::from(*self_peer_id);
-        let candidates_vec = Self::generate_candidates(&self_key, INITIAL_GENERATION_ATTEMPTS);
-
-        let mut candidates: HashMap<u32, VecDeque<NetworkAddress>> = HashMap::new();
-        for (ilog2, candidate) in candidates_vec {
-            match candidates.entry(ilog2) {
-                Entry::Occupied(mut entry) => {
-                    let entry = entry.get_mut();
-                    if entry.len() >= MAX_PEERS_PER_BUCKET {
-                        continue;
-                    } else {
-                        entry.push_back(candidate);
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    let _ = entry.insert(VecDeque::from([candidate]));
-                }
-            }
-        }
+        let candidates = Self::generate_candidates(&self_key, INITIAL_GENERATION_ATTEMPTS);
 
         info!(
             "Time to generate NetworkDiscoveryCandidates: {:?}",
@@ -70,82 +54,121 @@ impl NetworkDiscovery {
         }
     }
 
-    /// Tries to refresh our current candidate list. The candidates at the front of the list are used when querying the
-    /// network, so if a new peer for that bucket is generated, the first candidate is removed and the new candidate
-    /// is inserted at the last
+    /// Tries to refresh our current candidate list. We replace the old ones with new if we find any.
     pub(crate) fn try_refresh_candidates(&mut self) {
         let candidates_vec = Self::generate_candidates(&self.self_key, GENERATION_ATTEMPTS);
-        for (ilog2, candidate) in candidates_vec {
-            match self.candidates.entry(ilog2) {
-                Entry::Occupied(mut entry) => {
-                    let entry = entry.get_mut();
-                    if entry.len() >= MAX_PEERS_PER_BUCKET {
-                        // pop the front (as it might have been already used for querying and insert the new one at the back
-                        let _ = entry.pop_front();
-                        entry.push_back(candidate);
-                    } else {
-                        entry.push_back(candidate);
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    let _ = entry.insert(VecDeque::from([candidate]));
-                }
-            }
+        for (ilog2, candidates) in candidates_vec {
+            self.insert_candidates(ilog2, candidates);
         }
     }
 
-    /// Returns one candidate per bucket
-    /// Todo: Limit the candidates to return. Favor the closest buckets.
-    pub(crate) fn candidates(&self) -> impl Iterator<Item = &NetworkAddress> {
-        self.candidates
-            .values()
-            .filter_map(|candidates| candidates.front())
-    }
-
-    /// The result from the kad::GetClosestPeers are again used to update our kbuckets if they're not full.
+    /// The result from the kad::GetClosestPeers are again used to update our kbucket.
     pub(crate) fn handle_get_closest_query(&mut self, closest_peers: HashSet<PeerId>) {
         let now = Instant::now();
-        for peer in closest_peers {
-            let peer = NetworkAddress::from_peer(peer);
-            let peer_key = peer.as_kbucket_key();
-            if let Some(ilog2_distance) = peer_key.distance(&self.self_key).ilog2() {
-                match self.candidates.entry(ilog2_distance) {
-                    Entry::Occupied(mut entry) => {
-                        let entry = entry.get_mut();
-                        // extra check to make sure we don't insert the same peer again
-                        if entry.len() >= MAX_PEERS_PER_BUCKET && !entry.contains(&peer) {
-                            // pop the front (as it might have been already used for querying and insert the new one at the back
-                            let _ = entry.pop_front();
-                            entry.push_back(peer);
-                        } else {
-                            entry.push_back(peer);
-                        }
-                    }
-                    Entry::Vacant(entry) => {
-                        let _ = entry.insert(VecDeque::from([peer]));
-                    }
-                }
-            }
+
+        let candidates_map: HashMap<u32, Vec<NetworkAddress>> = closest_peers
+            .into_iter()
+            .filter_map(|peer| {
+                let peer = NetworkAddress::from_peer(peer);
+                let peer_key = peer.as_kbucket_key();
+                peer_key
+                    .distance(&self.self_key)
+                    .ilog2()
+                    .map(|ilog2| (ilog2, peer))
+            })
+            // To collect the NetworkAddresses into a vector.
+            .fold(HashMap::new(), |mut acc, (ilog2, peer)| {
+                acc.entry(ilog2).or_default().push(peer);
+                acc
+            });
+
+        for (ilog2, candidates) in candidates_map {
+            self.insert_candidates(ilog2, candidates);
         }
+
         trace!(
             "It took {:?} to NetworkDiscovery::handle get closest query",
             now.elapsed()
         );
     }
 
+    /// Returns one random candidate per bucket
+    /// Todo: Limit the candidates to return. Favor the closest buckets.
+    pub(crate) fn candidates(&self) -> Vec<&NetworkAddress> {
+        let mut rng = thread_rng();
+        let mut op = Vec::with_capacity(self.candidates.len());
+
+        let candidates = self.candidates.values().filter_map(|candidates| {
+            // get a random index each time
+            let random_index = rng.gen::<usize>() % candidates.len();
+            candidates.get(random_index)
+        });
+        op.extend(candidates);
+        op
+    }
+
+    // Insert the new candidates and remove the old ones to maintain MAX_PEERS_PER_BUCKET.
+    fn insert_candidates(&mut self, ilog2: u32, new_candidates: Vec<NetworkAddress>) {
+        match self.candidates.entry(ilog2) {
+            Entry::Occupied(mut entry) => {
+                let existing_candidates = entry.get_mut();
+                // insert only newly seen new_candidates
+                let new_candidates: Vec<_> = new_candidates
+                    .into_iter()
+                    .filter(|candidate| !existing_candidates.contains(candidate))
+                    .collect();
+                existing_candidates.extend(new_candidates);
+                // Keep only the last MAX_PEERS_PER_BUCKET elements i.e., the newest ones
+                let excess = existing_candidates
+                    .len()
+                    .saturating_sub(MAX_PEERS_PER_BUCKET);
+                if excess > 0 {
+                    existing_candidates.drain(..excess);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(new_candidates);
+            }
+        }
+    }
+
     /// Uses rayon to parallelize the generation
     fn generate_candidates(
         self_key: &KBucketKey<PeerId>,
         num_to_generate: usize,
-    ) -> Vec<(u32, NetworkAddress)> {
+    ) -> HashMap<u32, Vec<NetworkAddress>> {
         (0..num_to_generate)
             .into_par_iter()
             .filter_map(|_| {
                 let candidate = NetworkAddress::from_peer(PeerId::random());
                 let candidate_key = candidate.as_kbucket_key();
-                let ilog2_distance = candidate_key.distance(&self_key).ilog2()?;
-                Some((ilog2_distance, candidate))
+                let ilog2 = candidate_key.distance(&self_key).ilog2()?;
+                Some((ilog2, candidate))
             })
-            .collect::<Vec<_>>()
+            // Since it is parallel iterator, the fold fn batches the items and will produce multiple outputs. So we
+            // should use reduce fn to combine multiple outputs.
+            .fold(
+                HashMap::new,
+                |mut acc: HashMap<u32, Vec<NetworkAddress>>, (ilog2, candidate)| {
+                    acc.entry(ilog2).or_default().push(candidate);
+                    acc
+                },
+            )
+            .reduce(
+                HashMap::new,
+                |mut acc: HashMap<u32, Vec<NetworkAddress>>, map| {
+                    for (ilog2, candidates) in map {
+                        let entry = acc.entry(ilog2).or_default();
+                        for candidate in candidates {
+                            if entry.len() < MAX_PEERS_PER_BUCKET {
+                                entry.push(candidate);
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    acc
+                },
+            )
     }
 }

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -66,7 +66,7 @@ use libp2p::PeerId;
 use sn_networking::{Network, SwarmLocalState};
 use sn_protocol::NetworkAddress;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     path::PathBuf,
 };
 use tokio::sync::broadcast;
@@ -122,8 +122,9 @@ impl RunningNode {
         Ok(addresses)
     }
 
-    /// Returns the map of ilog2 distance of the Kbucket to the peers in that bucket
-    pub async fn get_kbuckets(&self) -> Result<HashMap<u32, Vec<PeerId>>> {
+    /// Returns a map where each key is the ilog2 distance of that Kbucket and each value is a vector of peers in that
+    /// bucket.
+    pub async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
         let kbuckets = self.network.get_kbuckets().await?;
         Ok(kbuckets)
     }

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -65,7 +65,10 @@ use bytes::Bytes;
 use libp2p::PeerId;
 use sn_networking::{Network, SwarmLocalState};
 use sn_protocol::NetworkAddress;
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 use tokio::sync::broadcast;
 
 /// Once a node is started and running, the user obtains
@@ -117,6 +120,12 @@ impl RunningNode {
             .cloned()
             .collect();
         Ok(addresses)
+    }
+
+    /// Returns the map of ilog2 distance of the Kbucket to the peers in that bucket
+    pub async fn get_kbuckets(&self) -> Result<HashMap<u32, Vec<PeerId>>> {
+        let kbuckets = self.network.get_kbuckets().await?;
+        Ok(kbuckets)
     }
 
     /// Subscribe to given gossipsub topic

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -10,7 +10,7 @@ mod common;
 
 use assert_fs::TempDir;
 use common::{
-    get_funded_wallet, get_gossip_client_and_wallet, get_wallet, node_restart,
+    get_funded_wallet, get_gossip_client_and_wallet, get_wallet, node_restart, NODE_COUNT,
     PAYING_WALLET_INITIAL_BALANCE,
 };
 use eyre::{bail, eyre, Result};
@@ -37,8 +37,6 @@ use tempfile::tempdir;
 use tokio::{sync::RwLock, task::JoinHandle, time::sleep};
 use tracing::{debug, trace};
 use xor_name::XorName;
-
-const NODE_COUNT: u32 = 25;
 
 const EXTRA_CHURN_COUNT: u32 = 5;
 const CHURN_CYCLES: u32 = 1;

--- a/sn_node/tests/verify_routing_table.rs
+++ b/sn_node/tests/verify_routing_table.rs
@@ -24,8 +24,8 @@ use std::{
 use tonic::Request;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn verify_routing_tables() -> Result<()> {
-    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("routing_table");
+async fn verify_routing_table() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("verify_routing_table");
 
     let all_peers = get_all_peer_ids().await?;
     let mut all_failed_list = HashMap::new();

--- a/sn_node/tests/verify_routing_table.rs
+++ b/sn_node/tests/verify_routing_table.rs
@@ -18,7 +18,7 @@ use libp2p::{
 use sn_logging::LogBuilder;
 use sn_protocol::safenode_proto::{safe_node_client::SafeNodeClient, KBucketsRequest};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
@@ -44,7 +44,7 @@ async fn verify_routing_table() -> Result<()> {
     tokio::time::sleep(sleep_duration).await;
 
     let all_peers = get_all_peer_ids().await?;
-    let mut all_failed_list = HashMap::new();
+    let mut all_failed_list = BTreeMap::new();
 
     for node_index in 1..NODE_COUNT + 1 {
         let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
@@ -68,7 +68,7 @@ async fn verify_routing_table() -> Result<()> {
                     .collect::<HashSet<_>>();
                 (ilog2, peers)
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let current_peer = all_peers[node_index as usize - 1];
         let current_peer_key = KBucketKey::from(current_peer);

--- a/sn_node/tests/verify_routing_table.rs
+++ b/sn_node/tests/verify_routing_table.rs
@@ -70,9 +70,7 @@ async fn verify_routing_table() -> Result<()> {
             })
             .collect::<HashMap<_, _>>();
 
-        let current_peer = *all_peers
-            .get(node_index as usize - 1)
-            .unwrap_or_else(|| panic!("Node should be present at index {}", node_index - 1));
+        let current_peer = all_peers[node_index as usize - 1];
         let current_peer_key = KBucketKey::from(current_peer);
 
         let mut failed_list = Vec::new();

--- a/sn_node/tests/verify_routing_table.rs
+++ b/sn_node/tests/verify_routing_table.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+#![allow(clippy::mutable_key_type)]
+mod common;
+
+use crate::common::{get_all_peer_ids, NODE_COUNT};
+use color_eyre::Result;
+use libp2p::{
+    kad::{KBucketKey, K_VALUE},
+    PeerId,
+};
+use sn_logging::LogBuilder;
+use sn_protocol::safenode_proto::{safe_node_client::SafeNodeClient, KBucketsRequest};
+use std::{
+    collections::{HashMap, HashSet},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+use tonic::Request;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn verify_routing_tables() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("routing_table");
+
+    let all_peers = get_all_peer_ids().await?;
+    let mut all_failed_list = HashMap::new();
+
+    for node_index in 1..NODE_COUNT + 1 {
+        let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12000);
+        addr.set_port(12000 + node_index as u16);
+        let endpoint = format!("https://{addr}");
+        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+
+        let response = rpc_client
+            .k_buckets(Request::new(KBucketsRequest {}))
+            .await?;
+
+        let k_buckets = response.get_ref().kbuckets.clone();
+        let k_buckets = k_buckets
+            .into_iter()
+            .map(|(ilog2, peers)| {
+                let peers = peers
+                    .peers
+                    .clone()
+                    .into_iter()
+                    .map(|peer_bytes| PeerId::from_bytes(&peer_bytes).unwrap())
+                    .collect::<HashSet<_>>();
+                (ilog2, peers)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let current_peer = *all_peers
+            .get(node_index as usize - 1)
+            .unwrap_or_else(|| panic!("Node should be present at index {}", node_index - 1));
+        let current_peer_key = KBucketKey::from(current_peer);
+
+        let mut failed_list = Vec::new();
+        for peer in all_peers.iter() {
+            let ilog2_distance = match KBucketKey::from(*peer).distance(&current_peer_key).ilog2() {
+                Some(distance) => distance,
+                // None if same key
+                None => continue,
+            };
+            match k_buckets.get(&ilog2_distance) {
+                Some(bucket) => {
+                    if bucket.contains(peer) {
+                        continue;
+                    } else if bucket.len() == K_VALUE.get() {
+                        println!("{peer:?} should be inside the ilog2 bucket: {ilog2_distance:?} of {current_peer:?}. But skipped as the bucket is full");
+                        continue;
+                    } else {
+                        println!("{peer:?} not found inside the kbucket with ilog2 {ilog2_distance:?} of {current_peer:?} RT");
+                        failed_list.push(*peer);
+                    }
+                }
+                None => {
+                    println!("Current peer {current_peer:?} should be {ilog2_distance} ilog2 distance away from {peer:?}, but that kbucket is not present for current_peer.");
+                    failed_list.push(*peer);
+                }
+            }
+        }
+        if !failed_list.is_empty() {
+            all_failed_list.insert(current_peer, failed_list);
+        }
+    }
+    if !all_failed_list.is_empty() {
+        println!("Failed to verify routing table:\n{all_failed_list:?}");
+        panic!("Failed to verify routing table");
+    }
+    Ok(())
+}

--- a/sn_protocol/src/safenode_proto/req_resp_types.proto
+++ b/sn_protocol/src/safenode_proto/req_resp_types.proto
@@ -45,6 +45,16 @@ message RecordAddressesResponse {
     repeated bytes addresses = 1;
 }
 
+// KBuckets of this node
+message KBucketsRequest {}
+
+message KBucketsResponse {
+    message Peers {
+        repeated bytes peers = 1;
+    }
+    map<uint32, Peers> kbuckets = 1;
+}
+
 // Subsribe to a gossipsub topic
 message GossipsubSubscribeRequest {
   string topic = 1;

--- a/sn_protocol/src/safenode_proto/safenode.proto
+++ b/sn_protocol/src/safenode_proto/safenode.proto
@@ -37,6 +37,9 @@ service SafeNode {
   // Returns the Addresses of all the Records stored by this node
   rpc RecordAddresses (RecordAddressesRequest) returns (RecordAddressesResponse);
 
+  // Returns the entire Kbucket of this node
+  rpc KBuckets (KBucketsRequest) returns (KBucketsResponse);
+
   // Subscribe to a Gossipsub topic
   rpc SubscribeToTopic (GossipsubSubscribeRequest) returns (GossipsubSubscribeResponse);
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Nov 23 16:57 UTC
This pull request includes the following changes:

1. In the file `rpc_service.rs`:
   - Added a new import statement for `k_buckets_response` in the `safenode_proto` module.
   - Added a new method `k_buckets` for handling the RPC request for `KBucketsRequest`.
   - Updated the `record_addresses` method to return a response containing addresses.

2. In the file `msgs_over_gossipsub.rs`:
   - Added imports for `HashMap` and `HashSet`.
   - Added a new `get_kbuckets` method that returns a map of ilog2 distance of the Kbucket to the peers in that bucket.
   - Updated the `RunningNode` struct implementation with the new method `get_kbuckets`.
   - Added documentation for the new method `get_kbuckets`.
   - Added a call to `self.network.get_kbuckets().await?` in the `get_kbuckets` method.
   - Updated the `subscribe_to_topic` method signature to take a `String` parameter instead of a `&str`.

3. In the file `lib.rs`:
   - Added a new method `get_kbuckets` to the `Network` struct. This method returns a map of ilog2 distance of the Kbucket to the peers in that bucket.
   - The `get_kbuckets` method uses a channel to communicate with the swarm and fetches the map of Kbucket distances. If there is an error in receiving the result, it returns an `InternalMsgChannelDropped` error.

4. In the file ".github/workflows/merge.yml":
   - Renamed the job "verify_data_location" to "verify_data_location_routing_table".
   - Updated the name and run command of the step "Build data location test" to "Build data location and routing table tests".
   - Added a new step "Verify the Routing table of the nodes" with a corresponding run command.
   - Updated the `timeout-minutes` value for the step "Verify the Routing table of the nodes" to 5 minutes.
   - Adjusted the `timeout-minutes` value for the step "Verify the location of the data on the network" to 5 minutes.

5. In the file "req_resp_types.proto":
   - Added the messages `KBucketsRequest`, `KBucketsResponse`, and a nested message `Peers` within `KBucketsResponse`.
   - Updated the existing messages in the file to include the new messages at the appropriate position.

6. In the file "common.rs":
   - Imported `get_all_peer_ids`, `NODE_COUNT`, and `PAYING_WALLET_INITIAL_BALANCE`.
   - Changed the type of `NodeIndex` from `u8` to `u32`.
   - Removed the `get_all_peer_ids` function and its implementation.
   - Updated the `verify_location` function to use the `get_all_peer_ids` function directly rather than importing it.
   - Removed the comment explaining the purpose of the `get_all_peer_ids` function.
   - Updated the comment explaining the purpose of the `CHUNK_COUNT` constant.
   - Removed the `CHURN_COUNT` constant.
   - Updated the type of `NodeIndex` from `u8` to `u32` in the `RecordHolders` type alias.
   - Updated the return type of the `verify_location` function to `Result<()>`.
   - Removed the `get_all_peer_ids` function definition.
   - Updated the `get_all_peer_ids` function call to use a direct URL string rather than formatting it.
   - Removed the `println!` statement in the `get_all_peer_ids` function.
   - Removed the comment explaining the purpose of the `store_chunks` function.
   - Removed the unused `wallet_dir` parameter in the `store_chunks` function.

Please let me know if you need further assistance with this pull request.
<!-- reviewpad:summarize:end --> 
