### PR TITLE
feat(cli): peers displayed as list

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -87,10 +87,11 @@ async fn main() -> Result<()> {
 
     let bootstrap_peers = parse_peers_args(opt.peers).await?;
 
-    println!(
-        "Connecting to the network w/peers: {:?}...",
-        bootstrap_peers
-    );
+    println!("Connecting to the network w/peers:");
+    for peer in &bootstrap_peers {
+        println!("{}", peer);
+    }
+
     let bootstrap_peers = if bootstrap_peers.is_empty() {
         // empty vec is returned if `local-discovery` flag is provided
         None


### PR DESCRIPTION
## Description

cli would print a vec of peers as a single line making a big blob of unreadable text when every command is run.

This changes it so each peer is printed on a single line.

I'd suggest this is a temporary improvement, and this info should not be displayed with every command. It may be useful to introduce a `safe peers` command or a `--show-peers` flag for anyone who wants to see this info printed.

The peer info is useful sometimes, but almost no regular users will ever need to see this info.