### PR TITLE
chore(networking): reduce nodes receiving replication updates.

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -198,7 +198,7 @@ impl Network {
     /// Returns the closest peers to the given `NetworkAddress` that is fetched from the local
     /// Routing Table. It is ordered by increasing distance of the peers
     /// Note self peer_id is not included in the result.
-    pub async fn get_closest_local_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
+    pub async fn get_close_group_local_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetCloseGroupLocalPeers {
             key: key.clone(),

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -45,7 +45,7 @@ use tokio::{
 pub const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
 
 /// Interval to trigger replication on a random close_group peer
-const PERIODIC_REPLICATION_INTERVAL: Duration = Duration::from_secs(30);
+const PERIODIC_REPLICATION_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -45,7 +45,7 @@ use tokio::{
 pub const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
 
 /// Interval to trigger replication on a random close_group peer
-const PERIODIC_REPLICATION_INTERVAL: Duration = Duration::from_secs(60);
+const PERIODIC_REPLICATION_INTERVAL: Duration = Duration::from_secs(180);
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -44,8 +44,9 @@ use tokio::{
 /// serialised transfer info encrypted against the referenced public key.
 pub const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
 
-/// Interval to trigger replication on a random close_group peer
-const PERIODIC_REPLICATION_INTERVAL: Duration = Duration::from_secs(180);
+/// Interval to trigger replication of all records to all peers.
+/// This is the max time it should take. Minimum interval at any ndoe will be half this
+const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 60;
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {
@@ -192,10 +193,13 @@ impl Node {
         let _handle = spawn(async move {
             // use a random inactivity timeout to ensure that the nodes do not sync when messages
             // are being transmitted.
-            let inactivity_timeout: i32 = rng.gen_range(20..40);
-            let inactivity_timeout = Duration::from_secs(inactivity_timeout as u64);
+            let replication_interval: u64 = rng.gen_range(
+                PERIODIC_REPLICATION_INTERVAL_MAX_S / 2..PERIODIC_REPLICATION_INTERVAL_MAX_S,
+            );
+            let replication_interval_time = Duration::from_secs(replication_interval);
+            debug!("Replication interval set to {replication_interval_time:?}");
 
-            let mut replication_interval = tokio::time::interval(PERIODIC_REPLICATION_INTERVAL);
+            let mut replication_interval = tokio::time::interval(replication_interval_time);
             let _ = replication_interval.tick().await; // first tick completes immediately
 
             loop {
@@ -222,10 +226,6 @@ impl Node {
                                 break;
                             }
                         }
-                    }
-                    _ = tokio::time::sleep(inactivity_timeout) => {
-                        trace!("NetworkEvent inactivity timeout hit");
-                        Marker::NoNetworkActivity( inactivity_timeout ).log();
                     }
                     // runs every replication_interval time
                     _ = replication_interval.tick() => {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -46,7 +46,7 @@ pub const TRANSFER_NOTIF_TOPIC: &str = "TRANSFER_NOTIFICATION";
 
 /// Interval to trigger replication of all records to all peers.
 /// This is the max time it should take. Minimum interval at any ndoe will be half this
-const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 60;
+const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 45;
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {
@@ -516,18 +516,16 @@ impl Node {
                     );
 
                     if let Some(peer_id) = holder.as_peer_id() {
-                        let local_peers = match network
-                            .get_close_group_local_peers(&NetworkAddress::from_peer(
-                                network.peer_id,
-                            ))
-                            .await
-                        {
-                            Ok(peers) => peers,
-                            Err(err) => {
-                                error!("Failed to get close group local peers: {err:?}");
-                                return;
-                            }
-                        };
+                        let local_peers: Vec<_> =
+                            match network.get_closest_k_value_local_peers().await {
+                                // accept replication requests from the close_group * 2 peers away, giving us some margin
+                                // for replication on churn
+                                Ok(peers) => peers.into_iter().take(CLOSE_GROUP_SIZE * 2).collect(),
+                                Err(err) => {
+                                    error!("Failed to get close group local peers: {err:?}");
+                                    return;
+                                }
+                            };
 
                         // lets be sure we should handle this message
                         if local_peers.contains(&peer_id) {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -73,18 +73,6 @@ impl Node {
         Ok(())
     }
 
-    /// Add a list of keys to the Replication fetcher.
-    /// These keys are later fetched from network.
-    #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-    pub(crate) fn add_keys_to_replication_fetcher(
-        &self,
-        holder: PeerId,
-        keys: HashMap<NetworkAddress, RecordType>,
-    ) -> Result<()> {
-        self.network.add_keys_to_replication_fetcher(holder, keys)?;
-        Ok(())
-    }
-
     /// Get the Record from a peer or from the network without waiting.
     pub(crate) fn fetch_replication_keys_without_wait(
         &self,

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -41,6 +41,12 @@ impl Node {
         // remove our peer id from the calculations here:
         let _we_were_there = closest_k_peers.remove(&self.network.peer_id);
 
+        // Only grab the closest nodes
+        let closest_k_peers = closest_k_peers
+            .into_iter()
+            .take(CLOSE_GROUP_SIZE + 2)
+            .collect::<Vec<_>>();
+
         trace!("Try trigger interval replication started@{start:?}, peers found_and_sorted, took: {:?}", start.elapsed());
         self.record_metrics(Marker::IntervalReplicationTriggered);
 

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -44,7 +44,8 @@ impl Node {
         // Only grab the closest nodes
         let closest_k_peers = closest_k_peers
             .into_iter()
-            .take(CLOSE_GROUP_SIZE + 2)
+            // add some leeway to allow for divergent knowledge
+            .take(CLOSE_GROUP_SIZE * 2)
             .collect::<Vec<_>>();
 
         trace!("Try trigger interval replication started@{start:?}, peers found_and_sorted, took: {:?}", start.elapsed());

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -45,7 +45,7 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(120);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(180);
 
 // Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 3;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -45,7 +45,7 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(180);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(200);
 
 // Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 3;

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -48,7 +48,7 @@ const CHUNK_SIZE: usize = 1024;
 const VERIFICATION_DELAY: Duration = Duration::from_secs(200);
 
 // Number of times to retry verification if it fails
-const VERIFICATION_ATTEMPTS: usize = 3;
+const VERIFICATION_ATTEMPTS: usize = 5;
 
 // Default number of churns that should be performed. After each churn, we
 // wait for VERIFICATION_DELAY time before verifying the data location.

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -45,10 +45,13 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(200);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(120);
 
-// Number of times to retry verification if it fails
+/// Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 5;
+
+/// Length of time to wait before re-verifying the data location
+const REVERIFICATION_DELAY: Duration = Duration::from_secs(30);
 
 // Default number of churns that should be performed. After each churn, we
 // wait for VERIFICATION_DELAY time before verifying the data location.
@@ -253,7 +256,7 @@ async fn verify_location(all_peers: &[PeerId], node_rpc_addresses: &[SocketAddr]
                 .for_each(|(idx, peer)| println!("{idx} : {peer:?}"));
             verification_attempts += 1;
             println!("Sleeping before retrying verification");
-            tokio::time::sleep(Duration::from_secs(20)).await;
+            tokio::time::sleep(REVERIFICATION_DELAY).await;
         } else {
             // if successful, break out of the loop
             break;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Nov 23 09:29 UTC
This pull request includes two patches. 

The first patch makes a change in the `node.rs` file of the `sn_node` module. It reduces the number of nodes receiving replication updates from `K_VALUE` down to `CLOSE_GROUP_SIZE + 2`. This change is intended to optimize the replication process.

The second patch also modifies the `node.rs` file of the `sn_node` module. It increases the interval for triggering replication on a random close_group peer from 60 seconds to 180 seconds. This change is made in the constant `PERIODIC_REPLICATION_INTERVAL` and aims to adjust the replication interval for better performance.

Overall, these patches make adjustments to the networking and node modules to optimize replication and improve the interval for triggering replication updates.
<!-- reviewpad:summarize:end --> 
