### PR TITLE
feat: all serialisation with MsgPack instead of bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,6 +4506,7 @@ dependencies = [
  "rand",
  "rayon",
  "reqwest",
+ "rmp-serde",
  "sn_build_info",
  "sn_client",
  "sn_logging",
@@ -4631,7 +4632,6 @@ version = "0.98.36"
 dependencies = [
  "assert_fs",
  "async-trait",
- "bincode",
  "blsttc",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,7 +4491,6 @@ dependencies = [
 name = "sn_cli"
 version = "0.86.25"
 dependencies = [
- "bincode",
  "blsttc",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,13 +4747,13 @@ dependencies = [
 name = "sn_registers"
 version = "0.3.3"
 dependencies = [
- "bincode",
  "blsttc",
  "crdts",
  "eyre",
  "hex",
  "proptest",
  "rand",
+ "rmp-serde",
  "self_encryption",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,7 +4526,6 @@ name = "sn_client"
 version = "0.98.18"
 dependencies = [
  "async-trait",
- "bincode",
  "blsttc",
  "bytes",
  "custom_debug",
@@ -4540,6 +4539,7 @@ dependencies = [
  "prometheus-client 0.22.0",
  "rand",
  "rayon",
+ "rmp-serde",
  "self_encryption",
  "serde",
  "sn_networking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,6 @@ name = "sn_transfers"
 version = "0.14.21"
 dependencies = [
  "assert_fs",
- "bincode",
  "blsttc",
  "criterion 0.4.0",
  "custom_debug",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -26,7 +26,6 @@ network-contacts = ["sn_peers_acquisition/network-contacts"]
 open-metrics = ["sn_client/open-metrics"]
 
 [dependencies]
-bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.5.0"

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,6 +39,7 @@ indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = {   version="0.53", features = ["identify", "kad"] }
 rayon = "1.8.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
+rmp-serde = "1.1.1"
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.98.18" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.21" }

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -242,7 +242,7 @@ impl ChunkManager {
             .par_iter()
             .filter_map(|(path_xor, chunked_file)| {
                 let metadata_path = unpaid_dir.join(&path_xor.0).join(METADATA_FILE);
-                let metadata = bincode::serialize(&chunked_file.file_xor_addr)
+                let metadata = rmp_serde::to_vec(&chunked_file.file_xor_addr)
                     .map_err(|_| error!("Failed to serialize file_xor_addr for writing metadata"))
                     .ok()?;
                 let mut metadata_file = File::create(&metadata_path)
@@ -643,7 +643,7 @@ impl ChunkManager {
         let metadata = fs::read(path)
             .map_err(|err| error!("Failed to read metadata with err {err:?}"))
             .ok()?;
-        let metadata: XorName = bincode::deserialize(&metadata)
+        let metadata: XorName = rmp_serde::from_slice(&metadata)
             .map_err(|err| error!("Failed to deserialize metadata with err {err:?}"))
             .ok()?;
         Some(metadata)

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -442,6 +442,6 @@ fn try_decode_transfer_notif(msg: &[u8]) -> Result<(PublicKey, Vec<CashNoteRedem
             .ok_or_else(|| eyre!("msg doesn't have enough bytes"))?,
     );
     let key = PublicKey::from_bytes(key_bytes)?;
-    let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
     Ok((key, cashnote_redemptions))
 }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -17,7 +17,6 @@ open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 
 [dependencies]
 async-trait = "0.1"
-bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.5.0"
@@ -29,6 +28,7 @@ libp2p = {   version="0.53" ,  features = ["identify"] }
 prometheus-client = { version = "0.22", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "1.8.0"
+rmp-serde = "1.1.1"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_networking = { path = "../sn_networking", version = "0.10.22" }

--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -30,7 +30,10 @@ pub enum Error {
     Io(#[from] io::Error),
 
     #[error(transparent)]
-    Serialisation(#[from] Box<bincode::ErrorKind>),
+    Serialisation(#[from] rmp_serde::encode::Error),
+
+    #[error(transparent)]
+    Deserialisation(#[from] rmp_serde::decode::Error),
 
     #[error("Cannot store empty file.")]
     EmptyFileProvided,

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -423,7 +423,7 @@ impl Files {
     /// the process repeats itself until it obtains the first level DataMapLevel.
     async fn unpack_chunk(&self, mut chunk: Chunk, batch_size: usize) -> Result<DataMap> {
         loop {
-            match bincode::deserialize(chunk.value()).map_err(ChunksError::Serialisation)? {
+            match rmp_serde::from_slice(chunk.value()).map_err(ChunksError::Deserialisation)? {
                 DataMapLevel::First(data_map) => {
                     return Ok(data_map);
                 }
@@ -432,8 +432,8 @@ impl Files {
                         .read_all(data_map, None, false, batch_size)
                         .await?
                         .unwrap();
-                    chunk = bincode::deserialize(&serialized_chunk)
-                        .map_err(ChunksError::Serialisation)?;
+                    chunk = rmp_serde::from_slice(&serialized_chunk)
+                        .map_err(ChunksError::Deserialisation)?;
                 }
             }
         }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -25,7 +25,6 @@ quic=["sn_networking/quic"]
 [dependencies]
 assert_fs = "1.0.0"
 async-trait = "0.1"
-bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -537,7 +537,7 @@ fn try_decode_transfer_notif(msg: &[u8], filter: PublicKey) -> eyre::Result<Opti
     );
     let key = PublicKey::from_bytes(key_bytes)?;
     if key == filter {
-        let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
+        let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
         Ok(Some(NodeEvent::TransferNotif {
             key,
             cashnote_redemptions,

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use bytes::{BufMut, BytesMut};
 use libp2p::kad::{Record, RecordKey};
+use serde::Serialize;
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::CmdOk,
@@ -542,22 +543,18 @@ impl Node {
         trace!("Publishing a royalties transfer notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}");
         let royalties_pk_bytes = royalties_pk.to_bytes();
 
-        if let Ok(transfers_size) = bincode::serialized_size(&royalties_cash_notes_r) {
-            let mut msg =
-                BytesMut::with_capacity(royalties_pk_bytes.len() + transfers_size as usize);
-            msg.extend_from_slice(&royalties_pk_bytes);
-            let mut msg = msg.writer();
-            match bincode::serialize_into(&mut msg, &royalties_cash_notes_r) {
-                Ok(_) => {
-                    let msg = msg.into_inner().freeze();
-                    if let Err(err) = self.network.publish_on_topic(TRANSFER_NOTIF_TOPIC.to_string(), msg) {
-                        debug!("Failed to publish a network royalties payment notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}: {err:?}");
-                    }
+        let mut msg = BytesMut::with_capacity(royalties_pk_bytes.len());
+        msg.extend_from_slice(&royalties_pk_bytes);
+        let mut msg = msg.writer();
+        let mut serialiser = rmp_serde::Serializer::new(&mut msg);
+        match royalties_cash_notes_r.serialize(&mut serialiser) {
+            Ok(()) => {
+                let msg = msg.into_inner().freeze();
+                if let Err(err) = self.network.publish_on_topic(TRANSFER_NOTIF_TOPIC.to_string(), msg) {
+                    debug!("Failed to publish a network royalties payment notification over gossipsub for record {pretty_key} and beneficiary {royalties_pk:?}: {err:?}");
                 }
-                Err(err) => warn!("Failed to serialise network royalties payment data to publish a notification over gossipsub for record {pretty_key}: {err:?}"),
             }
-        } else {
-            warn!("Failed to get serialized_size for network royalties payment data to publish a notification over gossipsub for record {pretty_key}");
+            Err(err) => warn!("Failed to serialise network royalties payment data to publish a notification over gossipsub for record {pretty_key}: {err:?}"),
         }
 
         // check if the quote is valid

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -398,6 +398,6 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<(PublicKey, Vec<CashNot
             .ok_or_else(|| eyre::eyre!("msg doesn't have enough bytes"))?,
     );
     let key = PublicKey::from_bytes(key_bytes)?;
-    let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
+    let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
     Ok((key, cashnote_redemptions))
 }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.3.3"
 
 [dependencies]
-bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
+rmp-serde = "1.1.1"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -155,7 +155,7 @@ impl Register {
     /// Returns a bytes version of the Register used for signing
     /// Use this API when you want to sign a Register withtout providing a secret key to the Register API
     pub fn bytes(&self) -> Result<Vec<u8>> {
-        bincode::serialize(self).map_err(|_| Error::SerialisationFailed)
+        rmp_serde::to_vec(self).map_err(|_| Error::SerialisationFailed)
     }
 
     /// Sign a Register into a SignedRegister

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.14.21"
 
 [dependencies]
-bincode = "1.3.3"
 bls = { package = "blsttc", version = "8.0.1" }
 custom_debug = "~0.5.0"
 dirs-next = "~2.0.0"

--- a/sn_transfers/src/cashnotes/cashnote.rs
+++ b/sn_transfers/src/cashnotes/cashnote.rs
@@ -178,7 +178,7 @@ impl CashNote {
         let mut bytes =
             hex::decode(hex).map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
         bytes.reverse();
-        let cashnote: CashNote = bincode::deserialize(&bytes)
+        let cashnote: CashNote = rmp_serde::from_slice(&bytes)
             .map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
         Ok(cashnote)
     }
@@ -186,7 +186,7 @@ impl CashNote {
     /// Serialize this `CashNote` instance to a hex string.
     pub fn to_hex(&self) -> Result<String, Error> {
         let mut serialized =
-            bincode::serialize(&self).map_err(|e| Error::HexSerializationFailed(e.to_string()))?;
+            rmp_serde::to_vec(&self).map_err(|e| Error::HexSerializationFailed(e.to_string()))?;
         serialized.reverse();
         Ok(hex::encode(serialized))
     }

--- a/sn_transfers/src/transfers/transfer.rs
+++ b/sn_transfers/src/transfers/transfer.rs
@@ -109,14 +109,14 @@ impl Transfer {
         let mut bytes = hex::decode(hex).map_err(|_| Error::TransferDeserializationFailed)?;
         bytes.reverse();
         let transfer: Transfer =
-            bincode::deserialize(&bytes).map_err(|_| Error::TransferDeserializationFailed)?;
+            rmp_serde::from_slice(&bytes).map_err(|_| Error::TransferDeserializationFailed)?;
         Ok(transfer)
     }
 
     /// Serialize this `Transfer` instance to a readable hex string that a human can copy paste
     pub fn to_hex(&self) -> Result<String> {
         let mut serialized =
-            bincode::serialize(&self).map_err(|_| Error::TransferSerializationFailed)?;
+            rmp_serde::to_vec(&self).map_err(|_| Error::TransferSerializationFailed)?;
         serialized.reverse();
         Ok(hex::encode(serialized))
     }

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -64,9 +64,12 @@ pub enum Error {
     /// Bls error
     #[error("Bls error: {0}")]
     Bls(#[from] bls::error::Error),
-    /// Bincode error
-    #[error("Bincode error:: {0}")]
-    Bincode(#[from] bincode::Error),
+    /// MsgPack serialisation error
+    #[error("MsgPack serialisation error:: {0}")]
+    Serialisation(#[from] rmp_serde::encode::Error),
+    /// MsgPack deserialisation error
+    #[error("MsgPack deserialisation error:: {0}")]
+    Deserialisation(#[from] rmp_serde::decode::Error),
     /// I/O error
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
Resolves #749 .

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Nov 23 20:20 UTC
This pull request updates the serialization method of royalties notifications in the `sn_node` codebase. It replaces the usage of `bincode` with `MsgPack` as the serialization format. The changes are made in the `node.rs` and `put_validation.rs` files. The `Cargor.lock` and `Cargo.toml` files are also modified to remove the `bincode` dependency. The patch includes both additions and deletions in different files. Overall, there are 13 insertions and 18 deletions in this patch.
<!-- reviewpad:summarize:end --> 
