### PR TITLE
feat(networking): allow port reuse

### DIFF
--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -14,6 +14,8 @@ version = "0.98.17"
 default=[]
 local-discovery=["sn_networking/local-discovery"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
+# required to pass on flag to node builds
+quic = ["sn_networking/quic"]
 
 [dependencies]
 async-trait = "0.1"

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.1.45"
 
+[features]
+# required to pass on flag to node builds
+quic = ["sn_client/quic"]
+
 [[bin]]
 path="src/main.rs"
 name="faucet"

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -393,14 +393,15 @@ impl NetworkBuilder {
 
         // Transport
         #[cfg(not(feature = "quic"))]
-        let mut transport = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default())
-            .upgrade(libp2p::core::upgrade::Version::V1)
-            .authenticate(
-                libp2p::noise::Config::new(&self.keypair)
-                    .expect("Signing libp2p-noise static DH keypair failed."),
-            )
-            .multiplex(libp2p::yamux::Config::default())
-            .boxed();
+        let mut transport =
+            libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::new().port_reuse(true))
+                .upgrade(libp2p::core::upgrade::Version::V1)
+                .authenticate(
+                    libp2p::noise::Config::new(&self.keypair)
+                        .expect("Signing libp2p-noise static DH keypair failed."),
+                )
+                .multiplex(libp2p::yamux::Config::default())
+                .boxed();
 
         #[cfg(feature = "quic")]
         let mut transport = libp2p::quic::tokio::Transport::new(quic::Config::new(&self.keypair))


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Nov 23 08:49 UTC
This pull request includes two patches. 

The first patch modifies the `sn_networking/src/driver.rs` file. It allows port reuse in the networking module by adding the `port_reuse(true)` configuration option to the TCP transport.

The second patch modifies the `sn_client/Cargo.toml` and `sn_faucet/Cargo.toml` files. It adds the missing quic feature to the dependencies, which allows passing on the flag to node builds.

Overall, these patches add support for port reuse in networking and add the required quic feature for node builds.
<!-- reviewpad:summarize:end --> 
