### PR TITLE
feat: verify spend in cli and auditing all the way to genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,6 +4499,7 @@ dependencies = [
  "criterion 0.5.1",
  "custom_debug",
  "dirs-next",
+ "eyre",
  "hex",
  "indicatif",
  "libp2p 0.53.1",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -54,6 +54,7 @@ walkdir = "~2.4.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
+eyre = "0.6.8"
 criterion = "0.5.1"
 tempfile = "3.6.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -198,6 +198,12 @@ fn parse_pubkey_address(str_addr: &str) -> Result<SpendAddress> {
 /// Verify a spend on the Network.
 /// if genesis is true, verify all the way to Genesis, note that this might take A VERY LONG TIME
 async fn verify(spend_address: String, genesis: bool, client: &Client) -> Result<()> {
+    if genesis {
+        println!("Verifying spend all the way to Genesis, note that this might take a while...");
+    } else {
+        println!("Verifying spend...");
+    }
+
     let addr = parse_pubkey_address(&spend_address)?;
     match client.verify_spend(addr, genesis).await {
         Ok(()) => println!("Spend verified to be stored and unique at {addr:?}"),
@@ -209,8 +215,7 @@ async fn verify(spend_address: String, genesis: bool, client: &Client) -> Result
 
 fn address(root_dir: &Path) -> Result<()> {
     let wallet = LocalWallet::load_from(root_dir)?;
-    let address_hex = hex::encode(wallet.address().to_bytes());
-    println!("{address_hex}");
+    println!("{:?}", wallet.address());
     Ok(())
 }
 
@@ -222,7 +227,7 @@ fn balance(root_dir: &Path) -> Result<NanoTokens> {
 
 async fn get_faucet(root_dir: &Path, client: &Client, url: String) -> Result<()> {
     let wallet = LocalWallet::load_from(root_dir)?;
-    let address_hex = hex::encode(wallet.address().to_bytes());
+    let address_hex = wallet.address().to_hex();
     let url = if !url.contains("://") {
         format!("{}://{}", "http", url)
     } else {

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -111,7 +111,7 @@ pub enum WalletCmds {
     /// Verify a spend on the Network.
     Verify {
         /// The Network address or hex encoded UniquePubkey of the Spend to verify
-        #[clap(name = "address")]
+        #[clap(name = "spend")]
         spend_address: String,
         /// Verify all the way to Genesis
         ///

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -65,8 +65,8 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
     println!("Verifying the transfer from genesis...");
     debug!("Verifying the transfer from genesis...");
     if let Err(error) = client.verify_cashnote(&cash_note).await {
-        error!("Could not verify the transfer from genesis: {error:?}. Panicking.");
-        panic!("Could not verify the transfer from genesis: {error:?}");
+        error!("Could not verify the transfer from genesis: {error}. Panicking.");
+        panic!("Could not verify the transfer from genesis: {error}");
     } else {
         println!("Successfully verified the transfer from genesis on the second try.");
         info!("Successfully verified the transfer from genesis on the second try.");

--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -64,7 +64,7 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
 
     println!("Verifying the transfer from genesis...");
     debug!("Verifying the transfer from genesis...");
-    if let Err(error) = client.verify(&cash_note).await {
+    if let Err(error) = client.verify_cashnote(&cash_note).await {
         error!("Could not verify the transfer from genesis: {error:?}. Panicking.");
         panic!("Could not verify the transfer from genesis: {error:?}");
     } else {

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -395,16 +395,73 @@ impl Client {
 
     /// Verify that a spend is valid on the network.
     /// Optionally verify its ancestors as well, all the way to genesis (might take a LONG time)
+    /// Prints progress on stdout
     pub async fn verify_spend(&self, addr: SpendAddress, to_genesis: bool) -> WalletResult<()> {
-        let _spend = self
+        let first_spend = self
             .get_spend_from_network(addr)
             .await
             .map_err(|err| WalletError::CouldNotVerifyTransfer(err.to_string()))?;
 
-        if to_genesis {
-            todo!("Verify spend to genesis");
+        if !to_genesis {
+            return Ok(());
         }
 
+        // use iteration instead of recursion to avoid stack overflow
+        let mut txs_to_verify = BTreeSet::from_iter([first_spend.spend.parent_tx]);
+        let mut depth = 0;
+        let mut verified_tx = BTreeSet::new();
+        let start = std::time::Instant::now();
+
+        while !txs_to_verify.is_empty() {
+            let mut next_gen_tx = BTreeSet::new();
+
+            for parent_tx in txs_to_verify {
+                let parent_tx_hash = parent_tx.hash();
+                let parent_keys = parent_tx.inputs.iter().map(|input| input.unique_pubkey);
+                let addrs_to_verify = parent_keys.map(|k| SpendAddress::from_unique_pubkey(&k));
+                debug!("Depth {depth} - Verifying parent Tx : {parent_tx_hash:?}");
+
+                // get all parent spends in parallel
+                let tasks: Vec<_> = addrs_to_verify
+                    .into_iter()
+                    .map(|a| self.get_spend_from_network(a))
+                    .collect();
+                let spends = join_all(tasks).await
+                    .into_iter()
+                    .collect::<Result<BTreeSet<_>>>()
+                    .map_err(|err| WalletError::CouldNotVerifyTransfer(format!("at depth {depth} - Failed to get spends from network for parent Tx {parent_tx_hash:?}: {err}")))?;
+                debug!(
+                    "Depth {depth} - Got {:?} spends for parent Tx: {parent_tx_hash:?}",
+                    spends.len()
+                );
+                trace!("Spends for {parent_tx_hash:?} - {spends:?}");
+
+                // verify tx with those spends
+                parent_tx
+                    .verify_against_inputs_spent(&spends)
+                    .map_err(|err| WalletError::CouldNotVerifyTransfer(format!("at depth {depth} - Failed to verify parent Tx {parent_tx_hash:?}: {err}")))?;
+                verified_tx.insert(parent_tx_hash);
+                debug!("Depth {depth} - Verified parent Tx: {parent_tx_hash:?}");
+
+                // add new parent spends to next gen
+                next_gen_tx.extend(spends.into_iter().map(|s| s.spend.parent_tx));
+            }
+
+            // only verify parents we haven't already verified
+            txs_to_verify = next_gen_tx
+                .into_iter()
+                .filter(|tx| !verified_tx.contains(&tx.hash()))
+                .collect();
+
+            depth += 1;
+            let elapsed = start.elapsed();
+            let n = verified_tx.len();
+            println!("Now at depth {depth} - Verified {n} transactions in {elapsed:?}")
+        }
+
+        let elapsed = start.elapsed();
+        let n = verified_tx.len();
+        println!("Verified all the way to genesis! Through {depth} generations, verifying {n} transactions in {elapsed:?}");
         Ok(())
     }
 }

--- a/sn_faucet/src/main.rs
+++ b/sn_faucet/src/main.rs
@@ -14,7 +14,7 @@ use faucet_server::run_faucet_server;
 use sn_client::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet, Client};
 use sn_logging::{LogBuilder, LogOutputDest};
 use sn_peers_acquisition::{parse_peers_args, PeersArgs};
-use sn_transfers::{parse_main_pubkey, NanoTokens, Transfer};
+use sn_transfers::{MainPubkey, NanoTokens, Transfer};
 use std::path::PathBuf;
 use tracing::{error, info};
 use tracing_core::Level;
@@ -142,7 +142,7 @@ async fn claim_genesis(client: &Client) -> Result<()> {
 
 /// returns the hex-encoded transfer
 async fn send_tokens(client: &Client, amount: &str, to: &str) -> Result<String> {
-    let to = parse_main_pubkey(to)?;
+    let to = MainPubkey::from_hex(to)?;
     use std::str::FromStr;
     let amount = NanoTokens::from_str(amount)?;
     if amount.as_nano() == 0 {

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinSet;
 impl Network {
     /// Gets a spend from the Network.
     pub async fn get_spend(&self, address: SpendAddress, re_attempt: bool) -> Result<SignedSpend> {
-        let key = NetworkAddress::from_cash_note_address(address).to_record_key();
+        let key = NetworkAddress::from_spend_address(address).to_record_key();
         let record = self
             .get_record_from_network(key, None, GetQuorum::All, re_attempt, Default::default())
             .await

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -355,7 +355,7 @@ impl Node {
         };
         let cash_note_addr = SpendAddress::from_unique_pubkey(&unique_pubkey);
 
-        let key = NetworkAddress::from_cash_note_address(cash_note_addr).to_record_key();
+        let key = NetworkAddress::from_spend_address(cash_note_addr).to_record_key();
         let pretty_key = PrettyPrintRecordKey::from(&key);
         debug!(
             "validating and storing spends {:?} - {pretty_key:?}",
@@ -659,7 +659,7 @@ impl Node {
     ) -> Result<Option<Vec<SignedSpend>>, ProtocolError> {
         // get the UniquePubkey; used for validation
         let cash_note_addr = SpendAddress::from_unique_pubkey(&unique_pubkey);
-        let record_key = NetworkAddress::from_cash_note_address(cash_note_addr).to_record_key();
+        let record_key = NetworkAddress::from_spend_address(cash_note_addr).to_record_key();
         debug!(
             "Validating and storing spend {cash_note_addr:?}, present_locally: {present_locally}"
         );

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -754,16 +754,16 @@ impl Node {
 
                 // Get parents
                 let mut parent_spends = BTreeSet::new();
-                if is_genesis_parent_tx(&signed_spend.spend.cashnote_creation_tx)
+                if is_genesis_parent_tx(&signed_spend.spend.parent_tx)
                     && signed_spend.unique_pubkey() == &GENESIS_CASHNOTE.id
                 {
                     trace!("GENESIS_CASHNOTE {cash_note_addr:?} doesn't have a parent");
                 } else {
                     trace!(
                         "Checking cash_note {cash_note_addr:?} parent transaction {:?}",
-                        signed_spend.spend.cashnote_creation_tx
+                        signed_spend.spend.parent_tx
                     );
-                    for parent_input in &signed_spend.spend.cashnote_creation_tx.inputs {
+                    for parent_input in &signed_spend.spend.parent_tx.inputs {
                         let parent_cash_note_address =
                             SpendAddress::from_unique_pubkey(&parent_input.unique_pubkey());
                         trace!(

--- a/sn_node/tests/common/client.rs
+++ b/sn_node/tests/common/client.rs
@@ -153,7 +153,7 @@ impl NonDroplet {
         let tokens = send(from, wallet_balance, local_wallet.address(), client, true).await?;
 
         println!("Verifying the transfer from faucet...");
-        client.verify(&tokens).await?;
+        client.verify_cashnote(&tokens).await?;
         local_wallet.deposit_and_store_to_disk(&vec![tokens])?;
         assert_eq!(local_wallet.balance(), wallet_balance);
         println!("CashNotes deposited to the wallet that'll pay for storage: {wallet_balance}.");

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -613,7 +613,7 @@ async fn query_content(
     match net_addr {
         NetworkAddress::SpendAddress(addr) => {
             if let Some(cash_note) = cash_notes.read().await.get(addr) {
-                match client.verify(cash_note).await {
+                match client.verify_cashnote(cash_note).await {
                     Ok(_) => Ok(()),
                     Err(err) => Err(Error::CouldNotVerifyTransfer(format!(
                         "Verification of cash_note {addr:?} failed with error: {err:?}"

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -41,7 +41,7 @@ async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
     )
     .await?;
     println!("Verifying the transfer from first wallet...");
-    client.verify(&tokens).await?;
+    client.verify_cashnote(&tokens).await?;
     second_wallet.deposit_and_store_to_disk(&vec![tokens])?;
     assert_eq!(second_wallet.balance(), second_wallet_balance);
     println!("CashNotes deposited to second wallet: {second_wallet_balance}.");
@@ -109,8 +109,8 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     let cash_notes_for_2: Vec<_> = transfer_to_2.created_cash_notes.clone();
     let cash_notes_for_3: Vec<_> = transfer_to_3.created_cash_notes.clone();
 
-    let could_err1 = client.verify(&cash_notes_for_2[0]).await;
-    let could_err2 = client.verify(&cash_notes_for_3[0]).await;
+    let could_err1 = client.verify_cashnote(&cash_notes_for_2[0]).await;
+    let could_err2 = client.verify_cashnote(&cash_notes_for_3[0]).await;
     println!("Verifying at least one fails : {could_err1:?} {could_err2:?}");
     assert!(could_err1.is_err() || could_err2.is_err());
 

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -68,7 +68,7 @@ impl NetworkAddress {
     }
 
     /// Return a `NetworkAddress` representation of the `SpendAddress`.
-    pub fn from_cash_note_address(cash_note_address: SpendAddress) -> Self {
+    pub fn from_spend_address(cash_note_address: SpendAddress) -> Self {
         NetworkAddress::SpendAddress(cash_note_address)
     }
 
@@ -187,10 +187,10 @@ impl Debug for NetworkAddress {
                     chunk_address.xorname()
                 )
             }
-            NetworkAddress::SpendAddress(cash_note_address) => {
+            NetworkAddress::SpendAddress(spend_address) => {
                 format!(
                     "NetworkAddress::SpendAddress({:?} - ",
-                    cash_note_address.xorname()
+                    spend_address.to_hex()
                 )
             }
             NetworkAddress::RegisterAddress(register_address) => format!(
@@ -342,6 +342,7 @@ mod tests {
     use bls::rand::thread_rng;
     use bytes::Bytes;
     use libp2p::kad::{KBucketKey, RecordKey};
+    use sn_transfers::SpendAddress;
 
     // A struct that implements hex representation of RecordKey using `bytes::Bytes`
     struct OldRecordKeyPrint(RecordKey);
@@ -391,5 +392,17 @@ mod tests {
         let old_record_key = OldRecordKeyPrint(key);
 
         assert_eq!(format!("{pretty_key:?}"), format!("{old_record_key:?}"));
+    }
+
+    #[test]
+    fn verify_spend_addr_is_actionable() {
+        let xorname = xor_name::XorName::random(&mut thread_rng());
+        let spend_addr = SpendAddress::new(xorname);
+        let net_addr = NetworkAddress::from_spend_address(spend_addr);
+
+        let spend_addr_hex = spend_addr.to_hex();
+        let net_addr_fmt = format!("{}", net_addr);
+
+        assert!(net_addr_fmt.contains(&spend_addr_hex));
     }
 }

--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -97,7 +97,7 @@ impl TransactionBuilder {
                     spent_tx: spent_tx.clone(),
                     reason,
                     token: input.amount,
-                    cashnote_creation_tx: input_src_tx.clone(),
+                    parent_tx: input_src_tx.clone(),
                 };
                 let derived_key_sig = derived_key.sign(&spend.to_bytes());
                 signed_spends.insert(SignedSpend {

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Hash, NanoTokens, Transaction, UniquePubkey};
-use crate::{Error, Result, Signature, GENESIS_CASHNOTE};
+use crate::{Error, Result, Signature};
 
 use custom_debug::Debug;
 use serde::{Deserialize, Serialize};
@@ -70,15 +70,10 @@ impl SignedSpend {
     pub fn verify(&self, spent_tx_hash: Hash) -> Result<()> {
         // verify that input spent_tx_hash matches self.spent_tx_hash
         if spent_tx_hash != self.spent_tx_hash() {
-            if self.unique_pubkey() == &GENESIS_CASHNOTE.id {
-                // This is the genesis Spend, we can skip to the next part
-                // and check the signature
-            } else {
-                return Err(Error::TransactionHashMismatch(
-                    spent_tx_hash,
-                    self.spent_tx_hash(),
-                ));
-            }
+            return Err(Error::TransactionHashMismatch(
+                spent_tx_hash,
+                self.spent_tx_hash(),
+            ));
         }
 
         // check signature

--- a/sn_transfers/src/cashnotes/unique_keys.rs
+++ b/sn_transfers/src/cashnotes/unique_keys.rs
@@ -38,7 +38,7 @@ impl DerivationIndex {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct UniquePubkey(PublicKey);
 
 impl UniquePubkey {
@@ -66,6 +66,15 @@ impl UniquePubkey {
     pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self> {
         let public_key = bls_public_from_hex(hex)?;
         Ok(Self::new(public_key))
+    }
+}
+
+/// Actionable way to print a UniquePubkey
+/// This way to print it is lengthier but allows to copy/paste it into the safe cli or other apps
+/// To use for verification purposes
+impl std::fmt::Debug for UniquePubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
     }
 }
 
@@ -116,7 +125,7 @@ impl DerivedSecretKey {
 /// the MainPubkey can also see that the UniquePubkey is related to this MainPubkey.
 /// The recipient can then use the received DerivationIndex to generate the DerivedSecretKey
 /// corresponding to that UniquePubkey, and thus unlock the value of the CashNote by using that DerivedSecretKey.
-#[derive(Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Clone, Serialize, Deserialize, Hash)]
+#[derive(Copy, PartialEq, Eq, Ord, PartialOrd, Clone, Serialize, Deserialize, Hash)]
 pub struct MainPubkey(pub PublicKey);
 
 impl MainPubkey {
@@ -153,6 +162,12 @@ impl MainPubkey {
     pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self> {
         let public_key = bls_public_from_hex(hex)?;
         Ok(Self::new(public_key))
+    }
+}
+
+impl std::fmt::Debug for MainPubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
     }
 }
 

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{NanoTokens, UniquePubkey};
+use crate::{Hash, NanoTokens, UniquePubkey};
 use thiserror::Error;
 
 /// Specialisation of `std::Result`.
@@ -29,8 +29,8 @@ pub enum Error {
 
     #[error("Invalid Spend Signature for {0:?}")]
     InvalidSpendSignature(UniquePubkey),
-    #[error("Transaction hash does not match the transaction signed by spentbook.")]
-    InvalidTransactionHash,
+    #[error("Transaction hash is different from the hash in the the Spend: {0:?} != {1:?}")]
+    TransactionHashMismatch(Hash, Hash),
     #[error("CashNote ciphers are not present in transaction outputs.")]
     CashNoteCiphersNotPresentInTransactionOutput,
     #[error("Output not found in transaction outputs.")]

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -35,8 +35,8 @@ pub enum Error {
     CashNoteCiphersNotPresentInTransactionOutput,
     #[error("Output not found in transaction outputs.")]
     OutputNotFound,
-    #[error("UniquePubkey is not unique across all transaction outputs.")]
-    UniquePubkeyNotUniqueAcrossOutputs,
+    #[error("UniquePubkey is not unique across all transaction inputs and outputs.")]
+    UniquePubkeyNotUniqueInTx,
     #[error("The number of SignedSpend ({got}) does not match the number of inputs ({expected}).")]
     SignedSpendInputLenMismatch { got: usize, expected: usize },
     #[error("A SignedSpend UniquePubkey does not match an MlsagSignature UniquePubkey.")]
@@ -57,8 +57,6 @@ pub enum Error {
     InconsistentTransaction,
     #[error("The CashNote tx must have at least one input.")]
     MissingTxInputs,
-    #[error("CashNote id is not unique across all tx inputs.")]
-    UniquePubkeyNotUniqueAcrossInputs,
     #[error("Overflow occurred while adding values")]
     NumericOverflow,
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -89,7 +89,7 @@ pub fn load_genesis_wallet() -> Result<LocalWallet, Error> {
     let mut genesis_wallet = create_genesis_wallet();
 
     info!(
-        "Depositing genesis CashNote: {:#?}",
+        "Depositing genesis CashNote: {:?}",
         GENESIS_CASHNOTE.unique_pubkey()
     );
     genesis_wallet

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -32,7 +32,7 @@ pub use genesis::{
     GENESIS_CASHNOTE_SK, NETWORK_ROYALTIES_PK,
 };
 pub use transfers::create_offline_transfer;
-pub use wallet::{bls_secret_from_hex, parse_main_pubkey};
+pub use wallet::bls_secret_from_hex;
 pub use wallet::{
     Error as WalletError, LocalWallet, Payment, PaymentQuote, Result as WalletResult,
 };

--- a/sn_transfers/src/wallet/keys.rs
+++ b/sn_transfers/src/wallet/keys.rs
@@ -8,7 +8,7 @@
 
 use super::error::{Error, Result};
 
-use crate::{MainPubkey, MainSecretKey};
+use crate::MainSecretKey;
 
 use hex::{decode, encode};
 use std::path::Path;
@@ -17,12 +17,6 @@ use std::path::Path;
 const MAIN_SECRET_KEY_FILENAME: &str = "main_secret_key";
 /// Filename for storing the node's reward (BLS hex-encoded) public key.
 const MAIN_PUBKEY_FILENAME: &str = "main_pubkey";
-
-/// Parse a public address from a hex-encoded string.
-pub fn parse_main_pubkey<T: AsRef<[u8]>>(hex: T) -> Result<MainPubkey> {
-    let public_key = bls_public_from_hex(hex)?;
-    Ok(MainPubkey::new(public_key))
-}
 
 /// Writes the public address and main key (hex-encoded) to different locations at disk.
 pub(crate) fn store_new_keypair(wallet_dir: &Path, main_key: &MainSecretKey) -> Result<()> {
@@ -56,17 +50,6 @@ pub fn bls_secret_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::SecretKey> {
         .map_err(|_| Error::FailedToParseBlsKey)?;
     let sk = bls::SecretKey::from_bytes(bytes_fixed_len)?;
     Ok(sk)
-}
-
-/// Construct a BLS public key from a hex-encoded string.
-fn bls_public_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::PublicKey> {
-    let bytes = decode(hex).map_err(|_| Error::FailedToDecodeHexToKey)?;
-    let bytes_fixed_len: [u8; bls::PK_SIZE] = bytes
-        .as_slice()
-        .try_into()
-        .map_err(|_| Error::FailedToParseBlsKey)?;
-    let pk = bls::PublicKey::from_bytes(bytes_fixed_len)?;
-    Ok(pk)
 }
 
 #[cfg(test)]

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -63,7 +63,7 @@ use data_payments::ContentPaymentsMap;
 pub use self::{
     data_payments::{Payment, PaymentQuote},
     error::{Error, Result},
-    keys::{bls_secret_from_hex, parse_main_pubkey},
+    keys::bls_secret_from_hex,
     local_store::LocalWallet,
 };
 pub(crate) use keys::store_new_keypair;


### PR DESCRIPTION
## Description

- verify spends in cli with `safe wallet verify <spend_address/unique_pubkey>`
- option to verify them all the way to genesis (for auditing) `safe wallet verify --genesis <spend_address/unique_pubkey>`
- make spends logging actionable by printing the spend_address and unique_pubkey in hex (copy/pastable to the cli)
- reinforce Tx verification code

---

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Nov 23 11:45 UTC
This pull request includes the following changes:

1. In the `client.rs` file, the function `verify()` has been replaced with `verify_cashnote()`. This change improves the clarity and accuracy of the code.

2. In the `address.rs` file, several changes have been made:
   - Import statements for `Error` and `Result` have been added.
   - New methods `to_hex()` and `from_hex()` have been added to the `SpendAddress` struct.
   - The `Debug` trait has been implemented for the `SpendAddress` struct.
   - A unit test for hex conversions of `SpendAddress` has been added.

3. In the `wallet.rs` file, the following changes have been made:
   - Import statements for `SpendAddress` have been added.
   - A debug log statement has been added to print the spend key being marked as spent on the Network.
   - The `verify()` function has been renamed to `verify_cashnote()` and its documentation has been updated.
   - A new function `verify_spend()` has been added to verify a spend and its ancestors on the network.
   - Minor changes have been made to debug log messages.

4. In the `sn_cli/src/subcommands/wallet.rs` file, the following changes have been made:
   - Import statements have been modified to include new types and modules: `MainPubkey`, `SpendAddress`, and `UniquePubkey`.
   - A new subcommand `Verify` has been added, which can be used to verify a spend on the network.
   - A new function `parse_pubkey_address` has been added to parse a spend address or a unique pubkey address.
   - The `verify` function has been implemented to verify a spend on the network.
   - Additional test cases have been added for the `parse_pubkey_address` function.

5. In the `sn_cli/src/networking/api.rs` file, the following changes have been made:
   - The import statement for `UniquePubkey` has been removed.
   - The function `get_spend_from_network` now takes an argument of type `SpendAddress` instead of `unique_pubkey`.
   - The variable `cash_note_addr` has been renamed to `address` in the `put_spend_to_network` function.
   - The function `get_spend_from_network` now takes an argument of type `SpendAddress` instead of `unique_pubkey`.
   - Log messages have been updated to include the `address` instead of `unique_pubkey`.

6. In the `sn_network/src/transfers.rs` file, the following change has been made:
   - The method call `from_cash_note_address` has been changed to `from_spend_address` when obtaining a key from a `NetworkAddress`.

7. In the `common/mod.rs` file, the following change has been made:
   - The method `client.verify` has been replaced with `client.verify_cashnote`.

8. In the `sn_transfers/src/cashnotes/signed_spend.rs` file, the following changes have been made:
   - The `GENESIS_CASHNOTE` has been imported from the crate.
   - The method `cashnote_creation_tx_hash` has been renamed to `parent_tx_hash`.
   - The `verify` method has been modified to handle cases where the `spent_tx_hash` does not match `self.spent_tx_hash()`.
   - The comments have been updated to reflect the changes.

9. In the `unique_keys.rs` file, the following changes have been made:
   - Import statements for `Error` and `Result` have been added.
   - New methods `to_hex()` and `from_hex()` have been added to the `UniquePubkey` and `MainPubkey` structs.
   - The `Debug` trait has been implemented for both structs.
   - A new function `bls_public_from_hex()` has been added.
   - Test cases have been added for the key conversion functions.

10. In the `sn_node/src/spends.rs` file, the following changes have been made:
    - The code now checks if a spent CashNote is Genesis using `signed_spend.spend.parent_tx` instead of `signed_spend.spend.cashnote_creation_tx`.
    - The code now checks if a spent CashNote is an output of the parent tx using `signed_spend.spend.parent_tx.outputs` instead of `signed_spend.spend.cashnote_creation_tx.outputs`.
    - The variable `tx_our_cash_note_was_created_in` now gets the value of `signed_spend.parent_tx_hash()` instead of `signed_spend.cashnote_creation_tx_hash()`.
    - The code compares `tx_our_cash_note_was_created_in` with `tx_its_parents_where_spent_in` instead of `tx_our_cash_note_was_created_in` with `tx_its_parents_where_spent_in`.
    - The code now verifies the CashNote was created in a valid tx using `signed_spend.parent_tx.verify_against_inputs_spent(parent_spends)` instead of `signed_spend.cashnote_creation_tx.verify_against_inputs_spent(parent_spends)`.

11. The `Cargo.lock` file has been modified to add the `eyre` dependency.

12. The `Cargo.toml` file has been modified to add the `eyre` crate as a development dependency with version 0.6.8.

13. In the `data_with_churn.rs` file, the `verify()` method call has been changed to `verify_cashnote()` on the `client` object. The exact intention behind this change is unclear from the diff alone.

14. In the `sequential_transfers.rs` file, the method call `verify()` has been replaced with `verify_cashnote()` in the `cash_note_transfer_multiple_sequential_succeed()` and `cash_note_transfer_double_spend_fail()` functions.

15. In the `wallet/mod.rs` file, the import of the `parse_main_pubkey` function has been removed, and the import of the `bls_secret_from_hex` function has been modified.

16. In the `main.rs` file, the import of the `parse_main_pubkey` function has
<!-- reviewpad:summarize:end --> 
