### PR TITLE
chore(node): increase node reward test timeout to match client wait

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -302,7 +302,7 @@ fn spawn_royalties_payment_listener(
         let mut count = 0;
         let mut stream = response.into_inner();
 
-        let duration = Duration::from_secs(10);
+        let duration = Duration::from_secs(80);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
             while let Some(Ok(e)) = stream.next().await {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Nov 23 12:22 UTC
This pull request increases the node reward test timeout in order to match the client wait.
<!-- reviewpad:summarize:end --> 
