### PR TITLE
fix: protect against amounts tampering and incomplete spends attack

### DIFF
--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -766,7 +766,7 @@ impl Node {
                     );
                     for parent_input in &signed_spend.spend.parent_tx.inputs {
                         let parent_cash_note_address =
-                            SpendAddress::from_unique_pubkey(&parent_input.unique_pubkey());
+                            SpendAddress::from_unique_pubkey(parent_input.unique_pubkey());
                         trace!(
                             "Checking parent input at {:?} - {parent_cash_note_address:?}",
                             parent_input.unique_pubkey(),

--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -38,7 +38,7 @@ impl TransactionBuilder {
         input_src_tx: InputSrcTx,
     ) -> Self {
         self.input_details
-            .insert(input.unique_pubkey(), (derived_key, input_src_tx));
+            .insert(*input.unique_pubkey(), (derived_key, input_src_tx));
         self.inputs.push(input);
         self
     }
@@ -93,7 +93,7 @@ impl TransactionBuilder {
             if let Some((derived_key, input_src_tx)) = self.input_details.get(&input.unique_pubkey)
             {
                 let spend = Spend {
-                    unique_pubkey: input.unique_pubkey(),
+                    unique_pubkey: *input.unique_pubkey(),
                     spent_tx: spent_tx.clone(),
                     reason,
                     token: input.amount,

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
     #[error("Failed to parse: {0}")]
     FailedToParseNanoToken(String),
 
+    #[error("Invalid Spend: value was tampered with {0:?}")]
+    InvalidSpendValue(UniquePubkey),
     #[error("Invalid Spend Signature for {0:?}")]
     InvalidSpendSignature(UniquePubkey),
     #[error("Transaction hash is different from the hash in the the Spend: {0:?} != {1:?}")]
@@ -54,9 +56,11 @@ pub enum Error {
     #[error("Could not serialize CashNote to hex: {0}")]
     HexSerializationFailed(String),
     #[error("The input and output amounts of the tx do not match.")]
-    InconsistentTransaction,
+    UnbalancedTransaction,
     #[error("The CashNote tx must have at least one input.")]
     MissingTxInputs,
+    #[error("The spends don't match the inputs of the Transaction.")]
+    SpendsDoNotMatchInputs,
     #[error("Overflow occurred while adding values")]
     NumericOverflow,
 

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -405,7 +405,7 @@ impl LocalWallet {
             .available_cash_notes
             .retain(|k, _| !spent_unique_pubkeys.contains(k));
         for spent in spent_unique_pubkeys {
-            self.wallet.spent_cash_notes.insert(spent);
+            self.wallet.spent_cash_notes.insert(*spent);
         }
 
         if let Some(cash_note) = transfer.change_cash_note {


### PR DESCRIPTION
## Description

Fixes critical security issues in Transfer verification.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Nov 23 08:02 UTC
This pull request includes several changes to fix issues related to amounts tampering and incomplete spends attack. The changes made in this patch are as follows:

- In the `sn_node/src/put_validation.rs` file, a change was made to fix the use of `from_unique_pubkey` method.
- In the `sn_transfers/src/cashnotes/builder.rs` file, changes were made to fix the use of `unique_pubkey()` method.
- In the `sn_transfers/src/cashnotes/signed_spend.rs` file, changes were made to verify the validity of the signed spend and to check for tampering of the spend value.
- In the `sn_transfers/src/cashnotes/transaction.rs` file, changes were made to verify the transaction against the inputs spent, including the signed spends.
- In the `sn_transfers/src/error.rs` file, a new error type `InvalidSpendValue` was added to handle cases where the spend value was tampered with.
- In the `sn_transfers/src/wallet/local_store.rs` file, a change was made to fix the use of `insert()` method.

Overall, these changes aim to provide better protection against amounts tampering and incomplete spends attack.
<!-- reviewpad:summarize:end --> 
