### PR TITLE
fix(faucet): verify genesis spend after some delay

### DIFF
--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -1,9 +1,8 @@
-use super::{wallet::send, Result};
-use crate::Client;
-
-use sn_transfers::LocalWallet;
-use sn_transfers::{create_faucet_wallet, load_genesis_wallet};
-use sn_transfers::{CashNote, MainPubkey, NanoTokens};
+use super::{wallet::send, Client, Result};
+use sn_transfers::{
+    create_faucet_wallet, load_genesis_wallet, CashNote, LocalWallet, MainPubkey, NanoTokens,
+};
+use std::time::Duration;
 
 /// Returns a cash_note with the requested number of tokens, for use by E2E test instances.
 /// Note this will create a faucet having a Genesis balance
@@ -62,8 +61,11 @@ pub async fn load_faucet_wallet_from_genesis_wallet(client: &Client) -> Result<L
     println!("Faucet wallet balance: {}", faucet_wallet.balance());
     debug!("Faucet wallet balance: {}", faucet_wallet.balance());
 
-    println!("Verifying the transfer from genesis...");
-    debug!("Verifying the transfer from genesis...");
+    println!("Sleeping for 10s before verifying the transfer from genesis...");
+    debug!("Sleeping for 10s before verifying the transfer from genesis...");
+    // We do have re-attempts during verify cashnote, but since we're reading right after write, we might hit quorum
+    // error. So sleep before verify.
+    tokio::time::sleep(Duration::from_secs(10)).await;
     if let Err(error) = client.verify_cashnote(&cash_note).await {
         error!("Could not verify the transfer from genesis: {error}. Panicking.");
         panic!("Could not verify the transfer from genesis: {error}");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -357,7 +357,9 @@ impl Client {
         Ok(cashnotes)
     }
 
-    /// Verify that the spends refered to in the CashNote exist on the network.
+    /// Verify that the spends referred to in the CashNote exist on the network.
+    /// If you are verifying the CashNote right after performing the transaction, it might cause Quorum error even
+    /// after re-attempts. So we should retry on upper layers or have a delay before verification.
     pub async fn verify_cashnote(&self, cash_note: &CashNote) -> WalletResult<()> {
         // We need to get all the spends in the cash_note from the network,
         // and compare them to the spends in the cash_note, to know if the


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Nov 23 10:08 UTC
This pull request includes a fix for the faucet module. The patch adds a delay before verifying the transfer from genesis in order to avoid quorum errors.
<!-- reviewpad:summarize:end --> 
