### PR TITLE
revert to 2 days ago

### DIFF
--- a/sn_networking/CHANGELOG.md
+++ b/sn_networking/CHANGELOG.md
@@ -180,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.29](https://github.com/maidsafe/safe_network/compare/sn_networking-v0.9.28...sn_networking-v0.9.29) - 2023-11-08
 
+ss
 ### Other
 - *(networking)* use internal libp2p method
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Nov 23 14:47 UTC
This pull request reverts to the state of the code from 2 days ago. The only change made is the addition of a single line in the CHANGELOG.md file in the sn_networking directory. The line added in the CHANGELOG.md file seems to be an error as it only contains the letters "ss". Additionally, an internal libp2p method is now being used in the networking module.
<!-- reviewpad:summarize:end --> 
