### PR TITLE
[TEST] Revert "feat(chunks): serialise Chunks with MsgPack instead of bincode"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,7 +4507,6 @@ dependencies = [
  "rand",
  "rayon",
  "reqwest",
- "rmp-serde",
  "sn_build_info",
  "sn_client",
  "sn_logging",
@@ -4633,6 +4632,7 @@ version = "0.98.44"
 dependencies = [
  "assert_fs",
  "async-trait",
+ "bincode",
  "blsttc",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,6 +4527,7 @@ name = "sn_client"
 version = "0.98.23"
 dependencies = [
  "async-trait",
+ "bincode",
  "blsttc",
  "bytes",
  "custom_debug",
@@ -4540,7 +4541,6 @@ dependencies = [
  "prometheus-client 0.22.0",
  "rand",
  "rayon",
- "rmp-serde",
  "self_encryption",
  "serde",
  "sn_networking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
 name = "sn_cli"
 version = "0.86.33"
 dependencies = [
+ "bincode",
  "blsttc",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4791,6 +4791,7 @@ name = "sn_transfers"
 version = "0.14.23"
 dependencies = [
  "assert_fs",
+ "bincode",
  "blsttc",
  "criterion 0.4.0",
  "custom_debug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,13 +4748,13 @@ dependencies = [
 name = "sn_registers"
 version = "0.3.4"
 dependencies = [
+ "bincode",
  "blsttc",
  "crdts",
  "eyre",
  "hex",
  "proptest",
  "rand",
- "rmp-serde",
  "self_encryption",
  "serde",
  "thiserror",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,7 +39,6 @@ indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = {   version="0.53", features = ["identify", "kad"] }
 rayon = "1.8.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
-rmp-serde = "1.1.1"
 sn_build_info = { path="../sn_build_info", version = "0.1.2" }
 sn_client = { path = "../sn_client", version = "0.98.23" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.23" }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -26,6 +26,7 @@ network-contacts = ["sn_peers_acquisition/network-contacts"]
 open-metrics = ["sn_client/open-metrics"]
 
 [dependencies]
+bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.5.0"

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -242,7 +242,7 @@ impl ChunkManager {
             .par_iter()
             .filter_map(|(path_xor, chunked_file)| {
                 let metadata_path = unpaid_dir.join(&path_xor.0).join(METADATA_FILE);
-                let metadata = rmp_serde::to_vec(&chunked_file.file_xor_addr)
+                let metadata = bincode::serialize(&chunked_file.file_xor_addr)
                     .map_err(|_| error!("Failed to serialize file_xor_addr for writing metadata"))
                     .ok()?;
                 let mut metadata_file = File::create(&metadata_path)
@@ -643,7 +643,7 @@ impl ChunkManager {
         let metadata = fs::read(path)
             .map_err(|err| error!("Failed to read metadata with err {err:?}"))
             .ok()?;
-        let metadata: XorName = rmp_serde::from_slice(&metadata)
+        let metadata: XorName = bincode::deserialize(&metadata)
             .map_err(|err| error!("Failed to deserialize metadata with err {err:?}"))
             .ok()?;
         Some(metadata)

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -486,7 +486,7 @@ fn try_decode_transfer_notif(msg: &[u8]) -> Result<(PublicKey, Vec<CashNoteRedem
             .ok_or_else(|| eyre!("msg doesn't have enough bytes"))?,
     );
     let key = PublicKey::from_bytes(key_bytes)?;
-    let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
+    let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
     Ok((key, cashnote_redemptions))
 }
 

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -19,6 +19,7 @@ quic = ["sn_networking/quic"]
 
 [dependencies]
 async-trait = "0.1"
+bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.5.0"
@@ -30,7 +31,6 @@ libp2p = {   version="0.53" ,  features = ["identify"] }
 prometheus-client = { version = "0.22", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "1.8.0"
-rmp-serde = "1.1.1"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_networking = { path = "../sn_networking", version = "0.10.27" }

--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -30,10 +30,7 @@ pub enum Error {
     Io(#[from] io::Error),
 
     #[error(transparent)]
-    Serialisation(#[from] rmp_serde::encode::Error),
-
-    #[error(transparent)]
-    Deserialisation(#[from] rmp_serde::decode::Error),
+    Serialisation(#[from] Box<bincode::ErrorKind>),
 
     #[error("Cannot store empty file.")]
     EmptyFileProvided,

--- a/sn_client/src/chunks/pac_man.rs
+++ b/sn_client/src/chunks/pac_man.rs
@@ -118,9 +118,9 @@ fn pack_data_map(data_map: DataMap) -> Result<(XorName, Vec<Chunk>)> {
             // Returns the address of the last datamap, and all the chunks produced.
             break (name, chunks);
         } else {
-            let mut bytes = BytesMut::with_capacity(MAX_CHUNK_SIZE).writer();
-            let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
-            chunk.serialize(&mut serialiser)?;
+            let size = bincode::serialized_size(&chunk)?;
+            let mut bytes = BytesMut::with_capacity(size as usize).writer();
+            bincode::serialize_into(&mut bytes, &chunk)?;
             let serialized_chunk = bytes.into_inner().freeze();
 
             let (data_map, next_encrypted_chunks) = self_encryption::encrypt(serialized_chunk)?;
@@ -137,10 +137,9 @@ fn pack_data_map(data_map: DataMap) -> Result<(XorName, Vec<Chunk>)> {
 }
 
 fn wrap_data_map(data_map: DataMapLevel) -> Result<Bytes> {
-    // we use an initial/starting size of 300 bytes as that's roughly the current size of a DataMapLevel instance.
-    let mut bytes = BytesMut::with_capacity(300).writer();
-    let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
-    data_map.serialize(&mut serialiser)?;
+    let size = bincode::serialized_size(&data_map)?;
+    let mut bytes = BytesMut::with_capacity(size as usize).writer();
+    bincode::serialize_into(&mut bytes, &data_map)?;
     Ok(bytes.into_inner().freeze())
 }
 

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -423,7 +423,7 @@ impl Files {
     /// the process repeats itself until it obtains the first level DataMapLevel.
     async fn unpack_chunk(&self, mut chunk: Chunk, batch_size: usize) -> Result<DataMap> {
         loop {
-            match rmp_serde::from_slice(chunk.value()).map_err(ChunksError::Deserialisation)? {
+            match bincode::deserialize(chunk.value()).map_err(ChunksError::Serialisation)? {
                 DataMapLevel::First(data_map) => {
                     return Ok(data_map);
                 }
@@ -432,8 +432,8 @@ impl Files {
                         .read_all(data_map, None, false, batch_size)
                         .await?
                         .unwrap();
-                    chunk = rmp_serde::from_slice(&serialized_chunk)
-                        .map_err(ChunksError::Deserialisation)?;
+                    chunk = bincode::deserialize(&serialized_chunk)
+                        .map_err(ChunksError::Serialisation)?;
                 }
             }
         }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -25,6 +25,7 @@ quic=["sn_networking/quic"]
 [dependencies]
 assert_fs = "1.0.0"
 async-trait = "0.1"
+bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -574,7 +574,7 @@ fn try_decode_transfer_notif(msg: &[u8], filter: PublicKey) -> eyre::Result<Opti
     );
     let key = PublicKey::from_bytes(key_bytes)?;
     if key == filter {
-        let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
+        let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
         Ok(Some(NodeEvent::TransferNotif {
             key,
             cashnote_redemptions,

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -411,6 +411,6 @@ fn try_decode_transfer_notif(msg: &[u8]) -> eyre::Result<(PublicKey, Vec<CashNot
             .ok_or_else(|| eyre::eyre!("msg doesn't have enough bytes"))?,
     );
     let key = PublicKey::from_bytes(key_bytes)?;
-    let cashnote_redemptions: Vec<CashNoteRedemption> = rmp_serde::from_slice(&msg[PK_SIZE..])?;
+    let cashnote_redemptions: Vec<CashNoteRedemption> = bincode::deserialize(&msg[PK_SIZE..])?;
     Ok((key, cashnote_redemptions))
 }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.3.4"
 
 [dependencies]
+bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
-rmp-serde = "1.1.1"
 self_encryption = "~0.28.5"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -155,7 +155,7 @@ impl Register {
     /// Returns a bytes version of the Register used for signing
     /// Use this API when you want to sign a Register withtout providing a secret key to the Register API
     pub fn bytes(&self) -> Result<Vec<u8>> {
-        rmp_serde::to_vec(self).map_err(|_| Error::SerialisationFailed)
+        bincode::serialize(self).map_err(|_| Error::SerialisationFailed)
     }
 
     /// Sign a Register into a SignedRegister

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.14.23"
 
 [dependencies]
+bincode = "1.3.3"
 bls = { package = "blsttc", version = "8.0.1" }
 custom_debug = "~0.5.0"
 dirs-next = "~2.0.0"

--- a/sn_transfers/src/cashnotes/cashnote.rs
+++ b/sn_transfers/src/cashnotes/cashnote.rs
@@ -178,7 +178,7 @@ impl CashNote {
         let mut bytes =
             hex::decode(hex).map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
         bytes.reverse();
-        let cashnote: CashNote = rmp_serde::from_slice(&bytes)
+        let cashnote: CashNote = bincode::deserialize(&bytes)
             .map_err(|e| Error::HexDeserializationFailed(e.to_string()))?;
         Ok(cashnote)
     }
@@ -186,7 +186,7 @@ impl CashNote {
     /// Serialize this `CashNote` instance to a hex string.
     pub fn to_hex(&self) -> Result<String, Error> {
         let mut serialized =
-            rmp_serde::to_vec(&self).map_err(|e| Error::HexSerializationFailed(e.to_string()))?;
+            bincode::serialize(&self).map_err(|e| Error::HexSerializationFailed(e.to_string()))?;
         serialized.reverse();
         Ok(hex::encode(serialized))
     }

--- a/sn_transfers/src/transfers/transfer.rs
+++ b/sn_transfers/src/transfers/transfer.rs
@@ -109,14 +109,14 @@ impl Transfer {
         let mut bytes = hex::decode(hex).map_err(|_| Error::TransferDeserializationFailed)?;
         bytes.reverse();
         let transfer: Transfer =
-            rmp_serde::from_slice(&bytes).map_err(|_| Error::TransferDeserializationFailed)?;
+            bincode::deserialize(&bytes).map_err(|_| Error::TransferDeserializationFailed)?;
         Ok(transfer)
     }
 
     /// Serialize this `Transfer` instance to a readable hex string that a human can copy paste
     pub fn to_hex(&self) -> Result<String> {
         let mut serialized =
-            rmp_serde::to_vec(&self).map_err(|_| Error::TransferSerializationFailed)?;
+            bincode::serialize(&self).map_err(|_| Error::TransferSerializationFailed)?;
         serialized.reverse();
         Ok(hex::encode(serialized))
     }

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -64,12 +64,9 @@ pub enum Error {
     /// Bls error
     #[error("Bls error: {0}")]
     Bls(#[from] bls::error::Error),
-    /// MsgPack serialisation error
-    #[error("MsgPack serialisation error:: {0}")]
-    Serialisation(#[from] rmp_serde::encode::Error),
-    /// MsgPack deserialisation error
-    #[error("MsgPack deserialisation error:: {0}")]
-    Deserialisation(#[from] rmp_serde::decode::Error),
+    /// Bincode error
+    #[error("Bincode error:: {0}")]
+    Bincode(#[from] bincode::Error),
     /// I/O error
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Nov 23 15:30 UTC
This pull request includes the following changes:

- Added `bincode` dependency with version 1.3.1 in `Cargo.toml`
- Updated `bls` dependency to version 8.0.1 in `Cargo.toml`
- Updated `bytes` dependency to version 1.0.1 with feature serde in `Cargo.toml`
- Removed `rmp-serde` dependency in `Cargo.toml`
- Updated `indicatif` dependency to version 0.17.5 with feature tokio in `Cargo.toml`
- Updated `libp2p` dependency to version 0.53 with features identify and kad in `Cargo.toml`
- Updated `rayon` dependency to version 1.8.0 in `Cargo.toml`
- Updated `reqwest` dependency to version 0.11.18 with default-features set to false and feature rustls in `Cargo.toml`
- Updated `sn_build_info` dependency to version 0.1.2 in `Cargo.toml`
- Updated `sn_client` dependency to version 0.98.23 in `Cargo.toml`
- Updated `sn_transfers` dependency to version 0.14.23 in `Cargo.toml`
- Replaced the usage of `rmp_serde` with `bincode` for serialization and deserialization in several files
- Made improvements to serialization and deserialization processes
- Modified error handling related to serialization and deserialization
- Modified log messages

Please review these changes in the pull request.
<!-- reviewpad:summarize:end --> 
