### PR TITLE
chore(transfers): tidier debug methods for Transactions

### DIFF
--- a/sn_transfers/src/cashnotes/transaction.rs
+++ b/sn_transfers/src/cashnotes/transaction.rs
@@ -65,10 +65,22 @@ impl Output {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct Transaction {
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
+}
+
+/// debug method for Transaction which does not print the full content
+impl std::fmt::Debug for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // use self.hash to avoid printing the full content
+        f.debug_struct("Transaction")
+            .field("inputs", &self.inputs.len())
+            .field("outputs", &self.outputs.len())
+            .field("hash", &self.hash())
+            .finish()
+    }
 }
 
 impl PartialOrd for Transaction {

--- a/sn_transfers/src/wallet/data_payments.rs
+++ b/sn_transfers/src/wallet/data_payments.rs
@@ -13,9 +13,10 @@ use xor_name::XorName;
 
 use crate::{MainPubkey, NanoTokens, Transfer};
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, custom_debug::Debug)]
 pub struct Payment {
     /// The transfers we make
+    #[debug(skip)]
     pub transfers: Vec<Transfer>,
     /// The Quote we're paying for
     pub quote: PaymentQuote,
@@ -64,6 +65,7 @@ pub struct PaymentQuote {
     /// the local node time when the quote was created
     pub timestamp: SystemTime,
     /// the node's signature of the 3 fields above
+    #[debug(skip)]
     pub signature: QuoteSignature,
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Nov 23 20:46 UTC
This pull request includes changes to the code related to cash notes transactions and wallet data payments. 

In the `transaction.rs` file, a new debug method has been added to the `Transaction` struct. This method formats the struct for debugging purposes without printing the entire content, using the `hash` field instead. 

In the `data_payments.rs` file, two fields in the `Payment` struct have been annotated with `#[debug(skip)]`. This means that these fields will not be included when printing the struct for debugging.
<!-- reviewpad:summarize:end --> 
