### PR TITLE
majority only for spend get

### DIFF
--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -24,7 +24,13 @@ impl Network {
     pub async fn get_spend(&self, address: SpendAddress, re_attempt: bool) -> Result<SignedSpend> {
         let key = NetworkAddress::from_spend_address(address).to_record_key();
         let record = self
-            .get_record_from_network(key, None, GetQuorum::All, re_attempt, Default::default())
+            .get_record_from_network(
+                key,
+                None,
+                GetQuorum::Majority,
+                re_attempt,
+                Default::default(),
+            )
             .await
             .map_err(|_| Error::SpendNotFound(address))?;
         debug!(

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -56,7 +56,9 @@ mod spends;
 pub use self::{
     event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
     log_markers::Marker,
-    node::{NodeBuilder, NodeCmd, ROYALTY_TRANSFER_NOTIF_TOPIC},
+    node::{
+        NodeBuilder, NodeCmd, PERIODIC_REPLICATION_INTERVAL_MAX_S, ROYALTY_TRANSFER_NOTIF_TOPIC,
+    },
 };
 
 use crate::error::{Error, Result};

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -47,7 +47,7 @@ const FORWARDER_CHOOSING_FACTOR: usize = 50;
 
 /// Interval to trigger replication of all records to all peers.
 /// This is the max time it should take. Minimum interval at any ndoe will be half this
-const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 45;
+pub const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 45;
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -15,13 +15,8 @@ use bytes::Bytes;
 use libp2p::{autonat::NatStatus, identity::Keypair, Multiaddr};
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
-use rand::{
-    rngs::{OsRng, StdRng},
-    Rng, SeedableRng,
-};
-use sn_networking::{
-    MsgResponder, Network, NetworkBuilder, NetworkEvent, SwarmDriver, CLOSE_GROUP_SIZE,
-};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use sn_networking::{Network, NetworkBuilder, NetworkEvent, SwarmDriver, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::{Cmd, CmdResponse, Query, QueryResponse, Response},
@@ -153,7 +148,7 @@ impl NodeBuilder {
 
         // Having a portion of nodes (1/50) subscribe to the ROYALTY_TRANSFER_NOTIF_TOPIC
         // Such nodes become `forwarder` to ensure the actual beneficary won't miss.
-        let index: usize = OsRng.gen_range(0..FORWARDER_CHOOSING_FACTOR);
+        let index: usize = StdRng::from_entropy().gen_range(0..FORWARDER_CHOOSING_FACTOR);
         if index == FORWARDER_CHOOSING_FACTOR / 2 {
             trace!("Picked as a forwarding node to subscribe to the {ROYALTY_TRANSFER_NOTIF_TOPIC} topic");
             // Forwarder only needs to forward topic msgs on libp2p level,
@@ -223,16 +218,12 @@ impl Node {
                     net_event = network_event_receiver.recv() => {
                         match net_event {
                             Some(event) => {
-                                let stateless_node_copy = self.clone();
-                                let _handle =
-                                    spawn(async move {
-                                        let start = std::time::Instant::now();
-                                        let event_string = format!("{:?}", event);
+                                let start = std::time::Instant::now();
+                                let event_string = format!("{:?}", event);
 
-                                        stateless_node_copy.handle_network_event(event, peers_connected).await ;
-                                        info!("Handled non-blocking network event in {:?}: {:?}", start.elapsed(), event_string);
+                                self.handle_network_event(event, peers_connected).await ;
+                                info!("Handled non-blocking network event in {:?}: {:?}", start.elapsed(), event_string);
 
-                                    });
                             }
                             None => {
                                 error!("The `NetworkEvent` channel is closed");
@@ -245,13 +236,13 @@ impl Node {
                     _ = replication_interval.tick() => {
                         let start = std::time::Instant::now();
                         info!("Periodic replication triggered");
-                        let stateless_node_copy = self.clone();
-                        let _handle = spawn(async move {
+                        let network = self.network.clone();
+                        self.record_metrics(Marker::IntervalReplicationTriggered);
 
+                        let _handle = spawn(async move {
                             Marker::ForcedReplication.log();
 
-                            if let Err(err) = stateless_node_copy
-                                .try_interval_replication()
+                            if let Err(err) = Self::try_interval_replication(network)
                                 .await
                             {
                                 error!("Error while triggering replication {err:?}");
@@ -285,7 +276,7 @@ impl Node {
     // **** Private helpers *****
 
     /// Handle a network event.
-    /// This should be handled in a non blocking fashion, inside of a spawn
+    /// Spawns a thread for any likely long running tasks
     async fn handle_network_event(&self, event: NetworkEvent, peers_connected: Arc<AtomicUsize>) {
         // when the node has not been connected to enough peers, it should not perform activities
         // that might require peers in the RT to succeed.
@@ -323,21 +314,17 @@ impl Node {
         let event_string = format!("{:?}", event);
         trace!("Handling NetworkEvent {event_string:?}");
 
-        match event {
-            NetworkEvent::QueryRequestReceived { query, channel } => {
-                let res = self.handle_query(query).await;
+        self.handle_sync_network_event(event, peers_connected);
 
-                self.send_response(res, channel);
-            }
-            NetworkEvent::CmdRequestReceived { cmd } => {
-                self.handle_node_cmd(cmd);
-            }
-            NetworkEvent::ResponseReceived { res } => {
-                trace!("NetworkEvent::ResponseReceived {res:?}");
-                if let Err(err) = self.handle_response(res) {
-                    error!("Error while handling NetworkEvent::ResponseReceived {err:?}");
-                }
-            }
+        trace!(
+            "NetworkEvent handled in {:?} : {event_string:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Handle synchronous network events.
+    fn handle_sync_network_event(&self, event: NetworkEvent, peers_connected: Arc<AtomicUsize>) {
+        match event {
             NetworkEvent::PeerAdded(peer_id, connected_peers) => {
                 // increment peers_connected and send ConnectedToNetwork event if have connected to K_VALUE peers
                 let _ = peers_connected.fetch_add(1, Ordering::SeqCst);
@@ -348,28 +335,26 @@ impl Node {
                 self.record_metrics(Marker::PeersInRoutingTable(connected_peers));
                 self.record_metrics(Marker::PeerAddedToRoutingTable(peer_id));
 
-                if let Err(err) = self.try_interval_replication().await {
-                    error!("During CloseGroupUpdate, error while triggering replication {err:?}");
-                }
+                // try replication here
+                let net_clone = self.network.clone();
+                self.record_metrics(Marker::IntervalReplicationTriggered);
+                let _handle = spawn(async move {
+                    if let Err(err) = Self::try_interval_replication(net_clone).await {
+                        error!("Error while triggering replication {err:?}");
+                    }
+                });
             }
             NetworkEvent::PeerRemoved(peer_id, connected_peers) => {
                 self.record_metrics(Marker::PeersInRoutingTable(connected_peers));
                 self.record_metrics(Marker::PeerRemovedFromRoutingTable(peer_id));
-                // During a node restart, the new node got added before the old one got removed.
-                // If the old one is `pushed out of close_group by the new one`, then the records
-                // that being close to the old one won't got replicated during the CloseGroupUpdate
-                // of the new one, as the old one still sits in the local kBuckets.
-                // Hence, the replication attempts shall also be undertaken when PeerRemoved.
-                if let Err(err) = self.try_interval_replication().await {
-                    error!("During PeerRemoved, error while triggering replication {err:?}");
-                }
-            }
-            NetworkEvent::KeysForReplication(keys) => {
-                self.record_metrics(Marker::fetching_keys_for_replication(&keys));
 
-                if let Err(err) = self.fetch_replication_keys_without_wait(keys) {
-                    error!("Error while trying to fetch replicated data {err:?}");
-                }
+                let net = self.network.clone();
+                self.record_metrics(Marker::IntervalReplicationTriggered);
+                let _handle = spawn(async move {
+                    if let Err(e) = Self::try_interval_replication(net).await {
+                        error!("Error while triggering replication {e:?}");
+                    }
+                });
             }
             NetworkEvent::NewListenAddr(_) => {
                 if !cfg!(feature = "local-discovery") {
@@ -390,52 +375,82 @@ impl Node {
                     self.events_channel.broadcast(NodeEvent::BehindNat);
                 }
             }
-            NetworkEvent::UnverifiedRecord(record) => {
-                let key = PrettyPrintRecordKey::from(&record.key).into_owned();
-                match self.validate_and_store_record(record).await {
-                    Ok(cmdok) => trace!("UnverifiedRecord {key} stored with {cmdok:?}."),
-                    Err(err) => {
-                        self.record_metrics(Marker::RecordRejected(&key));
-                        trace!("UnverifiedRecord {key} failed to be stored with error {err:?}.")
-                    }
-                }
-            }
             NetworkEvent::FailedToWrite(key) => {
                 if let Err(e) = self.network.remove_failed_local_record(key) {
                     error!("Failed to remove local record: {e:?}");
                 }
             }
+            NetworkEvent::ResponseReceived { res } => {
+                trace!("NetworkEvent::ResponseReceived {res:?}");
+                if let Err(err) = self.handle_response(res) {
+                    error!("Error while handling NetworkEvent::ResponseReceived {err:?}");
+                }
+            }
+            NetworkEvent::KeysForReplication(keys) => {
+                self.record_metrics(Marker::fetching_keys_for_replication(&keys));
+
+                if let Err(err) = self.fetch_replication_keys_without_wait(keys) {
+                    error!("Error while trying to fetch replicated data {err:?}");
+                }
+            }
+            NetworkEvent::QueryRequestReceived { query, channel } => {
+                let network = self.network.clone();
+                let payment_address = *self.reward_address;
+
+                let _handle = spawn(async move {
+                    let res = Self::handle_query(&network, query, payment_address).await;
+
+                    if let Err(error) = network.send_response(res, channel) {
+                        error!("Error while sending response form query req: {error:?}");
+                    }
+                });
+            }
+            NetworkEvent::CmdRequestReceived { cmd } => {
+                self.handle_node_cmd(cmd);
+            }
+            NetworkEvent::UnverifiedRecord(record) => {
+                // queries can be long running and require validation, so we spawn a task to handle them
+                let self_clone = self.clone();
+                let _handle = spawn(async move {
+                    let key = PrettyPrintRecordKey::from(&record.key).into_owned();
+                    match self_clone.validate_and_store_record(record).await {
+                        Ok(cmdok) => trace!("UnverifiedRecord {key} stored with {cmdok:?}."),
+                        Err(err) => {
+                            self_clone.record_metrics(Marker::RecordRejected(&key));
+                            trace!("UnverifiedRecord {key} failed to be stored with error {err:?}.")
+                        }
+                    }
+                });
+            }
             NetworkEvent::GossipsubMsgReceived { topic, msg }
             | NetworkEvent::GossipsubMsgPublished { topic, msg } => {
                 trace!("Received a gossip msg for the topic of {topic}");
-                if self.events_channel.receiver_count() == 0 {
+                let events_channel = self.events_channel.clone();
+
+                if events_channel.receiver_count() == 0 {
                     return;
                 }
                 if topic == ROYALTY_TRANSFER_NOTIF_TOPIC {
                     // this is expected to be a notification of a transfer which we treat specially,
                     // and we try to decode it only if it's referring to a PK the user is interested in
                     if let Some(filter_pk) = self.transfer_notifs_filter {
-                        match try_decode_transfer_notif(&msg, filter_pk) {
-                            Ok(Some(notif_event)) => self.events_channel.broadcast(notif_event),
-                            Ok(None) => { /* transfer notif filered out */ }
-                            Err(err) => {
-                                warn!("GossipsubMsg matching the transfer notif. topic name, couldn't be decoded as such: {err:?}");
-                                self.events_channel
-                                    .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                        let _handle = spawn(async move {
+                            match try_decode_transfer_notif(&msg, filter_pk) {
+                                Ok(Some(notif_event)) => events_channel.broadcast(notif_event),
+                                Ok(None) => { /* transfer notif filered out */ }
+                                Err(err) => {
+                                    warn!("GossipsubMsg matching the transfer notif. topic name, couldn't be decoded as such: {err:?}");
+                                    events_channel
+                                        .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                                }
                             }
-                        }
+                        });
                     }
                 } else {
-                    self.events_channel
-                        .broadcast(NodeEvent::GossipsubMsg { topic, msg });
+                    events_channel.broadcast(NodeEvent::GossipsubMsg { topic, msg });
                 }
             }
         }
-
-        trace!(
-            "NetworkEvent handled in {:?} : {event_string:?}",
-            start.elapsed()
-        );
     }
 
     // Handle the response that was not awaited at the call site
@@ -456,15 +471,18 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_query(&self, query: Query) -> Response {
+    async fn handle_query(
+        network: &Network,
+        query: Query,
+        payment_address: MainPubkey,
+    ) -> Response {
         let resp: QueryResponse = match query {
             Query::GetStoreCost(address) => {
                 trace!("Got GetStoreCost request for {address:?}");
-                let payment_address = *self.reward_address;
 
                 let record_exists = {
                     if let Some(key) = address.as_record_key() {
-                        match self.network.is_record_key_present_locally(&key).await {
+                        match network.is_record_key_present_locally(&key).await {
                             Ok(res) => res,
                             Err(error) => {
                                 error!("Problem getting record key's existence: {error:?}");
@@ -484,14 +502,13 @@ impl Node {
                         payment_address,
                     }
                 } else {
-                    let store_cost = self
-                        .network
+                    let store_cost = network
                         .get_local_storecost()
                         .await
                         .map_err(|_| ProtocolError::GetStoreCostFailed);
 
                     QueryResponse::GetStoreCost {
-                        quote: self.create_quote_for_storecost(store_cost, address),
+                        quote: Self::create_quote_for_storecost(network, store_cost, address),
                         payment_address,
                     }
                 }
@@ -499,7 +516,7 @@ impl Node {
             Query::GetReplicatedRecord { requester, key } => {
                 trace!("Got GetReplicatedRecord from {requester:?} regarding {key:?}");
 
-                let our_address = NetworkAddress::from_peer(self.network.peer_id);
+                let our_address = NetworkAddress::from_peer(network.peer_id);
                 let mut result = Err(ProtocolError::ReplicatedRecordNotFound {
                     holder: Box::new(our_address.clone()),
                     key: Box::new(key.clone()),
@@ -507,7 +524,7 @@ impl Node {
                 let record_key = key.as_record_key();
 
                 if let Some(record_key) = record_key {
-                    if let Ok(Some(record)) = self.network.get_local_record(&record_key).await {
+                    if let Ok(Some(record)) = network.get_local_record(&record_key).await {
                         result = Ok((our_address, Bytes::from(record.value)));
                     }
                 }
@@ -557,12 +574,6 @@ impl Node {
                 });
             }
         };
-    }
-
-    fn send_response(&self, resp: Response, response_channel: MsgResponder) {
-        if let Err(err) = self.network.send_response(resp, response_channel) {
-            warn!("Error while sending response: {err:?}");
-        }
     }
 }
 

--- a/sn_node/src/quote.rs
+++ b/sn_node/src/quote.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use sn_networking::Network;
 use sn_protocol::error::Error as ProtocolError;
 use sn_protocol::NetworkAddress;
 use sn_transfers::{NanoTokens, PaymentQuote};
@@ -17,7 +18,7 @@ const QUOTE_EXPIRATION_SECS: u64 = 3600;
 
 impl Node {
     pub(crate) fn create_quote_for_storecost(
-        &self,
+        network: &Network,
         store_cost: Result<NanoTokens, ProtocolError>,
         address: NetworkAddress,
     ) -> Result<PaymentQuote, ProtocolError> {
@@ -29,7 +30,7 @@ impl Node {
         let timestamp = std::time::SystemTime::now();
         let bytes = PaymentQuote::bytes_for_signing(content, cost, timestamp);
 
-        let signature = match self.network.sign(&bytes) {
+        let signature = match network.sign(&bytes) {
             Ok(s) => s,
             Err(_) => return Err(ProtocolError::QuoteGenerationFailed),
         };

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::error::Result;
 use crate::node::Node;
-use crate::{error::Result, log_markers::Marker};
 use libp2p::{
     kad::{Record, RecordKey, K_VALUE},
     PeerId,
 };
-use sn_networking::{sort_peers_by_address, GetQuorum, CLOSE_GROUP_SIZE};
+use sn_networking::{sort_peers_by_address, GetQuorum, Network, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     storage::RecordType,
@@ -23,11 +23,11 @@ use tokio::task::{spawn, JoinHandle};
 
 impl Node {
     /// Sends _all_ record keys every interval to all peers.
-    pub(crate) async fn try_interval_replication(&self) -> Result<()> {
+    pub(crate) async fn try_interval_replication(network: Network) -> Result<()> {
         let start = std::time::Instant::now();
         trace!("Try trigger interval replication started@{start:?}");
         // Already contains self_peer_id
-        let mut closest_k_peers = self.network.get_closest_k_value_local_peers().await?;
+        let mut closest_k_peers = network.get_closest_k_value_local_peers().await?;
 
         // Do not carry out replication if not many peers present.
         if closest_k_peers.len() < K_VALUE.into() {
@@ -39,7 +39,7 @@ impl Node {
         }
 
         // remove our peer id from the calculations here:
-        let _we_were_there = closest_k_peers.remove(&self.network.peer_id);
+        let _we_were_there = closest_k_peers.remove(&network.peer_id);
 
         // Only grab the closest nodes
         let closest_k_peers = closest_k_peers
@@ -49,13 +49,12 @@ impl Node {
             .collect::<Vec<_>>();
 
         trace!("Try trigger interval replication started@{start:?}, peers found_and_sorted, took: {:?}", start.elapsed());
-        self.record_metrics(Marker::IntervalReplicationTriggered);
 
-        let our_peer_id = self.network.peer_id;
+        let our_peer_id = network.peer_id;
         let our_address = NetworkAddress::from_peer(our_peer_id);
 
         #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-        let all_records = self.network.get_all_local_record_addresses().await?;
+        let all_records = network.get_all_local_record_addresses().await?;
 
         if !all_records.is_empty() {
             debug!(
@@ -63,7 +62,16 @@ impl Node {
                 closest_k_peers.len()
             );
             for peer_id in closest_k_peers {
-                self.send_replicate_cmd_without_wait(&our_address, &peer_id, all_records.clone())?;
+                trace!(
+                    "Sending a replication list of {} keys to {peer_id:?} ",
+                    all_records.len()
+                );
+                let request = Request::Cmd(Cmd::Replicate {
+                    holder: our_address.clone(),
+                    keys: all_records.clone(),
+                });
+
+                network.send_req_ignore_reply(request, peer_id)?;
             }
         }
 
@@ -201,27 +209,5 @@ impl Node {
                 start.elapsed()
             );
         });
-    }
-
-    // Utility to send `Cmd::Replicate` without awaiting for the `Response` at the call site.
-    #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-    fn send_replicate_cmd_without_wait(
-        &self,
-        our_address: &NetworkAddress,
-        peer_id: &PeerId,
-        keys: HashMap<NetworkAddress, RecordType>,
-    ) -> Result<()> {
-        trace!(
-            "Sending a replication list of {} keys to {peer_id:?} ",
-            keys.len()
-        );
-        let request = Request::Cmd(Cmd::Replicate {
-            holder: our_address.clone(),
-            keys,
-        });
-
-        self.network.send_req_ignore_reply(request, *peer_id)?;
-
-        Ok(())
     }
 }

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -51,7 +51,8 @@ const VERIFICATION_DELAY: Duration = Duration::from_secs(120);
 const VERIFICATION_ATTEMPTS: usize = 5;
 
 /// Length of time to wait before re-verifying the data location
-const REVERIFICATION_DELAY: Duration = Duration::from_secs(30);
+const REVERIFICATION_DELAY: Duration =
+    Duration::from_secs(sn_node::PERIODIC_REPLICATION_INTERVAL_MAX_S);
 
 // Default number of churns that should be performed. After each churn, we
 // wait for VERIFICATION_DELAY time before verifying the data location.

--- a/sn_transfers/src/cashnotes/transaction.rs
+++ b/sn_transfers/src/cashnotes/transaction.rs
@@ -65,10 +65,22 @@ impl Output {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct Transaction {
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
+}
+
+/// debug method for Transaction which does not print the full content
+impl std::fmt::Debug for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // use self.hash to avoid printing the full content
+        f.debug_struct("Transaction")
+            .field("inputs", &self.inputs.len())
+            .field("outputs", &self.outputs.len())
+            .field("hash", &self.hash())
+            .finish()
+    }
 }
 
 impl PartialOrd for Transaction {

--- a/sn_transfers/src/wallet/data_payments.rs
+++ b/sn_transfers/src/wallet/data_payments.rs
@@ -13,9 +13,10 @@ use xor_name::XorName;
 
 use crate::{MainPubkey, NanoTokens, Transfer};
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, custom_debug::Debug)]
 pub struct Payment {
     /// The transfers we make
+    #[debug(skip)]
     pub transfers: Vec<Transfer>,
     /// The Quote we're paying for
     pub quote: PaymentQuote,
@@ -64,6 +65,7 @@ pub struct PaymentQuote {
     /// the local node time when the quote was created
     pub timestamp: SystemTime,
     /// the node's signature of the 3 fields above
+    #[debug(skip)]
     pub signature: QuoteSignature,
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Dec 23 08:25 UTC
This pull request includes the following changes:

- In the file "lib.rs", import statements have been added for the modules "spends" and "log_markers", and the import statement for the module "node" has been updated to include the constants "PERIODIC_REPLICATION_INTERVAL_MAX_S" and "ROYALTY_TRANSFER_NOTIF_TOPIC".

- In the file "transaction.rs", the `Transaction` struct has been modified to include a debug implementation that prints the length of `inputs` and `outputs` instead of their full content.

- In the file "transfers.rs", the `get_spend` function in the `Network` implementation has been updated. The `get_record_from_network` method call now includes additional arguments, the `GetQuorum` argument has been changed from `GetQuorum::All` to `GetQuorum::Majority`, and a new argument `Default::default()` has been added.

- In the file "quote.rs", the changes include importing the `Network` struct, renaming a parameter in a method to `network`, and replacing a `self.network.sign` statement with `network.sign` in a `match` statement related to generating a payment quote in the `Node` struct.

- In the file "verify_data_location.rs", there is a modification to the `REVERIFICATION_DELAY` constant, which now uses the value of `PERIODIC_REPLICATION_INTERVAL_MAX_S` from the `sn_node` module instead of a hardcoded value of 30 seconds.

- In the file "data_payments.rs", the `Payment` struct and the `PaymentQuote` struct have been modified. The `transfers` field in the `Payment` struct has been annotated with `#[debug(skip)]`, and the `quote` field in the `Payment` struct has been left unchanged. The `signature` field in the `PaymentQuote` struct has also been annotated with `#[debug(skip)]`.

- In the file "replication.rs", there are multiple changes, including import statements, modifications to function signatures, and replacement of specific method calls related to the `Network` struct.

Please review these changes for any potential issues or improvements.
<!-- reviewpad:summarize:end --> 
