### PR TITLE
feat(testnet): add option to wait for Command to finish

### DIFF
--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -324,10 +324,8 @@ fn run_faucet(gen_multi_addr: String, bin_path: PathBuf) -> Result<()> {
     args.push("--peer".to_string());
     args.push(gen_multi_addr);
     args.push("server".to_string());
-    testnet.launcher.launch(&launch_bin, args)?;
-    // The launch will immediately complete after fire the cmd out.
-    // Have to wait some extra time to allow the faucet to be properly created and funded
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    // wait for the faucet to complete
+    testnet.launcher.launch(&launch_bin, args, true)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Dec 23 11:55 UTC
This pull request adds an option to wait for the Command to finish when launching processes in the testnet. It modifies the `NodeLauncher` trait to include a `wait_till_completion` parameter and updates the implementation in the `SafeNodeLauncher` struct. It also makes changes to the `Testnet` struct to use the updated `launch` method and adds corresponding changes to the tests. In addition, it updates the `run_faucet` function in the `main.rs` file to wait for the faucet to complete. Overall, this patch improves the control and synchronization of process launching in the testnet.
<!-- reviewpad:summarize:end --> 
