### PR TITLE
feat(testnet): wait till faucet server starts

### DIFF
--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -41,6 +41,7 @@ pub async fn run_faucet_server(client: &Client) -> Result<()> {
         err
     })?;
 
+    // This println is used in sn_testnet to wait for the faucet to start.
     println!("Starting http server listening on port 8000...");
     debug!("Starting http server listening on port 8000...");
     for request in server.incoming_requests() {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Dec 23 12:51 UTC
This pull request adds a feature to the testnet module that waits until the faucet server starts. The changes include modifications to the `run_faucet` function in the `main.rs` file. The patch adds code to wait for the faucet server to start by checking for the "Starting http server" message in the server logs.
<!-- reviewpad:summarize:end --> 
