### PR TITLE
chore: reduce spend reverification time

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -518,8 +518,8 @@ impl Network {
             // Generate a random duration between MAX_REVERIFICATION_WAIT_TIME_S and MIN_REVERIFICATION_WAIT_TIME_S
             // Use the MAX_REVERIFICATION_WAIT_TIME_S if it is a spend.
             let wait_duration = match record_kind {
-                // todo: remove the *3 once spend validation GET queries complete in reasonable times.
-                RecordKind::Spend => MAX_REVERIFICATION_WAIT_TIME_S * 3,
+                // todo: remove the *2 once spend validation GET queries complete in reasonable times.
+                RecordKind::Spend => MAX_REVERIFICATION_WAIT_TIME_S * 2,
                 _ => rand::thread_rng()
                     .gen_range(MIN_REVERIFICATION_WAIT_TIME_S..MAX_REVERIFICATION_WAIT_TIME_S),
             };


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Dec 23 13:23 UTC
This pull request reduces spend reverification time in the `sn_networking` library. The patch modifies the `wait_duration` calculation by changing the multiplier from `3` to `2` for spend records. The comment in the code suggests removing the multiplier once spend validation GET queries complete in reasonable times.
<!-- reviewpad:summarize:end --> 
