### PR TITLE
feat(cli): Download path is familiar to users

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -113,7 +113,8 @@ pub(crate) async fn files_cmds(
                 );
             }
 
-            let file_api: Files = Files::new(client.clone(), root_dir.to_path_buf());
+            let download_dir = dirs_next::download_dir().unwrap_or(root_dir.to_path_buf());
+            let file_api: Files = Files::new(client.clone(), download_dir.clone());
 
             match (file_name, file_addr) {
                 (Some(name), Some(address)) => {
@@ -127,7 +128,7 @@ pub(crate) async fn files_cmds(
                         &file_api,
                         &xor_name,
                         &name,
-                        root_dir,
+                        &download_dir,
                         show_holders,
                         batch_size,
                     )
@@ -436,7 +437,7 @@ async fn download_files(
 ) -> Result<()> {
     info!("Downloading with batch size of {}", batch_size);
     let uploaded_files_path = root_dir.join("uploaded_files");
-    let download_path = root_dir.join("downloaded_files");
+    let download_path = dirs_next::download_dir().unwrap_or(root_dir.join("downloaded_files"));
     std::fs::create_dir_all(download_path.as_path())?;
 
     let file = std::fs::File::open(&uploaded_files_path)?;


### PR DESCRIPTION
## Description

Instead of downloading to data_dir which is not a familiar directory to most users, change downloads to be saved to the regular familiar Downloads folder (eg the one most browsers use).

This is especially helpful when cleaning up a disk with low disk space, usually the first place to delete stuff is from the Downloads folder.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 01:42 UTC
This pull request updates the CLI to use a more familiar download path for files. The patch modifies the `files_cmds` function in the `mod.rs` file to set the download directory to the system's default download directory. It also updates the `download_files` function to use the same download directory for file downloads.
<!-- reviewpad:summarize:end --> 
