### PR TITLE
fix(testnet): dont be taking faucet stdout

### DIFF
--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -325,25 +325,9 @@ fn run_faucet(gen_multi_addr: String, bin_path: PathBuf) -> Result<()> {
     debug!("Launching faucet {bin_path:#?} with args: {args:#?}");
     let mut child = Command::new(bin_path)
         .args(args)
-        .stdout(Stdio::piped())
+        .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()?;
-
-    // wait till we get "Starting http server" msg
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| eyre!("Child process (faucet) did not have a handle to stdout"))?;
-    let reader = BufReader::new(stdout);
-
-    for line in reader.lines() {
-        let line = line?;
-        println!("{line}");
-        if line.contains("Starting http server") {
-            println!("Faucet Server started successfully!");
-            break;
-        }
-    }
 
     Ok(())
 }


### PR DESCRIPTION
this stops odd bugs around faucet stdout processing

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 07:02 UTC
This pull request fixes an issue in the testnet code where the stdout of the faucet process was being captured, causing strange bugs. The patch changes the code to inherit the stdout instead of piping it, which resolves the issue.
<!-- reviewpad:summarize:end --> 
