### PR TITLE
chore(ci): build testnet bin during PR checks

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -54,6 +54,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ubuntu-latest
+          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -218,6 +219,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_benchmark
           platform: ubuntu-latest
+          build: true
 
       - name: Upload Faucet folder
         uses: actions/upload-artifact@main

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -69,6 +69,7 @@ jobs:
           faucet-path: target/release/faucet
           platform: ubuntu-latest
           set-safe-peers: false
+          build: true
 
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
       - name: Check SAFE_PEERS was not changed
@@ -206,6 +207,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_memcheck
           platform: ubuntu-latest
+          build: true
 
       - name: Check node memory usage
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -149,6 +149,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
+          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -205,6 +206,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_e2e
           platform: ${{ matrix.os }}
+          build: true
 
   gossipsub:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
@@ -236,6 +238,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
+          build: true
 
       - name: Gossipsub - nodes to subscribe to topics, and publish messages 
         run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
@@ -248,6 +251,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_gossipsub_e2e
           platform: ${{ matrix.os }}
+          build: true
 
   spend_test:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
@@ -281,6 +285,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
+          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -319,6 +324,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_spend
           platform: ${{ matrix.os }}
+          build: true
 
   churn:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
@@ -356,6 +362,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
+          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -424,6 +431,7 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_churn
           platform: ${{ matrix.os }}
+          build: true
 
   verify_data_location_routing_table:
       if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
@@ -461,6 +469,7 @@ jobs:
             node-path: target/release/safenode
             faucet-path: target/release/faucet
             platform: ${{ matrix.os }}
+            build: true
 
         - name: Check SAFE_PEERS was set
           shell: bash
@@ -514,3 +523,4 @@ jobs:
             action: stop
             log_file_prefix: safe_test_logs_data_location
             platform: ${{ matrix.os }}
+            build: true


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 08:08 UTC
This pull request adds the "build" flag to the CI workflows. The "build" flag enables the testnet binary to be built during PR checks in the benchmark-prs.yml, memcheck.yml, and merge.yml workflows. This ensures that the testnet binary is available for testing and analysis.
<!-- reviewpad:summarize:end --> 
