### PR TITLE
feat(network): dial back when received identify from incoming

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -544,11 +544,9 @@ impl NetworkBuilder {
             pending_get_closest_peers: Default::default(),
             pending_requests: Default::default(),
             pending_get_record: Default::default(),
-            // We use 63 here, as in practice the capacity will be rounded to the nearest 2^n-1.
-            // Source: https://users.rust-lang.org/t/the-best-ring-buffer-library/58489/8
-            // 63 will mean at least 63 most recent peers we have dialed, which should be allow for enough time for the
-            // `identify` protocol to kick in and get them in the routing table.
-            dialed_peers: CircularVec::new(63),
+            // We use 255 here which allows covering a network larger than 64k without any rotating.
+            // This is based on the libp2p kad::kBuckets peers distribution.
+            dialed_peers: CircularVec::new(255),
             is_gossip_handler: false,
             network_discovery: NetworkDiscovery::new(&peer_id),
         };

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -28,7 +28,10 @@ use libp2p::{
     },
     multiaddr::Protocol,
     request_response::{self, Message, ResponseChannel as PeerResponseChannel},
-    swarm::{DialError, SwarmEvent},
+    swarm::{
+        dial_opts::{DialOpts, PeerCondition},
+        DialError, SwarmEvent,
+    },
     Multiaddr, PeerId, TransportError,
 };
 
@@ -242,30 +245,54 @@ impl SwarmDriver {
                     libp2p::identify::Event::Received { peer_id, info } => {
                         trace!(%peer_id, ?info, "identify: received info");
 
-                        // If we are not local, we care only for peers that we dialed and thus are reachable.
-                        if self.local
-                            || self.dialed_peers.contains(&peer_id)
-                                && info
-                                    .agent_version
-                                    .starts_with(truncate_patch_version(IDENTIFY_AGENT_STR))
-                        {
-                            // If we're not in local mode, only add globally reachable addresses.
-                            // Strip the `/p2p/...` part of the multiaddresses.
-                            // Collect into a HashSet directly to avoid multiple allocations and handle deduplication.
-                            let addrs: HashSet<Multiaddr> = match self.local {
-                                true => info
-                                    .listen_addrs
-                                    .into_iter()
-                                    .map(|addr| multiaddr_strip_p2p(&addr))
-                                    .collect(),
-                                false => info
-                                    .listen_addrs
-                                    .into_iter()
-                                    .filter(multiaddr_is_global)
-                                    .map(|addr| multiaddr_strip_p2p(&addr))
-                                    .collect(),
-                            };
+                        let has_dialed = self.dialed_peers.contains(&peer_id);
+                        let peer_is_agent = info
+                            .agent_version
+                            .starts_with(truncate_patch_version(IDENTIFY_AGENT_STR));
 
+                        // If we're not in local mode, only add globally reachable addresses.
+                        // Strip the `/p2p/...` part of the multiaddresses.
+                        // Collect into a HashSet directly to avoid multiple allocations and handle deduplication.
+                        let addrs: HashSet<Multiaddr> = match self.local {
+                            true => info
+                                .listen_addrs
+                                .into_iter()
+                                .map(|addr| multiaddr_strip_p2p(&addr))
+                                .collect(),
+                            false => info
+                                .listen_addrs
+                                .into_iter()
+                                .filter(multiaddr_is_global)
+                                .map(|addr| multiaddr_strip_p2p(&addr))
+                                .collect(),
+                        };
+
+                        // When received an identify from un-dialed peer, try to dial it
+                        // The dial shall trigger the same identify to be sent again and confirm
+                        // peer is external accessable, hence safe to be added into RT.
+                        if !self.local && peer_is_agent && !has_dialed {
+                            info!(%peer_id, ?addrs, "not dailed but received identify info, dailed back to confirm external accesable");
+                            if let Err(err) = self.swarm.dial(
+                                DialOpts::peer_id(peer_id)
+                                    .condition(PeerCondition::NotDialing)
+                                    .addresses(addrs.iter().cloned().collect())
+                                    .build(),
+                            ) {
+                                warn!(%peer_id, ?addrs, "dialing error: {err:?}");
+                            } else {
+                                self.dialed_peers
+                                    .push(peer_id)
+                                    .map_err(|_| Error::CircularVecPopFrontError)?;
+                            }
+                            trace!(
+                                "SwarmEvent handled in {:?}: {event_string:?}",
+                                start.elapsed()
+                            );
+                            return Ok(());
+                        }
+
+                        // If we are not local, we care only for peers that we dialed and thus are reachable.
+                        if self.local || has_dialed && peer_is_agent {
                             trace!(%peer_id, ?addrs, "identify: attempting to add addresses to routing table");
 
                             // Attempt to add the addresses to the routing table.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 15:06 UTC
This pull request includes two patches. 

The first patch updates the event handling in the `sn_networking/src/event.rs` file. It refactors the code to improve readability and adds logic to dial back when receiving an identify from an undialed peer. It also verifies that the peer is externally accessible before adding it to the routing table.

The second patch modifies the `sn_networking/src/driver.rs` and `sn_networking/src/event.rs` files. It changes the size of the `dialed_peers` circular buffer from 63 to 255, allowing it to cover a larger network. It also adds logic to skip dialing back for peers in a full k-bucket.

Overall, these patches improve the behavior of the network driver and enhance the identification and dialing processes for peers.
<!-- reviewpad:summarize:end --> 
