### PR TITLE
test: tie node reward test to number of data.

### DIFF
--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -115,7 +115,7 @@ impl ContinuousBootstrap {
     /// Returns `true` if we should carry out the Kademlia Bootstrap process immediately.
     /// Also optionally returns the new interval to re-bootstrap.
     pub(crate) async fn should_we_bootstrap(
-        &mut self,
+        &self,
         peers_in_rt: u32,
         current_interval: Duration,
     ) -> (bool, Option<Interval>) {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -77,7 +77,7 @@ pub const fn close_group_majority() -> usize {
 }
 
 /// Max duration to wait for verification
-const MAX_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(5000);
+const MAX_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(3500);
 /// Min duration to wait for verification
 const MIN_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(1500);
 /// Number of attempts to GET a record

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -122,9 +122,12 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
         chunks_dir.path().to_path_buf(),
     )?;
 
-    let handle = spawn_royalties_payment_client_listener(client.clone())?;
+    let num_of_chunks = chunks.len();
+    let handle = spawn_royalties_payment_client_listener(client.clone(), num_of_chunks)?;
 
     let num_of_chunks = chunks.len();
+
+    tracing::info!("Paying for {num_of_chunks} random addresses...");
     println!("Paying for {num_of_chunks} random addresses...");
     let (_, storage_cost, royalties_fees) = files_api
         .pay_and_upload_bytes_test(*content_addr.xorname(), chunks, false)
@@ -162,7 +165,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let mut rng = rand::thread_rng();
     let register_addr = XorName::random(&mut rng);
 
-    let handle = spawn_royalties_payment_client_listener(client.clone())?;
+    let handle = spawn_royalties_payment_client_listener(client.clone(), 1)?;
 
     println!("Paying for random Register address {register_addr:?} ...");
     let (_, storage_cost, royalties_fees) = client
@@ -205,12 +208,13 @@ async fn nodes_rewards_transfer_notifs_filter() -> Result<()> {
 
     // this node shall receive the notifications since we set the correct royalties pk as filter
     let royalties_pk = NETWORK_ROYALTIES_PK.public_key();
-    let handle_1 = spawn_royalties_payment_listener(node_rpc_addresses[0], royalties_pk, true);
+    let handle_1 =
+        spawn_royalties_payment_listener(node_rpc_addresses[0], royalties_pk, true, chunks.len());
     // this other node shall *not* receive any notification since we set the wrong pk as filter
     let random_pk = SecretKey::random().public_key();
-    let handle_2 = spawn_royalties_payment_listener(node_rpc_addresses[1], random_pk, true);
+    let handle_2 = spawn_royalties_payment_listener(node_rpc_addresses[1], random_pk, true, 0);
     // this other node shall *not* receive any notification either since we don't set any pk as filter
-    let handle_3 = spawn_royalties_payment_listener(node_rpc_addresses[2], royalties_pk, false);
+    let handle_3 = spawn_royalties_payment_listener(node_rpc_addresses[2], royalties_pk, false, 0);
 
     sleep(Duration::from_secs(20)).await;
 
@@ -287,6 +291,7 @@ fn spawn_royalties_payment_listener(
     rpc_addr: SocketAddr,
     royalties_pk: PublicKey,
     set_filter: bool,
+    expected_royalties: usize,
 ) -> JoinHandle<Result<usize, eyre::Report>> {
     let endpoint = format!("https://{rpc_addr}");
     tokio::spawn(async move {
@@ -313,7 +318,8 @@ fn spawn_royalties_payment_listener(
         let mut count = 0;
         let mut stream = response.into_inner();
 
-        let duration = Duration::from_secs(80);
+        let secs = expected_royalties as u64 * 5; // 3.5 secs reverification time + a bit extra
+        let duration = Duration::from_secs(secs);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
             while let Some(Ok(e)) = stream.next().await {
@@ -344,6 +350,7 @@ fn spawn_royalties_payment_listener(
 
 fn spawn_royalties_payment_client_listener(
     client: Client,
+    expected_royalties: usize,
 ) -> Result<JoinHandle<Result<(usize, NanoTokens), eyre::Report>>> {
     let temp_dir = assert_fs::TempDir::new()?;
     let sk = SecretKey::from_hex(sn_transfers::GENESIS_CASHNOTE_SK)?;
@@ -356,7 +363,9 @@ fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        let duration = Duration::from_secs(80);
+        let secs = expected_royalties as u64 * 5; // 3.5 secs reverification time + a bit extra
+        let duration = Duration::from_secs(secs);
+        tracing::info!("Awaiting transfers notifs for {duration:?}...");
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
             while let Ok(event) = events_receiver.recv().await {

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -33,7 +33,7 @@ use clap::Parser;
 use color_eyre::{eyre::eyre, Help, Result};
 use std::{
     fs::remove_dir_all,
-    io::{BufRead, BufReader, ErrorKind},
+    io::ErrorKind,
     path::PathBuf,
     process::{Command, Stdio},
 };
@@ -323,7 +323,7 @@ fn run_faucet(gen_multi_addr: String, bin_path: PathBuf) -> Result<()> {
     args.push("server".to_string());
 
     debug!("Launching faucet {bin_path:#?} with args: {args:#?}");
-    let mut child = Command::new(bin_path)
+    let _ = Command::new(bin_path)
         .args(args)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
Upload test records in parallel
Reduce referividation time

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 13:27 UTC
This pull request includes several changes:
- In the `sn_client/src/file_apis.rs` file, the patch modifies the `Files` implementation to upload chunks in parallel, reducing the re-verification time.
- In the `sn_networking/src/bootstrap.rs` file, the patch updates the `should_we_bootstrap` function to take a shared reference instead of a mutable reference.
- In the `sn_networking/src/lib.rs` file, the patch adjusts the maximum re-verification wait time to 3.5 seconds instead of 5 seconds.
- In the `sn_node/tests/nodes_rewards.rs` file, the patch makes various changes to the tests related to nodes rewards, including spawning royalties payment client listeners with expected royalties count.
- In the `sn_testnet/src/main.rs` file, the patch modifies the `run_faucet` function to properly handle the child process.
<!-- reviewpad:summarize:end --> 
