### PR TITLE
feat: watch-only wallet

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -99,11 +99,13 @@ async fn main() -> Result<()> {
         Some(bootstrap_peers)
     };
 
-    let joins_gossip = false;
+    // use gossipsub only for the wallet cmd that requires it.
+    let joins_gossipsub = matches!(opt.cmd, SubCmd::Wallet(WalletCmds::ReceiveOnline { .. }));
+
     let client = Client::new(
         secret_key,
         bootstrap_peers,
-        joins_gossip,
+        joins_gossipsub,
         opt.connection_timeout,
     )
     .await?;
@@ -116,13 +118,7 @@ async fn main() -> Result<()> {
             wallet_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
         }
         SubCmd::Files(cmds) => {
-            files_cmds(
-                cmds,
-                client.clone(),
-                &client_data_dir_path,
-                should_verify_store,
-            )
-            .await?
+            files_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
         }
         SubCmd::Register(cmds) => {
             register_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -75,7 +75,7 @@ pub enum FilesCmds {
 
 pub(crate) async fn files_cmds(
     cmds: FilesCmds,
-    client: Client,
+    client: &Client,
     root_dir: &Path,
     verify_store: bool,
 ) -> Result<()> {
@@ -112,7 +112,7 @@ pub(crate) async fn files_cmds(
                 );
             }
 
-            let file_api: Files = Files::new(client, root_dir.to_path_buf());
+            let file_api: Files = Files::new(client.clone(), root_dir.to_path_buf());
 
             match (file_name, file_addr) {
                 (Some(name), Some(address)) => {
@@ -146,7 +146,7 @@ pub(crate) async fn files_cmds(
 /// verify if the data was stored successfully.
 async fn upload_files(
     files_path: PathBuf,
-    client: Client,
+    client: &Client,
     root_dir: &Path,
     verify_store: bool,
     batch_size: usize,

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -389,15 +389,14 @@ async fn receive(transfer: String, is_file: bool, client: &Client, root_dir: &Pa
 }
 
 async fn listen_notifs_and_deposit(root_dir: &Path, client: &Client, pk_hex: String) -> Result<()> {
-    let mut wallet = match PublicKey::from_hex(&pk_hex) {
-        Ok(pk) => {
-            let main_pk = MainPubkey::new(pk);
+    let mut wallet = match MainPubkey::from_hex(&pk_hex) {
+        Ok(main_pk) => {
             let folder_name = format!("pk_{}_{}", &pk_hex[..6], &pk_hex[pk_hex.len() - 6..]);
             let wallet_dir = root_dir.join(folder_name);
             println!("Loading local wallet from: {}", wallet_dir.display());
             WatchOnlyWallet::load_from(&wallet_dir, main_pk)?
         }
-        Err(err) => return Err(eyre!("Failed to parse hex-encoded SK: {err:?}")),
+        Err(err) => return Err(eyre!("Failed to parse hex-encoded public key: {err:?}")),
     };
 
     let main_pk = wallet.address();

--- a/sn_transfers/src/cashnotes/cashnote.rs
+++ b/sn_transfers/src/cashnotes/cashnote.rs
@@ -94,6 +94,17 @@ impl CashNote {
         Ok(main_key.derive_key(&self.derivation_index()))
     }
 
+    /// Return UniquePubkey using MainPubkey supplied by caller.
+    /// Will return an error if the supplied MainPubkey does not match the
+    /// CashNote MainPubkey.
+    pub fn derived_pubkey(&self, main_pubkey: &MainPubkey) -> Result<UniquePubkey> {
+        if main_pubkey != self.main_pubkey() {
+            // FIXME!!!: specific error type
+            return Err(Error::MainSecretKeyDoesNotMatchMainPubkey);
+        }
+        Ok(main_pubkey.new_unique_pubkey(&self.derivation_index()))
+    }
+
     /// Return the derivation index that was used to derive UniquePubkey and corresponding DerivedSecretKey of a CashNote.
     pub fn derivation_index(&self) -> DerivationIndex {
         self.derivation_index

--- a/sn_transfers/src/cashnotes/cashnote.rs
+++ b/sn_transfers/src/cashnotes/cashnote.rs
@@ -99,8 +99,7 @@ impl CashNote {
     /// CashNote MainPubkey.
     pub fn derived_pubkey(&self, main_pubkey: &MainPubkey) -> Result<UniquePubkey> {
         if main_pubkey != self.main_pubkey() {
-            // FIXME!!!: specific error type
-            return Err(Error::MainSecretKeyDoesNotMatchMainPubkey);
+            return Err(Error::MainPubkeyMismatch);
         }
         Ok(main_pubkey.new_unique_pubkey(&self.derivation_index()))
     }

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     UniquePubkeyNotFound,
     #[error("Main key does not match public address.")]
     MainSecretKeyDoesNotMatchMainPubkey,
+    #[error("Main pub key does not match.")]
+    MainPubkeyMismatch,
     #[error("Could not deserialize specified hex string to a CashNote: {0}")]
     HexDeserializationFailed(String),
     #[error("Could not serialize CashNote to hex: {0}")]

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -35,6 +35,7 @@ pub use transfers::create_offline_transfer;
 pub use wallet::bls_secret_from_hex;
 pub use wallet::{
     Error as WalletError, LocalWallet, Payment, PaymentQuote, Result as WalletResult,
+    WatchOnlyWallet,
 };
 
 // re-export crates used in our public API

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -39,6 +39,12 @@ pub enum Error {
     /// Failed to parse bytes into a bls key
     #[error("Unconfirmed transactions still persist even after retries")]
     UnconfirmedTxAfterRetries,
+    /// No main pub key found when loading wallet from path
+    #[error("No main pub key found when loading wallet from path: {0:#?}")]
+    NoPubKeyFound(std::path::PathBuf),
+    /// Main pub key doesn't match the key found when loading wallet from path
+    #[error("Main pub key doesn't match the key found when loading wallet from path: {0:#?}")]
+    PubKeyMismatch(std::path::PathBuf),
     /// Failed to parse bytes into a bls key
     #[error("Failed to parse bls key")]
     FailedToParseBlsKey,

--- a/sn_transfers/src/wallet/error.rs
+++ b/sn_transfers/src/wallet/error.rs
@@ -39,9 +39,6 @@ pub enum Error {
     /// Failed to parse bytes into a bls key
     #[error("Unconfirmed transactions still persist even after retries")]
     UnconfirmedTxAfterRetries,
-    /// No main pub key found when loading wallet from path
-    #[error("No main pub key found when loading wallet from path: {0:#?}")]
-    NoPubKeyFound(std::path::PathBuf),
     /// Main pub key doesn't match the key found when loading wallet from path
     #[error("Main pub key doesn't match the key found when loading wallet from path: {0:#?}")]
     PubKeyMismatch(std::path::PathBuf),

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 use super::{
-    data_payments::{ContentPaymentsMap, PaymentDetails, PaymentQuote},
+    data_payments::{PaymentDetails, PaymentQuote},
     keys::{get_main_key, store_new_keypair},
     wallet_file::{
         get_unconfirmed_spend_requests, get_wallet, load_cash_notes_from_disk,
@@ -530,7 +530,7 @@ fn load_from_path(
             wallet
         }
         None => {
-            let wallet = KeyLessWallet::new();
+            let wallet = KeyLessWallet::default();
             store_wallet(wallet_dir, &wallet)?;
             wallet
         }
@@ -540,17 +540,8 @@ fn load_from_path(
 }
 
 impl KeyLessWallet {
-    fn new() -> Self {
-        Self {
-            available_cash_notes: Default::default(),
-            cash_notes_created_for_others: Default::default(),
-            spent_cash_notes: Default::default(),
-            payment_transactions: ContentPaymentsMap::default(),
-        }
-    }
-
-    fn balance(&self) -> NanoTokens {
-        // loop through avaiable bcs and get total token count
+    pub fn balance(&self) -> NanoTokens {
+        // loop through avaiable cash notes and get total token count
         let mut balance = 0;
         for (_unique_pubkey, value) in self.available_cash_notes.iter() {
             balance += value.as_nano();
@@ -577,7 +568,7 @@ mod tests {
     #[tokio::test]
     async fn keyless_wallet_to_and_from_file() -> Result<()> {
         let key = MainSecretKey::random();
-        let mut wallet = KeyLessWallet::new();
+        let mut wallet = KeyLessWallet::default();
         let genesis = create_first_cash_note_from_key(&key).expect("Genesis creation to succeed.");
 
         let dir = create_temp_dir();
@@ -607,7 +598,7 @@ mod tests {
             key,
             unconfirmed_spend_requests: Default::default(),
 
-            wallet: KeyLessWallet::new(),
+            wallet: KeyLessWallet::default(),
             wallet_dir: dir.path().to_path_buf(),
         };
 
@@ -633,7 +624,7 @@ mod tests {
             key: MainSecretKey::random(),
             unconfirmed_spend_requests: Default::default(),
 
-            wallet: KeyLessWallet::new(),
+            wallet: KeyLessWallet::default(),
             wallet_dir: dir.path().to_path_buf(),
         };
 
@@ -658,7 +649,7 @@ mod tests {
             key,
             unconfirmed_spend_requests: Default::default(),
 
-            wallet: KeyLessWallet::new(),
+            wallet: KeyLessWallet::default(),
             wallet_dir: dir.path().to_path_buf(),
         };
 
@@ -679,7 +670,7 @@ mod tests {
             key: MainSecretKey::random(),
             unconfirmed_spend_requests: Default::default(),
 
-            wallet: KeyLessWallet::new(),
+            wallet: KeyLessWallet::default(),
             wallet_dir: dir.path().to_path_buf(),
         };
 
@@ -701,7 +692,7 @@ mod tests {
 
         let mut deposit_only = LocalWallet {
             key,
-            wallet: KeyLessWallet::new(),
+            wallet: KeyLessWallet::default(),
             unconfirmed_spend_requests: Default::default(),
             wallet_dir: dir.path().to_path_buf(),
         };

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -90,3 +90,15 @@ pub(super) struct KeyLessWallet {
     /// Cached proofs of storage transactions made to be used for uploading the paid content.
     payment_transactions: ContentPaymentsMap,
 }
+
+impl KeyLessWallet {
+    pub fn balance(&self) -> NanoTokens {
+        // loop through avaiable cash notes and get total token count
+        let mut balance = 0;
+        for (_unique_pubkey, value) in self.available_cash_notes.iter() {
+            balance += value.as_nano();
+        }
+
+        NanoTokens::from(balance)
+    }
+}

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -57,6 +57,7 @@ mod error;
 mod keys;
 mod local_store;
 mod wallet_file;
+mod watch_only;
 
 use data_payments::ContentPaymentsMap;
 
@@ -65,13 +66,14 @@ pub use self::{
     error::{Error, Result},
     keys::bls_secret_from_hex,
     local_store::LocalWallet,
+    watch_only::WatchOnlyWallet,
 };
 pub(crate) use keys::store_new_keypair;
 
 use crate::{NanoTokens, UniquePubkey};
 use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Default, serde::Serialize, serde::Deserialize)]
 /// This assumes the CashNotes are stored on disk
 pub(super) struct KeyLessWallet {
     /// These are the UniquePubkeys of cash_notes we've owned, that have been

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -86,10 +86,13 @@ pub(super) fn get_unconfirmed_spend_requests(
 
 /// Hex encode and write each `CashNote` to a separate file in respective
 /// recipient public address dir in the created cash_notes dir. Each file is named after the cash_note id.
-pub(super) fn store_created_cash_notes(
-    created_cash_notes: &[&CashNote],
+pub(super) fn store_created_cash_notes<'a, T>(
+    created_cash_notes: T,
     wallet_dir: &Path,
-) -> Result<()> {
+) -> Result<()>
+where
+    T: IntoIterator<Item = &'a CashNote>,
+{
     // The create cash_notes dir within the wallet dir.
     let created_cash_notes_path = wallet_dir.join(CASHNOTES_DIR_NAME);
     for cash_note in created_cash_notes {

--- a/sn_transfers/src/wallet/watch_only.rs
+++ b/sn_transfers/src/wallet/watch_only.rs
@@ -1,0 +1,237 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    data_payments::PaymentDetails,
+    error::{Error, Result},
+    keys::{get_main_pubkey, store_new_pubkey},
+    local_store::WalletExclusiveAccess,
+    wallet_file::{get_wallet, store_created_cash_notes, store_wallet, wallet_lockfile_name},
+    KeyLessWallet,
+};
+
+use crate::{CashNote, MainPubkey, NanoTokens, UniquePubkey};
+use fs2::FileExt;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
+use xor_name::XorName;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// This assumes the CashNotes are stored on disk
+pub struct WatchOnlyWallet {
+    /// Main public key which owns the cash notes.
+    main_pubkey: MainPubkey,
+    /// The dir of the wallet file, main key, public address, and new cash_notes.
+    wallet_dir: PathBuf,
+    /// The wallet containing all data, cash notes & transactions data that gets serialised and stored on disk.
+    pub(super) keyless_wallet: KeyLessWallet,
+}
+
+impl WatchOnlyWallet {
+    ///
+    pub(super) fn new(
+        main_pubkey: MainPubkey,
+        wallet_dir: &Path,
+        keyless_wallet: KeyLessWallet,
+    ) -> Self {
+        Self {
+            main_pubkey,
+            wallet_dir: wallet_dir.to_path_buf(),
+            keyless_wallet,
+        }
+    }
+
+    /// Loads a serialized wallet from a path.
+    pub fn load_from(wallet_dir: &Path, main_pubkey: MainPubkey) -> Result<Self> {
+        let main_pubkey = match get_main_pubkey(wallet_dir)? {
+            Some(pk) if pk != main_pubkey => {
+                return Err(Error::PubKeyMismatch(wallet_dir.to_path_buf()))
+            }
+            Some(pk) => pk,
+            None => {
+                store_new_pubkey(wallet_dir, &main_pubkey)?;
+                warn!("No main pub key found when loading wallet from path, storing it now: {main_pubkey:?}");
+                main_pubkey
+            }
+        };
+        let keyless_wallet = match get_wallet(wallet_dir)? {
+            Some(keyless_wallet) => {
+                debug!(
+                    "Loaded wallet from {wallet_dir:#?} with balance {:?}",
+                    keyless_wallet.balance()
+                );
+                keyless_wallet
+            }
+            None => {
+                let keyless_wallet = KeyLessWallet::default();
+                store_wallet(wallet_dir, &keyless_wallet)?;
+                keyless_wallet
+            }
+        };
+
+        Ok(Self {
+            main_pubkey,
+            wallet_dir: wallet_dir.to_path_buf(),
+            keyless_wallet,
+        })
+    }
+
+    pub fn address(&self) -> MainPubkey {
+        self.main_pubkey
+    }
+
+    pub fn balance(&self) -> NanoTokens {
+        self.keyless_wallet.balance()
+    }
+
+    pub fn wallet_dir(&self) -> &Path {
+        &self.wallet_dir
+    }
+
+    /// Deposit the given cash_notes on the wallet (without storing them to disk).
+    pub fn deposit(&mut self, received_cash_notes: &Vec<CashNote>) -> Result<()> {
+        for cash_note in received_cash_notes {
+            let id = cash_note.unique_pubkey();
+
+            if self.keyless_wallet.spent_cash_notes.contains(&id) {
+                debug!("skipping: cash_note is spent");
+                continue;
+            }
+
+            if cash_note.derived_pubkey(&self.main_pubkey).is_err() {
+                debug!("skipping: cash_note is not our key");
+                continue;
+            }
+
+            let value = cash_note.value()?;
+            self.keyless_wallet.available_cash_notes.insert(id, value);
+        }
+
+        Ok(())
+    }
+
+    /// Store the given cash_notes to the `cash_notes` dir in the wallet dir.
+    /// Update and store the updated wallet to disk
+    /// This function locks the wallet to prevent concurrent processes from writing to it
+    pub fn deposit_and_store_to_disk(&mut self, received_cash_notes: &Vec<CashNote>) -> Result<()> {
+        if received_cash_notes.is_empty() {
+            return Ok(());
+        }
+
+        // lock and load from disk to make sure we're up to date and others can't modify the wallet concurrently
+        let exclusive_access = self.lock()?;
+        self.reload()?;
+        trace!("Wallet locked and loaded!");
+
+        for cash_note in received_cash_notes {
+            let id = cash_note.unique_pubkey();
+
+            if self.keyless_wallet.spent_cash_notes.contains(&id) {
+                debug!("skipping: cash_note is spent");
+                continue;
+            }
+
+            if cash_note.derived_pubkey(&self.main_pubkey).is_err() {
+                debug!("skipping: cash_note is not our key");
+                continue;
+            }
+
+            let value = cash_note.value()?;
+            self.keyless_wallet.available_cash_notes.insert(id, value);
+
+            store_created_cash_notes(&[cash_note], &self.wallet_dir)?;
+        }
+
+        self.store(exclusive_access)
+    }
+
+    /// Attempts to reload the wallet from disk.
+    pub fn reload_from_disk_or_recreate(&mut self) -> Result<()> {
+        std::fs::create_dir_all(&self.wallet_dir)?;
+        // lock and load from disk to make sure we're up to date and others can't modify the wallet concurrently
+        trace!("Trying to lock wallet to get available cash_notes...");
+        let _exclusive_access = self.lock()?;
+        self.reload()?;
+        Ok(())
+    }
+
+    ///
+    pub fn available_cash_notes(&self) -> &BTreeMap<UniquePubkey, NanoTokens> {
+        &self.keyless_wallet.available_cash_notes
+    }
+
+    ///
+    pub fn available_cash_notes_mut(&mut self) -> &mut BTreeMap<UniquePubkey, NanoTokens> {
+        &mut self.keyless_wallet.available_cash_notes
+    }
+
+    ///
+    pub fn spent_cash_notes(&self) -> &BTreeSet<UniquePubkey> {
+        &self.keyless_wallet.spent_cash_notes
+    }
+
+    ///
+    pub fn spent_cash_notes_mut(&mut self) -> &mut BTreeSet<UniquePubkey> {
+        &mut self.keyless_wallet.spent_cash_notes
+    }
+
+    ///
+    pub fn cash_notes_created_for_others(&self) -> &BTreeSet<UniquePubkey> {
+        &self.keyless_wallet.cash_notes_created_for_others
+    }
+
+    ///
+    pub fn cash_notes_created_for_others_mut(&mut self) -> &mut BTreeSet<UniquePubkey> {
+        &mut self.keyless_wallet.cash_notes_created_for_others
+    }
+
+    ///
+    pub fn get_payment_transaction(&self, name: &XorName) -> Option<&PaymentDetails> {
+        self.keyless_wallet.payment_transactions.get(name)
+    }
+
+    ///
+    pub fn insert_payment_transaction(&mut self, name: XorName, payment: PaymentDetails) {
+        self.keyless_wallet
+            .payment_transactions
+            .insert(name, payment);
+    }
+
+    // Helpers
+
+    /// Stores the wallet to disk.
+    /// This requires having exclusive access to the wallet to prevent concurrent processes from writing to it
+    pub(super) fn store(&self, exclusive_access: WalletExclusiveAccess) -> Result<()> {
+        store_wallet(&self.wallet_dir, &self.keyless_wallet)?;
+        trace!("Releasing wallet lock");
+        std::mem::drop(exclusive_access);
+        Ok(())
+    }
+
+    /// reloads the wallet from disk.
+    fn reload(&mut self) -> Result<()> {
+        *self = Self::load_from(&self.wallet_dir, self.main_pubkey)?;
+        Ok(())
+    }
+
+    /// Locks the wallet and returns exclusive access to the wallet
+    /// This lock prevents any other process from locking the wallet dir, effectively acts as a mutex for the wallet
+    pub fn lock(&self) -> Result<WalletExclusiveAccess> {
+        let lock = wallet_lockfile_name(&self.wallet_dir);
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(lock)?;
+        file.lock_exclusive()?;
+        Ok(file)
+    }
+}


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 13:39 UTC
This pull request includes the following changes:

- The file `sn_cli/src/subcommands/files/mod.rs` has changes related to the `files_cmds` function, the `Files` constructor, and the `upload_files` function. The `client` parameter of these functions has been changed to a shared reference `&Client`.

- A new file `watch_only.rs` has been added, which includes the implementation of a `WatchOnlyWallet` struct. This struct represents a watch-only wallet in a SAFE Network and has various methods for loading, storing, and manipulating wallet data.

- The file `lib.rs` has changes related to adding the `WatchOnlyWallet` struct to the `wallet` module. This struct is now available for use in the API.

- The file `error.rs` has a new variant `PubKeyMismatch` added to the `Error` enum, with a custom error message that includes the path of the wallet.

- The file `cashnote.rs` has changes related to the `CashNote` struct. A new method `derived_pubkey` has been added, and the existing method `derivation_index` now has a specified return type.

- The file `main.rs` has changes related to the variables `joins_gossip` and `joins_gossipsub`, as well as the function `files_cmds`. These changes indicate updates to the usage of gossipsub and more efficient usage of the `client` object.

- The file `wallet_file.rs` has changes related to the `store_created_cash_notes` function, which now accepts a generic iterator and returns a `Result<()>` instead of `Result<()>`. This allows for more flexibility in accepting different types of iterators.

- The file `error.rs` has changes related to the addition of the `MainPubkeyMismatch` variant to the `Error` enum. This variant handles the scenario where the main public key does not match.

- The file `wallet/mod.rs` has changes related to the usage of the `MainPubkey` type and the addition of functions for storing and retrieving the main public key in the wallet directory.

- The file `wallet/mod.rs` has changes related to the addition of a new module called `watch_only` and the implementation of a `WatchOnlyWallet` struct. It also includes a new method called `balance` in the `KeyLessWallet` struct.

Please review these changes to ensure they are correct and do not introduce any bugs or performance issues. Let me know if you need further assistance.
<!-- reviewpad:summarize:end --> 
