### PR TITLE
chore(cli): fix -n flag

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -206,7 +206,7 @@ jobs:
         shell: bash
         run: |
           ls -l target/release
-          target/release/safe --log-output-dest=data-dir files upload target/release/faucet -n
+          target/release/safe --log-output-dest=data-dir files upload target/release/faucet
 
       #########################
       ### Stop Network      ###

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -182,7 +182,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to create a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -76,6 +76,6 @@ pub(crate) struct Opt {
     /// Prevent verification of data storage on the network.
     ///
     /// This may increase operation speed, but offers no guarantees that operations were successful.
-    #[clap(global = true, short = 'n')]
+    #[clap(global = true, long = "no-verify", short = 'x')]
     pub no_verify: bool,
 }

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -21,7 +21,7 @@ pub enum RegisterCmds {
     Create {
         /// The name of the register to create. This could be the app's name.
         /// This is used along with your public key to derive the address of the register
-        #[clap(name = "name")]
+        #[clap(name = "name", short = 'n')]
         name: String,
     },
     Edit {


### PR DESCRIPTION
## Description

This fixes a duplicate use of `-n` flag in the cli, for example:

```
$  safe register edit --help
Usage: safe register edit [OPTIONS] <address> <entry>

Arguments:
  <address>
          The address of the register to edit

  <entry>
          The entry to add to the register

Options:
  -n
          If you are the owner, the name of the register can be used as a shorthand to the address, as we can derive the address from the public key + name Use this flag if you are providing the register name instead of the address

      --timeout <CONNECTION_TIMEOUT>
          The maximum duration to wait for a connection to the network before timing out

  -n
          Prevent verification of data storage on the network.
          
          This may increase operation speed, but offers no guarantees that operations were successful.

  -h, --help
          Print help (see a summary with '-h')
```

Changed to

```diff
-  -n
+  -x, --no-verify
          Prevent verification of data storage on the network.
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Dec 23 22:40 UTC
This pull request adds a short flag 'n' for the 'name' option in the register subcommand of the CLI. Additionally, it fixes a duplicate use of the 'n' short flag, changing it to 'x' for the 'no-verify' option in the CLI.
<!-- reviewpad:summarize:end --> 
