### PR TITLE
feat: chunk put allow retrying un-get-able chunks

### DIFF
--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -445,11 +445,6 @@ impl ChunkManager {
             .ok()?;
         Some(XorName(decoded_xorname))
     }
-
-    #[allow(dead_code)]
-    fn hex_encode_xorname(xorname: XorName) -> String {
-        hex::encode(xorname)
-    }
 }
 
 #[cfg(test)]

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -166,7 +166,15 @@ async fn upload_files(
     if chunk_manager.is_chunks_empty() {
         // make sure we don't have any failed chunks in those
         let chunks = chunk_manager.already_put_chunks(&files_path)?;
-        let failed_chunks = client.verify_uploaded_chunks(chunks, batch_size).await?;
+        let failed_chunks = client.verify_uploaded_chunks(&chunks, batch_size).await?;
+
+        // mark the non-failed ones as completed
+        chunk_manager.mark_completed(
+            chunks
+                .into_iter()
+                .filter(|c| !failed_chunks.contains(c))
+                .map(|(xor, _)| xor),
+        );
 
         // if none are failed, we can return early
         if failed_chunks.is_empty() {

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -685,7 +685,7 @@ impl Client {
     /// Returns a vec of any chunks that could not be verified
     pub async fn verify_uploaded_chunks(
         &self,
-        chunks_paths: Vec<(XorName, PathBuf)>,
+        chunks_paths: &[(XorName, PathBuf)],
         batch_size: usize,
     ) -> Result<Vec<(XorName, PathBuf)>> {
         let mut failed_chunks = Vec::new();

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -204,48 +204,6 @@ impl Files {
         Ok((storage_cost, royalties_fees, new_balance))
     }
 
-    /// Verify that chunks were uploaded
-    ///
-    /// Returns a vec of any chunks that could not be verified
-    pub async fn verify_uploaded_chunks(
-        &self,
-        chunks_paths: Vec<(XorName, PathBuf)>,
-        batch_size: usize,
-    ) -> Result<Vec<(XorName, PathBuf)>> {
-        let mut failed_chunks = Vec::new();
-
-        for chunks_batch in chunks_paths.chunks(batch_size) {
-            // now we try and get batched chunks, keep track of any that fail
-            // Iterate over each uploaded chunk
-            let mut verify_handles = Vec::new();
-            for (name, path) in chunks_batch.iter().cloned() {
-                let client = self.client().clone();
-                // Spawn a new task to fetch each chunk concurrently
-                let handle = tokio::spawn(async move {
-                    let chunk_address: ChunkAddress = ChunkAddress::new(name);
-                    // make sure the chunk is stored
-                    let res = client.verify_chunk_stored(chunk_address).await;
-
-                    Ok::<_, ChunksError>(((name, path), res.is_err()))
-                });
-                verify_handles.push(handle);
-            }
-
-            // Await all fetch tasks and collect the results
-            let verify_results = join_all(verify_handles).await;
-
-            // Check for any errors during fetch
-            for result in verify_results {
-                if let ((chunk_addr, path), true) = result?? {
-                    warn!("Failed to fetch a chunk {chunk_addr:?}");
-                    failed_chunks.push((chunk_addr, path));
-                }
-            }
-        }
-
-        Ok(failed_chunks)
-    }
-
     // --------------------------------------------
     // ---------- Private helpers -----------------
     // --------------------------------------------
@@ -317,7 +275,10 @@ impl Files {
             return Ok((net_addr, storage_cost, royalties_fees));
         }
 
-        let mut failed_chunks = self.verify_uploaded_chunks(chunks, BATCH_SIZE).await?;
+        let mut failed_chunks = self
+            .client
+            .verify_uploaded_chunks(chunks, BATCH_SIZE)
+            .await?;
         warn!("Failed chunks: {:?}", failed_chunks.len());
 
         while !failed_chunks.is_empty() {
@@ -357,6 +318,7 @@ impl Files {
             trace!("Chunks uploaded again....");
 
             failed_chunks = self
+                .client
                 .verify_uploaded_chunks(failed_chunks, BATCH_SIZE)
                 .await?;
         }

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -277,7 +277,7 @@ impl Files {
 
         let mut failed_chunks = self
             .client
-            .verify_uploaded_chunks(chunks, BATCH_SIZE)
+            .verify_uploaded_chunks(&chunks, BATCH_SIZE)
             .await?;
         warn!("Failed chunks: {:?}", failed_chunks.len());
 
@@ -319,7 +319,7 @@ impl Files {
 
             failed_chunks = self
                 .client
-                .verify_uploaded_chunks(failed_chunks, BATCH_SIZE)
+                .verify_uploaded_chunks(&failed_chunks, BATCH_SIZE)
                 .await?;
         }
 


### PR DESCRIPTION
## Description

Depends on #1022, please merge #1022 first!

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Dec 23 09:36 UTC
This pull request includes the following changes:

- The `verify_uploaded_chunks` method has been removed from the `Files` struct. Instead, the logic of this method has been moved to the `upload_file` method of the same struct, which now calls the `verify_uploaded_chunks` method on the `client` field.
- Several import statements have been added for external modules and the standard library.
- A new method `verify_uploaded_chunks` has been added to the `Client` struct. This method takes a vector of chunk paths and a batch size, and returns a vector of chunks that could not be verified.
- A nested function `get_register_from_record` has been implemented, which converts a record into a signed register.
- The `upload_files` function in the `sn_cli/src/subcommands/files/mod.rs` file has been modified. The changes include adding error handling to check if the wallet is empty before uploading files, initializing the `ChunkManager` with the provided `root_dir`, adding a call to determine the chunk path for the given files path, printing messages for uploaded and verified files, handling different scenarios based on the existence of chunks to upload, and logging and printing payment and upload information.
- Import statements for `io::BufRead` and `io::BufReader` have been removed.
- The variable `child` has been assigned but is unused.

These changes aim to refactor the code, improve the upload process, handle failed chunks, provide better information about the upload and payment details, and remove unused imports and variables.
<!-- reviewpad:summarize:end --> 
