### PR TITLE
test(node): add min test time for reward listener tests

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -318,7 +318,10 @@ fn spawn_royalties_payment_listener(
         let mut count = 0;
         let mut stream = response.into_inner();
 
-        let secs = expected_royalties as u64 * 10; // a reasonable min
+        // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
+        // otherwise we'll wait for 10s per expected royalty
+        let secs = std::max(20, expected_royalties as u64 * 10);
+
         let duration = Duration::from_secs(secs);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
@@ -363,7 +366,9 @@ fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        let secs = expected_royalties as u64 * 10; // a reasonable min
+        // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
+        // otherwise we'll wait for 10s per expected royalty
+        let secs = std::max(20, expected_royalties as u64 * 10);
         let duration = Duration::from_secs(secs);
         tracing::info!("Awaiting transfers notifs for {duration:?}...");
         println!("Awaiting transfers notifs for {duration:?}...");

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -123,7 +123,7 @@ async fn nodes_rewards_for_chunks_notifs_over_gossipsub() -> Result<()> {
     )?;
 
     let num_of_chunks = chunks.len();
-    let handle = spawn_royalties_payment_client_listener(client.clone(), num_of_chunks)?;
+    let handle = spawn_royalties_payment_client_listener(client.clone(), num_of_chunks).await?;
 
     let num_of_chunks = chunks.len();
 
@@ -165,7 +165,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
     let mut rng = rand::thread_rng();
     let register_addr = XorName::random(&mut rng);
 
-    let handle = spawn_royalties_payment_client_listener(client.clone(), 1)?;
+    let handle = spawn_royalties_payment_client_listener(client.clone(), 1).await?;
 
     println!("Paying for random Register address {register_addr:?} ...");
     let (_, storage_cost, royalties_fees) = client
@@ -209,14 +209,15 @@ async fn nodes_rewards_transfer_notifs_filter() -> Result<()> {
     // this node shall receive the notifications since we set the correct royalties pk as filter
     let royalties_pk = NETWORK_ROYALTIES_PK.public_key();
     let handle_1 =
-        spawn_royalties_payment_listener(node_rpc_addresses[0], royalties_pk, true, chunks.len());
+        spawn_royalties_payment_listener(node_rpc_addresses[0], royalties_pk, true, chunks.len())
+            .await;
     // this other node shall *not* receive any notification since we set the wrong pk as filter
     let random_pk = SecretKey::random().public_key();
-    let handle_2 = spawn_royalties_payment_listener(node_rpc_addresses[1], random_pk, true, 0);
+    let handle_2 =
+        spawn_royalties_payment_listener(node_rpc_addresses[1], random_pk, true, 0).await;
     // this other node shall *not* receive any notification either since we don't set any pk as filter
-    let handle_3 = spawn_royalties_payment_listener(node_rpc_addresses[2], royalties_pk, false, 0);
-
-    sleep(Duration::from_secs(20)).await;
+    let handle_3 =
+        spawn_royalties_payment_listener(node_rpc_addresses[2], royalties_pk, false, 0).await;
 
     let num_of_chunks = chunks.len();
     println!("Paying for {num_of_chunks} chunks");
@@ -287,14 +288,14 @@ fn current_rewards_balance() -> Result<NanoTokens> {
     Ok(total_rewards)
 }
 
-fn spawn_royalties_payment_listener(
+async fn spawn_royalties_payment_listener(
     rpc_addr: SocketAddr,
     royalties_pk: PublicKey,
     set_filter: bool,
     expected_royalties: usize,
 ) -> JoinHandle<Result<usize, eyre::Report>> {
     let endpoint = format!("https://{rpc_addr}");
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
 
         if set_filter {
@@ -320,7 +321,7 @@ fn spawn_royalties_payment_listener(
 
         // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
         // otherwise we'll wait for 10s per expected royalty
-        let secs = std::max(20, expected_royalties as u64 * 10);
+        let secs = std::cmp::max(20, expected_royalties as u64 * 10);
 
         let duration = Duration::from_secs(secs);
         println!("Awaiting transfers notifs for {duration:?}...");
@@ -348,10 +349,15 @@ fn spawn_royalties_payment_listener(
         }
 
         Ok(count)
-    })
+    });
+
+    // small wait to ensure that the gossipsub subscription is in place
+    sleep(Duration::from_secs(10)).await;
+
+    handle
 }
 
-fn spawn_royalties_payment_client_listener(
+async fn spawn_royalties_payment_client_listener(
     client: Client,
     expected_royalties: usize,
 ) -> Result<JoinHandle<Result<(usize, NanoTokens), eyre::Report>>> {
@@ -368,7 +374,7 @@ fn spawn_royalties_payment_client_listener(
 
         // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
         // otherwise we'll wait for 10s per expected royalty
-        let secs = std::max(20, expected_royalties as u64 * 10);
+        let secs = std::cmp::max(20, expected_royalties as u64 * 10);
         let duration = Duration::from_secs(secs);
         tracing::info!("Awaiting transfers notifs for {duration:?}...");
         println!("Awaiting transfers notifs for {duration:?}...");
@@ -414,6 +420,9 @@ fn spawn_royalties_payment_client_listener(
 
         Ok((count, wallet.balance()))
     });
+
+    // small wait to ensure that the gossipsub subscription is in place
+    sleep(Duration::from_secs(10)).await;
 
     Ok(handle)
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Dec 23 11:31 UTC
This pull request adds a minimum test time for reward listener tests in the `nodes_rewards.rs` file. Instead of always waiting for a fixed duration, the test now calculates the wait time based on the expected royalties. If the expected royalties are 0 or 1, the wait time is set to 20 seconds. Otherwise, the wait time is calculated as 10 seconds per expected royalty.
<!-- reviewpad:summarize:end --> 
