### PR TITLE
test(node): add min test time for reward listener tests

### DIFF
--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -318,7 +318,10 @@ fn spawn_royalties_payment_listener(
         let mut count = 0;
         let mut stream = response.into_inner();
 
-        let secs = expected_royalties as u64 * 10; // a reasonable min
+        // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
+        // otherwise we'll wait for 10s per expected royalty
+        let secs = std::max(20, expected_royalties as u64 * 10);
+
         let duration = Duration::from_secs(secs);
         println!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {
@@ -363,7 +366,9 @@ fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        let secs = expected_royalties as u64 * 10; // a reasonable min
+        // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
+        // otherwise we'll wait for 10s per expected royalty
+        let secs = std::max(20, expected_royalties as u64 * 10);
         let duration = Duration::from_secs(secs);
         tracing::info!("Awaiting transfers notifs for {duration:?}...");
         println!("Awaiting transfers notifs for {duration:?}...");


### PR DESCRIPTION
Closes https://github.com/maidsafe/safe_network/pull/1048

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Dec 23 13:18 UTC
This pull request includes two patches. 

The first patch adds a minimum test time for reward listener tests in the `sn_node/tests/nodes_rewards.rs` file. The minimum wait time is determined based on the number of expected royalties. If the expected royalties are 0 or 1, the minimum wait time is set to 20 seconds. Otherwise, the minimum wait time is calculated as 10 seconds multiplied by the expected number of royalties.

The second patch formalizes a small wait after starting the payment listener in the `sn_node/tests/nodes_rewards.rs` file. It also updates the wait time calculation logic similar to the first patch. Additionally, this patch includes some code refactoring.

Please review these patches for proper test time handling in the reward listener tests.
<!-- reviewpad:summarize:end --> 
