### PR TITLE
feat: replace bootstrap node if bucket full

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -52,7 +52,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     net::SocketAddr,
     num::NonZeroUsize,
@@ -549,6 +549,7 @@ impl NetworkBuilder {
             dialed_peers: CircularVec::new(255),
             is_gossip_handler: false,
             network_discovery: NetworkDiscovery::new(&peer_id),
+            bootstrap_peers: Default::default(),
         };
 
         Ok((
@@ -594,6 +595,7 @@ pub struct SwarmDriver {
     // A list of random `PeerId` candidates that falls into kbuckets,
     // This is to ensure a more accurate network discovery.
     pub(crate) network_discovery: NetworkDiscovery,
+    pub(crate) bootstrap_peers: BTreeMap<Option<u32>, HashSet<PeerId>>,
 }
 
 impl SwarmDriver {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -159,6 +159,7 @@ impl Network {
     }
 
     /// Dial the given peer at the given address.
+    /// This function will only be called for the bootstrap nodes.
     pub async fn dial(&self, addr: Multiaddr) -> Result<()> {
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::Dial { addr, sender })?;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Dec 23 10:25 UTC
This pull request includes a feature that replaces a bootstrap node if the bucket is full. It modifies multiple files in the sn_networking library, including cmd.rs, driver.rs, event.rs, and lib.rs. The changes involve adding logic to check if a dial peer is a bootstrap node and replacing it if necessary, as well as removing a bootstrap node from a full bucket if present.
<!-- reviewpad:summarize:end --> 
