### PR TITLE
refacot(network): simplify the get_record handling code.

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -434,7 +434,7 @@ impl Client {
         };
 
         let put_cfg = PutRecordCfg {
-            put_quorum: Quorum::All,
+            put_quorum: Quorum::One,
             re_attempt: true,
             verification,
         };

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -10,6 +10,7 @@ use crate::Error;
 
 use super::{error::Result, Client};
 use futures::{future::join_all, TryFutureExt};
+use sn_networking::GetRecordError;
 use sn_protocol::NetworkAddress;
 use sn_transfers::{
     CashNote, LocalWallet, MainPubkey, NanoTokens, Payment, PaymentQuote, SignedSpend,
@@ -322,8 +323,8 @@ impl Client {
         for (cash_note_key, spend_attempt_result) in join_all(tasks).await {
             // This is a record mismatch on spend, we need to clean up and remove the spent CashNote from the wallet
             // This only happens if we're verifying the store
-            if let Err(Error::Network(sn_networking::Error::ReturnedRecordDoesNotMatch(
-                record_key,
+            if let Err(Error::Network(sn_networking::Error::GetRecordError(
+                GetRecordError::RecordDoesNotMatch(record_key),
             ))) = spend_attempt_result
             {
                 warn!("Record mismatch on spend, removing CashNote from wallet: {record_key:?}");

--- a/sn_networking/src/bootstrap.rs
+++ b/sn_networking/src/bootstrap.rs
@@ -21,7 +21,7 @@ const BOOTSTRAP_CONNECTED_PEERS_STEP: u32 = 5;
 /// process. This is to make sure we don't flood the network with `FindNode` msgs.
 const LAST_PEER_ADDED_TIME_LIMIT: Duration = Duration::from_secs(180);
 
-/// A minumn interval to prevent bootstrap got triggered too often
+/// A minimum interval to prevent bootstrap got triggered too often
 const LAST_BOOTSTRAP_TRIGGERED_TIME_LIMIT: Duration = Duration::from_secs(30);
 
 /// The bootstrap interval to use if we haven't added any new peers in a while.

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -158,12 +158,10 @@ impl Debug for SwarmCmd {
             SwarmCmd::Dial { addr, .. } => {
                 write!(f, "SwarmCmd::Dial {{ addr: {addr:?} }}")
             }
-            SwarmCmd::GetNetworkRecord {
-                key, cfg: get_cfg, ..
-            } => {
+            SwarmCmd::GetNetworkRecord { key, cfg, .. } => {
                 write!(
                     f,
-                    "SwarmCmd::GetNetworkRecord {{ key: {:?}, get_cfg: {get_cfg:?}",
+                    "SwarmCmd::GetNetworkRecord {{ key: {:?}, cfg: {cfg:?}",
                     PrettyPrintRecordKey::from(key)
                 )
             }
@@ -334,22 +332,18 @@ impl SwarmDriver {
                     self.send_event(NetworkEvent::KeysForReplication(keys_to_fetch));
                 }
             }
-            SwarmCmd::GetNetworkRecord {
-                key,
-                sender,
-                cfg: get_cfg,
-            } => {
+            SwarmCmd::GetNetworkRecord { key, sender, cfg } => {
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key.clone());
 
                 debug!(
                     "Record {:?} with task {query_id:?} expected to be held by {:?}",
                     PrettyPrintRecordKey::from(&key),
-                    get_cfg.expected_holders
+                    cfg.expected_holders
                 );
 
                 if self
                     .pending_get_record
-                    .insert(query_id, (sender, Default::default(), get_cfg))
+                    .insert(query_id, (sender, Default::default(), cfg))
                     .is_some()
                 {
                     warn!("An existing get_record task {query_id:?} got replaced");

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -124,6 +124,12 @@ pub struct GetRecordCfg {
     pub expected_holders: HashSet<PeerId>,
 }
 
+impl GetRecordCfg {
+    pub fn does_target_match(&self, record: &Record) -> bool {
+        self.target_record.as_ref().is_some_and(|t| t == record)
+    }
+}
+
 impl Debug for GetRecordCfg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut f = f.debug_struct("GetRecordCfg");

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -153,8 +153,9 @@ impl Debug for GetRecordCfg {
 /// The various settings related to writing a record to the network.
 #[derive(Debug, Clone)]
 pub struct PutRecordCfg {
-    /// The quorum used by KAD PUT. This does not necessarily enforce any quorum, it just makes sure we deliver the PUT
-    /// the specified number of peers.
+    /// The quorum used by KAD PUT. KAD still sends out the request to all the peers set by the `replication_factor`, it
+    /// just makes sure that we get atleast `n` successful responses defined by the Quorum.
+    /// Our nodes currently send `Ok()` response for every KAD PUT. Thus this field does not do anything atm.
     pub put_quorum: Quorum,
     /// If set to true, we retry upto PUT_RETRY_ATTEMPTS times
     pub re_attempt: bool,

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -45,7 +45,7 @@ pub enum GetRecordError {
     #[error("Network query timed out")]
     QueryTimeout,
 
-    #[error("Record retrieved from the network does not match the one we attempted to store.")]
+    #[error("Record retrieved from the network does not match the provided target record.")]
     RecordDoesNotMatch(Record),
 }
 

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -31,7 +31,7 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(missing_docs)]
 pub enum GetRecordError {
     #[error("Get Record completed with non enough copies")]
-    RecordNotEnoughCopies(Record),
+    NotEnoughCopies(Record),
 
     #[error("Record not found in the network")]
     RecordNotFound,
@@ -46,7 +46,7 @@ pub enum GetRecordError {
     QueryTimeout,
 
     #[error("Record retrieved from the network does not match the one we attempted to store.")]
-    ReturnedRecordDoesNotMatch(Record),
+    RecordDoesNotMatch(Record),
 }
 
 /// Network Errors

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -44,6 +44,9 @@ pub enum GetRecordError {
 
     #[error("Network query timed out")]
     QueryTimeout,
+
+    #[error("Record retrieved from the network does not match the one we attempted to store.")]
+    ReturnedRecordDoesNotMatch(Record),
 }
 
 /// Network Errors
@@ -86,9 +89,6 @@ pub enum Error {
     /// No put_record attempts were successfully verified.
     #[error("Could not retrieve the record after storing it: {0:}")]
     FailedToVerifyRecordWasStored(PrettyPrintRecordKey<'static>),
-
-    #[error("Record retrieved from the network does not match the one we attempted to store {0:}")]
-    ReturnedRecordDoesNotMatch(PrettyPrintRecordKey<'static>),
 
     // ---------- Transfer Errors
     #[error("Failed to get transfer parent spend")]

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -812,7 +812,7 @@ impl SwarmDriver {
             } => {
                 event_string = "kad_event::get_record::finished_no_additional";
                 trace!("Query task {id:?} of get_record completed with {stats:?} - {step:?} - {cache_candidates:?}");
-                self.handle_get_record_finished(id, cache_candidates, stats, step)?;
+                self.handle_get_record_finished(id, step)?;
             }
             kad::Event::OutboundQueryProgressed {
                 id,

--- a/sn_networking/src/get_record_handler.rs
+++ b/sn_networking/src/get_record_handler.rs
@@ -1,0 +1,349 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{Error, Result};
+use libp2p::{
+    kad::{
+        self, KBucketDistance, PeerRecord, ProgressStep, QueryId, QueryResult, QueryStats, Quorum,
+        Record,
+    },
+    PeerId,
+};
+use sn_protocol::{storage::RecordHeader, PrettyPrintRecordKey};
+use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
+use tokio::sync::oneshot;
+use xor_name::XorName;
+
+use crate::{close_group_majority, GetRecordError, SwarmDriver, CLOSE_GROUP_SIZE};
+
+/// Using XorName to differentiate different record content under the same key.
+type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
+type ExpectedHoldersList = HashSet<PeerId>;
+pub(crate) type PendingGetRecord = HashMap<
+    QueryId,
+    (
+        oneshot::Sender<std::result::Result<Record, GetRecordError>>,
+        GetRecordResultMap,
+        Quorum,
+        ExpectedHoldersList,
+    ),
+>;
+
+// For `get_record` returning behaviour:
+//   1, targeting a non-existing entry
+//     there will only be one event of `kad::Event::OutboundQueryProgressed`
+//     with `ProgressStep::last` to be `true`
+//          `QueryStats::requests` to be 20 (K-Value)
+//          `QueryStats::success` to be over majority of the requests
+//          `err::NotFound::closest_peers` contains a list of CLOSE_GROUP_SIZE peers
+//   2, targeting an existing entry
+//     there will a sequence of (at least CLOSE_GROUP_SIZE) events of
+//     `kad::Event::OutboundQueryProgressed` to be received
+//     with `QueryStats::end` always being `None`
+//          `ProgressStep::last` all to be `false`
+//          `ProgressStep::count` to be increased with step of 1
+//             capped and stopped at CLOSE_GROUP_SIZE, may have duplicated counts
+//          `PeerRecord::peer` could be None to indicate from self
+//             in which case it always use a duplicated `ProgressStep::count`
+//     the sequence will be completed with `FinishedWithNoAdditionalRecord`
+//     where: `cache_candidates`: being the peers supposed to hold the record but not
+//            `ProgressStep::count`: to be `number of received copies plus one`
+//            `ProgressStep::last` to be `true`
+impl SwarmDriver {
+    // Completes when any of the following condition reaches first:
+    // 1, Return whenever reached majority of CLOSE_GROUP_SIZE
+    // 2, In case of split, return with NotFound,
+    //    whenever `ProgressStep::count` hits CLOSE_GROUP_SIZE
+    pub(crate) fn accumulate_get_record_found(
+        &mut self,
+        query_id: QueryId,
+        peer_record: PeerRecord,
+        stats: QueryStats,
+        step: ProgressStep,
+    ) -> Result<()> {
+        if self.try_early_completion_for_chunk(&query_id, &peer_record)? {
+            return Ok(());
+        }
+
+        let peer_id = if let Some(peer_id) = peer_record.peer {
+            peer_id
+        } else {
+            self.self_peer_id
+        };
+
+        if let Entry::Occupied(mut entry) = self.pending_get_record.entry(query_id) {
+            let (_sender, result_map, quorum, expected_holders) = entry.get_mut();
+
+            let pretty_key = PrettyPrintRecordKey::from(&peer_record.record.key).into_owned();
+
+            if !expected_holders.is_empty() {
+                if expected_holders.remove(&peer_id) {
+                    debug!("For record {pretty_key:?} task {query_id:?}, received a copy from an expected holder {peer_id:?}");
+                } else {
+                    debug!("For record {pretty_key:?} task {query_id:?}, received a copy from an unexpected holder {peer_id:?}");
+                }
+            }
+
+            // Insert the record and the peer into the result_map.
+            let record_content_hash = XorName::from_content(&peer_record.record.value);
+            let responded_peers =
+                if let Entry::Occupied(mut entry) = result_map.entry(record_content_hash) {
+                    let (_, peer_list) = entry.get_mut();
+                    let _ = peer_list.insert(peer_id);
+                    peer_list.len()
+                } else {
+                    let mut peer_list = HashSet::new();
+                    let _ = peer_list.insert(peer_id);
+                    result_map.insert(record_content_hash, (peer_record.record.clone(), peer_list));
+                    1
+                };
+
+            let expected_answers = match quorum {
+                Quorum::Majority => close_group_majority(),
+                Quorum::All => CLOSE_GROUP_SIZE,
+                Quorum::N(v) => v.get(),
+                Quorum::One => 1,
+            };
+
+            trace!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
+
+            if responded_peers >= expected_answers {
+                if !expected_holders.is_empty() {
+                    debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with non-responded expected holders {expected_holders:?}");
+                }
+
+                // Remove the query task and consume the variables.
+                let (sender, result_map, _, _) = entry.remove();
+
+                if result_map.len() == 1 {
+                    sender
+                        .send(Ok(peer_record.record))
+                        .map_err(|_| Error::InternalMsgChannelDropped)?;
+                } else {
+                    debug!("For record {pretty_key:?} task {query_id:?}, fetch completed with split record");
+                    sender
+                        .send(Err(GetRecordError::SplitRecord { result_map }))
+                        .map_err(|_| Error::InternalMsgChannelDropped)?;
+                }
+
+                // Stop the query; possibly stops more nodes from being queried.
+                if let Some(mut query) = self.swarm.behaviour_mut().kademlia.query_mut(&query_id) {
+                    query.finish();
+                }
+            } else if usize::from(step.count) >= CLOSE_GROUP_SIZE {
+                debug!("For record {pretty_key:?} task {query_id:?}, got {:?} with {} versions so far.",
+                   step.count, result_map.len());
+            }
+        } else {
+            // return error if the entry cannot be found
+            return Err(Error::ReceivedKademliaEventDropped(
+                kad::Event::OutboundQueryProgressed {
+                    id: query_id,
+                    result: QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(peer_record))),
+                    stats,
+                    step,
+                },
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn handle_get_record_finished(
+        &mut self,
+        query_id: QueryId,
+        cache_candidates: BTreeMap<KBucketDistance, PeerId>,
+        stats: QueryStats,
+        step: ProgressStep,
+    ) -> Result<()> {
+        // return error if the entry cannot be found
+        let (sender, result_map, _quorum, expected_holders) =
+            self.pending_get_record.remove(&query_id).ok_or_else(|| {
+                trace!(
+                    "Can't locate query task {query_id:?}, it has likely been completed already."
+                );
+                Error::ReceivedKademliaEventDropped(kad::Event::OutboundQueryProgressed {
+                    id: query_id,
+                    result: QueryResult::GetRecord(Ok(
+                        kad::GetRecordOk::FinishedWithNoAdditionalRecord { cache_candidates },
+                    )),
+                    stats,
+                    step: step.clone(),
+                })
+            })?;
+
+        let num_of_versions = result_map.len();
+        let (result, log_string) = if let Some((record, _)) = result_map.values().next() {
+            let result = if num_of_versions == 1 {
+                Err(GetRecordError::RecordNotEnoughCopies(record.clone()))
+            } else {
+                Err(GetRecordError::SplitRecord {
+                    result_map: result_map.clone(),
+                })
+            };
+
+            (result, format!(
+                "Getting record {:?} completed with only {:?} copies received, and {num_of_versions} versions.",
+                PrettyPrintRecordKey::from(&record.key),
+                usize::from(step.count) - 1
+            ))
+        } else {
+            (
+                    Err(GetRecordError::RecordNotFound),
+                    format!(
+                "Getting record task {query_id:?} completed with step count {:?}, but no copy found.",
+                step.count
+            ),
+                )
+        };
+
+        if expected_holders.is_empty() {
+            debug!("{log_string}");
+        } else {
+            debug!("{log_string}, and {expected_holders:?} expected holders not responded");
+        }
+
+        sender
+            .send(result)
+            .map_err(|_| Error::InternalMsgChannelDropped)?;
+
+        Ok(())
+    }
+
+    pub(crate) fn handle_get_record_error(
+        &mut self,
+        query_id: QueryId,
+        get_record_err: kad::GetRecordError,
+        stats: QueryStats,
+        step: ProgressStep,
+    ) -> Result<()> {
+        match &get_record_err {
+            kad::GetRecordError::NotFound { .. } => {}
+            kad::GetRecordError::QuorumFailed { .. } => {}
+            kad::GetRecordError::Timeout { key } => {
+                let pretty_key = PrettyPrintRecordKey::from(key);
+                let (sender, result_map, quorum, expected_holders) =
+                    self.pending_get_record.remove(&query_id).ok_or_else(|| {
+                        trace!(
+                            "Can't locate query task {query_id:?} for {pretty_key:?}, it has likely been completed already."
+                        );
+                        Error::ReceivedKademliaEventDropped( kad::Event::OutboundQueryProgressed {
+                            id: query_id,
+                            result: QueryResult::GetRecord(Err(get_record_err.clone())),
+                            stats,
+                            step,
+                        })
+                    })?;
+
+                let required_response_count = match quorum {
+                    Quorum::Majority => close_group_majority(),
+                    Quorum::All => CLOSE_GROUP_SIZE,
+                    Quorum::N(v) => v.into(),
+                    Quorum::One => 1,
+                };
+
+                // if we've a split over the result xorname, then we don't attempt to resolve this here.
+                // Retry and resolve through normal flows without a timeout.
+                if result_map.len() > 1 {
+                    warn!(
+                        "Get record task {query_id:?} for {pretty_key:?} timed out with split result map"
+                    );
+                    sender
+                        .send(Err(GetRecordError::QueryTimeout))
+                        .map_err(|_| Error::InternalMsgChannelDropped)?;
+
+                    return Ok(());
+                }
+
+                // if we have enough responses here, we can return the record
+                if let Some((record, peers)) = result_map.values().next() {
+                    if peers.len() >= required_response_count {
+                        sender
+                            .send(Ok(record.clone()))
+                            .map_err(|_| Error::InternalMsgChannelDropped)?;
+
+                        return Ok(());
+                    }
+                }
+
+                warn!("Get record task {query_id:?} for {pretty_key:?} returned insufficient responses. {expected_holders:?} did not return record");
+                // Otherwise report the timeout
+                sender
+                    .send(Err(GetRecordError::QueryTimeout))
+                    .map_err(|_| Error::InternalMsgChannelDropped)?;
+
+                return Ok(());
+            }
+        }
+
+        // return error if the entry cannot be found
+        let (sender, _, _, expected_holders) =
+            self.pending_get_record.remove(&query_id).ok_or_else(|| {
+                trace!(
+                    "Can't locate query task {query_id:?}, it has likely been completed already."
+                );
+                Error::ReceivedKademliaEventDropped(kad::Event::OutboundQueryProgressed {
+                    id: query_id,
+                    result: QueryResult::GetRecord(Err(get_record_err.clone())),
+                    stats,
+                    step,
+                })
+            })?;
+        if expected_holders.is_empty() {
+            info!("Get record task {query_id:?} failed with error {get_record_err:?}");
+        } else {
+            debug!("Get record task {query_id:?} failed with {expected_holders:?} expected holders not responded, error {get_record_err:?}");
+        }
+        sender
+            .send(Err(GetRecordError::RecordNotFound))
+            .map_err(|_| Error::InternalMsgChannelDropped)?;
+        Ok(())
+    }
+
+    // For chunk record which can be self-verifiable,
+    // complete the flow with the first copy that fetched.
+    // Return `true` if early completed, otherwise return `false`.
+    // Situations that can be early completed:
+    // 1, Not finding an entry within pending_get_record, i.e. no more further action required
+    // 2, For a `Chunk` that not required to verify expected holders,
+    //    whenever fetched a first copy that passed the self-verification.
+    fn try_early_completion_for_chunk(
+        &mut self,
+        query_id: &QueryId,
+        peer_record: &PeerRecord,
+    ) -> Result<bool> {
+        if let Entry::Occupied(mut entry) = self.pending_get_record.entry(*query_id) {
+            let (_, _, quorum, expected_holders) = entry.get_mut();
+
+            if expected_holders.is_empty() &&
+               RecordHeader::is_record_of_type_chunk(&peer_record.record).unwrap_or(false) &&
+               // Ensure that we only exit early if quorum is indeed for only one match
+               matches!(quorum, Quorum::One)
+            {
+                // Stop the query; possibly stops more nodes from being queried.
+                if let Some(mut query) = self.swarm.behaviour_mut().kademlia.query_mut(query_id) {
+                    query.finish();
+                }
+
+                // Stop tracking the query task by removing the entry and consume the sender.
+                let (sender, ..) = entry.remove();
+                // A claimed Chunk type record can be trusted.
+                // Punishment of peer that sending corrupted Chunk type record
+                // maybe carried out by other verification mechanism.
+                sender
+                    .send(Ok(peer_record.record.clone()))
+                    .map_err(|_| Error::InternalMsgChannelDropped)?;
+                return Ok(true);
+            }
+        } else {
+            // A non-existing pending entry does not need to undertake any further action.
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+}

--- a/sn_networking/src/get_record_handler.rs
+++ b/sn_networking/src/get_record_handler.rs
@@ -195,9 +195,9 @@ impl SwarmDriver {
                 .send(result)
                 .map_err(|_| Error::InternalMsgChannelDropped)?;
         } else {
-            // Should we return a ReceivedKademliaEventDropped here? We manually perform `query.finish()` if we return
-            // early from accumulate fn. So the kad query should not make any more progress? Logging it here for now.
-            warn!("Can't locate query task {query_id:?} during GetRecord finished.");
+            // We manually perform `query.finish()` if we return early from accumulate fn.
+            // Thus we will still get FinishedWithNoAdditionalRecord.
+            trace!("Can't locate query task {query_id:?} during GetRecord finished. We might have already returned the result to the sender.");
         }
         Ok(())
     }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -363,18 +363,16 @@ impl Network {
                     info!("Record returned: {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
                     return Ok(returned_record);
                 }
-                Err(GetRecordError::ReturnedRecordDoesNotMatch(returned_record)) => {
+                Err(GetRecordError::RecordDoesNotMatch(returned_record)) => {
                     warn!("The returned record does not match target {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
                     if retry_attempts >= total_attempts {
-                        return Err(
-                            GetRecordError::ReturnedRecordDoesNotMatch(returned_record).into()
-                        );
+                        return Err(GetRecordError::RecordDoesNotMatch(returned_record).into());
                     }
                 }
-                Err(GetRecordError::RecordNotEnoughCopies(returned_record)) => {
+                Err(GetRecordError::NotEnoughCopies(returned_record)) => {
                     warn!("Not enough copies found yet for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
                     if retry_attempts >= total_attempts {
-                        return Err(GetRecordError::RecordNotEnoughCopies(returned_record).into());
+                        return Err(GetRecordError::NotEnoughCopies(returned_record).into());
                     }
                 }
                 Err(GetRecordError::RecordNotFound) => {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -352,8 +352,7 @@ impl Network {
             self.send_swarm_cmd(SwarmCmd::GetNetworkRecord {
                 key: key.clone(),
                 sender,
-                quorum: cfg.get_quorum,
-                expected_holders: cfg.expected_holders.clone(),
+                cfg: cfg.clone(),
             })?;
 
             match receiver.await.map_err(|e| {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -15,6 +15,7 @@ mod cmd;
 mod driver;
 mod error;
 mod event;
+mod get_record_handler;
 #[cfg(feature = "open-metrics")]
 mod metrics;
 #[cfg(feature = "open-metrics")]


### PR DESCRIPTION
## Description
- Refactors the `get_record` re attempt code by moving the `target check` inside the kad event handling loop
- This is achieved by moving `GetRecordCfg` inside the SwarmDriver.
- Also removes early completion for chunks
	- This code exited early if the `RecordHeader::RecordKind` is found to be a chunk AND if `Quorum::One`. 
	- But we can mimic the same behavior by just setting the `Qourum::One` in the main code.
	- Thus, we can safely remove the extra code.
- Moves all the get record event handling code to its own file.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Dec 23 08:01 UTC
This pull request includes the following changes:

- In the `bootstrap.rs` file, a typo in the comment on line 24 has been corrected, changing "minumn" to "minimum".

- Changes related to handling errors and inconsistencies in retrieving and storing records from the network have been made. This includes an additional variant called `ReturnedRecordDoesNotMatch` in the `GetRecordError` enum, which now takes a `Record` parameter. The `ReturnedRecordDoesNotMatch` variant has also been removed from the `Error` enum. Additionally, the `ReturnedRecordDoesNotMatch` variant in the `GetRecordError` enum now includes a more detailed error message.

- In the `sn_networking` crate's `lib.rs` file, the following changes have been made:
  - A new module called `get_record_handler` has been added.
  - The `Quorum` and `RecordKey` imports from the `libp2p::kad` module have been removed.
  - The `RecordHeader` and `RecordKind` imports from the `sn_protocol` module have been removed.
  - The `impl Network` block has been updated with changes related to the handling of record retrieval attempts.

- In the code diff, there are various changes including import statement modifications, code reorganization, removal of unused type definition, and the addition of a new struct named `GetRecordCfg`. The `Debug` trait has also been implemented for the `GetRecordCfg` struct.

- The file diff includes changes to the `SwarmCmd` enum and its implementation. The import statement for `REPLICATE_RANGE` has been removed. The `GetNetworkRecord` variant of the `SwarmCmd` enum now includes a `cfg` field of type `GetRecordCfg` instead of `quorum` and `expected_holders` fields. The `Debug` implementation for the `SwarmCmd` enum has been updated accordingly. The `impl Debug for SwarmCmd` block has been updated to use the `{holder:?}` syntax for formatting the `holder` field in the `AddKeysToReplicationFetcher` variant and the `topic_id` field in the `GossipsubPublish` variant. The `GetNetworkRecord` match arm in the `impl SwarmDriver` block has been modified to use the `get_cfg` field instead of the `quorum` and `expected_holders` fields.

Please review the specific changes in the diff for more details.
<!-- reviewpad:summarize:end --> 
