### PR TITLE
refactor: take either SAFE_PEERS or --peer

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           action: start
           interval: 2000
+          join: true # Join the bootstrap node, set by the env var SAFE_PEERS
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ubuntu-latest

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           mkdir -p $BOOTSTRAP_NODE_DATA_PATH
           ./target/release/safenode \
-            --root-dir $BOOTSTRAP_NODE_DATA_PATH --log-output-dest $BOOTSTRAP_NODE_DATA_PATH --local &
+            --root-dir $BOOTSTRAP_NODE_DATA_PATH --log-output-dest $BOOTSTRAP_NODE_DATA_PATH --local --rpc=127.0.0.1:12001 &
           sleep 10
         env:
           SN_LOG: "all"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           action: start
           interval: 2000
+          node-count: 25
           join: true # Join the bootstrap node, set by the env var SAFE_PEERS
           node-path: target/release/safenode
           faucet-path: target/release/faucet

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           mkdir -p $BOOTSTRAP_NODE_DATA_PATH
           ./target/release/safenode \
-            --root-dir $BOOTSTRAP_NODE_DATA_PATH --log-output-dest $BOOTSTRAP_NODE_DATA_PATH --local --rpc=127.0.0.1:12001 &
+            --root-dir $BOOTSTRAP_NODE_DATA_PATH --log-output-dest $BOOTSTRAP_NODE_DATA_PATH --local &
           sleep 10
         env:
           SN_LOG: "all"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -65,7 +65,7 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
-          interval: 2000
+          interval: 5000
           node-count: 25
           join: true # Join the bootstrap node, set by the env var SAFE_PEERS
           node-path: target/release/safenode

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -39,7 +39,7 @@ pub struct PeersArgs {
     /// Peers can also be provided by an environment variable (see below), but the
     /// command-line argument (`--peer`) takes precedence. To pass multiple peers with the
     /// environment variable, separate them with commas.
-    #[clap(long = "peer", value_name = "multiaddr", value_delimiter = ',', value_parser = parse_peer_addr)]
+    #[clap(long = "peer", value_name = "multiaddr", env = SAFE_PEERS_ENV, value_delimiter = ',', value_parser = parse_peer_addr)]
     pub peers: Vec<Multiaddr>,
 
     /// Specify the URL to fetch the network contacts from.
@@ -73,16 +73,6 @@ pub async fn parse_peers_args(args: PeersArgs) -> Result<Vec<Multiaddr>> {
     } else {
         vec![]
     };
-
-    if let Ok(safe_peers_str) = std::env::var(SAFE_PEERS_ENV) {
-        let peers_str = safe_peers_str.split(',');
-        for peer_str in peers_str {
-            match parse_peer_addr(peer_str) {
-                Ok(safe_peer) => peers.push(safe_peer),
-                Err(_) => println!("Failed to parse safe_peer from {peer_str:?}"),
-            }
-        }
-    }
 
     if peers.is_empty() {
         let err_str = "No peers given, 'local-discovery' and 'network-contacts' feature flags are disabled. We cannot connect to the network.";

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -268,11 +268,7 @@ impl Testnet {
     /// * The node data directories cannot be created
     /// * The node process fails
     pub fn launch_nodes(&mut self, number_of_nodes: usize, node_args: &[String]) -> Result<()> {
-        let start = if self.node_count == 0 {
-            self.node_count + 2
-        } else {
-            self.node_count + 1
-        };
+        let start = self.node_count + 1;
         let end = self.node_count + number_of_nodes;
         for i in start..=end {
             info!("Launching node {i} of {end}...");

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -599,7 +599,7 @@ mod test {
         genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 2..=20 {
+        for i in 1..=20 {
             let rpc_port = 12000 + i;
             node_launcher
                 .expect_launch()
@@ -646,7 +646,7 @@ mod test {
         genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 2..=20 {
+        for i in 1..=20 {
             let rpc_port = 12000 + i;
             let graph_output_file_path = nodes_dir
                 .join(format!("safenode-{i}-flame.svg"))
@@ -703,7 +703,7 @@ mod test {
         genesis_node_dir.create_dir_all()?;
 
         let mut node_launcher = MockNodeLauncher::new();
-        for i in 2..=30 {
+        for i in 1..=30 {
             let rpc_port = 12000 + i;
             node_launcher
                 .expect_launch()

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -346,10 +346,12 @@ async fn run_network(
         .build()?;
 
     let gen_multi_addr = testnet.launch_genesis(node_args.clone()).await?;
+    // This will start additional nodes from the right RPC ports.
+    testnet.node_count += 1;
 
     node_args.push("--peer".to_string());
     node_args.push(gen_multi_addr.clone());
-    testnet.launch_nodes(node_count as usize, &node_args)?;
+    testnet.launch_nodes(node_count as usize - 1, &node_args)?;
 
     sn_testnet::check_testnet::run(&testnet.nodes_dir_path, node_count).await?;
 
@@ -366,9 +368,7 @@ fn join_network(
         .node_bin_path(node_bin_path)
         .node_launch_interval(node_launch_interval)
         .build()?;
-    // The testnet::node_count is set to total_count - 1 to offset for the genesis.
-    // Then plus 2 for start. Hence need an offset 1 here.
-    testnet.launch_nodes(node_count as usize + 1, node_args)?;
+    testnet.launch_nodes(node_count as usize, node_args)?;
     Ok(())
 }
 


### PR DESCRIPTION
This is the conventional way to set arguments in clap. However, the
churn test launched a genesis node, but also a testnet that includes a
'new' genesis node. The testnet would pass --peer for the 'new' node,
while we'd actually want our first genesis node to be used to bootstrap,
which is set in SAFE_PEERS.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Dec 23 15:58 UTC
This pull request includes a series of patches that make several changes to the codebase. Here is a summary of each patch:

1/7 - Refactors the code to allow either SAFE_PEERS or the --peer flag to be used for setting arguments in clap. This is done to handle a scenario where the testnet passes --peer for a new genesis node, but the first genesis node should be used for bootstrapping.

2/7 - Adds the node-count parameter to the memcheck workflow, setting it to 25.

3/7 - Enables the RPC on the genesis node in the memcheck workflow.

4/7 - Fixes a bug in the testnet where the number of nodes launched is not counted correctly.

5/7 - Fixes another bug in the testnet where the number of nodes launched is not counted correctly.

6/7 - Removes the RPC configuration from the genesis node in the memcheck workflow.

7/7 - Increases the interval for the memcheck testnet to 5 seconds.

Overall, these patches aim to improve the functionality and reliability of the codebase, particularly in the context of the memcheck workflow in a testnet environment.
<!-- reviewpad:summarize:end --> 
