### PR TITLE
fix(networking): use default DialCondition

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -81,8 +81,6 @@ const MAX_PACKET_SIZE: usize = 1024 * 1024 * 5; // the chunk size is 1mb, so sho
 
 // Timeout for requests sent/received through the request_response behaviour.
 const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(30);
-// Sets the keep-alive timeout of idle connections.
-const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The suffix is the version of the node.
 const SN_NODE_VERSION_STR: &str = concat!("safe/node/", env!("CARGO_PKG_VERSION"));
@@ -519,8 +517,7 @@ impl NetworkBuilder {
             autonat,
             gossipsub,
         };
-        let swarm_config = libp2p::swarm::Config::with_tokio_executor()
-            .with_idle_connection_timeout(CONNECTION_KEEP_ALIVE_TIMEOUT);
+        let swarm_config = libp2p::swarm::Config::with_tokio_executor();
 
         let swarm = Swarm::new(transport, behaviour, peer_id, swarm_config);
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -696,7 +696,7 @@ impl SwarmDriver {
         let opts = match peer_id {
             Some(peer_id) => DialOpts::peer_id(peer_id)
                 // If we have a peer ID, we can prevent simultaneous dials.
-                .condition(PeerCondition::NotDialing)
+                .condition(PeerCondition::Always)
                 .addresses(vec![addr])
                 .build(),
             None => DialOpts::unknown_peer_id().address(addr).build(),

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -98,6 +98,7 @@ pub async fn parse_peers_args(args: PeersArgs) -> Result<Vec<Multiaddr>> {
 }
 
 // should not be reachable, but needed for the compiler to be happy.
+#[allow(clippy::unused_async)]
 #[cfg(not(feature = "network-contacts"))]
 async fn get_network_contacts(_args: &PeersArgs) -> Result<Vec<Multiaddr>> {
     Ok(vec![])


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Dec 23 09:45 UTC
This pull request includes two patches. 

The first patch fixes a networking issue by changing the code to use the default DialCondition when determining peer connections. This simplifies the code and avoids potential errors. 

The second patch updates the code to remove non-default KEEP_ALIVE settings. This change removes the connection keep-alive timeout, resulting in improved performance and stability.

Overall, these patches improve the networking functionality and optimize the code.
<!-- reviewpad:summarize:end --> 
