### PR TITLE
feat: close outdated connections to non-RT peers

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -453,8 +453,6 @@ impl NetworkBuilder {
         let gossipsub = if self.enable_gossip {
             // Gossipsub behaviour
             let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
-                // disable sending to ALL_PEERS subscribed to a topic, which is the default behaviour
-                .flood_publish(false)
                 // we don't currently require source peer id and/or signing
                 .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
                 // we use the hash of the msg content as the msg id to deduplicate them
@@ -467,6 +465,10 @@ impl NetworkBuilder {
                 })
                 // set the heartbeat interval to be higher than default 1sec
                 .heartbeat_interval(Duration::from_secs(5))
+                // default is 3sec, increase to 10sec to avoid false alert
+                .iwant_followup_time(Duration::from_secs(10))
+                // default is 10sec, increase to 60sec to reduce the risk of looping
+                .published_message_ids_cache_time(Duration::from_secs(60))
                 .build()
                 .map_err(|err| Error::GossipsubConfigError(err.to_string()))?;
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -41,7 +41,7 @@ use libp2p::{
     swarm::{
         behaviour::toggle::Toggle,
         dial_opts::{DialOpts, PeerCondition},
-        DialError, NetworkBehaviour, StreamProtocol, Swarm,
+        ConnectionId, DialError, NetworkBehaviour, StreamProtocol, Swarm,
     },
     Multiaddr, PeerId, Transport,
 };
@@ -58,7 +58,7 @@ use std::{
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tiny_keccak::{Hasher, Sha3};
 use tokio::sync::{mpsc, oneshot};
@@ -547,6 +547,7 @@ impl NetworkBuilder {
             is_gossip_handler: false,
             network_discovery: NetworkDiscovery::new(&peer_id),
             bootstrap_peers: Default::default(),
+            live_connected_peers: Default::default(),
         };
 
         Ok((
@@ -593,6 +594,9 @@ pub struct SwarmDriver {
     // This is to ensure a more accurate network discovery.
     pub(crate) network_discovery: NetworkDiscovery,
     pub(crate) bootstrap_peers: BTreeMap<Option<u32>, HashSet<PeerId>>,
+    // Peers that having live connection to. Any peer got contacted during kad network query
+    // will have live connection established. And they may not appear in the RT.
+    pub(crate) live_connected_peers: BTreeMap<ConnectionId, (PeerId, Instant)>,
 }
 
 impl SwarmDriver {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -42,8 +42,9 @@ use tokio::{
 /// serialised transfer info encrypted against the referenced public key.
 pub const ROYALTY_TRANSFER_NOTIF_TOPIC: &str = "ROYALTY_TRANSFER_NOTIFICATION";
 
-/// Defines the percentage (ie 1/FORWARDER_CHOOSING_FACTOR th of all nodes) of nodes which will act as royalty_transfer_notify forwarder.
-const FORWARDER_CHOOSING_FACTOR: usize = 50;
+/// Defines the percentage (ie 1/FORWARDER_CHOOSING_FACTOR th of all nodes) of nodes
+/// which will act as royalty_transfer_notify forwarder.
+const FORWARDER_CHOOSING_FACTOR: usize = 10;
 
 /// Interval to trigger replication of all records to all peers.
 /// This is the max time it should take. Minimum interval at any ndoe will be half this


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Dec 23 11:32 UTC
This pull request includes two patches. 

The first patch adds a new feature to close outdated connections to non-RT (real-time) peers. It introduces a new data structure `live_connected_peers` to keep track of peers that have a live connection. It also implements a method `remove_outdated_connections` to remove outdated connections to peers that are not present in the RT (routing table). This ensures that connections to non-RT peers are closed in a timely manner.

The second patch includes changes related to the Gossipsub behavior. It modifies the configuration of Gossipsub to avoid message loops. It sets the `iwant_followup_time` to 10 seconds and the `published_message_ids_cache_time` to 120 seconds. These changes increase the intervals at which certain actions are triggered, reducing the risk of message looping.

These patches improve the networking behavior and stability of the system.
<!-- reviewpad:summarize:end --> 
