### PR TITLE
fix(network): implement custom Debug for GetRecordError

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -17,6 +17,7 @@ use sn_protocol::{messages::Response, storage::RecordKind, PrettyPrintRecordKey}
 use sn_transfers::{SignedSpend, SpendAddress};
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Debug,
     io,
     path::PathBuf,
 };
@@ -27,7 +28,7 @@ use xor_name::XorName;
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// GetRecord Query errors
-#[derive(Debug, Error)]
+#[derive(Error)]
 #[allow(missing_docs)]
 pub enum GetRecordError {
     #[error("Get Record completed with non enough copies")]
@@ -47,6 +48,29 @@ pub enum GetRecordError {
 
     #[error("Record retrieved from the network does not match the provided target record.")]
     RecordDoesNotMatch(Record),
+}
+
+impl Debug for GetRecordError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotEnoughCopies(record) => {
+                let pretty_key = PrettyPrintRecordKey::from(&record.key);
+                f.debug_tuple("NotEnoughCopies").field(&pretty_key).finish()
+            }
+            Self::RecordNotFound => write!(f, "RecordNotFound"),
+            Self::SplitRecord { result_map } => f
+                .debug_struct("SplitRecord")
+                .field("result_map count", &result_map.len())
+                .finish(),
+            Self::QueryTimeout => write!(f, "QueryTimeout"),
+            Self::RecordDoesNotMatch(record) => {
+                let pretty_key = PrettyPrintRecordKey::from(&record.key);
+                f.debug_tuple("RecordDoesNotMatch")
+                    .field(&pretty_key)
+                    .finish()
+            }
+        }
+    }
 }
 
 /// Network Errors


### PR DESCRIPTION
## Description
- We were printing the whole record

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Dec 23 14:27 UTC
This pull request fixes the implementation of custom Debug for GetRecordError in the sn_networking module. It adds the fmt::Debug trait for the GetRecordError enum and implements the fmt method to format the debug output. The implementation includes handling different variants of the enum and printing relevant information for each variant. Overall, this patch improves the debug output for GetRecordError.
<!-- reviewpad:summarize:end --> 
