### PR TITLE
feat: use hash based record verification for chunks

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -325,7 +325,7 @@ jobs:
           echo "Total swarm_driver long handling duration is: $total_long_handling ms"
           echo "Total average swarm_driver long handling duration is: $average_handling_ms ms"
           total_num_of_times_limit_hits="10000" # hits
-          total_long_handling_limit_ms="150000" # ms
+          total_long_handling_limit_ms="170000" # ms
           average_handling_limit_ms="20" # ms
           if (( $(echo "$total_num_of_times > $total_num_of_times_limit_hits" | bc -l) )); then
             echo "Swarm_driver long handling times exceeded threshold: $total_num_of_times hits"

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Start a client to upload files
         run: |
           ls -l
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders -r 0
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" -r 0
         env:
           SN_LOG: "all"
         timeout-minutes: 25
@@ -120,7 +120,7 @@ jobs:
           cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex
           cat transfer_hex
           cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data_1.zip" --show-holders -r 0 > second_upload.txt
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data_1.zip" -r 0 > second_upload.txt
           cat second_upload.txt
           rg "New wallet balance: 5000000.000000000" second_upload.txt -c --stats
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ dependencies = [
  "sn_registers",
  "sn_transfers",
  "thiserror",
+ "tiny-keccak",
  "tonic 0.6.2",
  "tonic-build",
  "tracing",

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -48,10 +48,6 @@ pub enum FilesCmds {
         /// during payment and upload processing.
         #[clap(long, default_value_t = BATCH_SIZE, short='b')]
         batch_size: usize,
-        /// Flagging whether to show the holders of the uploaded chunks.
-        /// Default to be not showing.
-        #[clap(long, name = "show_holders", default_value = "false")]
-        show_holders: bool,
         /// The retry_count for retrying failed chunks
         /// during payment and upload processing.
         #[clap(long, default_value_t = MAX_UPLOAD_RETRIES, short = 'r')]
@@ -92,7 +88,6 @@ pub(crate) async fn files_cmds(
         FilesCmds::Upload {
             path,
             batch_size,
-            show_holders,
             max_retries,
         } => {
             upload_files(
@@ -101,7 +96,6 @@ pub(crate) async fn files_cmds(
                 root_dir.to_path_buf(),
                 verify_store,
                 batch_size,
-                show_holders,
                 max_retries,
             )
             .await?
@@ -162,7 +156,6 @@ async fn upload_files(
     root_dir: PathBuf,
     verify_store: bool,
     batch_size: usize,
-    show_holders: bool,
     max_retries: usize,
 ) -> Result<()> {
     debug!("Uploading file(s) from {files_path:?}, batch size {batch_size:?} will verify?: {verify_store}");
@@ -227,7 +220,6 @@ async fn upload_files(
     let mut files = Files::new(files_api)
         .set_batch_size(batch_size)
         .set_verify_store(verify_store)
-        .set_show_holders(show_holders)
         .set_max_retries(max_retries);
     let mut upload_event_rx = files.get_upload_events();
     // keep track of the progress in a separate task

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -468,7 +468,8 @@ impl Client {
     }
 
     /// Verify if a `Chunk` is stored by expected nodes on the network.
-    pub async fn verify_chunk_stored(&self, address: NetworkAddress, chunk: &Chunk) -> Result<()> {
+    pub async fn verify_chunk_stored(&self, chunk: &Chunk) -> Result<()> {
+        let address = chunk.network_address();
         info!("Verifying chunk: {address:?}");
         let random_nonce = thread_rng().gen::<u64>();
         let record_value = try_serialize_record(&chunk, RecordKind::Chunk)?;
@@ -693,9 +694,7 @@ impl Client {
                 let handle = tokio::spawn(async move {
                     // make sure the chunk is stored;
                     let chunk = Chunk::new(Bytes::from(std::fs::read(&chunk_path)?));
-                    let res = client
-                        .verify_chunk_stored(chunk.network_address(), &chunk)
-                        .await;
+                    let res = client.verify_chunk_stored(&chunk).await;
 
                     Ok::<_, ChunksError>(((name, chunk_path), res.is_err()))
                 });

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -383,7 +383,6 @@ impl Client {
         chunk: Chunk,
         payment: Payment,
         verify_store: bool,
-        _show_holders: bool, // The holders are logged during ChunkProof verification by default. Todo: remove?
     ) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());
         let key = chunk.network_address().to_record_key();

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -25,7 +25,7 @@ use prometheus_client::registry::Registry;
 use rand::{thread_rng, Rng};
 use sn_networking::{
     multiaddr_is_global, Error as NetworkError, GetRecordCfg, GetRecordError, NetworkBuilder,
-    NetworkEvent, PutRecordCfg, CLOSE_GROUP_SIZE,
+    NetworkEvent, PutRecordCfg, VerificationKind, CLOSE_GROUP_SIZE,
 };
 use sn_protocol::{
     error::Error as ProtocolError,
@@ -408,7 +408,18 @@ impl Client {
             // The `ChunkWithPayment` is only used to send out via PutRecord.
             // The holders shall only hold the `Chunk` copies.
             // Hence the fetched copies shall only be a `Chunk`
-            Some((RecordKind::Chunk, verification_cfg))
+
+            let stored_on_node = try_serialize_record(&chunk, RecordKind::Chunk)?.to_vec();
+            let random_nonce = thread_rng().gen::<u64>();
+            let expected_proof = ChunkProof::new(&stored_on_node, random_nonce);
+
+            Some((
+                VerificationKind::ChunkProof {
+                    expected_proof,
+                    nonce: random_nonce,
+                },
+                verification_cfg,
+            ))
         } else {
             None
         };
@@ -466,7 +477,7 @@ impl Client {
         if let Err(err) = self
             .network
             .verify_chunk_existence(
-                &address,
+                address.clone(),
                 random_nonce,
                 expected_proof,
                 Quorum::N(NonZeroUsize::new(2).ok_or(Error::NonZeroUsizeWasInitialisedAsZero)?),
@@ -528,7 +539,7 @@ impl Client {
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::All,
             re_attempt: true,
-            verification: Some((record_kind, verification_cfg)),
+            verification: Some((VerificationKind::Network, verification_cfg)),
         };
         Ok(self.network.put_record(record, &put_cfg).await?)
     }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -383,7 +383,7 @@ impl Client {
         chunk: Chunk,
         payment: Payment,
         verify_store: bool,
-        _show_holders: bool,
+        _show_holders: bool, // The holders are logged during ChunkProof verification by default. Todo: remove?
     ) -> Result<()> {
         info!("Store chunk: {:?}", chunk.address());
         let key = chunk.network_address().to_record_key();
@@ -396,18 +396,29 @@ impl Client {
             expires: None,
         };
 
+        let verification = if verify_store {
+            let verification_cfg = GetRecordCfg {
+                get_quorum: Quorum::N(
+                    NonZeroUsize::new(2).ok_or(Error::NonZeroUsizeWasInitialisedAsZero)?,
+                ),
+                re_attempt: true,
+                target_record: None, // Not used since we use ChunkProof
+                expected_holders: Default::default(),
+            };
+            // The `ChunkWithPayment` is only used to send out via PutRecord.
+            // The holders shall only hold the `Chunk` copies.
+            // Hence the fetched copies shall only be a `Chunk`
+            Some((RecordKind::Chunk, verification_cfg))
+        } else {
+            None
+        };
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::One,
             re_attempt: true,
-            verification: None,
+            verification,
         };
         self.network.put_record(record, &put_cfg).await?;
 
-        if verify_store {
-            tokio::time::sleep(Duration::from_millis(1500)).await;
-            self.verify_chunk_stored(chunk.network_address(), &chunk)
-                .await?;
-        }
         Ok(())
     }
 
@@ -455,7 +466,8 @@ impl Client {
         if let Err(err) = self
             .network
             .verify_chunk_existence(
-                (&address, random_nonce),
+                &address,
+                random_nonce,
                 expected_proof,
                 Quorum::N(NonZeroUsize::new(2).ok_or(Error::NonZeroUsizeWasInitialisedAsZero)?),
                 false,

--- a/sn_client/src/files/api.rs
+++ b/sn_client/src/files/api.rs
@@ -158,7 +158,6 @@ impl FilesApi {
         &self,
         chunk: Chunk,
         verify_store: bool,
-        show_holders: bool,
     ) -> Result<()> {
         let chunk_addr = chunk.network_address();
         trace!("Client upload started for chunk: {chunk_addr:?}");
@@ -172,7 +171,7 @@ impl FilesApi {
         );
 
         self.client
-            .store_chunk(chunk, payment, verify_store, show_holders)
+            .store_chunk(chunk, payment, verify_store)
             .await?;
 
         trace!("Client upload completed for chunk: {chunk_addr:?}");
@@ -219,7 +218,7 @@ impl FilesApi {
 
         for (_chunk_name, chunk_path) in chunks_paths {
             let chunk = Chunk::new(Bytes::from(fs::read(chunk_path)?));
-            self.get_local_payment_and_upload_chunk(chunk, verify, false)
+            self.get_local_payment_and_upload_chunk(chunk, verify)
                 .await?;
         }
 

--- a/sn_client/src/files/mod.rs
+++ b/sn_client/src/files/mod.rs
@@ -321,15 +321,9 @@ impl Files {
         for chunk_info in chunks_to_upload.into_iter() {
             let files_api = self.api.clone();
             let verify_store = self.verify_store;
-            let show_holders = self.show_holders;
 
             // Spawn a task for each chunk to be uploaded
-            let handle = tokio::spawn(Self::upload_chunk(
-                files_api,
-                chunk_info,
-                verify_store,
-                show_holders,
-            ));
+            let handle = tokio::spawn(Self::upload_chunk(files_api, chunk_info, verify_store));
             self.progress_uploading_chunks(false).await?;
 
             self.uploading_chunks.push(handle);
@@ -386,7 +380,6 @@ impl Files {
         files_api: FilesApi,
         chunk_info: ChunkInfo,
         verify_store: bool,
-        show_holders: bool,
     ) -> (ChunkInfo, Result<()>) {
         let chunk_address = ChunkAddress::new(chunk_info.name);
         let bytes = match tokio::fs::read(chunk_info.path.clone()).await {
@@ -400,7 +393,7 @@ impl Files {
         };
         let chunk = Chunk::new(bytes);
         match files_api
-            .get_local_payment_and_upload_chunk(chunk, verify_store, show_holders)
+            .get_local_payment_and_upload_chunk(chunk, verify_store)
             .await
         {
             Ok(()) => (chunk_info, Ok(())),

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -10,7 +10,7 @@ use crate::{Client, Error, Result, WalletClient};
 
 use bls::PublicKey;
 use libp2p::kad::{Quorum, Record};
-use sn_networking::{GetRecordCfg, PutRecordCfg};
+use sn_networking::{GetRecordCfg, PutRecordCfg, VerificationKind};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::RegisterCmd,
@@ -398,7 +398,7 @@ impl ClientRegister {
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::All,
             re_attempt: true,
-            verification: Some((RecordKind::Register, verification_cfg)),
+            verification: Some((VerificationKind::Network, verification_cfg)),
         };
 
         // Register edits might exist so we cannot be sure that just because we get a record back that this should fail

--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -31,7 +31,6 @@ use tracing::{debug, error, trace};
 ///
 /// # balance should be updated
 /// ```
-
 pub async fn run_faucet_server(client: &Client) -> Result<()> {
     let server =
         Server::http("0.0.0.0:8000").map_err(|err| eyre!("Failed to start server: {err}"))?;

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -48,8 +48,7 @@ use libp2p::{
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
 use sn_protocol::{
-    messages::{Request, Response},
-    storage::RecordKind,
+    messages::{ChunkProof, Nonce, Request, Response},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use std::{
@@ -159,8 +158,20 @@ pub struct PutRecordCfg {
     pub put_quorum: Quorum,
     /// If set to true, we retry upto PUT_RETRY_ATTEMPTS times
     pub re_attempt: bool,
-    /// Enables verification after writing. The RecordKind is used to determine the verification delay.
-    pub verification: Option<(RecordKind, GetRecordCfg)>,
+    /// Enables verification after writing. The VerificationKind is used to determine the method to use.
+    pub verification: Option<(VerificationKind, GetRecordCfg)>,
+}
+
+/// The methods in which verification on a PUT can be carried out.
+#[derive(Debug, Clone)]
+pub enum VerificationKind {
+    /// Uses the default KAD GET to perform verification.
+    Network,
+    /// Uses the hash based verification for chunks.
+    ChunkProof {
+        expected_proof: ChunkProof,
+        nonce: Nonce,
+    },
 }
 
 /// NodeBehaviour struct

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -13,7 +13,7 @@ use libp2p::{
     swarm::DialError,
     PeerId, TransportError,
 };
-use sn_protocol::{messages::Response, storage::RecordKind, PrettyPrintRecordKey};
+use sn_protocol::{messages::Response, storage::RecordKind, NetworkAddress, PrettyPrintRecordKey};
 use sn_transfers::{SignedSpend, SpendAddress};
 use std::{
     collections::{HashMap, HashSet},
@@ -128,6 +128,10 @@ pub enum Error {
 
     #[error("Transfer is invalid: {0}")]
     InvalidTransfer(String),
+
+    // ---------- Chunk Errors
+    #[error("Failed to verify the ChunkProof with the provided quorum")]
+    FailedToVerifyChunkProof(NetworkAddress),
 
     // ---------- Spend Errors
     #[error("Spend not found: {0:?}")]

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -28,7 +28,7 @@ mod transfers;
 
 pub use self::{
     cmd::SwarmLocalState,
-    driver::{GetRecordCfg, NetworkBuilder, PutRecordCfg, SwarmDriver},
+    driver::{GetRecordCfg, NetworkBuilder, PutRecordCfg, SwarmDriver, VerificationKind},
     error::{Error, GetRecordError},
     event::{MsgResponder, NetworkEvent},
     record_store::NodeRecordStore,
@@ -45,14 +45,11 @@ use libp2p::{
     multiaddr::Protocol,
     Multiaddr, PeerId,
 };
-use rand::{
-    thread_rng,
-    {seq::SliceRandom, Rng},
-};
+use rand::{seq::SliceRandom, Rng};
 use sn_protocol::{
     error::Error as ProtocolError,
     messages::{ChunkProof, Nonce, Query, QueryResponse, Request, Response},
-    storage::{RecordKind, RecordType},
+    storage::RecordType,
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
 use sn_transfers::{MainPubkey, NanoTokens, PaymentQuote};
@@ -263,7 +260,7 @@ impl Network {
     /// Get the Chunk existence proof from the close nodes to the provided chunk address.
     pub async fn verify_chunk_existence(
         &self,
-        chunk_address: &NetworkAddress,
+        chunk_address: NetworkAddress,
         nonce: Nonce,
         expected_proof: ChunkProof,
         quorum: Quorum,
@@ -288,7 +285,7 @@ impl Network {
             // The close_nodes don't change often and the previous set of close_nodes might be taking a while to write
             // the Chunk, so query them again incase of a failure.
             if retry_attempts % 2 == 0 {
-                close_nodes = self.get_closest_peers(chunk_address, true).await?;
+                close_nodes = self.get_closest_peers(&chunk_address, true).await?;
             }
             let request = Request::Query(Query::GetChunkExistenceProof {
                 key: chunk_address.clone(),
@@ -299,16 +296,19 @@ impl Network {
                 .await;
             let n_verified = responses
                 .into_iter()
-                .filter_map(|(_, resp)| {
+                .filter_map(|(peer, resp)| {
                     if let Ok(Response::Query(QueryResponse::GetChunkExistenceProof(Ok(proof)))) =
                         resp
                     {
                         if expected_proof.verify(&proof) {
+                            debug!("Got a valid ChunkProof from {peer:?}");
                             Some(())
                         } else {
+                            warn!("Failed to verify the ChunkProof from {peer:?}. The chunk might have been tampered?");
                             None
                         }
                     } else {
+                        debug!("Did not get a valid response for the ChunkProof from {peer:?}");
                         None
                     }
                 })
@@ -318,7 +318,7 @@ impl Network {
             if n_verified >= expected_n_verified {
                 return Ok(());
             }
-            debug!("The obtained {n_verified} verified proofs did not match the expected {expected_n_verified} verified proofs");
+            warn!("The obtained {n_verified} verified proofs did not match the expected {expected_n_verified} verified proofs");
         }
 
         Err(Error::FailedToVerifyChunkProof(chunk_address.clone()))
@@ -534,7 +534,7 @@ impl Network {
         })?;
         let response = receiver.await?;
 
-        if let Some((record_kind, get_cfg)) = &cfg.verification {
+        if let Some((verification_kind, get_cfg)) = &cfg.verification {
             // Generate a random duration between MAX_WAIT_BEFORE_READING_A_PUT and MIN_WAIT_BEFORE_READING_A_PUT
             let wait_duration = rand::thread_rng()
                 .gen_range(MIN_WAIT_BEFORE_READING_A_PUT..MAX_WAIT_BEFORE_READING_A_PUT);
@@ -544,16 +544,15 @@ impl Network {
             debug!("Attempting to verify {pretty_key:?} after we've slept for {wait_duration:?}");
 
             // Verify the record is stored, requiring re-attempts
-            if let RecordKind::Chunk = record_kind {
-                // use ChunkProof when we are trying to verify a Chunk
-                let address = NetworkAddress::from_record_key(&record_key);
-                let random_nonce = thread_rng().gen::<u64>();
-
-                let expected_proof = ChunkProof::new(&record.value, random_nonce);
+            if let VerificationKind::ChunkProof {
+                expected_proof,
+                nonce,
+            } = verification_kind
+            {
                 self.verify_chunk_existence(
-                    &address,
-                    random_nonce,
-                    expected_proof,
+                    NetworkAddress::from_record_key(&record_key),
+                    *nonce,
+                    expected_proof.clone(),
                     get_cfg.get_quorum,
                     get_cfg.re_attempt,
                 )

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -48,7 +48,7 @@ use libp2p::{
 use rand::{seq::SliceRandom, Rng};
 use sn_protocol::{
     error::Error as ProtocolError,
-    messages::{Query, QueryResponse, Request, Response},
+    messages::{ChunkProof, Nonce, Query, QueryResponse, Request, Response},
     storage::RecordType,
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
@@ -59,7 +59,6 @@ use std::{
     time::Duration,
 };
 use tokio::sync::{mpsc, oneshot};
-use tracing::warn;
 
 /// The maximum number of peers to return in a `GetClosestPeers` response.
 /// This is the group size used in safe network protocol to be responsible for
@@ -86,10 +85,12 @@ const MAX_GET_RETRY_DURATION: Duration = Duration::from_millis(MAX_GET_RETRY_DUR
 /// Max duration for all PUT attempts
 const MAX_PUT_RETRY_DURATION: Duration = Duration::from_millis(MAX_GET_RETRY_DURATION_MS * 3);
 
-/// Max duration to wait for verification
-const MAX_REVERIFICATION_WAIT_TIME_MS: Duration = Duration::from_millis(750);
+/// Max duration to wait for verification.
+const MAX_WAIT_BEFORE_READING_A_PUT: Duration = Duration::from_millis(750);
 /// Min duration to wait for verification
-const MIN_REVERIFICATION_WAIT_TIME_MS: Duration = Duration::from_millis(300);
+const MIN_WAIT_BEFORE_READING_A_PUT: Duration = Duration::from_millis(300);
+/// Number of attempts to get a ChunkProof
+const GET_CHUNK_PROOF_RETRY_ATTEMPTS: usize = 3;
 
 /// Sort the provided peers by their distance to the given `NetworkAddress`.
 /// Return with the closest expected number of entries if has.
@@ -256,6 +257,70 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)
     }
 
+    /// Get the Chunk existence proof from the close nodes to the provided chunk address.
+    pub async fn verify_chunk_existence(
+        &self,
+        (chunk_address, nonce): (&NetworkAddress, Nonce),
+        expected_proof: ChunkProof,
+        quorum: Quorum,
+        re_attempt: bool,
+    ) -> Result<()> {
+        let total_attempts = if re_attempt {
+            GET_CHUNK_PROOF_RETRY_ATTEMPTS
+        } else {
+            1
+        };
+        let pretty_key = PrettyPrintRecordKey::from(&chunk_address.to_record_key()).into_owned();
+        let expected_n_verified = get_quorum_value(&quorum);
+
+        let mut close_nodes = Vec::new();
+        let mut retry_attempts = 0;
+        while retry_attempts < total_attempts {
+            retry_attempts += 1;
+            info!(
+                "Getting ChunkProof for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}",
+            );
+            // Do not query the closest_peers during every re-try attempt.
+            // The close_nodes don't change often and the previous set of close_nodes might be taking a while to write
+            // the Chunk, so query them again incase of a failure.
+            if retry_attempts % 2 == 0 {
+                close_nodes = self.get_closest_peers(chunk_address, true).await?;
+            }
+            let request = Request::Query(Query::GetChunkExistenceProof {
+                key: chunk_address.clone(),
+                nonce,
+            });
+            let responses = self
+                .send_and_get_responses(&close_nodes, &request, true)
+                .await;
+            let n_verified = responses
+                .into_iter()
+                .filter_map(|(_, resp)| {
+                    if let Ok(Response::Query(QueryResponse::GetChunkExistenceProof(Ok(proof)))) =
+                        resp
+                    {
+                        if expected_proof.verify(&proof) {
+                            Some(())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .count();
+            debug!("Got {n_verified} verified chunk existence proofs for chunk_address {chunk_address:?}");
+
+            if n_verified >= expected_n_verified {
+                return Ok(());
+            }
+            debug!("The obtained {n_verified} verified proofs did not match the expected {expected_n_verified} verified proofs");
+        }
+
+        Err(Error::FailedToVerifyChunkProof(chunk_address.clone()))
+    }
+
+    /// Get the store costs from the majority of the closest peers to the provided RecordKey.
     pub async fn get_store_costs_from_network(
         &self,
         record_address: NetworkAddress,
@@ -266,7 +331,7 @@ impl Network {
 
         let request = Request::Query(Query::GetStoreCost(record_address.clone()));
         let responses = self
-            .send_and_get_responses(close_nodes, &request, true)
+            .send_and_get_responses(&close_nodes, &request, true)
             .await;
 
         // loop over responses, generating an average fee and storing all responses along side
@@ -466,9 +531,9 @@ impl Network {
         let response = receiver.await?;
 
         if let Some((_record_kind, get_cfg)) = &cfg.verification {
-            // Generate a random duration between MAX_REVERIFICATION_WAIT_TIME_S and MIN_REVERIFICATION_WAIT_TIME_S
+            // Generate a random duration between MAX_WAIT_BEFORE_READING_A_PUT and MIN_WAIT_BEFORE_READING_A_PUT
             let wait_duration = rand::thread_rng()
-                .gen_range(MIN_REVERIFICATION_WAIT_TIME_MS..MAX_REVERIFICATION_WAIT_TIME_MS);
+                .gen_range(MIN_WAIT_BEFORE_READING_A_PUT..MAX_WAIT_BEFORE_READING_A_PUT);
             // Small wait before we attempt to verify.
             // There will be `re-attempts` to be carried out within the later step anyway.
             tokio::time::sleep(wait_duration).await;
@@ -665,7 +730,7 @@ impl Network {
     /// If `get_all_responses` is false, we return the first successful response that we get
     pub async fn send_and_get_responses(
         &self,
-        peers: Vec<PeerId>,
+        peers: &[PeerId],
         req: &Request,
         get_all_responses: bool,
     ) -> BTreeMap<PeerId, Result<Response>> {

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -177,7 +177,7 @@ impl Network {
                 }
                 let self_clone = self.clone();
                 let addr = SpendAddress::from_unique_pubkey(input_key);
-                let _ = tasks.spawn(async move { self_clone.get_spend(addr, false).await });
+                let _ = tasks.spawn(async move { self_clone.get_spend(addr).await });
             }
             while let Some(result) = tasks.join_next().await {
                 let signed_spend = result

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -512,7 +512,12 @@ impl Node {
                 let mut result = Err(ProtocolError::ChunkDoesNotExist(key.clone()));
                 if let Ok(Some(record)) = network.get_local_record(&key.to_record_key()).await {
                     let proof = ChunkProof::new(&record.value, nonce);
+                    trace!("Chunk proof for {key:?} is {proof:?}");
                     result = Ok(proof)
+                } else {
+                    trace!(
+                        "Could not get ChunkProof for {key:?} as we don't have the record locally."
+                    );
                 }
 
                 QueryResponse::GetChunkExistenceProof(result)

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -720,11 +720,7 @@ impl Node {
                             "Checking parent input at {:?} - {parent_cash_note_address:?}",
                             parent_input.unique_pubkey(),
                         );
-                        let parent = match self
-                            .network
-                            .get_spend(parent_cash_note_address, false)
-                            .await
-                        {
+                        let parent = match self.network.get_spend(parent_cash_note_address).await {
                             Ok(parent) => parent,
                             Err(err) => {
                                 error!("Error while getting parent spend {parent_cash_note_address:?} for cash_note addr {cash_note_addr:?}: {err:?}");
@@ -747,7 +743,7 @@ impl Node {
 
                 // check the network if any spend has happened for the same unique_pubkey
                 debug!("Check if any spend exist for the same unique_pubkey {cash_note_addr:?}");
-                let mut spends = match self.network.get_spend(cash_note_addr, false).await {
+                let mut spends = match self.network.get_spend(cash_note_addr).await {
                     Ok(spend) => {
                         debug!("Got spend from network for the same unique_pubkey");
                         vec![spend]

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -6,16 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::error::Result;
-use crate::node::Node;
-use libp2p::kad::Quorum;
+use crate::{error::Result, node::Node};
 use libp2p::{
-    kad::{Record, RecordKey},
+    kad::{Quorum, Record, RecordKey},
     PeerId,
 };
-use sn_networking::{
-    sort_peers_by_address, GetRecordCfg, Network, CLOSE_GROUP_SIZE, REPLICATE_RANGE,
-};
+use sn_networking::{sort_peers_by_address, GetRecordCfg, Network, REPLICATE_RANGE};
 use sn_protocol::{
     messages::{Cmd, Query, QueryResponse, Request, Response},
     storage::RecordType,
@@ -201,7 +197,7 @@ impl Node {
             let sorted_based_on_addr = match sort_peers_by_address(
                 &closest_k_peers,
                 &data_addr,
-                CLOSE_GROUP_SIZE,
+                REPLICATE_RANGE,
             ) {
                 Ok(result) => result,
                 Err(err) => {

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -28,6 +28,7 @@ sha2 = "0.10.7"
 sn_transfers = { path = "../sn_transfers", version = "0.14.31" }
 sn_registers = { path = "../sn_registers", version = "0.3.6" }
 thiserror = "1.0.23"
+tiny-keccak = { version = "~2.0.2", features = [ "sha3" ] }
 tracing = { version = "~0.1.26" }
 # # watch out updating this, protoc compiler needs to be installed on all build systems
 # # arm builds + musl are very problematic

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -17,6 +17,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Error, Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 #[non_exhaustive]
 pub enum Error {
+    // ---------- Chunk Proof errors
+    #[error("Chunk does not exist {0:?}")]
+    ChunkDoesNotExist(NetworkAddress),
+
     // ---------- Register Errors
     #[error("Register not found: {0}")]
     RegisterNotFound(Box<RegisterAddress>),

--- a/sn_protocol/src/messages/chunk_proof.rs
+++ b/sn_protocol/src/messages/chunk_proof.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// The nonce provided by the verifier
+pub type Nonce = u64;
+
+/// The hash(record_value + nonce) that is used to prove the existence of a chunk
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ChunkProof([u8; 32]);
+
+impl ChunkProof {
+    pub fn new(record_value: &[u8], nonce: Nonce) -> Self {
+        let nonce_bytes = nonce.to_be_bytes();
+        let combined = [record_value, &nonce_bytes].concat();
+        let hash = sha3_256(&combined);
+        ChunkProof(hash)
+    }
+
+    pub fn verify(&self, other_proof: &ChunkProof) -> bool {
+        self.0 == other_proof.0
+    }
+
+    /// Serialize this `ChunkProof` instance to a hex string.
+    fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+fn sha3_256(input: &[u8]) -> [u8; 32] {
+    use tiny_keccak::{Hasher, Sha3};
+
+    let mut sha3 = Sha3::v256();
+    let mut output = [0; 32];
+    sha3.update(input);
+    sha3.finalize(&mut output);
+    output
+}
+
+impl fmt::Debug for ChunkProof {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ChunkProof").field(&self.to_hex()).finish()
+    }
+}

--- a/sn_protocol/src/messages/mod.rs
+++ b/sn_protocol/src/messages/mod.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 //! Data messages and their possible responses.
+mod chunk_proof;
 mod cmd;
 mod node_id;
 mod query;
@@ -14,6 +15,7 @@ mod register;
 mod response;
 
 pub use self::{
+    chunk_proof::{ChunkProof, Nonce},
     cmd::{Cmd, Hash},
     node_id::NodeId,
     query::Query,

--- a/sn_protocol/src/messages/query.rs
+++ b/sn_protocol/src/messages/query.rs
@@ -6,8 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::NetworkAddress;
-
+use crate::{messages::Nonce, NetworkAddress};
 use serde::{Deserialize, Serialize};
 
 /// Data queries - retrieving data and inspecting their structure.
@@ -32,6 +31,13 @@ pub enum Query {
         /// Key of the record to be fetched
         key: NetworkAddress,
     },
+    /// Get the proof that the chunk with the given NetworkAddress exists with the requested node.
+    GetChunkExistenceProof {
+        /// The Address of the chunk that we are trying to verify.
+        key: NetworkAddress,
+        /// The random nonce that the node uses to produce the Proof (i.e., hash(record+nonce))
+        nonce: Nonce,
+    },
 }
 
 impl Query {
@@ -40,8 +46,9 @@ impl Query {
         match self {
             Query::GetStoreCost(address) => address.clone(),
             // Shall not be called for this, as this is a `one-to-one` message,
-            // and the destionation shall be decided by the requester already.
+            // and the destination shall be decided by the requester already.
             Query::GetReplicatedRecord { key, .. } => key.clone(),
+            Query::GetChunkExistenceProof { key, .. } => key.clone(),
         }
     }
 }
@@ -54,6 +61,9 @@ impl std::fmt::Display for Query {
             }
             Query::GetReplicatedRecord { key, requester } => {
                 write!(f, "Query::GetStoreCost({requester:?} {key:?})")
+            }
+            Query::GetChunkExistenceProof { key, nonce } => {
+                write!(f, "Query::GetChunkExistenceProof({key:?} {nonce:?})")
             }
         }
     }

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -8,6 +8,7 @@
 
 use crate::{error::Result, NetworkAddress};
 
+use super::ChunkProof;
 use bytes::Bytes;
 use core::fmt;
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,11 @@ use std::fmt::Debug;
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QueryResponse {
+    // ===== GetStoreCost =====
+    //
+    /// Response to [`GetStoreCost`]
+    ///
+    /// [`GetStoreCost`]: crate::messages::Query::GetStoreCost
     GetStoreCost {
         /// The store cost quote for storing the next record.
         quote: Result<PaymentQuote>,
@@ -32,6 +38,12 @@ pub enum QueryResponse {
     ///
     /// [`GetReplicatedRecord`]: crate::messages::Query::GetReplicatedRecord
     GetReplicatedRecord(Result<(NetworkAddress, Bytes)>),
+    // ===== ReplicatedRecord =====
+    //
+    /// Response to [`GetChunkExistenceProof`]
+    ///
+    /// [`GetChunkExistenceProof`]: crate::messages::Query::GetChunkExistenceProof
+    GetChunkExistenceProof(Result<ChunkProof>),
 }
 
 // Debug implementation for QueryResponse, to avoid printing Vec<u8>
@@ -61,6 +73,9 @@ impl Debug for QueryResponse {
                     write!(f, "GetReplicatedRecord(Err({err:?}))")
                 }
             },
+            QueryResponse::GetChunkExistenceProof(proof) => {
+                write!(f, "GetChunkExistenceProof(proof: {proof:?})")
+            }
         }
     }
 }

--- a/sn_testnet/src/main.rs
+++ b/sn_testnet/src/main.rs
@@ -35,6 +35,7 @@ use std::{
     io::ErrorKind,
     path::PathBuf,
     process::{Command, Stdio},
+    time::Duration,
 };
 use tracing::{debug, info};
 
@@ -211,8 +212,9 @@ async fn main() -> Result<()> {
         faucet_bin_path.push(FAUCET_BIN_NAME);
     }
 
-    info!("Launching CashNote faucet server");
+    info!("Launching CashNote faucet server and sleeping for 5 seconds");
     run_faucet(gen_multi_addr, faucet_bin_path)?;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
     println!("Testnet and faucet launched successfully");
     Ok(())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Dec 23 15:52 UTC
This pull request includes changes to multiple files. 

- The `mod.rs` file in the `messages` module adds support for chunk proofs and organizes message-related components.
- Changes in the `FilesCmds` enum, `upload_files` and `upload_chunk` functions remove the `show_holders` functionality.
- The `QueryResponse` enum adds new variants for `GetStoreCost` and `GetChunkExistenceProof` queries.
- The `Node` implementation in the `node.rs` file adds support for handling `GetChunkExistenceProof` queries.
- The `Cargo.toml` file adds the `tiny-keccak` dependency.
- Changes in the `query.rs` file update imports and add new variants to the `Query` enum.
- The `chunk_proof.rs` file adds the `ChunkProof` struct and associated methods.
- Changes in the `Files` implementation simplify parameter passing and remove unused `show_holders` functionality.
- Changes in various files import `ChunkProof` and modify functionality related to chunk storage and verification.
- Changes in the `event.rs` file modify the `SwarmDriver` implementation for handling Kademlia events.
- Changes in the `error.rs` file import types and add new error variants for chunk existence and register not found.
- Changes in the file add new functions for retrieving chunk proofs and store costs from the network.

Please review these changes and let me know if you have any questions.
<!-- reviewpad:summarize:end --> 
