### PR TITLE
fix: add missing clippy allow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to create a register
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create baobao
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register create -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -318,7 +318,7 @@ async fn spawn_royalties_payment_listener(
 
         // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
         // otherwise we'll wait for 10s per expected royalty
-        let secs = std::cmp::max(40, expected_royalties as u64 * 10);
+        let secs = std::cmp::max(40, expected_royalties as u64 * 15);
 
         let duration = Duration::from_secs(secs);
         println!("Awaiting transfers notifs for {duration:?}...");
@@ -373,7 +373,7 @@ async fn spawn_royalties_payment_client_listener(
 
         // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
         // otherwise we'll wait for 10s per expected royalty
-        let secs = std::cmp::max(40, expected_royalties as u64 * 10);
+        let secs = std::cmp::max(40, expected_royalties as u64 * 15);
         let duration = Duration::from_secs(secs);
         tracing::info!("Awaiting transfers notifs for {duration:?}...");
         println!("Awaiting transfers notifs for {duration:?}...");

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -98,6 +98,7 @@ pub async fn parse_peers_args(args: PeersArgs) -> Result<Vec<Multiaddr>> {
 }
 
 // should not be reachable, but needed for the compiler to be happy.
+#[allow(clippy::unused_async)]
 #[cfg(not(feature = "network-contacts"))]
 async fn get_network_contacts(_args: &PeersArgs) -> Result<Vec<Multiaddr>> {
     Ok(vec![])


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Dec 23 07:49 UTC
This pull request includes three patches. 

The first patch fixes a missing clippy allow in the .github/workflows/nightly.yml file. The run command in the workflow has been updated to include the -n flag for the register create command.

The second patch updates the reward test awaits in the sn_node/tests/nodes_rewards.rs file. The verify_rewards function has been modified to include additional parameters for the previous rewards balance, rewards paid, and the length of chunks. The sleep durations have also been adjusted.

The third patch increases the wait time for royalty transfers in the sn_node/tests/nodes_rewards.rs file. The secs variable in the spawn_royalties_payment_listener and spawn_royalties_payment_client_listener functions has been adjusted based on the expected number of royalties.
<!-- reviewpad:summarize:end --> 
