### PR TITLE
fix(networking): return Vec for closest queries to reliably sort

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -25,7 +25,7 @@ use sn_protocol::{
 };
 use sn_transfers::NanoTokens;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     fmt::Debug,
 };
 use tokio::sync::oneshot;
@@ -59,12 +59,12 @@ pub enum SwarmCmd {
     // Returns up to K_VALUE peers from all the k-buckets from the local Routing Table.
     // And our PeerId as well.
     GetClosestKLocalPeers {
-        sender: oneshot::Sender<HashSet<PeerId>>,
+        sender: oneshot::Sender<Vec<PeerId>>,
     },
     // Get closest peers from the network
     GetClosestPeersToAddressFromNetwork {
         key: NetworkAddress,
-        sender: oneshot::Sender<HashSet<PeerId>>,
+        sender: oneshot::Sender<Vec<PeerId>>,
     },
     // Get closest peers from the local RoutingTable
     GetCloseGroupLocalPeers {
@@ -657,7 +657,7 @@ impl SwarmDriver {
     // are none among target b011111's close range.
     // Hence, the ilog2 calculation based on close_range cannot cover such case.
     // And have to sort all nodes to figure out whether self is among the close_group to the target.
-    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &HashSet<PeerId>) -> bool {
+    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &Vec<PeerId>) -> bool {
         if all_peers.len() <= REPLICATE_RANGE {
             return true;
         }

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -70,9 +70,9 @@ pub(crate) enum PendingGetClosestType {
     /// Thus we can just process the queries made by NetworkDiscovery without using any channels
     NetworkDiscovery,
     /// These are queries made by a function at the upper layers and contains a channel to send the result back.
-    FunctionCall(oneshot::Sender<HashSet<PeerId>>),
+    FunctionCall(oneshot::Sender<Vec<PeerId>>),
 }
-type PendingGetClosest = HashMap<QueryId, (PendingGetClosestType, HashSet<PeerId>)>;
+type PendingGetClosest = HashMap<QueryId, (PendingGetClosestType, Vec<PeerId>)>;
 
 /// What is the largest packet to send over the network.
 /// Records larger than this will be rejected.
@@ -671,8 +671,9 @@ impl SwarmDriver {
         all_peers
     }
 
-    // get closest k_value the peers from our local RoutingTable. Contains self
-    pub(crate) fn get_closest_k_value_local_peers(&mut self) -> HashSet<PeerId> {
+    /// get closest k_value the peers from our local RoutingTable. Contains self.
+    /// Is sorted for closeness to self.
+    pub(crate) fn get_closest_k_value_local_peers(&mut self) -> Vec<PeerId> {
         let self_peer_id = self.self_peer_id.into();
         let peers = self
             .swarm

--- a/sn_networking/src/network_discovery.rs
+++ b/sn_networking/src/network_discovery.rs
@@ -11,7 +11,7 @@ use rand::{thread_rng, Rng};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sn_protocol::NetworkAddress;
 use std::{
-    collections::{btree_map::Entry, BTreeMap, HashSet},
+    collections::{btree_map::Entry, BTreeMap},
     time::Instant,
 };
 
@@ -54,7 +54,7 @@ impl NetworkDiscovery {
     }
 
     /// The result from the kad::GetClosestPeers are again used to update our kbucket.
-    pub(crate) fn handle_get_closest_query(&mut self, closest_peers: HashSet<PeerId>) {
+    pub(crate) fn handle_get_closest_query(&mut self, closest_peers: Vec<PeerId>) {
         let now = Instant::now();
 
         let candidates_map: BTreeMap<u32, Vec<NetworkAddress>> = closest_peers

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -88,6 +88,8 @@ impl ReplicationFetcher {
     pub(crate) fn next_keys_to_fetch(&mut self) -> Vec<(PeerId, RecordKey)> {
         self.prune_expired_keys();
 
+        info!("Next to fetch....");
+
         if self.on_going_fetches.len() >= MAX_PARALLEL_FETCH {
             warn!("Replication Fetcher doesn't have free capacity.");
             return vec![];

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -31,7 +31,7 @@ impl Node {
         let mut closest_k_peers = network.get_closest_k_value_local_peers().await?;
 
         // remove our peer id from the calculations here:
-        let _we_were_there = closest_k_peers.remove(&network.peer_id);
+        closest_k_peers.retain(|peer_id| peer_id != &network.peer_id);
 
         // Only grab the closest nodes
         let closest_k_peers = closest_k_peers
@@ -153,7 +153,7 @@ impl Node {
             };
 
             // remove ourself from these calculations
-            let _we_were_there = closest_k_peers.remove(&network.peer_id);
+            closest_k_peers.retain(|peer_id| peer_id != &network.peer_id);
 
             let data_addr = NetworkAddress::from_record_key(&paid_key);
 

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -61,7 +61,7 @@ const CHURN_COUNT: u8 = 4;
 
 /// Default number of chunks that should be PUT to the network.
 // It can be overridden by setting the 'CHUNK_COUNT' env var.
-const CHUNK_COUNT: usize = 5;
+const CHUNK_COUNT: usize = 15;
 
 type NodeIndex = usize;
 type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;


### PR DESCRIPTION
Our close peers were not actually being sorted by closeness, just by hash in the HashSet. This changes it to vec (back to), so we retain sorting from the kbuckets