### PR TITLE
feat(ci): don't log raw data

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -83,7 +83,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -131,7 +130,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -263,7 +261,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -335,10 +332,13 @@ jobs:
         include:
           - os: ubuntu-latest
             node_data_path: /home/runner/.local/share/safe/node
+            safe_path: /home/runner/.local/share/safe
           - os: windows-latest
             node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
           - os: macos-latest
             node_data_path: /Users/runner/Library/Application Support/safe/node
+            safe_path: /Users/runner/Library/Application Support/safe
     steps:
       - uses: actions/checkout@v4
 
@@ -432,6 +432,18 @@ jobs:
           log_file_prefix: safe_test_logs_churn
           platform: ${{ matrix.os }}
           build: true
+      
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi
 
   verify_data_location_routing_table:
       if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
@@ -442,10 +454,13 @@ jobs:
           include:
             - os: ubuntu-latest
               node_data_path: /home/runner/.local/share/safe/node
+              safe_path: /home/runner/.local/share/safe
             - os: windows-latest
               node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+              safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
             - os: macos-latest
               node_data_path: /Users/runner/Library/Application Support/safe/node
+              safe_path: /Users/runner/Library/Application Support/safe
       steps:
         - uses: actions/checkout@v4
 
@@ -524,3 +539,15 @@ jobs:
             log_file_prefix: safe_test_logs_data_location
             platform: ${{ matrix.os }}
             build: true
+
+        # Only error out after uploading the logs
+        - name: Don't log raw data
+          if: matrix.os != 'windows-latest' # causes error
+          shell: bash
+          timeout-minutes: 10
+          run: |
+            if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+            then
+              echo "We are logging an extremely large data"
+              exit 1
+            fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -277,10 +277,13 @@ jobs:
         include:
           - os: ubuntu-latest
             node_data_path: /home/runner/.local/share/safe/node
+            safe_path: /home/runner/.local/share/safe
           - os: windows-latest
             node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
           - os: macos-latest
             node_data_path: /Users/runner/Library/Application Support/safe/node
+            safe_path: /Users/runner/Library/Application Support/safe
     steps:
       - uses: actions/checkout@v4
 
@@ -373,6 +376,18 @@ jobs:
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Nightly Churn Test Run Failed"
 
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi
+
   verify_data_location_routing_table:
       name: Verify data location and Routing Table
       runs-on: ${{ matrix.os }}
@@ -381,10 +396,13 @@ jobs:
           include:
             - os: ubuntu-latest
               node_data_path: /home/runner/.local/share/safe/node
+              safe_path: /home/runner/.local/share/safe
             - os: windows-latest
               node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+              safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
             - os: macos-latest
               node_data_path: /Users/runner/Library/Application Support/safe/node
+              safe_path: /Users/runner/Library/Application Support/safe
       steps:
         - uses: actions/checkout@v4
 
@@ -461,3 +479,15 @@ jobs:
             SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
             SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
             SLACK_TITLE: "Nightly Data Location Test Run Failed"
+
+        # Only error out after uploading the logs
+        - name: Don't log raw data
+          if: matrix.os != 'windows-latest' # causes error
+          shell: bash
+          timeout-minutes: 10
+          run: |
+            if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+            then
+              echo "We are logging an extremely large data"
+              exit 1
+            fi


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Dec 23 10:59 UTC
This pull request adds a feature to the CI workflow. It modifies the merge.yml and nightly.yml files to prevent logging of raw data. It includes new steps in the workflow that check the length of the logs and exit with an error message if the length exceeds a certain threshold. The safe_path is also defined for each operating system.
<!-- reviewpad:summarize:end --> 
