### PR TITLE
feat(cli): skip payment and upload for existing chunks

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -10,6 +10,7 @@ on:
     branches: ["*"]
 
 env:
+  SAFE_DATA_PATH: /home/runner/.local/share/safe
   CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
   NODE_DATA_PATH: /home/runner/.local/share/safe/node
   BOOTSTRAP_NODE_DATA_PATH: /home/runner/.local/share/safe/bootstrap_node
@@ -97,6 +98,23 @@ jobs:
         run: |
           ls -l
           cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 25
+
+      # Uploading same file using different client shall not incur any payment neither uploads
+      # Note rg will throw an error directly in case of failed to find a matching pattern.
+      - name: Start a different client to upload the same file
+        run: |
+          mv $CLIENT_DATA_PATH $SAFE_DATA_PATH/client_first
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 5000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet_1.txt
+          cat initial_balance_from_faucet_1.txt
+          cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex
+          cat transfer_hex
+          cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders > second_upload.txt
+          cat second_upload.txt
+          rg "New wallet balance: 5000000.000000000" second_upload.txt -c --stats
         env:
           SN_LOG: "all"
         timeout-minutes: 25

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -206,7 +206,7 @@ impl ClientRegister {
                 // Let's check if the user has already paid for this address first
                 let net_addr = sn_protocol::NetworkAddress::RegisterAddress(addr);
                 // Let's make the storage payment
-                (storage_cost, royalties_fees) = wallet_client
+                ((storage_cost, royalties_fees), _) = wallet_client
                     .pay_for_storage(std::iter::once(net_addr.clone()))
                     .await?;
                 let cost = storage_cost

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -453,16 +453,13 @@ impl Node {
             Query::GetStoreCost(address) => {
                 trace!("Got GetStoreCost request for {address:?}");
 
-                let record_exists = {
-                    if let Some(key) = address.as_record_key() {
-                        match network.is_record_key_present_locally(&key).await {
-                            Ok(res) => res,
-                            Err(error) => {
-                                error!("Problem getting record key's existence: {error:?}");
-                                false
-                            }
-                        }
-                    } else {
+                let record_exists = match network
+                    .is_record_key_present_locally(&address.to_record_key())
+                    .await
+                {
+                    Ok(res) => res,
+                    Err(error) => {
+                        error!("Problem getting record key's existence: {error:?}");
                         false
                     }
                 };

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -127,7 +127,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
     // let's first pay only for a subset of the addresses
     let subset_len = random_content_addrs.len() / 3;
     println!("Paying for {subset_len} random addresses...",);
-    let (storage_cost, royalties_fees) = wallet_client
+    let ((storage_cost, royalties_fees), _) = wallet_client
         .pay_for_storage(random_content_addrs.clone().into_iter().take(subset_len))
         .await?;
 
@@ -151,7 +151,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
 
     // now let's request to pay for all addresses, even that we've already paid for a subset of them
     let mut wallet_client = WalletClient::new(client.clone(), paying_wallet);
-    let (storage_cost, royalties_fees) = wallet_client
+    let ((storage_cost, royalties_fees), _) = wallet_client
         .pay_for_storage(random_content_addrs.clone().into_iter())
         .await?;
     let total_cost = storage_cost


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Dec 23 13:13 UTC
This pull request includes the following changes:

1. Added an environment variable "SAFE_DATA_PATH" and set its value to "/home/runner/.local/share/safe".
2. Added a step to start a different client to upload the same file using a different client. This step includes various commands to perform the upload and display the output.
3. Added a step for testing data integrity during nodes churn.
4. Made changes in the `sn_cli` module to handle the verification of chunks and payment for storage.
5. Made changes in the `sn_client` module to handle payment for chunks and storage, and added a function to skip existing chunks during payment.
6. Made changes in the `sn_client` module to handle payment for storage in the `ClientRegister` struct.
7. Made changes in the `sn_client` module to add a list of existing chunks that need to be skipped during payment for storage.
8. Made changes in the `sn_client` module to return a list of skipped chunks during payment for storage.
9. Made changes in the `sn_node` module to handle storage payment proofs cached in the wallet.
10. Updated the test cases in the `storage_payments` module to reflect the changes in payment for storage.

Overall, these changes improve the handling of payment for storage and the verification of chunks in the code.
<!-- reviewpad:summarize:end --> 
