### PR TITLE
chore(cli): refactor upload_files

### DIFF
--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -542,7 +542,7 @@ impl Node {
                             // todo: error is not propagated to the caller here
                             let _ = network.add_keys_to_replication_fetcher(peer_id, keys);
                         } else {
-                            warn!("Received replication list from {peer_id:?} which is not in our close group. Ignored {keys:?}");
+                            warn!("Received replication list from {peer_id:?} which is not in our close group. Ignored {:?}", keys.len());
                         }
                     } else {
                         error!(


### PR DESCRIPTION
Split up the big big function

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 12:39 UTC
This pull request refactors the `upload_files` function in the `sn_cli/src/subcommands/files/mod.rs` file. It splits up the big function into smaller functions for better readability and maintainability. The changes include:
- Introducing a `UploadParams` struct to hold the parameters for the upload process.
- Adding a `progress_uploading_chunks` function to handle the uploading of chunks in batches.
- Adding a `handle_chunk_batch` function to handle a batch of chunks for upload.
- Modifying the existing code to use the new functions and the `UploadParams` struct.

Overall, these changes aim to improve the organization and modularity of the `upload_files` function.
<!-- reviewpad:summarize:end --> 
