### PR TITLE
feat(cli): simple retries

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Start a client instance to compare memory usage
         shell: bash
-        run: target/release/safe --log-output-dest=data-dir files upload the-test-data.zip
+        run: target/release/safe --log-output-dest=data-dir files upload the-test-data.zip -r 0
         env:
           SN_LOG: "all"
 
@@ -206,7 +206,7 @@ jobs:
         shell: bash
         run: |
           ls -l target/release
-          target/release/safe --log-output-dest=data-dir files upload target/release/faucet
+          target/release/safe --log-output-dest=data-dir files upload target/release/faucet -r 0
 
       #########################
       ### Stop Network      ###

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Start a client instance to compare memory usage
         shell: bash
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload the-test-data.zip
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload the-test-data.zip -r 0
         env:
           SN_LOG: "all"
       

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Start a client to upload files
         run: |
           ls -l
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders -r 0
         env:
           SN_LOG: "all"
         timeout-minutes: 25
@@ -112,7 +112,7 @@ jobs:
           cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex
           cat transfer_hex
           cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders > second_upload.txt
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders -r 0 > second_upload.txt 
           cat second_upload.txt
           rg "New wallet balance: 5000000.000000000" second_upload.txt -c --stats
         env:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Start a client to upload files
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload -- "./resources"
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources" -r 0
         env:
           SN_LOG: "all"
         timeout-minutes: 15

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to carry out chunk actions
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources"
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources" -r 0
         env:
           SN_LOG: "all"
         timeout-minutes: 2

--- a/sn_cli/benches/files.rs
+++ b/sn_cli/benches/files.rs
@@ -30,6 +30,8 @@ fn safe_files_upload(dir: &str) {
         .arg("files")
         .arg("upload")
         .arg(dir)
+        .arg("-r") // no retries
+        .arg("0")
         .output()
         .expect("Failed to execute command");
 

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -54,6 +54,7 @@ pub enum Error {
     /// A general error when verifying a transfer validity in the network.
     #[error("Failed to verify transfer validity in the network {0}")]
     CouldNotVerifyTransfer(String),
+
     #[error("There is no Spend record at this address: {0:?}")]
     MissingSpendRecord(SpendAddress),
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -81,7 +81,7 @@ pub const fn close_group_majority() -> usize {
 /// Max duration to wait for verification
 const MAX_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(750);
 /// Min duration to wait for verification
-const MIN_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(150);
+const MIN_REVERIFICATION_WAIT_TIME_S: std::time::Duration = std::time::Duration::from_millis(300);
 /// Number of attempts to GET a record
 const GET_RETRY_ATTEMPTS: usize = 3;
 /// Number of attempts to PUT a record


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 14:49 UTC
This pull request includes changes that involve error handling and transfer verification in the network. The file `error.rs` introduces two new variants to the `Error` enum: `CouldNotVerifyTransfer` and `MissingSpendRecord`. Additionally, there is a change in the `node.rs` file at line 542, where the ignored replication list is replaced with the length of the received keys in a warning log statement, providing more information about the ignored replication list.
<!-- reviewpad:summarize:end --> 
