### PR TITLE
TEST: lower batch size to test benching and perf

### DIFF
--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -43,7 +43,7 @@ pub struct Files {
 type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
 
 // Defines the size of batch for the parallel downloading of data.
-pub const BATCH_SIZE: usize = 64;
+pub const BATCH_SIZE: usize = 16;
 
 impl Files {
     /// Create file apis instance.

--- a/sn_client/src/file_apis.rs
+++ b/sn_client/src/file_apis.rs
@@ -43,7 +43,7 @@ pub struct Files {
 type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
 
 // Defines the size of batch for the parallel downloading of data.
-pub const BATCH_SIZE: usize = 16;
+pub const BATCH_SIZE: usize = 32;
 
 impl Files {
     /// Create file apis instance.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 15:42 UTC
This pull request lowers the batch size for testing benchmarking and performance in the `sn_client/src/file_apis.rs` file. The batch size was changed from 64 to 16.
<!-- reviewpad:summarize:end --> 
