### PR TITLE
chore(cli): tidy cli output by removing peers list

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -87,10 +87,10 @@ async fn main() -> Result<()> {
 
     let bootstrap_peers = parse_peers_args(opt.peers).await?;
 
-    println!("Connecting to the network w/peers:");
-    for peer in &bootstrap_peers {
-        println!("{peer}");
-    }
+    println!(
+        "Connecting to the network with {} peers:",
+        bootstrap_peers.len()
+    );
 
     let bootstrap_peers = if bootstrap_peers.is_empty() {
         // empty vec is returned if `local-discovery` flag is provided

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -257,7 +257,7 @@ async fn get_faucet(root_dir: &Path, client: &Client, url: String) -> Result<()>
         url
     };
     let req_url = Url::parse(&format!("{url}/{address_hex}"))?;
-    println!("Requesting token for wallet address: {address_hex}...");
+    println!("Requesting token for wallet address: {address_hex}");
 
     let response = reqwest::get(req_url).await?;
     let is_ok = response.status().is_success();


### PR DESCRIPTION
## Description

Small ergonomic improvements to the cli output.

I tried to copy the address when calling `safe wallet get-faucet` by double clicking the address and it also included the `...` at the end of the address.

The peer list is not useful and is very long so can be removed from the output. Might be useful to add a `safe peers` command or something like that to list peers? Related to #1007

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 20:48 UTC
This pull request includes two patches. 

The first patch updates the code in the main.rs file to improve the stdout output when connecting to the network with peers. Instead of printing each individual peer, it now prints the number of peers.

The second patch modifies the wallet.rs file to remove the unnecessary ellipsis in the println statement, making it easier to copy the wallet address.
<!-- reviewpad:summarize:end --> 
