### PR TITLE
chore: small fixes 

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -110,10 +110,6 @@ pub enum Error {
     #[error("Record header is incorrect")]
     InCorrectRecordHeader,
 
-    /// No put_record attempts were successfully verified.
-    #[error("Could not retrieve the record after storing it: {0:}")]
-    FailedToVerifyRecordWasStored(PrettyPrintRecordKey<'static>),
-
     // ---------- Transfer Errors
     #[error("Failed to get transfer parent spend")]
     FailedToGetTransferParentSpend,

--- a/sn_networking/src/get_record_handler.rs
+++ b/sn_networking/src/get_record_handler.rs
@@ -155,9 +155,15 @@ impl SwarmDriver {
         // return error if the entry cannot be found
         if let Some((sender, result_map, cfg)) = self.pending_get_record.remove(&query_id) {
             let num_of_versions = result_map.len();
-            let (result, log_string) = if let Some((record, _)) = result_map.values().next() {
+            let (result, log_string) = if let Some((record, from_peers)) =
+                result_map.values().next()
+            {
                 let result = if num_of_versions == 1 {
-                    Err(GetRecordError::NotEnoughCopies(record.clone()))
+                    Err(GetRecordError::NotEnoughCopies {
+                        record: record.clone(),
+                        expected: get_quorum_value(&cfg.get_quorum),
+                        got: from_peers.len(),
+                    })
                 } else {
                     Err(GetRecordError::SplitRecord {
                         result_map: result_map.clone(),

--- a/sn_networking/src/get_record_handler.rs
+++ b/sn_networking/src/get_record_handler.rs
@@ -7,11 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    close_group_majority, Error, GetRecordCfg, GetRecordError, Result, SwarmDriver,
-    CLOSE_GROUP_SIZE,
+    get_quorum_value, Error, GetRecordCfg, GetRecordError, Result, SwarmDriver, CLOSE_GROUP_SIZE,
 };
 use libp2p::{
-    kad::{self, PeerRecord, ProgressStep, QueryId, QueryResult, QueryStats, Quorum, Record},
+    kad::{self, PeerRecord, ProgressStep, QueryId, QueryResult, QueryStats, Record},
     PeerId,
 };
 use sn_protocol::PrettyPrintRecordKey;
@@ -97,12 +96,7 @@ impl SwarmDriver {
                     1
                 };
 
-            let expected_answers = match cfg.get_quorum {
-                Quorum::Majority => close_group_majority(),
-                Quorum::All => CLOSE_GROUP_SIZE,
-                Quorum::N(v) => v.get(),
-                Quorum::One => 1,
-            };
+            let expected_answers = get_quorum_value(&cfg.get_quorum);
 
             trace!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
 
@@ -255,12 +249,7 @@ impl SwarmDriver {
                         })
                     })?;
 
-                let required_response_count = match cfg.get_quorum {
-                    Quorum::Majority => close_group_majority(),
-                    Quorum::All => CLOSE_GROUP_SIZE,
-                    Quorum::N(v) => v.into(),
-                    Quorum::One => 1,
-                };
+                let required_response_count = get_quorum_value(&cfg.get_quorum);
 
                 // if we've a split over the result xorname, then we don't attempt to resolve this here.
                 // Retry and resolve through normal flows without a timeout.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -40,7 +40,7 @@ use bytes::Bytes;
 use futures::future::select_all;
 use libp2p::{
     identity::Keypair,
-    kad::{KBucketDistance, KBucketKey, Record, RecordKey},
+    kad::{KBucketDistance, KBucketKey, Quorum, Record, RecordKey},
     multiaddr::Protocol,
     Multiaddr, PeerId,
 };
@@ -736,6 +736,16 @@ fn get_fees_from_store_cost_responses(
     info!("Final fees calculated as: {lowest:?}");
     // we dont need to have the address outside of here for now
     Ok((lowest.1, lowest.2))
+}
+
+/// Get the value of the provided Quorum
+pub fn get_quorum_value(quorum: &Quorum) -> usize {
+    match quorum {
+        Quorum::Majority => close_group_majority(),
+        Quorum::All => CLOSE_GROUP_SIZE,
+        Quorum::N(v) => v.get(),
+        Quorum::One => 1,
+    }
 }
 
 /// Verifies if `Multiaddr` contains IPv4 address that is not global.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -368,8 +368,8 @@ impl Network {
                 Err(GetRecordError::RecordDoesNotMatch(_)) => {
                     warn!("The returned record does not match target {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
                 }
-                Err(GetRecordError::NotEnoughCopies(_)) => {
-                    warn!("Not enough copies found yet for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
+                Err(GetRecordError::NotEnoughCopies { expected, got, .. }) => {
+                    warn!("Not enough copies ({got}/{expected}) found yet for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}");
                 }
                 // libp2p RecordNotFound does mean no holders answered.
                 // it does not actually mean the record does not exist.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -267,7 +267,7 @@ impl Network {
 
         // loop over responses, generating an average fee and storing all responses along side
         let mut all_costs = vec![];
-        for response in responses.into_iter().flatten() {
+        for response in responses.into_values().flatten() {
             debug!(
                 "StoreCostReq for {record_address:?} received response: {:?}",
                 response
@@ -680,25 +680,30 @@ impl Network {
         peers: Vec<PeerId>,
         req: &Request,
         get_all_responses: bool,
-    ) -> Vec<Result<Response>> {
+    ) -> BTreeMap<PeerId, Result<Response>> {
         debug!("send_and_get_responses for {req:?}");
         let mut list_of_futures = peers
             .iter()
-            .map(|peer| Box::pin(self.send_request(req.clone(), *peer)))
+            .map(|peer| {
+                Box::pin(async {
+                    let resp = self.send_request(req.clone(), *peer).await;
+                    (*peer, resp)
+                })
+            })
             .collect::<Vec<_>>();
 
-        let mut responses = Vec::new();
+        let mut responses = BTreeMap::new();
         while !list_of_futures.is_empty() {
-            let (res, _, remaining_futures) = select_all(list_of_futures).await;
-            let res_string = match &res {
-                Ok(res) => format!("{res}"),
+            let ((peer, resp), _, remaining_futures) = select_all(list_of_futures).await;
+            let resp_string = match &resp {
+                Ok(resp) => format!("{resp}"),
                 Err(err) => format!("{err:?}"),
             };
-            debug!("Got response for the req: {req:?}, res: {res_string}");
-            if !get_all_responses && res.is_ok() {
-                return vec![res];
+            debug!("Got response from {peer:?} for the req: {req:?}, resp: {resp_string}");
+            if !get_all_responses && resp.is_ok() {
+                return BTreeMap::from([(peer, resp)]);
             }
-            responses.push(res);
+            responses.insert(peer, resp);
             list_of_futures = remaining_futures;
         }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -749,8 +749,12 @@ impl Node {
                         warn!("Spends for {cash_note_addr:?} is a double-spend. Aggregating and storing them.");
                         vec![*spend1, *spend2]
                     }
-                    Err(NetworkError::GetRecordError(GetRecordError::NotEnoughCopies(record))) => {
-                        warn!("Spends for {cash_note_addr:?} resulted in a failed quorum. Trying to aggregate the spends in them.");
+                    Err(NetworkError::GetRecordError(GetRecordError::NotEnoughCopies {
+                        record,
+                        expected,
+                        got,
+                    })) => {
+                        warn!("Spends for {cash_note_addr:?} resulted in a failed quorum ({got}/{expected}). Trying to aggregate the spends in them.");
                         match get_singed_spends_from_record(&record) {
                             Ok(spends) => spends,
                             Err(err) => {

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -314,7 +314,7 @@ fn create_cash_note_task(
             let cash_note = wallet_client
                 .send_cash_note(NanoTokens::from(10), dest_pk, true)
                 .await
-                .expect("Failed to send CashNote to {dest_pk}");
+                .unwrap_or_else(|_| panic!("Failed to send CashNote to {dest_pk:?}"));
 
             let cash_note_addr = SpendAddress::from_unique_pubkey(&cash_note.unique_pubkey());
             let net_addr = NetworkAddress::SpendAddress(cash_note_addr);


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Dec 23 09:01 UTC
This pull request includes changes to various files in the codebase. Here is a summary of the key changes:

1. In the `error.rs` file, modifications were made to the `GetRecordError` enum to include additional fields in the `NotEnoughCopies` variant. The `Debug` implementation and `Error` enum were also updated to reflect the changes.

2. The `get_record_handler.rs` file in the `sn_networking` module underwent changes. The import of `kad::Quorum` was removed, and a new function `get_quorum_value` was introduced. The calculation of `expected_answers` and `required_response_count` was updated to use the `get_quorum_value` function. Additionally, the error `GetRecordError::NotEnoughCopies` was modified to provide more information about the expected and received number of copies.

3. In the `lib.rs` file of the `sn_networking` module, several changes were made. The `Quorum` import was added, the for loop in the `impl Network` implementation was updated, error patterns and messages were modified to include details about `NotEnoughCopies`, and the return type and code inside the `send_and_get_responses` function were changed.

4. The `chunk_path` and `impl ChunkManager` functions were modified in another file. The `chunk_path` function now prints different messages based on the `read_cache` parameter, and additional print statements and a progress bar were added to the `impl ChunkManager` function.

5. In the `event.rs` file of the `sn_networking` module, changes were made to the `impl SwarmDriver` block. The handling of query tasks and closest peers was modified, and a trace log message was added for specific scenarios.

6. The error handling in the `data_with_churn.rs` file was changed for sending a CashNote, improving the error message with the value of `dest_pk`.

7. The file `file_apis.rs` underwent changes in error handling and parallel chunk uploads. The usage of `expect` was replaced with `unwrap_or_else`, and the code for parallel uploads was modified.

8. The `put_validation.rs` file had changes related to error handling and warning messages for spend validations. The error handling now handles the `GetRecordError::NotEnoughCopies`, and the warning message includes the actual and expected number of copies.

These changes aim to improve error reporting, handling, and overall functionality. Please review them to ensure they meet the project's requirements and standards.
<!-- reviewpad:summarize:end --> 
