### PR TITLE
feat: network royalties through audit POC

### DIFF
--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -83,7 +83,11 @@ impl TransactionBuilder {
     }
 
     /// Build the Transaction by signing the inputs. Return a CashNoteBuilder.
-    pub fn build(self, reason: Hash) -> Result<CashNoteBuilder> {
+    pub fn build(
+        self,
+        reason: Hash,
+        network_royalties: Vec<DerivationIndex>,
+    ) -> Result<CashNoteBuilder> {
         let spent_tx = Transaction {
             inputs: self.inputs,
             outputs: self.outputs,
@@ -98,6 +102,7 @@ impl TransactionBuilder {
                     reason,
                     token: input.amount,
                     parent_tx: input_src_tx.clone(),
+                    network_royalties: network_royalties.clone(),
                 };
                 let derived_key_sig = derived_key.sign(&spend.to_bytes());
                 signed_spends.insert(SignedSpend {

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Hash, NanoTokens, Transaction, UniquePubkey};
-use crate::{Error, Result, Signature};
+use crate::{DerivationIndex, Error, Result, Signature};
 
 use custom_debug::Debug;
 use serde::{Deserialize, Serialize};
@@ -148,6 +148,9 @@ pub struct Spend {
     /// The transaction that the input CashNote was created in (where it is an output)
     #[debug(skip)]
     pub parent_tx: Transaction,
+    /// Data to claim the Network Royalties (if any) from the Spend's descendants (outputs in spent_tx)
+    #[debug(skip)]
+    pub network_royalties: Vec<DerivationIndex>,
 }
 
 impl Spend {

--- a/sn_transfers/src/cashnotes/transaction.rs
+++ b/sn_transfers/src/cashnotes/transaction.rs
@@ -176,6 +176,7 @@ impl Transaction {
             .map(|s| s.unique_pubkey())
             .collect::<BTreeSet<_>>();
         if input_keys != signed_spend_keys {
+            debug!("SpendsDoNotMatchInputs: {input_keys:#?} != {signed_spend_keys:#?}");
             return Err(Error::SpendsDoNotMatchInputs);
         }
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -146,7 +146,7 @@ pub fn create_first_cash_note_from_key(
             main_pubkey,
             derivation_index,
         )
-        .build(reason)
+        .build(reason, vec![])
         .map_err(|err| {
             Error::GenesisCashNoteError(format!(
                 "Failed to build the CashNote transaction for genesis CashNote: {err}",


### PR DESCRIPTION
## Description

Note that this PR is a proof of concept

- piggy back royalties in spends
- experimental cli tool to test out royalties redemption: `safe wallet audit --royalties`
- fixes a bug in the receive code

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Dec 23 09:07 UTC
This pull request includes the following changes:

1. Imported `Transfer` and `NETWORK_ROYALTIES_PK` from `sn_transfers` module.
2. Imported `path::Path` from `std` module.
3. Added two new arguments, `find_royalties` and `root_dir`, to the `follow_spend` function.
4. Added a new function `redeem_royalties` to handle the redemption of royalties.
5. Updated the `follow_spend` function to call `redeem_royalties` if `find_royalties` is true.
6. Added print statements to log the progress and results of the audit and redemption process.
7. Added a loop in the `transfers.rs` file to validate parent spends for each transaction.
8. Defined a new variable `tx_inputs_keys` to store unique public keys for the inputs of the transaction.
9. Created a `JoinSet` named `tasks` to store async tasks in the `transfers.rs` file.
10. Spawned async tasks to retrieve missing input spends from the network in the `transfers.rs` file.
11. Waited for the completion of each async task, retrieved the signed spend, and inserted it into `parent_spends` in the `transfers.rs` file.
12. Filtered and stored the input spends for a specific transaction in the `input_spends` variable in the `transfers.rs` file.
13. Verified the transaction against the input spends using the `verify_against_inputs_spent` method in the `transfers.rs` file.
14. Added two new options, `royalties` and `dot`, to the `WalletCmds` enum and the `wallet_cmds` function.
15. Added the `royalties` parameter to the `WalletCmds::Audit` variant in the `wallet_cmds` function.
16. Added the `find_royalties` and `root_dir` parameters to the `audit` function in the `wallet_cmds` file.
17. Added a debug log statement when the `input_keys` and `signed_spend_keys` do not match in the `transaction.rs` file.
18. Changed the method call in the function `create_first_cash_note_from_key` in the `genesis.rs` file.
19. Added the argument `vec![]` to the method call in the function `create_first_cash_note_from_key` in the `genesis.rs` file.
20. Updated the error handling for building the CashNote transaction in the `genesis.rs` file.
21. Imported the constant `NETWORK_ROYALTIES_PK` from the module in the file with an unknown name.
22. Added the `network_royalties` variable to collect the derivation indexes for network royalties in the file with an unknown name.
23. Built the transaction and created a change cash note if needed in the file with an unknown name.
24. Finalized the transaction builder to get the cash note builder in the file with an unknown name.
25. Added an import statement for `DerivationIndex` in the `signed_spend.rs` file.
26. Added a new field named `network_royalties` of type `Vec<DerivationIndex>` to the `Spend` struct in the `signed_spend.rs` file.
27. Updated the `build` function in the `builder.rs` file to take an additional parameter `network_royalties`.
28. Added the `network_royalties` field to the `CashNoteBuilder` struct inside the `build` function in the `builder.rs` file.
29. Cloned the `network_royalties` field when creating the `SignedSpend` struct in the `builder.rs` file.

Overall, this pull request adds functionality related to auditing and redeeming royalties, enhances the validation process, adds experimental options to the wallet, introduces debug logging, updates method calls and error handling, and includes various other changes to different files.
<!-- reviewpad:summarize:end --> 
