### PR TITLE
chore(cli): make upload summary printout clearer

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -331,16 +331,17 @@ async fn upload_files(
     file.flush()?;
 
     let elapsed = format_elapsed_time(now.elapsed());
-    println!("Uploaded {chunks_to_upload_len} chunks (with {total_existing_chunks} exist chunks) in {elapsed}");
-    info!("Uploaded {chunks_to_upload_len} chunks (with {total_existing_chunks} exist chunks) in {elapsed}");
+    let uploaded_chunks = chunks_to_upload_len - total_existing_chunks;
+    println!("Among {chunks_to_upload_len} chunks, find {total_existing_chunks} already existed in network, uploaded the leftover {uploaded_chunks} chunks in {elapsed}");
+    info!("Among {chunks_to_upload_len} chunks, find {total_existing_chunks} already existed in network, uploaded the leftover {uploaded_chunks} chunks in {elapsed}");
 
     println!("**************************************");
     println!("*          Payment Details           *");
     println!("**************************************");
-    println!("Made payment of {total_cost} for {chunks_to_upload_len} chunks");
+    println!("Made payment of {total_cost} for {uploaded_chunks} chunks");
     println!("Made payment of {total_royalties} for royalties fees");
     println!("New wallet balance: {final_balance}");
-    info!("Made payment of {total_cost} for {chunks_to_upload_len} chunks");
+    info!("Made payment of {total_cost} for {uploaded_chunks} chunks");
     info!("New wallet balance: {final_balance}");
 
     Ok(())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Dec 23 13:04 UTC
This pull request updates the upload summary printout in the CLI. It clarifies the information displayed about the uploaded chunks, existing chunks, and payment details.
<!-- reviewpad:summarize:end --> 
