### PR TITLE
 chore(protocol): print the first 6 hex characters for every address type 

### DIFF
--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -200,9 +200,9 @@ mod tests {
         let network_address = NetworkAddress::from_chunk_address(address);
         let record_key = network_address.to_record_key();
         let record_str = format!("{}", PrettyPrintRecordKey::from(&record_key));
+        let xor_name_str = &format!("{xor_name:64x}")[0..6]; // only the first 6 chars are logged
         let xor_name_str = format!(
-            "{:64x}({:?})",
-            xor_name,
+            "{xor_name_str}({:?})",
             PrettyPrintKBucketKey(network_address.as_kbucket_key())
         );
         println!("record_str: {record_str}");

--- a/sn_protocol/src/storage/address/chunk.rs
+++ b/sn_protocol/src/storage/address/chunk.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
+use std::{fmt, hash::Hash};
 use xor_name::XorName;
 
 /// Address of a Chunk
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct ChunkAddress(XorName);
 
 impl ChunkAddress {
@@ -23,5 +23,15 @@ impl ChunkAddress {
     /// Returns the name.
     pub fn xorname(&self) -> &XorName {
         &self.0
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+impl std::fmt::Debug for ChunkAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChunkAddress({})", &self.to_hex()[0..6])
     }
 }

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -27,7 +27,7 @@ pub struct RegisterAddress {
 
 impl Display for RegisterAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}({:?})", self.to_hex(), self.xorname())
+        write!(f, "{}({:?})", &self.to_hex()[0..6], self.xorname())
     }
 }
 
@@ -35,8 +35,8 @@ impl Debug for RegisterAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RegisterAddress({:?}) {{ meta: {:?}, owner: {:?} }}",
-            self.xorname(),
+            "RegisterAddress({}) {{ meta: {:?}, owner: {:?} }}",
+            &self.to_hex()[0..6],
             self.meta,
             self.owner
         )

--- a/sn_transfers/src/cashnotes/address.rs
+++ b/sn_transfers/src/cashnotes/address.rs
@@ -52,7 +52,7 @@ impl SpendAddress {
 
 impl std::fmt::Debug for SpendAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SpendAddress({})", self.to_hex())
+        write!(f, "SpendAddress({})", &self.to_hex()[0..6])
     }
 }
 


### PR DESCRIPTION

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Dec 23 13:12 UTC
This pull request updates the code in the sn_protocol and sn_registers repositories. The changes involve using the hex representation of `XorName` for different addresses. The patch modifies the `NetworkAddress` and `ChunkAddress` structs in the `sn_protocol` repository to use the `to_hex()` method for string conversion. Additionally, the `RegisterAddress` struct in the `sn_registers` repository is updated to use the `to_hex()` method as well. Overall, this patch improves the handling of address representations in the codebase.
<!-- reviewpad:summarize:end --> 
