### PR TITLE
feat(client): move upload retry logic from CLI to client

### DIFF
--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -9,7 +9,7 @@
 use crate::subcommands::files::get_progress_bar;
 use color_eyre::{eyre::bail, Result};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use sn_client::Files;
+use sn_client::FilesApi;
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsString,
@@ -173,7 +173,7 @@ impl ChunkManager {
                     }
                 };
 
-                match Files::chunk_file(path, &file_chunks_dir) {
+                match FilesApi::chunk_file(path, &file_chunks_dir) {
                     Ok((file_xor_addr, size, chunks)) => {
                         progress_bar.clone().inc(1);
                         debug!("Chunked {original_file_name:?} with {path_xor:?} into file's XorName: {file_xor_addr:?} of size {size}, and chunks len: {}", chunks.len());

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -42,7 +42,7 @@ sn_transfers = { path = "../sn_transfers", version = "0.14.29" }
 tempfile = "3.6.0"
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"
-tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time"] }
+tokio = { version = "1.32.0", features = ["io-util", "macros", "parking_lot", "rt", "sync", "time", "fs"] }
 tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -359,9 +359,9 @@ impl Client {
                         .await?;
                 let reg_address = reg.address();
 
-                total_cost = total_cost.checked_add(top_up_cost).ok_or(Error::Transfers(
-                    sn_transfers::WalletError::from(sn_transfers::Error::ExcessiveNanoValue),
-                ))?;
+                total_cost = total_cost
+                    .checked_add(top_up_cost)
+                    .ok_or(Error::TotalPriceTooHigh)?;
                 total_royalties =
                     total_cost
                         .checked_add(royalties_top_up)

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -66,6 +66,7 @@ pub enum Error {
 
     #[error("The provided amount contains zero nanos")]
     AmountIsZero,
+
     /// CashNote add would overflow
     #[error("Total price exceed possible token amount")]
     TotalPriceTooHigh,
@@ -76,7 +77,6 @@ pub enum Error {
     #[error("Could not connect to the network in {0:?}")]
     ConnectionTimeout(Duration),
 
-    // ----------- files error
     #[error("Too many sequential upload payment failures")]
     SequentialUploadPaymentError,
 

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -75,4 +75,11 @@ pub enum Error {
 
     #[error("Could not connect to the network in {0:?}")]
     ConnectionTimeout(Duration),
+
+    // ----------- files error
+    #[error("Too many sequential upload payment failures")]
+    SequentialUploadPaymentError,
+
+    #[error("Could not send files event")]
+    CouldNotSendFilesEvent,
 }

--- a/sn_client/src/files/api.rs
+++ b/sn_client/src/files/api.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
+use crate::{
     chunks::{to_chunk, DataMapLevel, Error as ChunksError, SmallFile},
     error::{Error, Result},
     Client, WalletClient,
@@ -35,7 +35,7 @@ use xor_name::XorName;
 
 /// File APIs.
 #[derive(Clone)]
-pub struct Files {
+pub struct FilesApi {
     client: Client,
     wallet_dir: PathBuf,
 }
@@ -45,7 +45,7 @@ type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
 // Defines the size of batch for the parallel downloading of data.
 pub const BATCH_SIZE: usize = 64;
 
-impl Files {
+impl FilesApi {
     /// Create file apis instance.
     pub fn new(client: Client, wallet_dir: PathBuf) -> Self {
         Self { client, wallet_dir }
@@ -505,7 +505,7 @@ fn encrypt_large(
     file_path: &Path,
     output_dir: &Path,
 ) -> Result<(XorName, Vec<(XorName, PathBuf)>)> {
-    Ok(super::chunks::encrypt_large(file_path, output_dir)?)
+    Ok(crate::chunks::encrypt_large(file_path, output_dir)?)
 }
 
 /// Packages a [`SmallFile`] and returns the resulting address and the chunk.

--- a/sn_client/src/files/api.rs
+++ b/sn_client/src/files/api.rs
@@ -9,6 +9,7 @@
 use crate::{
     chunks::{to_chunk, DataMapLevel, Error as ChunksError, SmallFile},
     error::{Error, Result},
+    files::BATCH_SIZE,
     Client, WalletClient,
 };
 use bytes::Bytes;
@@ -41,9 +42,6 @@ pub struct FilesApi {
 }
 
 type ChunkFileResult = Result<(XorName, u64, Vec<(XorName, PathBuf)>)>;
-
-// Defines the size of batch for the parallel downloading of data.
-pub const BATCH_SIZE: usize = 64;
 
 impl FilesApi {
     /// Create file apis instance.

--- a/sn_client/src/files/mod.rs
+++ b/sn_client/src/files/mod.rs
@@ -25,6 +25,7 @@ use xor_name::XorName;
 
 // Defines the size of batch for the parallel downloading of data.
 pub const BATCH_SIZE: usize = 64;
+pub const MAX_UPLOAD_RETRIES: usize = 3;
 
 /// The maximum number of sequential payment failures before aborting the upload process.
 const MAX_SEQUENTIAL_PAYMENT_FAILS: usize = 3;
@@ -67,18 +68,12 @@ pub struct Files {
 }
 
 impl Files {
-    pub fn new(
-        files_api: FilesApi,
-        batch_size: usize,
-        verify_store: bool,
-        show_holders: bool,
-        max_retries: usize,
-    ) -> Self {
+    pub fn new(files_api: FilesApi) -> Self {
         Self {
-            batch_size,
-            verify_store,
-            show_holders,
-            max_retries,
+            batch_size: BATCH_SIZE,
+            verify_store: true,
+            show_holders: false,
+            max_retries: MAX_UPLOAD_RETRIES,
             api: files_api,
             failed_chunks: Default::default(),
             uploading_chunks: Default::default(),
@@ -88,6 +83,25 @@ impl Files {
             event_sender: None,
             logged_event_sender_absence: false,
         }
+    }
+    pub fn set_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    pub fn set_verify_store(mut self, verify_store: bool) -> Self {
+        self.verify_store = verify_store;
+        self
+    }
+
+    pub fn set_show_holders(mut self, show_holders: bool) -> Self {
+        self.show_holders = show_holders;
+        self
+    }
+
+    pub fn set_max_retries(mut self, max_retries: usize) -> Self {
+        self.max_retries = max_retries;
+        self
     }
 
     // new rx per upload session.

--- a/sn_client/src/files/mod.rs
+++ b/sn_client/src/files/mod.rs
@@ -1,0 +1,327 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+pub(crate) mod api;
+
+use crate::{
+    error::{Error as ClientError, Result},
+    FilesApi,
+};
+use bytes::Bytes;
+use futures::{stream::FuturesUnordered, StreamExt};
+use sn_protocol::storage::{Chunk, ChunkAddress};
+use sn_transfers::NanoTokens;
+use std::{collections::HashSet, path::PathBuf};
+use tokio::{
+    sync::mpsc::{self},
+    task::JoinHandle,
+};
+use xor_name::XorName;
+
+/// The maximum number of sequential payment failures before aborting the upload process.
+const MAX_SEQUENTIAL_PAYMENT_FAILS: usize = 3;
+
+pub enum FileUploadEvent {
+    Uploaded(ChunkAddress),
+    AlreadyExistsInNetwork(ChunkAddress),
+    PayedForChunks {
+        storage_cost: NanoTokens,
+        royalty_fees: NanoTokens,
+        new_balance: NanoTokens,
+    },
+    FailedToUpload(ChunkAddress),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ChunkInfo {
+    name: XorName,
+    path: PathBuf,
+}
+
+pub struct Files {
+    batch_size: usize,
+    verify_store: bool,
+    show_holders: bool,
+    max_retries: usize,
+
+    api: FilesApi,
+
+    failed_chunks: HashSet<ChunkInfo>,
+    uploading_chunks: FuturesUnordered<JoinHandle<(ChunkInfo, Result<()>)>>,
+
+    event_sender: Option<mpsc::Sender<FileUploadEvent>>,
+    logged_event_sender_absence: bool,
+}
+
+impl Files {
+    pub fn new(
+        files_api: FilesApi,
+        batch_size: usize,
+        verify_store: bool,
+        show_holders: bool,
+        max_retries: usize,
+    ) -> Self {
+        Self {
+            batch_size,
+            verify_store,
+            show_holders,
+            max_retries,
+            api: files_api,
+            failed_chunks: Default::default(),
+            uploading_chunks: Default::default(),
+            event_sender: None,
+            logged_event_sender_absence: false,
+        }
+    }
+
+    // new rx per upload session.
+    pub fn get_upload_events(&mut self) -> mpsc::Receiver<FileUploadEvent> {
+        let (event_sender, event_receiver) = mpsc::channel(10);
+        // should we return error if an sender is already set?
+        self.event_sender = Some(event_sender);
+
+        event_receiver
+    }
+    pub async fn upload_chunks(&mut self, chunks: Vec<(XorName, PathBuf)>) -> Result<()> {
+        // make sure we log that the event sender is absent atleast once
+        self.logged_event_sender_absence = false;
+        // new fn to upload chunks
+
+        let result = self.upload(chunks).await;
+
+        // drop the sender
+        let sender = self.event_sender.take();
+        drop(sender);
+
+        result
+    }
+
+    pub fn failed_chunks(&self) -> HashSet<XorName> {
+        self.failed_chunks
+            .clone()
+            .into_iter()
+            .map(|chunk_info| chunk_info.name)
+            .collect()
+    }
+
+    async fn upload(&mut self, chunks: Vec<(XorName, PathBuf)>) -> Result<()> {
+        let mut sequential_payment_fails = 0;
+
+        let mut chunk_batches = Vec::with_capacity(chunks.len());
+        chunk_batches.extend(
+            chunks
+                .into_iter()
+                .map(|(name, path)| ChunkInfo { name, path }),
+        );
+        let chunk_batches = chunk_batches.chunks(self.batch_size);
+
+        for chunks_batch in chunk_batches {
+            if sequential_payment_fails >= MAX_SEQUENTIAL_PAYMENT_FAILS {
+                return Err(ClientError::SequentialUploadPaymentError);
+            }
+            // if the payment fails, we can continue to the next batch
+            let res = self.handle_chunk_batch(chunks_batch).await;
+            match res {
+                Ok(()) => {
+                    trace!("Uploaded a batch");
+                }
+                Err(err) => match err {
+                    ClientError::CouldNotVerifyTransfer(err) => {
+                        warn!(
+                            "Failed to verify transfer validity in the network. Chunk batch will be retried... {err:?}"
+                        );
+                        println!(
+                            "Failed to verify transfer validity in the network. Chunk batch will be retried..."
+                        );
+                        sequential_payment_fails += 1;
+                        continue;
+                    }
+                    error => {
+                        return Err(error);
+                    }
+                },
+            }
+        }
+
+        // ensure we wait on any remaining uploading_chunks
+        self.progress_uploading_chunks(true).await?;
+
+        let mut retry_count = 0;
+        let max_retries = self.max_retries;
+        let mut failed_chunks_to_upload = self.take_failed_chunks();
+        while !failed_chunks_to_upload.is_empty() && retry_count < max_retries {
+            warn!(
+                "Retrying failed chunks {:?}, attempt {retry_count}/{max_retries}...",
+                failed_chunks_to_upload.len()
+            );
+            println!(
+                "Retrying failed chunks {:?}, attempt {retry_count}/{max_retries}...",
+                failed_chunks_to_upload.len()
+            );
+            retry_count += 1;
+            let batches = failed_chunks_to_upload.chunks(self.batch_size);
+            for chunks_batch in batches {
+                self.handle_chunk_batch(chunks_batch).await?;
+            }
+            // ensure we wait on any remaining uploading_chunks w/ drain_all
+            self.progress_uploading_chunks(true).await?;
+
+            // take the new failed chunks
+            failed_chunks_to_upload = self.take_failed_chunks();
+        }
+
+        Ok(())
+    }
+
+    /// Handles a batch of chunks for upload. This includes paying for the chunks, uploading them,
+    /// and handling any errors that occur during the process.
+    async fn handle_chunk_batch(&mut self, chunks_batch: &[ChunkInfo]) -> Result<()> {
+        // while we don't have a full batch_size of ongoing uploading_chunks
+        // we can pay for the next batch and carry on
+        self.progress_uploading_chunks(false).await?;
+
+        // pay for and verify payment... if we don't verify here, chunks uploads will surely fail
+        let skipped_chunks = match self
+            .api
+            .pay_for_chunks(chunks_batch.iter().map(|info| info.name).collect())
+            .await
+        {
+            Ok(((storage_cost, royalty_fees, new_balance), skipped_chunks)) => {
+                self.send_event(FileUploadEvent::PayedForChunks {
+                    storage_cost,
+                    royalty_fees,
+                    new_balance,
+                })
+                .await?;
+                skipped_chunks
+            }
+            Err(err) => return Err(err),
+        };
+
+        let mut chunks_to_upload = chunks_batch.to_vec();
+        // don't reupload skipped chunks
+        chunks_to_upload.retain(|info| !skipped_chunks.contains(&info.name));
+
+        // send update about the existing chunks
+        for chunk in skipped_chunks {
+            self.send_event(FileUploadEvent::AlreadyExistsInNetwork(ChunkAddress::new(
+                chunk,
+            )))
+            .await?;
+        }
+
+        // upload paid chunks
+        for chunk_info in chunks_to_upload.into_iter() {
+            let file_api = self.api.clone();
+            let verify_store = self.verify_store;
+            let show_holders = self.show_holders;
+
+            // Spawn a task for each chunk to be uploaded
+            let handle = tokio::spawn(Self::upload_chunk(
+                file_api,
+                chunk_info,
+                verify_store,
+                show_holders,
+            ));
+            self.progress_uploading_chunks(false).await?;
+
+            self.uploading_chunks.push(handle);
+        }
+
+        Ok(())
+    }
+
+    /// Progresses the uploading of chunks. If the number of ongoing uploading chunks is less than the batch size,
+    /// it pays for the next batch and continues. If an error occurs during the upload, it will be returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - The parameters for the upload, including the chunk manager and the batch size.
+    /// * `drain_all` - If true, will wait for all ongoing uploads to complete before returning.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<()>` - The result of the upload. If successful, it will return `Ok(())`. If an error occurs, it will return `Err(report)`.
+    async fn progress_uploading_chunks(&mut self, drain_all: bool) -> Result<()> {
+        while drain_all || self.uploading_chunks.len() >= self.batch_size {
+            if let Some(result) = self.uploading_chunks.next().await {
+                // bail if we've had any errors so far
+                match result? {
+                    // or cleanup via chunk_manager
+                    (chunk_info, Ok(())) => {
+                        // mark the chunk as completed
+                        self.send_event(FileUploadEvent::Uploaded(ChunkAddress::new(
+                            chunk_info.name,
+                        )))
+                        .await?;
+                    }
+                    (chunk_info, Err(err)) => {
+                        warn!("Failed to upload a chunk: {err}");
+                        self.send_event(FileUploadEvent::FailedToUpload(ChunkAddress::new(
+                            chunk_info.name,
+                        )))
+                        .await?;
+                        // store the failed chunk to be retried later
+                        self.failed_chunks.insert(chunk_info);
+                    }
+                }
+            } else {
+                // we're finished
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Store chunks from chunk_paths (assuming payments have already been made and are in our local wallet).
+    /// If verify_store is true, we will attempt to fetch the chunks from the network to verify it is stored.
+    async fn upload_chunk(
+        file_api: FilesApi,
+        chunk_info: ChunkInfo,
+        verify_store: bool,
+        show_holders: bool,
+    ) -> (ChunkInfo, Result<()>) {
+        let chunk_address = ChunkAddress::new(chunk_info.name);
+        let bytes = match tokio::fs::read(chunk_info.path.clone()).await {
+            Ok(bytes) => Bytes::from(bytes),
+            Err(error) => {
+                warn!("Chunk {chunk_address:?} could not be read from the system from {:?}. 
+            Normally this happens if it has been uploaded, but the cleanup process was interrupted. Ignoring error: {error}", chunk_info.path);
+
+                return (chunk_info, Ok(()));
+            }
+        };
+        let chunk = Chunk::new(bytes);
+        match file_api
+            .get_local_payment_and_upload_chunk(chunk, verify_store, show_holders)
+            .await
+        {
+            Ok(()) => (chunk_info, Ok(())),
+            Err(err) => (chunk_info, Err(err)),
+        }
+    }
+
+    fn take_failed_chunks(&mut self) -> Vec<ChunkInfo> {
+        std::mem::take(&mut self.failed_chunks)
+            .into_iter()
+            .collect()
+    }
+
+    async fn send_event(&mut self, event: FileUploadEvent) -> Result<()> {
+        if let Some(sender) = self.event_sender.as_ref() {
+            sender.send(event).await.map_err(|err| {
+                error!("Could not send files event due to {err:?}");
+                ClientError::CouldNotSendFilesEvent
+            })?;
+        } else if !self.logged_event_sender_absence {
+            info!("Files upload event sender is not set. Use get_upload_events() if you need to keep track of the progress");
+            self.logged_event_sender_absence = true;
+        }
+        Ok(())
+    }
+}

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -25,10 +25,7 @@ pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
     faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
-    files::{
-        api::{FilesApi, BATCH_SIZE},
-        FileUploadEvent, Files,
-    },
+    files::{api::FilesApi, FileUploadEvent, Files, BATCH_SIZE},
     register::ClientRegister,
     wallet::{send, WalletClient},
 };

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -15,7 +15,7 @@ mod chunks;
 mod error;
 mod event;
 mod faucet;
-mod file_apis;
+mod files;
 mod register;
 mod wallet;
 
@@ -25,7 +25,10 @@ pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
     faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
-    file_apis::{Files, BATCH_SIZE},
+    files::{
+        api::{FilesApi, BATCH_SIZE},
+        FileUploadEvent, Files,
+    },
     register::ClientRegister,
     wallet::{send, WalletClient},
 };

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::{
     error::Error,
     event::{ClientEvent, ClientEventsReceiver},
     faucet::{get_tokens_from_faucet, load_faucet_wallet_from_genesis_wallet},
-    files::{api::FilesApi, FileUploadEvent, Files, BATCH_SIZE},
+    files::{api::FilesApi, FileUploadEvent, Files, BATCH_SIZE, MAX_UPLOAD_RETRIES},
     register::ClientRegister,
     wallet::{send, WalletClient},
 };

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -17,7 +17,7 @@ use rand::{
     Rng,
 };
 use self_encryption::MIN_ENCRYPTABLE_BYTES;
-use sn_client::{Client, Files};
+use sn_client::{Client, FilesApi};
 use sn_protocol::safenode_proto::{
     safe_node_client::SafeNodeClient, NodeInfoRequest, RestartRequest,
 };
@@ -31,7 +31,7 @@ use std::{
 use tonic::Request;
 use xor_name::XorName;
 
-type ResultRandomContent = Result<(Files, Bytes, ChunkAddress, Vec<(XorName, PathBuf)>)>;
+type ResultRandomContent = Result<(FilesApi, Bytes, ChunkAddress, Vec<(XorName, PathBuf)>)>;
 
 pub fn random_content(
     client: &Client,
@@ -50,8 +50,8 @@ pub fn random_content(
     let mut output_file = File::create(file_path.clone())?;
     output_file.write_all(&random_length_content)?;
 
-    let files_api = Files::new(client.clone(), wallet_dir);
-    let (file_addr, _file_size, chunks) = Files::chunk_file(&file_path, chunk_dir)?;
+    let files_api = FilesApi::new(client.clone(), wallet_dir);
+    let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunk_dir)?;
 
     Ok((
         files_api,

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -378,7 +378,7 @@ fn store_chunks_task(
         // Store Chunks at a higher frequency than the churning events
         let delay = churn_period / CHUNK_CREATION_RATIO_TO_CHURN;
 
-        let file_api = FilesApi::new(client, paying_wallet_dir);
+        let files_api = FilesApi::new(client, paying_wallet_dir);
         let mut rng = OsRng;
 
         loop {
@@ -410,7 +410,7 @@ fn store_chunks_task(
             let chunks_len = chunks.len();
             let chunks_name = chunks.iter().map(|(name, _)| *name).collect::<Vec<_>>();
 
-            let mut files = Files::new(file_api.clone(), BATCH_SIZE, true, true, 3);
+            let mut files = Files::new(files_api.clone()).set_show_holders(true);
             if let Err(err) = files.upload_chunks(chunks).await {
                 bail!("Bailing w/ new Chunk ({addr:?}) due to error: {err:?}");
             }

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -18,7 +18,7 @@ use common::{
 };
 use eyre::{bail, eyre, Result};
 use rand::{rngs::OsRng, Rng};
-use sn_client::{Client, Error, Files, WalletClient, BATCH_SIZE};
+use sn_client::{Client, Error, FilesApi, WalletClient, BATCH_SIZE};
 use sn_logging::LogBuilder;
 use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress, SpendAddress},
@@ -378,7 +378,7 @@ fn store_chunks_task(
         // Store Chunks at a higher frequency than the churning events
         let delay = churn_period / CHUNK_CREATION_RATIO_TO_CHURN;
 
-        let file_api = Files::new(client, paying_wallet_dir);
+        let file_api = FilesApi::new(client, paying_wallet_dir);
         let mut rng = OsRng;
 
         loop {
@@ -398,7 +398,7 @@ fn store_chunks_task(
                 .expect("failed to write to temp chunk file");
 
             let (addr, _file_size, chunks) =
-                Files::chunk_file(&file_path, &output_dir).expect("Failed to chunk bytes");
+                FilesApi::chunk_file(&file_path, &output_dir).expect("Failed to chunk bytes");
 
             println!(
                 "Paying storage for ({}) new Chunk/s of file ({} bytes) at {addr:?} in {delay:?}",
@@ -629,7 +629,7 @@ async fn query_content(
             Ok(())
         }
         NetworkAddress::ChunkAddress(addr) => {
-            let file_api = Files::new(client.clone(), wallet_dir.to_path_buf());
+            let file_api = FilesApi::new(client.clone(), wallet_dir.to_path_buf());
             let _ = file_api.read_bytes(*addr, None, false, BATCH_SIZE).await?;
             Ok(())
         }

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -624,8 +624,8 @@ async fn query_content(
             Ok(())
         }
         NetworkAddress::ChunkAddress(addr) => {
-            let file_api = FilesApi::new(client.clone(), wallet_dir.to_path_buf());
-            let _ = file_api.read_bytes(*addr, None, false, BATCH_SIZE).await?;
+            let files_api = FilesApi::new(client.clone(), wallet_dir.to_path_buf());
+            let _ = files_api.read_bytes(*addr, None, false, BATCH_SIZE).await?;
             Ok(())
         }
         _other => Ok(()), // we don't create/store any other type of content in this test yet

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -12,7 +12,7 @@ use crate::common::{client::get_gossip_client_and_wallet, random_content};
 use assert_fs::TempDir;
 use eyre::{eyre, Result};
 use rand::Rng;
-use sn_client::{Error as ClientError, WalletClient, BATCH_SIZE};
+use sn_client::{Error as ClientError, Files, WalletClient, BATCH_SIZE};
 use sn_logging::LogBuilder;
 use sn_networking::{Error as NetworkError, GetRecordError};
 use sn_protocol::{
@@ -199,9 +199,8 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         )
         .await?;
 
-    files_api
-        .pay_and_upload_bytes_test(*file_addr.xorname(), chunks, true)
-        .await?;
+    let mut files = Files::new(files_api.clone(), BATCH_SIZE, true, true, 3);
+    files.upload_chunks(chunks).await?;
 
     files_api
         .read_bytes(file_addr, None, false, BATCH_SIZE)

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -199,7 +199,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
         )
         .await?;
 
-    let mut files = Files::new(files_api.clone(), BATCH_SIZE, true, true, 3);
+    let mut files = Files::new(files_api.clone()).set_show_holders(true);
     files.upload_chunks(chunks).await?;
 
     files_api

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -20,7 +20,7 @@ use libp2p::{
     PeerId,
 };
 use rand::{rngs::OsRng, Rng};
-use sn_client::{Client, Files};
+use sn_client::{Client, FilesApi};
 use sn_logging::LogBuilder;
 use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::safenode_proto::{
@@ -270,7 +270,7 @@ async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAd
 async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -> Result<()> {
     let start = Instant::now();
     let mut rng = OsRng;
-    let file_api = Files::new(client, wallet_dir);
+    let file_api = FilesApi::new(client, wallet_dir);
 
     let mut uploaded_chunks_count = 0;
     loop {
@@ -289,7 +289,7 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
         let mut output_file = File::create(file_path.clone())?;
         output_file.write_all(&random_bytes)?;
 
-        let (file_addr, _file_size, chunks) = Files::chunk_file(&file_path, chunks_dir.path())?;
+        let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunks_dir.path())?;
 
         println!(
             "Paying storage for ({}) new Chunk/s of file ({} bytes) at {file_addr:?}",

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -20,7 +20,7 @@ use libp2p::{
     PeerId,
 };
 use rand::{rngs::OsRng, Rng};
-use sn_client::{Client, Files, FilesApi, BATCH_SIZE};
+use sn_client::{Client, Files, FilesApi};
 use sn_logging::LogBuilder;
 use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::safenode_proto::{
@@ -298,7 +298,9 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
         );
 
         let key = PrettyPrintRecordKey::from(&RecordKey::new(&file_addr)).into_owned();
-        let mut files = Files::new(files_api.clone(), BATCH_SIZE, false, true, 3);
+        let mut files = Files::new(files_api.clone())
+            .set_show_holders(true)
+            .set_verify_store(false);
         files.upload_chunks(chunks).await?;
         uploaded_chunks_count += 1;
 


### PR DESCRIPTION
## Description
- Moves the upload retry logic from CLI -> Client
- Renames `sn_client::Files` -> `sn_client::FilesApi` and the higher level code with the retry logic + batching etc are inside `sn_client::Files` now.
- Emits `FileUploadEvent` to track the progress of the upload process.
- Todo: move the downloads logic from CLI to `sn_client::Files`

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Dec 23 07:52 UTC
This pull request involves several changes across multiple files. Here is a summary of the changes:

1. The file `sn_client/src/files/mod.rs` has been added. It contains implementations related to file uploads, including handling chunk batches, uploading chunks, and progress tracking. It also defines structs and enums related to file upload events and chunk information. Additionally, it defines the `Files` struct with methods for uploading files and retrieving upload events.

2. In the file `lib.rs`, the following changes have been made:
   - The module `file_apis` has been renamed to `files`.
   - The struct `Files` has been moved to the `files` module.
   - The constant `BATCH_SIZE` has been moved to the `files` module.
   - The trait `FilesApi` has been added to the `files` module.
   - The struct `FileUploadEvent` has been added to the `files` module.

3. The file `mod.rs` has the following changes:
   - An import statement `use sn_client::{Client, FilesApi};` has been added.
   - The type `ResultRandomContent` has been modified to use `FilesApi` instead of `Files`.
   - The function `random_content` has been modified to use `FilesApi` instead of `Files`.
   - The variable `files_api` has been modified to use `FilesApi` instead of `Files`.

4. The file `error.rs` has been modified with the addition of two new variants to the `Error` enum: `SequentialUploadPaymentError` and `CouldNotSendFilesEvent`. These variants handle specific error scenarios related to network connection and file handling.

5. The file `sn_client/src/file_apis.rs` has been renamed to `sn_client/src/files/api.rs`. Additionally, the struct `Files` has been renamed to `FilesApi` with corresponding updates to import statements and function calls.

6. The file `sn_node/tests/verify_data_location.rs` has undergone changes related to updating the usage of the `Files` module to the `FilesApi` module from the `sn_client` crate. These changes involve modifying import statements and updating variable declarations and function calls.

In summary, this pull request introduces changes to improve file upload functionality, adjust module structure, handle specific error scenarios, and update the usage of the `Files` module to the new `FilesApi` module.
<!-- reviewpad:summarize:end --> 
