### PR TITLE
test(CI): upload same file with different names

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -106,13 +106,21 @@ jobs:
       # Note rg will throw an error directly in case of failed to find a matching pattern.
       - name: Start a different client to upload the same file
         run: |
+          pwd
           mv $CLIENT_DATA_PATH $SAFE_DATA_PATH/client_first
+          ls -l $SAFE_DATA_PATH
+          ls -l $SAFE_DATA_PATH/client_first
+          mkdir $SAFE_DATA_PATH/client
+          ls -l $SAFE_DATA_PATH
+          mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
+          ls -l $CLIENT_DATA_PATH
+          cp ./the-test-data.zip ./the-test-data_1.zip
           cargo run --bin faucet --release -- --log-output-dest=data-dir send 5000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet_1.txt
           cat initial_balance_from_faucet_1.txt
           cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex
           cat transfer_hex
           cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" --show-holders -r 0 > second_upload.txt 
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data_1.zip" --show-holders -r 0 > second_upload.txt
           cat second_upload.txt
           rg "New wallet balance: 5000000.000000000" second_upload.txt -c --stats
         env:
@@ -201,8 +209,8 @@ jobs:
             echo "Only downloaded $downloaded_files files, less than the 1 file uploaded"
             exit 1
           fi
-          file_size1=$(stat -c "%s" ./the-test-data.zip)
-          file_size2=$(stat -c "%s" $CLIENT_DATA_PATH/downloaded_files/the-test-data.zip)
+          file_size1=$(stat -c "%s" ./the-test-data_1.zip)
+          file_size2=$(stat -c "%s" $CLIENT_DATA_PATH/downloaded_files/the-test-data_1.zip)
           if [ $file_size1 != $file_size2 ]; then
             echo "The downloaded file has a different size $file_size2 to the original $file_size1."
             exit 1


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Dec 23 15:49 UTC
This pull request includes a test for uploading the same file with different names. The patch modifies the memcheck.yml file in the .github/workflows directory. It adds a step to rename the client data path and copy the logs to the original path. It also creates a new file called the-test-data_1.zip and uploads it using the safe binary.
<!-- reviewpad:summarize:end --> 
