### PR TITLE
feat(cli): random shuffle upload chunks to allow clients co-operation

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -37,6 +37,7 @@ futures = "~0.3.13"
 hex = "~0.4.3"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = { version="0.53", features = ["identify", "kad"] }
+rand = "0.8.5"
 rayon = "1.8.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 rmp-serde = "1.1.1"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Dec 23 11:20 UTC
This pull request adds a feature to the CLI that allows for random shuffling of uploaded chunks. This enables clients to cooperate during file uploads, potentially speeding up the process. The patch includes changes to the `Cargo.toml` and `src/subcommands/files/mod.rs` files.
<!-- reviewpad:summarize:end --> 
