### PR TITLE
feat(transfers): add api for cleaning up CashNotes

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -102,7 +102,7 @@ impl WalletClient {
             )));
         } else {
             // clear unconfirmed txs
-            self.wallet.clear_unconfirmed_spend_requests();
+            self.wallet.clear_confirmed_spend_requests();
         }
 
         // return the first CashNote (assuming there is only one because we only sent to one recipient)
@@ -264,7 +264,7 @@ impl WalletClient {
             )));
         } else {
             info!("Spend has completed: {:?}", spend_attempt_result);
-            self.wallet.clear_unconfirmed_spend_requests();
+            self.wallet.clear_confirmed_spend_requests();
         }
 
         Ok(total_cost)
@@ -282,7 +282,7 @@ impl WalletClient {
             .await
             .is_ok()
         {
-            self.wallet.clear_unconfirmed_spend_requests();
+            self.wallet.clear_confirmed_spend_requests();
             // We might want to be _really_ sure and do the below
             // as well, but it's not necessary.
             // use crate::domain::wallet::VerifyingClient;

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -387,10 +387,6 @@ impl LocalWallet {
             self.store_cash_notes_to_disk(&[cash_note])?;
         }
 
-        for cash_note in &transfer.created_cash_notes {
-            self.watchonly_wallet
-                .insert_cash_note_created_for_others(cash_note.unique_pubkey());
-        }
         // Store created CashNotes in a batch, improving IO performance
         self.store_cash_notes_to_disk(&transfer.created_cash_notes)?;
 
@@ -513,11 +509,6 @@ mod tests {
             .watchonly_wallet
             .available_cash_notes()
             .is_empty());
-        assert!(deposit_only
-            .watchonly_wallet
-            .cash_notes_created_for_others()
-            .is_empty());
-        assert!(deposit_only.watchonly_wallet.spent_cash_notes().is_empty());
 
         Ok(())
     }
@@ -546,11 +537,6 @@ mod tests {
             .watchonly_wallet
             .available_cash_notes()
             .is_empty());
-        assert!(deposit_only
-            .watchonly_wallet
-            .cash_notes_created_for_others()
-            .is_empty());
-        assert!(deposit_only.watchonly_wallet.spent_cash_notes().is_empty());
 
         Ok(())
     }
@@ -641,27 +627,11 @@ mod tests {
         assert_eq!(GENESIS_CASHNOTE_AMOUNT, deserialized.balance().as_nano());
 
         assert_eq!(1, depositor.watchonly_wallet.available_cash_notes().len());
-        assert_eq!(
-            0,
-            depositor
-                .watchonly_wallet
-                .cash_notes_created_for_others()
-                .len()
-        );
-        assert_eq!(0, depositor.watchonly_wallet.spent_cash_notes().len());
 
         assert_eq!(
             1,
             deserialized.watchonly_wallet.available_cash_notes().len()
         );
-        assert_eq!(
-            0,
-            deserialized
-                .watchonly_wallet
-                .cash_notes_created_for_others()
-                .len()
-        );
-        assert_eq!(0, deserialized.watchonly_wallet.spent_cash_notes().len());
 
         let a_available = depositor
             .watchonly_wallet
@@ -746,27 +716,11 @@ mod tests {
         );
 
         assert_eq!(1, sender.watchonly_wallet.available_cash_notes().len());
-        assert_eq!(
-            1,
-            sender
-                .watchonly_wallet
-                .cash_notes_created_for_others()
-                .len()
-        );
-        assert_eq!(1, sender.watchonly_wallet.spent_cash_notes().len());
 
         assert_eq!(
             1,
             deserialized.watchonly_wallet.available_cash_notes().len()
         );
-        assert_eq!(
-            1,
-            deserialized
-                .watchonly_wallet
-                .cash_notes_created_for_others()
-                .len()
-        );
-        assert_eq!(1, deserialized.watchonly_wallet.spent_cash_notes().len());
 
         let a_available = sender
             .watchonly_wallet
@@ -781,26 +735,6 @@ mod tests {
             .last()
             .expect("There to be an available CashNote.");
         assert_eq!(a_available, b_available);
-
-        let a_created_for_others = sender.watchonly_wallet.cash_notes_created_for_others();
-        let b_created_for_others = deserialized
-            .watchonly_wallet
-            .cash_notes_created_for_others();
-        assert_eq!(a_created_for_others, b_created_for_others);
-
-        let a_spent = sender
-            .watchonly_wallet
-            .spent_cash_notes()
-            .iter()
-            .last()
-            .expect("There to be a spent CashNote.");
-        let b_spent = deserialized
-            .watchonly_wallet
-            .spent_cash_notes()
-            .iter()
-            .last()
-            .expect("There to be a spent CashNote.");
-        assert_eq!(a_spent, b_spent);
 
         Ok(())
     }

--- a/sn_transfers/src/wallet/mod.rs
+++ b/sn_transfers/src/wallet/mod.rs
@@ -60,6 +60,8 @@ mod wallet_file;
 mod watch_only;
 
 use data_payments::ContentPaymentsMap;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 pub use self::{
     data_payments::{Payment, PaymentQuote},
@@ -71,34 +73,19 @@ pub use self::{
 pub(crate) use keys::store_new_keypair;
 
 use crate::{NanoTokens, UniquePubkey};
-use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(Default, serde::Serialize, serde::Deserialize)]
-/// This assumes the CashNotes are stored on disk
+#[derive(Default, Serialize, Deserialize)]
 pub(super) struct KeyLessWallet {
-    /// These are the UniquePubkeys of cash_notes we've owned, that have been
-    /// spent when sending tokens to other addresses.
-    spent_cash_notes: BTreeSet<UniquePubkey>,
-    /// These are the UniquePubkeys of cash_notes we own that are not yet spent.
     available_cash_notes: BTreeMap<UniquePubkey, NanoTokens>,
-    /// These are the UniquePubkeys of cash_notes we've created by
-    /// sending tokens to other addresses.
-    /// They are not owned by us, but we
-    /// keep them here so we can track our
-    /// transfer history.
-    cash_notes_created_for_others: BTreeSet<UniquePubkey>,
-    /// Cached proofs of storage transactions made to be used for uploading the paid content.
     payment_transactions: ContentPaymentsMap,
 }
 
 impl KeyLessWallet {
     pub fn balance(&self) -> NanoTokens {
-        // loop through avaiable cash notes and get total token count
         let mut balance = 0;
         for (_unique_pubkey, value) in self.available_cash_notes.iter() {
             balance += value.as_nano();
         }
-
         NanoTokens::from(balance)
     }
 }

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -144,6 +144,26 @@ where
     Ok(())
 }
 
+/// Hex encode and remove each `CashNote` from a separate file in respective
+pub(super) fn remove_cash_notes<'a, T>(cash_notes: T, wallet_dir: &Path) -> Result<()>
+where
+    T: IntoIterator<Item = &'a UniquePubkey>,
+{
+    // The create cash_notes dir within the wallet dir.
+    let created_cash_notes_path = wallet_dir.join(CASHNOTES_DIR_NAME);
+    for cash_note_key in cash_notes {
+        let unique_pubkey_name = *SpendAddress::from_unique_pubkey(&cash_note_key).xorname();
+        let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));
+
+        debug!("Removing cash note from: {:?}", created_cash_notes_path);
+
+        let cash_note_file_path = created_cash_notes_path.join(unique_pubkey_file_name);
+
+        fs::remove_file(cash_note_file_path)?;
+    }
+    Ok(())
+}
+
 /// Loads all the cash_notes found in the cash_notes dir.
 pub(super) fn load_cash_notes_from_disk(wallet_dir: &Path) -> Result<Vec<CashNote>> {
     let cash_notes_path = match std::env::var("CASHNOTES_PATH") {

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -152,7 +152,7 @@ where
     // The create cash_notes dir within the wallet dir.
     let created_cash_notes_path = wallet_dir.join(CASHNOTES_DIR_NAME);
     for cash_note_key in cash_notes {
-        let unique_pubkey_name = *SpendAddress::from_unique_pubkey(&cash_note_key).xorname();
+        let unique_pubkey_name = *SpendAddress::from_unique_pubkey(cash_note_key).xorname();
         let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));
 
         debug!("Removing cash note from: {:?}", created_cash_notes_path);

--- a/sn_transfers/src/wallet/watch_only.rs
+++ b/sn_transfers/src/wallet/watch_only.rs
@@ -180,7 +180,7 @@ impl WatchOnlyWallet {
         &self.keyless_wallet.available_cash_notes
     }
 
-    /// Remove referenced CashNotes from available_cash_notes and add it to spent_cash_notes.
+    /// Remove referenced CashNotes from available_cash_notes
     pub fn mark_notes_as_spent<'a, T>(&mut self, unique_pubkeys: T)
     where
         T: IntoIterator<Item = &'a UniquePubkey>,

--- a/sn_transfers/src/wallet/watch_only.rs
+++ b/sn_transfers/src/wallet/watch_only.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{CashNote, MainPubkey, NanoTokens, UniquePubkey};
 use fs2::FileExt;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     fs::OpenOptions,
     path::{Path, PathBuf},
 };
@@ -106,11 +106,6 @@ impl WatchOnlyWallet {
         for cash_note in received_cash_notes {
             let id = cash_note.unique_pubkey();
 
-            if self.keyless_wallet.spent_cash_notes.contains(&id) {
-                debug!("skipping: cash_note is spent");
-                continue;
-            }
-
             if cash_note.derived_pubkey(&self.main_pubkey).is_err() {
                 debug!("skipping: cash_note is not our key");
                 continue;
@@ -140,11 +135,6 @@ impl WatchOnlyWallet {
 
         for cash_note in received_cash_notes {
             let id = cash_note.unique_pubkey();
-
-            if self.keyless_wallet.spent_cash_notes.contains(&id) {
-                debug!("skipping: cash_note is spent");
-                continue;
-            }
 
             if cash_note.derived_pubkey(&self.main_pubkey).is_err() {
                 debug!("skipping: cash_note is not our key");
@@ -187,36 +177,7 @@ impl WatchOnlyWallet {
     {
         for k in unique_pubkeys {
             self.keyless_wallet.available_cash_notes.remove(k);
-            self.keyless_wallet.spent_cash_notes.insert(*k);
         }
-    }
-
-    /// Return the set of UnniquePubjkey's of spent cash notes.
-    pub fn spent_cash_notes(&self) -> &BTreeSet<UniquePubkey> {
-        &self.keyless_wallet.spent_cash_notes
-    }
-
-    /// Insert provided UniquePubkey's into the set of spent cash notes.
-    pub fn insert_spent_cash_notes<'a, T>(&mut self, spent_cash_notes: T)
-    where
-        T: IntoIterator<Item = &'a UniquePubkey>,
-    {
-        for pk in spent_cash_notes {
-            let _ = self.keyless_wallet.spent_cash_notes.insert(*pk);
-        }
-    }
-
-    /// Return cash notes created for others
-    pub fn cash_notes_created_for_others(&self) -> &BTreeSet<UniquePubkey> {
-        &self.keyless_wallet.cash_notes_created_for_others
-    }
-
-    /// Record pubkey as a cash note created for others
-    pub fn insert_cash_note_created_for_others(&mut self, unique_pubkey: UniquePubkey) {
-        let _ = self
-            .keyless_wallet
-            .cash_notes_created_for_others
-            .insert(unique_pubkey);
     }
 
     /// Return a payment transaction detail
@@ -277,8 +238,6 @@ mod tests {
         assert_eq!(wallet_dir.path(), wallet.wallet_dir());
         assert_eq!(main_pubkey, wallet.address());
         assert_eq!(NanoTokens::zero(), wallet.balance());
-        assert!(wallet.cash_notes_created_for_others().is_empty());
-        assert!(wallet.spent_cash_notes().is_empty());
         assert!(wallet.available_cash_notes().is_empty());
 
         Ok(())
@@ -301,12 +260,6 @@ mod tests {
 
         assert_eq!(GENESIS_CASHNOTE_AMOUNT, wallet.balance().as_nano());
         assert_eq!(GENESIS_CASHNOTE_AMOUNT, deserialised.balance().as_nano());
-
-        assert!(wallet.cash_notes_created_for_others().is_empty());
-        assert!(deserialised.cash_notes_created_for_others().is_empty());
-
-        assert!(wallet.spent_cash_notes().is_empty());
-        assert!(deserialised.spent_cash_notes().is_empty());
 
         assert_eq!(1, wallet.available_cash_notes().len());
         assert_eq!(1, deserialised.available_cash_notes().len());


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Dec 23 12:27 UTC
This pull request includes the following changes:

1. The `Cargo.toml` file has a new dependency `uluru` with version `3.0.0`.
2. The `wallet_file.rs` file has new functions `remove_cash_notes` and modified function `load_cash_notes_from_disk`.
3. The `wallet.rs` file contains the implementation of a local Wallet with various features.
4. The `WalletClient` implementation has renamed the `clear_unconfirmed_spend_requests()` method to `clear_confirmed_unconfirmed_spend_requests()`.
5. The `Cargo.lock` file has added the `uluru` dependency with its version and dependencies.
6. The `local_store.rs` file has new functions `remove_cash_notes_from_disk`, updated functions, and improved clearing and cleaning up of spend requests.
7. The `watch_only.rs` file has changes related to the efficiency and performance of handling spent cash notes and cash notes created for others.

Let me know if you need more information or have any questions.
<!-- reviewpad:summarize:end --> 
