### PR TITLE
chore: add data path field to node info

### DIFF
--- a/sn_node/src/bin/safenode/rpc_service.rs
+++ b/sn_node/src/bin/safenode/rpc_service.rs
@@ -61,6 +61,11 @@ impl SafeNode for SafeNodeRpcService {
         let resp = Response::new(NodeInfoResponse {
             peer_id: self.running_node.peer_id().to_bytes(),
             log_dir: self.log_dir.clone(),
+            data_dir: self
+                .running_node
+                .root_dir_path()
+                .to_string_lossy()
+                .to_string(),
             pid: process::id(),
             bin_version: env!("CARGO_PKG_VERSION").to_string(),
             uptime_secs: self.started_instant.elapsed().as_secs(),
@@ -352,7 +357,7 @@ impl SafeNode for SafeNodeRpcService {
 
 pub(crate) fn start_rpc_service(
     addr: SocketAddr,
-    log_dir: &str,
+    log_dir_path: &str,
     running_node: RunningNode,
     ctrl_tx: Sender<NodeCtrl>,
     started_instant: Instant,
@@ -360,7 +365,7 @@ pub(crate) fn start_rpc_service(
     // creating a service
     let service = SafeNodeRpcService {
         addr,
-        log_dir: log_dir.to_string(),
+        log_dir: log_dir_path.to_string(),
         running_node,
         ctrl_tx,
         started_instant,

--- a/sn_node_rpc_client/src/lib.rs
+++ b/sn_node_rpc_client/src/lib.rs
@@ -20,6 +20,7 @@ pub struct NodeInfo {
     pub pid: u32,
     pub peer_id: PeerId,
     pub log_path: PathBuf,
+    pub data_path: PathBuf,
     pub version: String,
     pub uptime: Duration,
 }
@@ -71,6 +72,7 @@ impl RpcActions for RpcClient {
             pid: node_info_resp.pid,
             peer_id,
             log_path: PathBuf::from(node_info_resp.log_dir.clone()),
+            data_path: PathBuf::from(node_info_resp.data_dir.clone()),
             version: node_info_resp.bin_version.clone(),
             uptime: Duration::from_secs(node_info_resp.uptime_secs),
         };

--- a/sn_protocol/src/safenode_proto/req_resp_types.proto
+++ b/sn_protocol/src/safenode_proto/req_resp_types.proto
@@ -21,6 +21,7 @@ message NodeInfoResponse {
   string log_dir = 3;
   string bin_version = 4;
   uint64 uptime_secs = 5;
+  string data_dir = 6;
 }
 
 // Information about how this node's connections to the network and peers

--- a/sn_testnet/src/protocol/safenode_proto/req_resp_types.proto
+++ b/sn_testnet/src/protocol/safenode_proto/req_resp_types.proto
@@ -21,6 +21,7 @@ message NodeInfoResponse {
   string log_dir = 3;
   string bin_version = 4;
   uint64 uptime_secs = 5;
+  string data_dir = 6;
 }
 
 // Stream of node events


### PR DESCRIPTION
Since we provide the logs path, it's useful for the node manager to also have access here to the data path, which it can provide to the user.

I also wanted to provide the port the node is running on, but it's not easy to get access to that if the port is assigned by libp2p.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Dec 23 20:56 UTC
This pull request adds a data path field to the node info, allowing the node manager to provide it to the user. It also includes changes to the RPC service and client to handle this new field. Additionally, an attempt to provide the port the node is running on has been made, but it's not easily accessible if the port is assigned by libp2p.
<!-- reviewpad:summarize:end --> 
