### PR TITLE
fix: no retry_after to avoid looping

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -436,7 +436,7 @@ impl Network {
                 warn!("Failed to PUT record with key: {pretty_key:?} to network (retry via backoff) with error: {err:?}");
 
                 if cfg.re_attempt {
-                    BackoffError::Transient { err, retry_after: Some(Duration::from_millis(rand::thread_rng().gen_range(1500..5000))) }
+                    BackoffError::Transient { err, retry_after: None }
                 } else {
                     BackoffError::Permanent(err)
                 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Dec 23 08:48 UTC
This pull request fixes an issue where a retry_after value was being set in the BackoffError struct. The fix removes the retry_after value to avoid looping.
<!-- reviewpad:summarize:end --> 
