### PR TITLE
fix(test): tests should try to load just the faucet wallet

### DIFF
--- a/sn_client/src/faucet/mod.rs
+++ b/sn_client/src/faucet/mod.rs
@@ -1,9 +1,15 @@
-use super::{wallet::send, Result};
-use crate::Client;
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_transfers::LocalWallet;
-use sn_transfers::{create_faucet_wallet, load_genesis_wallet};
-use sn_transfers::{CashNote, MainPubkey, NanoTokens};
+use crate::{wallet::send, Client, Result};
+use sn_transfers::{
+    create_faucet_wallet, load_genesis_wallet, CashNote, LocalWallet, MainPubkey, NanoTokens,
+};
 
 /// Returns a cash_note with the requested number of tokens, for use by E2E test instances.
 /// Note this will create a faucet having a Genesis balance


### PR DESCRIPTION
- We start a faucet server before each test, so we should be not trying to load the genesis wallet again, instead try to wait for the faucet wallet to get filled in by the faucet_server

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Dec 23 09:34 UTC
This pull request fixes an issue with the tests. Previously, the tests were trying to load the genesis wallet instead of waiting for the faucet wallet to get filled in by the faucet server. This pull request updates the code to wait for the faucet wallet to be filled in before continuing with the tests.
<!-- reviewpad:summarize:end --> 
