### PR TITLE
chore(node): log wallet balance on earning

### DIFF
--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -499,6 +499,7 @@ impl Node {
 
         // load wallet
         let mut wallet = LocalWallet::load_from(&self.network.root_dir_path)?;
+        let old_balance = wallet.balance().as_nano();
 
         // unpack transfer
         trace!("Unpacking incoming Transfers for record {pretty_key}");
@@ -510,11 +511,17 @@ impl Node {
 
         // deposit the CashNotes in our wallet
         wallet.deposit_and_store_to_disk(&cash_notes)?;
+        let new_balance = wallet.balance().as_nano();
+        info!(
+            "The new wallet balance is {new_balance}, after earning {}",
+            new_balance - old_balance
+        );
+
         #[cfg(feature = "open-metrics")]
         let _ = self
             .node_metrics
             .reward_wallet_balance
-            .set(wallet.balance().as_nano() as i64);
+            .set(new_balance as i64);
 
         if royalties_cash_notes_r.is_empty() {
             warn!("No network royalties payment found for record {pretty_key}");


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Dec 23 12:57 UTC
This pull request includes two patches. 

The first patch in `sn_node/src/put_validation.rs` adds logging of the wallet balance when earning. It retrieves the old and new balance of the wallet, deposits the CashNotes, and updates the reward wallet balance metric. 

The second patch in `sn_networking/src/lib.rs` introduces a change to randomly select the payee instead of selecting the lowest cost. It shuffles the costs and selects a random payee from the list. It also includes updates to tests related to the payee selection logic.
<!-- reviewpad:summarize:end --> 
