### PR TITLE
chore: reduce default batch size

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -77,7 +77,7 @@ pub enum FilesCmds {
         #[clap(long, name = "show_holders", default_value = "false")]
         show_holders: bool,
         /// The batch_size for parallel downloading
-        #[clap(long, default_value_t = BATCH_SIZE / 4, short='b')]
+        #[clap(long, default_value_t = BATCH_SIZE , short='b')]
         batch_size: usize,
     },
 }

--- a/sn_client/src/files/mod.rs
+++ b/sn_client/src/files/mod.rs
@@ -24,7 +24,7 @@ use tokio::{
 use xor_name::XorName;
 
 /// `BATCH_SIZE` determines the number of chunks that are processed in parallel during the payment and upload process.
-pub const BATCH_SIZE: usize = 64;
+pub const BATCH_SIZE: usize = 16;
 
 /// The maximum number of retries to perform on a failed chunk.
 pub const MAX_UPLOAD_RETRIES: usize = 3;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Dec 23 13:53 UTC
This pull request reduces the default batch size for parallel downloading in the `sn_cli` and `sn_client` modules. The batch size was changed from 64 to 16.
<!-- reviewpad:summarize:end --> 
