### PR TITLE
chore: log entire RegisterAddress to facilitate debugging

### DIFF
--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -95,12 +95,12 @@ async fn create_register(
     if storage_cost.is_zero() {
         println!(
             "Register '{name}' already exists at {}!",
-            register.address()
+            register.address().to_hex()
         );
     } else {
         println!(
             "Successfully created register '{name}' at {} for {storage_cost:?} (royalties fees: {royalties_fees:?})!",
-            register.address()
+            register.address().to_hex()
         );
     }
     Ok(())

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -89,7 +89,7 @@ async fn create_register(
 
     let meta = XorName::from_content(name.as_bytes());
     let (register, storage_cost, royalties_fees) = client
-        .create_and_pay_for_register(meta, &mut wallet_client, verify_store)
+        .create_and_pay_for_register(meta, &mut wallet_client, verify_store, false)
         .await?;
 
     if storage_cost.is_zero() {

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -340,11 +340,18 @@ impl Client {
         address: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        public: bool,
     ) -> Result<(ClientRegister, NanoTokens, NanoTokens)> {
         info!("Instantiating a new Register replica with address {address:?}");
-        let (reg, mut total_cost, mut total_royalties) =
-            ClientRegister::create_online(self.clone(), address, wallet_client, false).await?;
-
+        let (reg, mut total_cost, mut total_royalties) = match public {
+            false => {
+                ClientRegister::create_online(self.clone(), address, wallet_client, false).await?
+            }
+            true => {
+                ClientRegister::create_public_online(self.clone(), address, wallet_client, false)
+                    .await?
+            }
+        };
         debug!("{address:?} Created in theorryyyyy");
         let reg_address = reg.address();
         if verify_store {

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -60,10 +60,10 @@ impl ClientRegister {
         meta: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
-    ) -> Result<Self> {
+    ) -> Result<(Self, NanoTokens, NanoTokens)> {
         let mut reg = Self::create_register(client, meta, Permissions::new_anyone_can_write())?;
-        reg.sync(wallet_client, verify_store).await?;
-        Ok(reg)
+        let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store).await?;
+        Ok((reg, storage_cost, royalties_fees))
     }
 
     /// Create a new Register and send it to the Network.
@@ -410,7 +410,7 @@ impl ClientRegister {
         client: &Client,
         address: RegisterAddress,
     ) -> Result<Register> {
-        debug!("Retrieving Register from: {address}");
+        debug!("Retrieving Register from: {address:?}");
         let reg = client
             .get_signed_register_from_network(address, false)
             .await?;

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -67,17 +67,17 @@ async fn main() -> Result<()> {
 
     let meta = XorName::from_content(reg_nickname.as_bytes());
     let address = RegisterAddress::new(meta, client.signer_pk());
-    println!("Retrieving Register '{reg_nickname}':'{address:?}' from SAFE, as user '{user}'");
+    println!("Retrieving Register '{reg_nickname}':'{:?}' from SAFE, as user '{user}'", address.to_hex());
     let mut reg_replica = match client.get_register(address).await {
         Ok(register) => {
             println!(
                 "Register '{reg_nickname}' found at {:?}!",
-                register.address(),
+                register.address().to_hex(),
             );
             register
         }
         Err(_) => {
-            println!("Register '{reg_nickname}' not found, creating it at {address:?}");
+            println!("Register '{reg_nickname}' not found, creating it at {:?}", address.to_hex());
             let (register, _cost, _royalties_fees) = client
                 .create_and_pay_for_register(meta, &mut wallet_client, true, true)
                 .await?;
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
             register
         }
     };
-    println!("Register address: {:?}", reg_replica.address());
+    println!("Register address: {:?}", reg_replica.address().to_hex());
     println!("Register owned by: {:?}", reg_replica.owner());
     println!("Register permissions: {:?}", reg_replica.permissions());
 

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -63,9 +63,11 @@ async fn main() -> Result<()> {
 
     // we'll retrieve (or create if not found) a Register, and write on it
     // in offline mode, syncing with the network periodically.
+
+
     let meta = XorName::from_content(reg_nickname.as_bytes());
     let address = RegisterAddress::new(meta, client.signer_pk());
-    println!("Retrieving Register '{reg_nickname}' from SAFE, as user '{user}'");
+    println!("Retrieving Register '{reg_nickname}':'{address:?}' from SAFE, as user '{user}'");
     let mut reg_replica = match client.get_register(address).await {
         Ok(register) => {
             println!(
@@ -75,14 +77,15 @@ async fn main() -> Result<()> {
             register
         }
         Err(_) => {
-            println!("Register '{reg_nickname}' not found, creating it at {address}");
+            println!("Register '{reg_nickname}' not found, creating it at {address:?}");
             let (register, _cost, _royalties_fees) = client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(meta, &mut wallet_client, true, true)
                 .await?;
 
             register
         }
     };
+    println!("Register address: {:?}", reg_replica.address());
     println!("Register owned by: {:?}", reg_replica.owner());
     println!("Register permissions: {:?}", reg_replica.permissions());
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -349,7 +349,7 @@ fn create_registers_task(
             sleep(delay).await;
 
             match client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(meta, &mut wallet_client, true, false)
                 .await
             {
                 Ok(_) => content

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -84,7 +84,7 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
     let prev_rewards_balance = current_rewards_balance()?;
 
     let (_register, storage_cost, _royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(register_addr, &mut wallet_client, false, false)
         .await?;
     println!("Cost is {storage_cost:?}: {prev_rewards_balance:?}");
 
@@ -155,7 +155,7 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     println!("Paying for random Register address {register_addr:?} ...");
     let (_, storage_cost, royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(register_addr, &mut wallet_client, false, false)
         .await?;
     println!("Random Register created, paid {storage_cost}/{royalties_fees}");
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -283,7 +283,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
         .await?;
 
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, true)
+        .create_and_pay_for_register(xor_name, &mut wallet_client, true, false)
         .await?;
 
     let retrieved_reg = client.get_register(address).await?;
@@ -337,7 +337,7 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
 
     // this should fail to store as the amount paid is not enough
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, false)
+        .create_and_pay_for_register(xor_name, &mut wallet_client, false, false)
         .await?;
 
     sleep(Duration::from_secs(5)).await;

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -36,7 +36,7 @@ impl Debug for RegisterAddress {
         write!(
             f,
             "RegisterAddress({}) {{ meta: {:?}, owner: {:?} }}",
-            &self.to_hex(),
+            &self.to_hex()[0..6],
             self.meta,
             self.owner
         )

--- a/sn_registers/src/address.rs
+++ b/sn_registers/src/address.rs
@@ -36,7 +36,7 @@ impl Debug for RegisterAddress {
         write!(
             f,
             "RegisterAddress({}) {{ meta: {:?}, owner: {:?} }}",
-            &self.to_hex()[0..6],
+            &self.to_hex(),
             self.meta,
             self.owner
         )


### PR DESCRIPTION
## Description

This resolves issue #1087

It enables printing/logging of the entire RegisterAddress so that developers can use it to debug code issues.

See a discussion thread here: https://safenetforum.org/t/communication-via-safe-network/38958/14?u=southside

In addition, it also updates `create_and_pay_for_register` with additional function argument `public` which dictates if it should create private or public register.  The example app sn_node/examples/registers.rs was creating a private register which cannot be written by everyone (which is the point that this example showcases).  That example still does't work, but this extra debug info will hopefully make pinpointing the issue easier.
