### PR TITLE
feat(transfers): use MsgPack for serialising Spends, CashNotes and SignedSpends

### DIFF
--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -104,7 +104,7 @@ impl TransactionBuilder {
                     parent_tx: input_src_tx.clone(),
                     network_royalties: network_royalties.clone(),
                 };
-                let derived_key_sig = derived_key.sign(&spend.to_bytes());
+                let derived_key_sig = derived_key.sign(&spend.to_bytes()?);
                 signed_spends.insert(SignedSpend {
                     spend,
                     derived_key_sig,

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
     #[error("Failed to parse: {0}")]
     FailedToParseNanoToken(String),
 
+    #[error("Spend serialisation failed: {0}")]
+    SpendSerializationFailed(String),
     #[error("Invalid Spend: value was tampered with {0:?}")]
     InvalidSpendValue(UniquePubkey),
     #[error("Invalid Spend Signature for {0:?}")]
@@ -45,6 +47,8 @@ pub enum Error {
     SignedSpendInputIdMismatch,
     #[error("SignedSpends for {0:?} have mismatching reasons.")]
     SignedSpendReasonMismatch(UniquePubkey),
+    #[error("SignedSpend serialisation failed: {0}")]
+    SignedSpendSerializationFailed(String),
     #[error("Decryption failed.")]
     DecryptionBySecretKeyFailed,
     #[error("UniquePubkey not found.")]
@@ -79,6 +83,8 @@ pub enum Error {
     CashNoteRedemptionDecryptionFailed,
     #[error("CashNoteRedemption encryption failed")]
     CashNoteRedemptionEncryptionFailed,
+    #[error("Cashnote serialisation failed: {0}")]
+    CashNoteSerializationFailed(String),
     #[error("We are not a recipient of this Transfer")]
     NotRecipient,
     #[error("Transfer serialisation failed")]


### PR DESCRIPTION

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 19 Dec 23 18:36 UTC
This pull request features the use of MsgPack for serializing Spends, CashNotes, and SignedSpends. It includes changes to several files, such as `builder.rs`, `cashnote.rs`, `signed_spend.rs`, `error.rs`, and `local_store.rs`. The patch implements the serialization of various structs using MsgPack and includes error handling for serialization failures.
<!-- reviewpad:summarize:end --> 
