### PR TITLE
chore: log full Register address when created in cli and example app  #1087

### DIFF
--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -95,12 +95,12 @@ async fn create_register(
     if storage_cost.is_zero() {
         println!(
             "Register '{name}' already exists at {}!",
-            register.address()
+            register.address().to_hex()
         );
     } else {
         println!(
             "Successfully created register '{name}' at {} for {storage_cost:?} (royalties fees: {royalties_fees:?})!",
-            register.address()
+            register.address().to_hex()
         );
     }
     Ok(())

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -83,6 +83,7 @@ async fn main() -> Result<()> {
             register
         }
     };
+    println!("Register address: {:?}", reg_replica.address().to_hex());
     println!("Register owned by: {:?}", reg_replica.owner());
     println!("Register permissions: {:?}", reg_replica.permissions());
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 00:44 UTC
This pull request updates the code to log the full Register address when created in the CLI and example app.
<!-- reviewpad:summarize:end --> 

This resolves issue #1087

It enables printing/logging of the entire RegisterAddress so that developers can use it to debug code issues.

See a discussion thread here: https://safenetforum.org/t/communication-via-safe-network/38958/14?u=southside