### PR TITLE
feat(client): Clients no longer upload data_map by default.

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -172,12 +172,12 @@ jobs:
           value: ((if .throughput[0].unit == "KiB/s" then (.throughput[0].per_iteration / (1024*1024*1024)) else (.throughput[0].per_iteration / (1024*1024)) end) / (.mean.estimate / 1e9))
           })' > files-benchmark.json
 
-      - name: Confirming the number of files got uploaded and downloaded during the benchmark test
+      - name: Confirming the number of files uploaded and downloaded during the benchmark test
         shell: bash
         run: |
           ls -l $CLIENT_DATA_PATH
           ls -l $CLIENT_DATA_PATH/uploaded_files
-          ls -l $CLIENT_DATA_PATH/downloaded_files
+          ls -l $CLIENT_DATA_PATH/safe_files
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -190,8 +190,8 @@ jobs:
       - name: Start a client to download files
         run: |
           cargo run --bin safe --release -- --log-output-dest=data-dir files download
-          ls -l $CLIENT_DATA_PATH/downloaded_files
-          downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
+          ls -l $CLIENT_DATA_PATH/safe_files
+          downloaded_files=$(ls $CLIENT_DATA_PATH/safe_files | wc -l)
           if [ $downloaded_files -lt 1 ]; then
             echo "Only downloaded $downloaded_files files, less than the 1 file uploaded"
             exit 1
@@ -204,14 +204,14 @@ jobs:
       - name: Start a client to download the same files again
         run: |
           cargo run --bin safe --release -- --log-output-dest=data-dir files download --show-holders
-          ls -l $CLIENT_DATA_PATH/downloaded_files
-          downloaded_files=$(ls $CLIENT_DATA_PATH/downloaded_files | wc -l)
+          ls -l $CLIENT_DATA_PATH/safe_files
+          downloaded_files=$(ls $CLIENT_DATA_PATH/safe_files | wc -l)
           if [ $downloaded_files -lt 1 ]; then
             echo "Only downloaded $downloaded_files files, less than the 1 file uploaded"
             exit 1
           fi
           file_size1=$(stat -c "%s" ./the-test-data_1.zip)
-          file_size2=$(stat -c "%s" $CLIENT_DATA_PATH/downloaded_files/the-test-data_1.zip)
+          file_size2=$(stat -c "%s" $CLIENT_DATA_PATH/safe_files/the-test-data_1.zip)
           if [ $file_size1 != $file_size2 ]; then
             echo "The downloaded file has a different size $file_size2 to the original $file_size1."
             exit 1

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -95,9 +95,10 @@ jobs:
       # The resources file we upload may change, and with it mem consumption.
       # Be aware!
       - name: Start a client to upload files
+      # -p makes files public
         run: |
           ls -l
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" -r 0
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data.zip" -r 0 -p
         env:
           SN_LOG: "all"
         timeout-minutes: 25
@@ -120,7 +121,7 @@ jobs:
           cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex
           cat transfer_hex
           cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data_1.zip" -r 0 > second_upload.txt
+          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./the-test-data_1.zip" -r 0 -p > second_upload.txt
           cat second_upload.txt
           rg "New wallet balance: 5000000.000000000" second_upload.txt -c --stats
         env:

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -432,7 +432,7 @@ impl ChunkManager {
         //     if let Some(chunked_file) = self.chunks.remove(path_xor) {
         //         trace!("removed {path_xor:?} from chunks list");
         //         self.verified_files
-        //             .push((chunked_file.file_name, chunked_file.file_xor_addr));
+        //             .push((chunked_file.file_name, chunked_file.head_chunk_address));
         //     }
         // }
     }
@@ -614,7 +614,7 @@ mod tests {
             .values()
             .next()
             .expect("1 file should be present")
-            .file_xor_addr;
+            .head_chunk_address;
         assert_eq!(file_xor_addr_from_metadata, file_xor_addr);
 
         // 5. make sure the chunked file's name is the XorName of that chunk
@@ -687,7 +687,7 @@ mod tests {
             .values()
             .next()
             .expect("1 file should be present")
-            .file_xor_addr;
+            .head_chunk_address;
         assert_eq!(file_xor_addr_from_metadata, file_xor_addr);
 
         // 5. make sure the chunked file's name is the XorName of that chunk
@@ -723,7 +723,7 @@ mod tests {
 
         let path_xor = manager.chunks.keys().next().unwrap().clone();
         let chunked_file = manager.chunks.values().next().unwrap().clone();
-        let file_xor_addr = chunked_file.file_xor_addr;
+        let file_xor_addr = chunked_file.head_chunk_address;
         let (chunk, _) = chunked_file
             .chunks
             .first()
@@ -750,7 +750,7 @@ mod tests {
             ChunkManager::read_file_chunks_dir(file_chunks_dir, &path_xor, chunked_file.file_name)
                 .expect("Folder and metadata should be present");
         assert_eq!(chunked_file_from_dir.chunks.len(), total_chunks - 1);
-        assert_eq!(chunked_file_from_dir.file_xor_addr, file_xor_addr);
+        assert_eq!(chunked_file_from_dir.head_chunk_address, file_xor_addr);
         assert_eq!(path_xor_from_dir, path_xor);
 
         // 2. file should not be marked as verified
@@ -792,8 +792,8 @@ mod tests {
             .expect("Folder and metadata should be present");
             assert_eq!(chunked_file_from_dir.chunks.len(), 0);
             assert_eq!(
-                chunked_file_from_dir.file_xor_addr,
-                chunked_file.file_xor_addr
+                chunked_file_from_dir.head_chunk_address,
+                chunked_file.head_chunk_address
             );
             assert_eq!(&path_xor_from_dir, path_xor);
         }

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -202,7 +202,15 @@ async fn upload_files(
             println!("All files were already uploaded and verified");
             println!("**************************************");
             println!("*          Uploaded Files            *");
+
+            if !make_data_public {
+                println!("*                                    *");
+                println!("*  These are not public by default.  *");
+                println!("*     Reupload with `-p` option      *");
+                println!("*      to publish the datamaps.      *");
+            }
             println!("**************************************");
+
             if chunk_manager.verified_files().is_empty() {
                 println!("chunk_manager doesn't have any verified_files, nor any failed_chunks to re-upload.");
             }

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -35,6 +35,9 @@ use std::{
 use walkdir::WalkDir;
 use xor_name::XorName;
 
+/// The default folder to download files to.
+const DOWNLOAD_FOLDER: &str = "safe_files";
+
 #[derive(Parser, Debug)]
 pub enum FilesCmds {
     Upload {
@@ -205,11 +208,11 @@ async fn upload_files(
             }
             for (file_name, addr) in chunk_manager.verified_files() {
                 if let Some(file_name) = file_name.to_str() {
-                    println!("\"{file_name}\" {addr:x}");
-                    info!("Uploaded {file_name} to {addr:x}");
+                    println!("\"{file_name}\" {addr:?}");
+                    info!("Uploaded {file_name} to {addr:?}");
                 } else {
-                    println!("\"{file_name:?}\" {addr:x}");
-                    info!("Uploaded {file_name:?} to {addr:x}");
+                    println!("\"{file_name:?}\" {addr:?}");
+                    info!("Uploaded {file_name:?} to {addr:?}");
                 }
             }
             return Ok(());
@@ -282,11 +285,11 @@ async fn upload_files(
             println!("**************************************");
             for (file_name, addr) in chunk_manager.verified_files() {
                 if let Some(file_name) = file_name.to_str() {
-                    println!("\"{file_name}\" {addr:x}");
-                    info!("Uploaded {file_name} to {addr:x}");
+                    println!("\"{file_name}\" {addr:?}");
+                    info!("Uploaded {file_name} to {addr:?}");
                 } else {
-                    println!("\"{file_name:?}\" {addr:x}");
-                    info!("Uploaded {file_name:?} to {addr:x}");
+                    println!("\"{file_name:?}\" {addr:?}");
+                    info!("Uploaded {file_name:?} to {addr:?}");
                 }
             }
         } else {
@@ -350,7 +353,7 @@ async fn download_files(
     let uploaded_files_path = root_dir.join(UPLOADED_FILES);
     let download_path = dirs_next::download_dir()
         .unwrap_or(root_dir.to_path_buf())
-        .join("safe_files");
+        .join(DOWNLOAD_FOLDER);
     std::fs::create_dir_all(download_path.as_path())?;
 
     #[allow(clippy::mutable_key_type)]
@@ -425,7 +428,7 @@ fn format_elapsed_time(elapsed_time: std::time::Duration) -> String {
 async fn download_file(
     files_api: &FilesApi,
     xorname: &XorName,
-    // file name and optional datamap chunk
+    // original file name and optional datamap chunk
     file_data: &(String, Option<Chunk>),
     download_path: &Path,
     show_holders: bool,

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -359,7 +359,9 @@ async fn download_files(
 ) -> Result<()> {
     info!("Downloading with batch size of {}", batch_size);
     let uploaded_files_path = root_dir.join("uploaded_files");
-    let download_path = dirs_next::download_dir().unwrap_or(root_dir.join("downloaded_files"));
+    let download_path = dirs_next::download_dir()
+        .unwrap_or(root_dir.to_path_buf())
+        .join("safe_files");
     std::fs::create_dir_all(download_path.as_path())?;
 
     let file = std::fs::File::open(&uploaded_files_path)?;

--- a/sn_client/src/chunks/pac_man.rs
+++ b/sn_client/src/chunks/pac_man.rs
@@ -107,7 +107,7 @@ fn pack_data_map(data_map: DataMap) -> Result<(Chunk, Vec<Chunk>)> {
         // If datamap chunk is less than `MAX_CHUNK_SIZE` return it so it can be directly sent to the network.
         if MAX_CHUNK_SIZE >= chunk.serialised_size() {
             chunks.reverse();
-            // Returns the address of the last datamap, the datamap chunk, and all the chunks produced.
+            // Returns the last datamap, and all the chunks produced.
             break (chunk, chunks);
         } else {
             let mut bytes = BytesMut::with_capacity(MAX_CHUNK_SIZE).writer();

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -51,13 +51,13 @@ pub fn random_content(
     output_file.write_all(&random_length_content)?;
 
     let files_api = FilesApi::new(client.clone(), wallet_dir);
-    let (file_addr, _data_map, _file_size, chunks) =
+    let (head_chunk_address, _data_map, _file_size, chunks) =
         FilesApi::chunk_file(&file_path, chunk_dir, true)?;
 
     Ok((
         files_api,
         random_length_content.into(),
-        ChunkAddress::new(file_addr),
+        head_chunk_address,
         chunks,
     ))
 }

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -51,7 +51,7 @@ pub fn random_content(
     output_file.write_all(&random_length_content)?;
 
     let files_api = FilesApi::new(client.clone(), wallet_dir);
-    let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunk_dir)?;
+    let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunk_dir, true)?;
 
     Ok((
         files_api,

--- a/sn_node/tests/common/mod.rs
+++ b/sn_node/tests/common/mod.rs
@@ -51,7 +51,8 @@ pub fn random_content(
     output_file.write_all(&random_length_content)?;
 
     let files_api = FilesApi::new(client.clone(), wallet_dir);
-    let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunk_dir, true)?;
+    let (file_addr, _data_map, _file_size, chunks) =
+        FilesApi::chunk_file(&file_path, chunk_dir, true)?;
 
     Ok((
         files_api,

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -398,7 +398,7 @@ fn store_chunks_task(
                 .expect("failed to write to temp chunk file");
 
             let (addr, _file_size, chunks) =
-                FilesApi::chunk_file(&file_path, &output_dir).expect("Failed to chunk bytes");
+                FilesApi::chunk_file(&file_path, &output_dir, true).expect("Failed to chunk bytes");
 
             println!(
                 "Paying storage for ({}) new Chunk/s of file ({} bytes) at {addr:?} in {delay:?}",

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -397,7 +397,7 @@ fn store_chunks_task(
                 .write_all(&random_bytes)
                 .expect("failed to write to temp chunk file");
 
-            let (addr, _file_size, chunks) =
+            let (addr, _data_map, _file_size, chunks) =
                 FilesApi::chunk_file(&file_path, &output_dir, true).expect("Failed to chunk bytes");
 
             println!(
@@ -625,7 +625,9 @@ async fn query_content(
         }
         NetworkAddress::ChunkAddress(addr) => {
             let files_api = FilesApi::new(client.clone(), wallet_dir.to_path_buf());
-            let _ = files_api.read_bytes(*addr, None, false, BATCH_SIZE).await?;
+            let _ = files_api
+                .read_bytes(*addr, None, None, false, BATCH_SIZE)
+                .await?;
             Ok(())
         }
         _other => Ok(()), // we don't create/store any other type of content in this test yet

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -203,7 +203,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
     files.upload_chunks(chunks).await?;
 
     files_api
-        .read_bytes(file_addr, None, false, BATCH_SIZE)
+        .read_bytes(file_addr, None, None, false, BATCH_SIZE)
         .await?;
 
     Ok(())
@@ -249,7 +249,7 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
     assert!(
         matches!(
             files_api
-                .read_bytes(content_addr, None, false, BATCH_SIZE)
+                .read_bytes(content_addr, None, None, false, BATCH_SIZE)
                 .await,
             Err(ClientError::Network(NetworkError::GetRecordError(
                 GetRecordError::RecordNotFound

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -324,7 +324,8 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
         let mut output_file = File::create(file_path.clone())?;
         output_file.write_all(&random_bytes)?;
 
-        let (file_addr, _file_size, chunks) = FilesApi::chunk_file(&file_path, chunks_dir.path())?;
+        let (file_addr, _file_size, chunks) =
+            FilesApi::chunk_file(&file_path, chunks_dir.path(), true)?;
 
         println!(
             "Paying storage for ({}) new Chunk/s of file ({} bytes) at {file_addr:?}",

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -324,7 +324,7 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
         let mut output_file = File::create(file_path.clone())?;
         output_file.write_all(&random_bytes)?;
 
-        let (file_addr, _file_size, chunks) =
+        let (file_addr, _data_map, _file_size, chunks) =
             FilesApi::chunk_file(&file_path, chunks_dir.path(), true)?;
 
         println!(

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -324,23 +324,24 @@ async fn store_chunks(client: Client, chunk_count: usize, wallet_dir: PathBuf) -
         let mut output_file = File::create(file_path.clone())?;
         output_file.write_all(&random_bytes)?;
 
-        let (file_addr, _data_map, _file_size, chunks) =
+        let (head_chunk_addr, _data_map, _file_size, chunks) =
             FilesApi::chunk_file(&file_path, chunks_dir.path(), true)?;
 
         println!(
-            "Paying storage for ({}) new Chunk/s of file ({} bytes) at {file_addr:?}",
+            "Paying storage for ({}) new Chunk/s of file ({} bytes) at {head_chunk_addr:?}",
             chunks.len(),
             random_bytes.len()
         );
 
-        let key = PrettyPrintRecordKey::from(&RecordKey::new(&file_addr)).into_owned();
+        let key =
+            PrettyPrintRecordKey::from(&RecordKey::new(&head_chunk_addr.xorname())).into_owned();
         let mut files = Files::new(files_api.clone())
             .set_show_holders(true)
             .set_verify_store(false);
         files.upload_chunks(chunks).await?;
         uploaded_chunks_count += 1;
 
-        println!("Stored Chunk with {file_addr:?} / {key:?}");
+        println!("Stored Chunk with {head_chunk_addr:?} / {key:?}");
     }
 
     println!(


### PR DESCRIPTION
Data map will be written to disk unless specifically made

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 06:49 UTC
This pull request includes changes to multiple files. Here is a summary of the main changes:

1. The `FilesApi` struct and its associated methods have been modified:
- The `ChunkFileResult` type now includes an optional `Chunk` field.
- The `chunk_file` function returns the data map chunk, head address, file size, and chunk paths.
- The `upload_chunks` method now uploads the data map chunk.
- The `encrypt_large` function returns the data map chunk as a `Chunk` object along with the resulting chunks.

2. A new command-line option `make_public` has been introduced. It determines whether a file should be made accessible to all. By default, it is set to `false` and can be specified using either `--make_public` or `-p` options. Within the `files_cmds` function, the `make_public` option is passed to the `upload_files` function. If `make_data_public` is `true`, a log message is printed indicating that the file will be made public and linkable.

3. The following changes have been made in a specific file:
- The `Chunk` struct has been imported from the `sn_protocol::storage` module.
- A constant `DATA_MAP_FILE` representing the name of the data map file has been added.
- The `ChunkedFile` struct now includes a `data_map` field.
- The `ChunkedFile` struct constructor has been modified to include the `data_map` field.
- Various functions in the `ChunkManager` implementation have been adjusted to handle the `data_map` field.
- A step has been added to write the `data_map` file alongside the `metadata` file.
- The `get_chunks` function now optionally includes the `data_map` chunks.
- A step has been included to read the `data_map` file during the chunk manager resume process.

4. In the `pac_man.rs` file, the following changes have occurred:
- The return type of the `encrypt_from_path` function has changed from `(XorName, Vec<XorName>)` to `(Chunk, Vec<XorName>)`.
- The variable name `address` has been changed to `data_map_chunk`.
- The return type of the `encrypt_large` function has changed from `(XorName, Vec<(XorName, PathBuf)>)` to `(Chunk, Vec<(XorName, PathBuf)>)`.
- The variable name `address` has been changed to `data_map_chunk`.
- The return type of the `pack_data_map` function has changed from `(XorName, Vec<Chunk>)` to `(Chunk, Vec<Chunk>)`.
- The variable name `name` has been removed from the tuple, and the order of the elements has been changed.

Please let me know if you need more specific details or further assistance with the code review.
<!-- reviewpad:summarize:end --> 
