### PR TITLE
chore(client): emit chunk Uploaded event if a chunk was verified duri…

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -286,6 +286,8 @@ async fn upload_files(
             }
 
             file.flush()?;
+        } else {
+            error!("Got FileUploadEvent::Error inside upload event loop");
         }
 
         Ok::<_, ClientError>(())


### PR DESCRIPTION
…ng repayment

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 08:46 UTC
This pull request includes a chore client change that emits a "Chunk Uploaded" event if a chunk was verified during repayment. The patch also updates the handling of chunk batches to emit appropriate events for failed batches.
<!-- reviewpad:summarize:end --> 
