### PR TITLE
fix: printout un-verified files to alert user

### DIFF
--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -344,6 +344,14 @@ impl ChunkManager {
         &self.verified_files
     }
 
+    /// Return the filename of unverified_files.
+    pub(crate) fn unverified_files(&self) -> Vec<&OsString> {
+        self.chunks
+            .values()
+            .map(|chunked_file| &chunked_file.file_name)
+            .collect()
+    }
+
     /// Return the filename and the file's Xor address if all their chunks has been marked as
     /// verified
     pub(crate) fn already_put_chunks(

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -198,6 +198,9 @@ async fn upload_files(
             println!("**************************************");
             println!("*          Uploaded Files            *");
             println!("**************************************");
+            if chunk_manager.verified_files().is_empty() {
+                println!("chunk_manager doesn't have any verified_files, nor any failed_chunks to re-upload.");
+            }
             for (file_name, addr) in chunk_manager.verified_files() {
                 if let Some(file_name) = file_name.to_str() {
                     println!("\"{file_name}\" {addr:x}");
@@ -263,6 +266,16 @@ async fn upload_files(
         // terminates with an error. This race condition can happen as we bail on `upload_result` before we await the
         // handler.
         if !upload_terminated_with_error {
+            for file_name in chunk_manager.unverified_files() {
+                if let Some(file_name) = file_name.to_str() {
+                    println!("Unverified file \"{file_name}\", suggest to re-upload again.");
+                    info!("Unverified {file_name}");
+                } else {
+                    println!("Unverified file \"{file_name:?}\", suggest to re-upload again.");
+                    info!("Unverified file {file_name:?}");
+                }
+            }
+
             // log uploaded file information
             println!("**************************************");
             println!("*          Uploaded Files            *");


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 12:34 UTC
This pull request fixes an issue where un-verified files were not being printed out to alert the user. The patch adds a new function to return the filename of unverified files in `chunk_manager.rs` and adds a check in the `upload_files` function to print and log unverified filenames.
<!-- reviewpad:summarize:end --> 
