### PR TITLE
chore: reduce network_info and periodic replication logs

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -458,7 +458,7 @@ impl SwarmDriver {
                 send_back_addr,
             } => {
                 event_string = "incoming";
-                info!("{:?}", self.swarm.network_info());
+                // info!("{:?}", self.swarm.network_info());
                 trace!("IncomingConnection ({connection_id:?}) with local_addr: {local_addr:?} send_back_addr: {send_back_addr:?}");
             }
             SwarmEvent::ConnectionEstablished {
@@ -470,7 +470,7 @@ impl SwarmDriver {
             } => {
                 event_string = "ConnectionEstablished";
                 trace!(%peer_id, num_established, "ConnectionEstablished ({connection_id:?}): {}", endpoint_str(&endpoint));
-                info!(%peer_id, ?connection_id, "ConnectionEstablished {:?}", self.swarm.network_info());
+                // info!(%peer_id, ?connection_id, "ConnectionEstablished {:?}", self.swarm.network_info());
 
                 let _ = self.live_connected_peers.insert(
                     connection_id,
@@ -491,7 +491,7 @@ impl SwarmDriver {
                 connection_id,
             } => {
                 event_string = "ConnectionClosed";
-                info!(%peer_id, ?connection_id, "ConnectionClosed: {:?}", self.swarm.network_info());
+                // info!(%peer_id, ?connection_id, "ConnectionClosed: {:?}", self.swarm.network_info());
                 trace!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
                 let _ = self.live_connected_peers.remove(&connection_id);
             }
@@ -502,7 +502,7 @@ impl SwarmDriver {
             } => {
                 event_string = "OutgoingConnErr";
                 warn!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
-                info!("{:?}", self.swarm.network_info());
+                // info!("{:?}", self.swarm.network_info());
 
                 // we need to decide if this was a critical error and the peer should be removed from the routing table
                 let should_clean_peer = match error {
@@ -582,7 +582,7 @@ impl SwarmDriver {
                 send_back_addr,
                 error,
             } => {
-                info!("{:?}", self.swarm.network_info());
+                // info!("{:?}", self.swarm.network_info());
                 event_string = "Incoming ConnErr";
                 error!("IncomingConnectionError from local_addr:?{local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
             }
@@ -1056,6 +1056,18 @@ impl SwarmDriver {
                 shall_retained
             });
 
+        if !shall_removed.is_empty() {
+            info!(
+                "Current libp2p peers pool stats is {:?}",
+                self.swarm.network_info()
+            );
+            info!(
+                "Removing {} outdated live connections, still have {} left.",
+                shall_removed.len(),
+                self.live_connected_peers.len()
+            );
+        }
+
         // Only remove outdated peer not in the RT
         for (connection_id, peer_id) in shall_removed {
             if let Some(kbucket) = self.swarm.behaviour_mut().kademlia.kbucket(peer_id) {
@@ -1068,7 +1080,7 @@ impl SwarmDriver {
                 }
             }
 
-            info!("Removing outdated connection {connection_id:?} to {peer_id:?}");
+            trace!("Removing outdated connection {connection_id:?} to {peer_id:?}");
             let _result = self.swarm.close_connection(connection_id);
         }
     }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -223,7 +223,7 @@ impl Node {
                                 let event_string = format!("{event:?}");
 
                                 self.handle_network_event(event, peers_connected);
-                                info!("Handled non-blocking network event in {:?}: {:?}", start.elapsed(), event_string);
+                                trace!("Handled non-blocking network event in {:?}: {:?}", start.elapsed(), event_string);
 
                             }
                             None => {
@@ -236,20 +236,18 @@ impl Node {
                     // runs every replication_interval time
                     _ = replication_interval.tick() => {
                         let start = std::time::Instant::now();
-                        info!("Periodic replication triggered");
+                        trace!("Periodic replication triggered");
                         let network = self.network.clone();
                         self.record_metrics(Marker::IntervalReplicationTriggered);
 
                         let _handle = spawn(async move {
-                            Marker::ForcedReplication.log();
-
                             if let Err(err) = Self::try_interval_replication(network)
                                 .await
                             {
                                 error!("Error while triggering replication {err:?}");
                             }
 
-                            info!("Periodic replication took {:?}", start.elapsed());
+                            trace!("Periodic replication took {:?}", start.elapsed());
                         });
                     }
                     node_cmd = cmds_receiver.recv() => {

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -69,7 +69,7 @@ impl Node {
             }
         }
 
-        info!(
+        trace!(
             "Try trigger interval started@{start:?}, took {:?}",
             start.elapsed()
         );


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Dec 23 10:35 UTC
This pull request reduces the network_info and periodic replication logs. It modifies the event handling and replication logic to log at a lower level (trace) instead of info. It also removes some unnecessary log statements. Overall, this patch aims to reduce the logging verbosity and improve the performance of the code.
<!-- reviewpad:summarize:end --> 
