### PR TITLE
feat: use put_record_to during upload chunk

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -381,6 +381,7 @@ impl Client {
     pub(super) async fn store_chunk(
         &self,
         chunk: Chunk,
+        payee: PeerId,
         payment: Payment,
         verify_store: bool,
     ) -> Result<()> {
@@ -427,9 +428,7 @@ impl Client {
             re_attempt: true,
             verification,
         };
-        self.network.put_record(record, &put_cfg).await?;
-
-        Ok(())
+        Ok(self.network.put_record_to(payee, record, &put_cfg).await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Dec 23 16:53 UTC
This pull request includes various changes across multiple files:

- In `lib.rs`, changes were made to the `get_store_costs_from_network` function, including a change in the return type. Additionally, new functions (`put_record_to`, `put_record_once`, `put_record_to_once`) were added. The return type of `get_fees_from_store_cost_responses` function was also changed.

- In `mod.rs`, changes were made to include `libp2p::PeerId` and modify return values in `self.api.pay_for_chunks()` and `impl Files::upload_chunk()`.

- In `api.rs`, changes were made to the `store_chunk` method of the `Client` struct and the `put_record` call within it.

- In `sn_networking/src/cmd.rs`, changes were made to add a new variant in the `SwarmCmd` enum, implement handling for the new variant in the `SwarmDriver` struct, and update debug log messages.

- In `wallet.rs`, changes were made to include an import statement, modify return types and arguments in various functions, add a new variable, and modify storing of costs.

These changes seem to be related to storing and retrieving records in a network, specifying payees for chunks, calculating fees, and adding payment and peer information in the wallet functionality.

Let me know if there's anything else I can help with.
<!-- reviewpad:summarize:end --> 
