### PR TITLE
chore(logs): annotate selected messages and log at info level for vdash

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -357,6 +357,7 @@ impl NetworkBuilder {
         identify_version: String,
     ) -> Result<(Network, mpsc::Receiver<NetworkEvent>, SwarmDriver)> {
         let peer_id = PeerId::from(self.keypair.public());
+        // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
         info!("Node (PID: {}) with PeerId: {peer_id}", std::process::id());
         info!(
             "Self PeerID {peer_id} is represented as kbucket_key {:?}",

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -117,7 +117,8 @@ impl NodeRecordStore {
         // we should only be reading if we know the record is written to disk properly
         match fs::read(file_path) {
             Ok(value) => {
-                debug!(
+                // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
+                info!(
                     "Retrieved record from disk! filename: {filename} after {:?}",
                     start.elapsed()
                 );
@@ -247,7 +248,8 @@ impl NodeRecordStore {
         tokio::spawn(async move {
             let event = match fs::write(&file_path, r.value) {
                 Ok(_) => {
-                    trace!("Wrote record {record_key:?} to disk! filename: {filename}");
+                    // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
+                    info!("Wrote record {record_key:?} to disk! filename: {filename}");
                     NetworkEvent::CompletedWrite((r.key, record_type))
                 }
                 Err(err) => {
@@ -284,7 +286,8 @@ impl NodeRecordStore {
 
         let cost = calculate_cost_for_relevant_records(relevant_records_len);
 
-        debug!("Cost is now {cost:?} for {relevant_records_len:?} records stored of {MAX_RECORDS_COUNT:?} max");
+        // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
+        info!("Cost is now {cost:?} for {relevant_records_len:?} records stored of {MAX_RECORDS_COUNT:?} max");
         NanoTokens::from(cost)
     }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -569,6 +569,7 @@ impl Node {
                 expected: expected_fee,
             });
         }
+        // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
         info!("Total payment of {received_fee:?} nanos accepted for record {pretty_key}");
 
         Ok(())


### PR DESCRIPTION
## Description

Comments log messages used by [vdash](https://github.com/happybeing/vdash/issues) and setting to info level. See [forum conversation](https://safenetforum.org/t/zerotestnet-20-12-23-testnet/38978/87).

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Dec 23 17:32 UTC
This pull request includes changes to annotate selected log messages and log them at the info level for the "vdash" metric. The changes are made in the `sn_networking/src/driver.rs`, `sn_networking/src/record_store.rs`, and `sn_node/src/put_validation.rs` files.
<!-- reviewpad:summarize:end --> 
