### PR TITLE
feat(networking): remove problematic peers from routing table

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -433,10 +433,9 @@ jobs:
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
           timeout-minutes: 5
 
-        - name: Verify the location of the data on the network (approx 12 * 5 mins)
+        - name: Verify the location of the data on the network
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
           env:
-            CHURN_COUNT: 12
             SN_LOG: "all"
           timeout-minutes: 90
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -41,14 +41,14 @@ use tracing::{debug, trace};
 use xor_name::XorName;
 
 const EXTRA_CHURN_COUNT: u32 = 5;
-const CHURN_CYCLES: u32 = 1;
+const CHURN_CYCLES: u32 = 2;
 const CHUNK_CREATION_RATIO_TO_CHURN: u32 = 15;
-const REGISTER_CREATION_RATIO_TO_CHURN: u32 = 5;
-const CASHNOTE_CREATION_RATIO_TO_CHURN: u32 = 1;
+const REGISTER_CREATION_RATIO_TO_CHURN: u32 = 15;
+const CASHNOTE_CREATION_RATIO_TO_CHURN: u32 = 15;
 
 const CHUNKS_SIZE: usize = 1024 * 1024;
 
-const CONTENT_QUERY_RATIO_TO_CHURN: u32 = 12;
+const CONTENT_QUERY_RATIO_TO_CHURN: u32 = 40;
 const MAX_NUM_OF_QUERY_ATTEMPTS: u8 = 5;
 
 // Default total amount of time we run the checks for before reporting the outcome.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Dec 23 09:36 UTC
This pull request consists of two patches. 

The first patch modifies the `event.rs` file in the `sn_networking/src` directory. It adds checks against DialErrors to determine if certain errors like ConnectionRefused/Reset or HostUnreachable are serious issues. If they are, the patch removes the problematic peers from the routing table.

The second patch modifies the `nightly.yml`, `data_with_churn.rs`, and `verify_data_location.rs` files. It updates the churn tests to be harsher in order to more swiftly detect churn. It increases the churn cycles, creation ratios, and content query ratios.
<!-- reviewpad:summarize:end --> 
