### PR TITLE
feat: pick cheapest payee using linear pricing curve

### DIFF
--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -122,6 +122,15 @@ impl UnifiedRecordStore {
         }
     }
 
+    pub(crate) fn payment_received(&mut self) {
+        match self {
+            Self::Client(_) => {
+                warn!("Calling payment_received at Client. This should not happen");
+            }
+            Self::Node(store) => store.payment_received(),
+        }
+    }
+
     pub(crate) fn set_distance_range(&mut self, distance_range: Distance) {
         match self {
             Self::Client(store) => store.set_distance_range(distance_range),

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -509,6 +509,9 @@ impl Node {
 
         trace!("Received payment of {received_fee:?} for {pretty_key}");
 
+        // Notify `record_store` that the node received a payment.
+        let _ = self.network.notify_payment_received();
+
         // deposit the CashNotes in our wallet
         wallet.deposit_and_store_to_disk(&cash_notes)?;
         let new_balance = wallet.balance().as_nano();


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jan 24 12:40 UTC
This pull request includes several changes across different files:

1. In the file `record_store_api.rs`, a notification system has been added to the `record_store` when a payment is received. Additionally, CashNotes are now deposited in the wallet.

2. In the file `record_store_api.rs`, a new method called `got_paid` has been added to the `UnifiedRecordStore` struct. This method is now called within the `Node` variant of `UnifiedRecordStore`. A warning log message is printed if `got_paid` method is called in the `Client` variant. The `set_distance_range` method in the same struct has also been modified to accept a `Distance` parameter.

3. In another file, the import statement `use rand::{seq::SliceRandom, Rng};` has been removed. A new function called `notify_got_paid()` has been added to the `Network` impl block. This function notifies the node that it has been paid once. The sorting logic in the `get_fees_from_store_cost_responses()` function has been updated to sort costs in ascending order, with ties broken by comparing addresses. Two test functions have also been modified to reflect the changes in the `get_fees_from_store_cost_responses()` function.

4. The file `cmd.rs` includes changes to the `SwarmCmd` enum and the `SwarmDriver` struct. A new variant called `GotPaid` has been added to the `SwarmCmd` enum, used to notify that this node has been paid once. The `SwarmDriver` struct now has a new match arm to handle the `GotPaid` variant. It calls a method `got_paid()` on the `store_mut()` of the `kademlia` module in the `swarm` behavior. Additionally, a log statement in the `is_in_close_range` function has been changed from `warn!` to `trace!` to reduce log levels. The comment explains that this change was made to reduce log accumulation caused by a large number of records being out of the close range due to addressing margins.

5. Finally, the file `record_store.rs` within the `sn_networking` module has undergone several changes. These changes include adding a new field called `earned_times` of type `usize` to the `NodeRecordStore` struct to count how many times the node has been paid. A new method called `got_paid` has been implemented in the same struct to increment the `earned_times` field by one. The `calculate_cost_for_relevant_records` function has been modified to include the `earned_times` parameter, adjusting the cost calculation based on an exponential or linear growth function. The `calculate_cost` function in the same file now uses the `calculate_cost_for_relevant_records` function with the `earned_times` parameter. Some test functions related to payee selection algorithms have also been refactored and updated.

Let me know if you need more information or if there's anything specific you'd like me to review in the diff.
<!-- reviewpad:summarize:end --> 
