### PR TITLE
chore: no more max_records cap

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -527,11 +527,6 @@ impl RecordStore for ClientRecordStore {
 fn calculate_cost_for_relevant_records(step: usize, received_payment_count: usize) -> u64 {
     use std::cmp::max;
 
-    assert!(
-        step <= MAX_RECORDS_COUNT,
-        "step must be <= MAX_RECORDS_COUNT"
-    );
-
     let ori_cost = (10 * step) as u64;
     let divider = max(1, step / max(1, received_payment_count)) as u64;
     max(10, ori_cost / divider)


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jan 24 15:47 UTC
This pull request removes the cap on the maximum number of records in the record store. The assert statement that checks if the step is less than or equal to the maximum record count has been removed. The calculation of the cost for relevant records has also been modified.
<!-- reviewpad:summarize:end --> 
