### PR TITLE
chore(cli): print the datamap's entire hex addr

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -215,12 +215,13 @@ async fn upload_files(
                 println!("chunk_manager doesn't have any verified_files, nor any failed_chunks to re-upload.");
             }
             for (file_name, addr) in chunk_manager.verified_files() {
+                let hex_addr = addr.to_hex();
                 if let Some(file_name) = file_name.to_str() {
-                    println!("\"{file_name}\" {addr:?}");
-                    info!("Uploaded {file_name} to {addr:?}");
+                    println!("\"{file_name}\" {hex_addr}");
+                    info!("Uploaded {file_name} to {hex_addr}");
                 } else {
-                    println!("\"{file_name:?}\" {addr:?}");
-                    info!("Uploaded {file_name:?} to {addr:?}");
+                    println!("\"{file_name:?}\" {hex_addr}");
+                    info!("Uploaded {file_name:?} to {hex_addr}");
                 }
             }
             return Ok(());


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Jan 24 16:28 UTC
This pull request modifies the `sn_cli/src/subcommands/files/mod.rs` file. It adds code to print the entire hex address of the datamap when uploading files. The patch also includes formatting changes by replacing the `addr` variable with `hex_addr` variable in the `println!` and `info!` statements.
<!-- reviewpad:summarize:end --> 
