### PR TITLE
feat: offline signing wallet cmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4467,6 +4480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4517,6 +4536,7 @@ dependencies = [
  "color-eyre",
  "criterion 0.5.1",
  "custom_debug",
+ "dialoguer",
  "dirs-next",
  "eyre",
  "futures",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -32,6 +32,7 @@ custom_debug = "~0.5.0"
 chrono = "~0.4.19"
 clap = { version = "4.2.1", features = ["derive"]}
 color-eyre = "~0.6"
+dialoguer = "~0.11.0"
 dirs-next = "~2.0.0"
 futures = "~0.3.13"
 hex = "~0.4.3"

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -75,7 +75,8 @@ async fn main() -> Result<()> {
         if let WalletCmds::Address
         | WalletCmds::Balance { .. }
         | WalletCmds::Deposit { .. }
-        | WalletCmds::Create { .. } = cmds
+        | WalletCmds::Create { .. }
+        | WalletCmds::Transaction { .. } = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
             return Ok(());

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -76,7 +76,8 @@ async fn main() -> Result<()> {
         | WalletCmds::Balance { .. }
         | WalletCmds::Deposit { .. }
         | WalletCmds::Create { .. }
-        | WalletCmds::Transaction { .. } = cmds
+        | WalletCmds::Transaction { .. }
+        | WalletCmds::Sign { .. } = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
             return Ok(());

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -562,18 +562,18 @@ async fn broadcast_signed_spends(
     ) = rmp_serde::from_slice(&hex::decode(signed_tx)?)?;
 
     println!("The signed transaction has been successfully decoded:");
-    let mut spent_tx = None;
+    let mut transaction = None;
     for (i, signed_spend) in signed_spends.iter().enumerate() {
         println!("\nSpending input #{i}:");
         println!("\tKey: {}", signed_spend.unique_pubkey().to_hex());
         println!("\tAmount: {}", signed_spend.token());
-        let linked_spent_tx = signed_spend.spent_tx();
-        if let Some(ref tx) = spent_tx {
-            if tx != &linked_spent_tx {
+        let linked_tx = signed_spend.spent_tx();
+        if let Some(ref tx) = transaction {
+            if tx != &linked_tx {
                 bail!("Transaction seems corrupted, not all Spends (inputs) refer to the same transaction");
             }
         } else {
-            spent_tx = Some(linked_spent_tx);
+            transaction = Some(linked_tx);
         }
 
         if let Err(err) = signed_spend.verify(signed_spend.spent_tx_hash()) {
@@ -581,7 +581,7 @@ async fn broadcast_signed_spends(
         }
     }
 
-    let spent_tx = if let Some(tx) = spent_tx {
+    let tx = if let Some(tx) = transaction {
         for (i, output) in tx.outputs.iter().enumerate() {
             println!("\nOutput #{i}:");
             println!("\tKey: {}", output.unique_pubkey.to_hex());
@@ -609,7 +609,7 @@ async fn broadcast_signed_spends(
         wallet,
         client,
         signed_spends,
-        spent_tx,
+        tx,
         change_id,
         output_details,
         verify_store,

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::{
         FilesApi, BATCH_SIZE, MAX_UPLOAD_RETRIES,
     },
     register::ClientRegister,
-    wallet::{send, WalletClient},
+    wallet::{broadcast_signed_spends, send, WalletClient},
 };
 
 use self::event::ClientEventsChannel;

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -136,7 +136,7 @@ impl WalletClient {
         // send to network
         if let Err(error) = self
             .client
-            .send(
+            .send_spends(
                 self.wallet.unconfirmed_spend_requests().iter(),
                 verify_store,
             )

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -35,7 +35,11 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     // transfer to N_OUTPUTS recipients
     let zero = DerivationIndex([0u8; 32]);
     let offline_transfer = create_offline_transfer(
-        vec![(starting_cashnote, Some(starting_main_key.derive_key(&zero)))],
+        vec![(
+            starting_cashnote,
+            Some(starting_main_key.derive_key(&zero)),
+            zero,
+        )],
         recipients,
         starting_main_key.main_pubkey(),
         Hash::default(),
@@ -93,6 +97,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         vec![(
             starting_cashnote,
             Some(starting_main_key.derive_key(&derive)),
+            derive,
         )],
         recipients,
         starting_main_key.main_pubkey(),
@@ -125,7 +130,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .map(|cn| {
             let derivation_index = cn.derivation_index();
             let sk = recipient_of_100_mainkey.derive_key(&derivation_index);
-            (cn, Some(sk))
+            (cn, Some(sk), derivation_index)
         })
         .collect();
     let one_single_recipient = vec![(

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -35,11 +35,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     // transfer to N_OUTPUTS recipients
     let zero = DerivationIndex([0u8; 32]);
     let offline_transfer = create_offline_transfer(
-        vec![(
-            starting_cashnote,
-            Some(starting_main_key.derive_key(&zero)),
-            zero,
-        )],
+        vec![(starting_cashnote, Some(starting_main_key.derive_key(&zero)))],
         recipients,
         starting_main_key.main_pubkey(),
         Hash::default(),
@@ -97,7 +93,6 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         vec![(
             starting_cashnote,
             Some(starting_main_key.derive_key(&derive)),
-            derive,
         )],
         recipients,
         starting_main_key.main_pubkey(),
@@ -130,7 +125,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .map(|cn| {
             let derivation_index = cn.derivation_index();
             let sk = recipient_of_100_mainkey.derive_key(&derivation_index);
-            (cn, Some(sk), derivation_index)
+            (cn, Some(sk))
         })
         .collect();
     let one_single_recipient = vec![(

--- a/sn_transfers/benches/reissue.rs
+++ b/sn_transfers/benches/reissue.rs
@@ -35,7 +35,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     // transfer to N_OUTPUTS recipients
     let zero = DerivationIndex([0u8; 32]);
     let offline_transfer = create_offline_transfer(
-        vec![(starting_cashnote, starting_main_key.derive_key(&zero))],
+        vec![(starting_cashnote, Some(starting_main_key.derive_key(&zero)))],
         recipients,
         starting_main_key.main_pubkey(),
         Hash::default(),
@@ -90,7 +90,10 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     // transfer to N_OUTPUTS recipients derived from recipient_of_100_mainkey
     let derive = starting_cashnote.derivation_index();
     let offline_transfer = create_offline_transfer(
-        vec![(starting_cashnote, starting_main_key.derive_key(&derive))],
+        vec![(
+            starting_cashnote,
+            Some(starting_main_key.derive_key(&derive)),
+        )],
         recipients,
         starting_main_key.main_pubkey(),
         Hash::default(),
@@ -122,7 +125,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .map(|cn| {
             let derivation_index = cn.derivation_index();
             let sk = recipient_of_100_mainkey.derive_key(&derivation_index);
-            (cn, sk)
+            (cn, Some(sk))
         })
         .collect();
     let one_single_recipient = vec![(

--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -128,7 +128,11 @@ impl TransactionBuilder {
         self,
         reason: Hash,
         network_royalties: Vec<DerivationIndex>,
-    ) -> Result<BTreeSet<(Spend, DerivationIndex)>> {
+    ) -> Result<(
+        BTreeSet<(Spend, DerivationIndex)>,
+        Transaction,
+        BTreeMap<UniquePubkey, (MainPubkey, DerivationIndex)>,
+    )> {
         let spent_tx = Transaction {
             inputs: self.inputs,
             outputs: self.outputs,
@@ -150,7 +154,7 @@ impl TransactionBuilder {
             }
         }
 
-        Ok(spends)
+        Ok((spends, spent_tx, self.output_details))
     }
 }
 

--- a/sn_transfers/src/cashnotes/mod.rs
+++ b/sn_transfers/src/cashnotes/mod.rs
@@ -15,7 +15,7 @@ mod signed_spend;
 mod transaction;
 mod unique_keys;
 
-pub(crate) use builder::TransactionBuilder;
+pub(crate) use builder::{CashNoteBuilder, TransactionBuilder};
 pub(crate) use transaction::Input;
 
 pub use address::SpendAddress;

--- a/sn_transfers/src/cashnotes/mod.rs
+++ b/sn_transfers/src/cashnotes/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use builder::{CashNoteBuilder, TransactionBuilder};
 pub(crate) use transaction::Input;
 
 pub use address::SpendAddress;
+pub use builder::UnsignedTransfer;
 pub use cashnote::CashNote;
 pub use nano::NanoTokens;
 pub use reason_hash::Hash;

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -140,7 +140,12 @@ pub fn create_first_cash_note_from_key(
     let reason = Hash::hash(b"GENESIS");
 
     let cash_note_builder = TransactionBuilder::default()
-        .add_input(genesis_input, Some(derived_key), Transaction::empty())
+        .add_input(
+            genesis_input,
+            Some(derived_key),
+            Transaction::empty(),
+            derivation_index,
+        )
         .add_output(
             NanoTokens::from(GENESIS_CASHNOTE_AMOUNT),
             main_pubkey,

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -140,7 +140,7 @@ pub fn create_first_cash_note_from_key(
     let reason = Hash::hash(b"GENESIS");
 
     let cash_note_builder = TransactionBuilder::default()
-        .add_input(genesis_input, derived_key, Transaction::empty())
+        .add_input(genesis_input, Some(derived_key), Transaction::empty())
         .add_output(
             NanoTokens::from(GENESIS_CASHNOTE_AMOUNT),
             main_pubkey,

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -20,10 +20,10 @@ pub(crate) use cashnotes::{Input, TransactionBuilder};
 /// Types used in the public API
 pub use cashnotes::{
     CashNote, DerivationIndex, DerivedSecretKey, Hash, MainPubkey, MainSecretKey, NanoTokens,
-    SignedSpend, Spend, SpendAddress, Transaction, UniquePubkey,
+    SignedSpend, Spend, SpendAddress, Transaction, UniquePubkey, UnsignedTransfer,
 };
 pub use error::{Error, Result};
-pub use transfers::{CashNoteRedemption, OfflineTransfer, Transfer, UnsignedTransfer};
+pub use transfers::{CashNoteRedemption, OfflineTransfer, Transfer};
 
 /// Utilities exposed
 pub use genesis::{

--- a/sn_transfers/src/lib.rs
+++ b/sn_transfers/src/lib.rs
@@ -23,7 +23,7 @@ pub use cashnotes::{
     SignedSpend, Spend, SpendAddress, Transaction, UniquePubkey,
 };
 pub use error::{Error, Result};
-pub use transfers::{CashNoteRedemption, OfflineTransfer, Transfer};
+pub use transfers::{CashNoteRedemption, OfflineTransfer, Transfer, UnsignedTransfer};
 
 /// Utilities exposed
 pub use genesis::{

--- a/sn_transfers/src/transfers/mod.rs
+++ b/sn_transfers/src/transfers/mod.rs
@@ -30,5 +30,8 @@
 mod offline_transfer;
 mod transfer;
 
-pub use offline_transfer::{create_offline_transfer, create_unsigned_transaction, OfflineTransfer};
+pub use offline_transfer::{
+    create_offline_transfer, create_unsigned_transaction, offline_transfer_from_transaction,
+    OfflineTransfer, UnsignedTransfer,
+};
 pub use transfer::{CashNoteRedemption, Transfer};

--- a/sn_transfers/src/transfers/mod.rs
+++ b/sn_transfers/src/transfers/mod.rs
@@ -31,7 +31,7 @@ mod offline_transfer;
 mod transfer;
 
 pub use offline_transfer::{
-    create_offline_transfer, create_unsigned_transaction, offline_transfer_from_transaction,
-    OfflineTransfer, UnsignedTransfer,
+    create_offline_transfer, create_unsigned_transfer, offline_transfer_from_transaction,
+    CashNotesAndSecretKey, OfflineTransfer,
 };
 pub use transfer::{CashNoteRedemption, Transfer};

--- a/sn_transfers/src/transfers/mod.rs
+++ b/sn_transfers/src/transfers/mod.rs
@@ -30,5 +30,5 @@
 mod offline_transfer;
 mod transfer;
 
-pub use offline_transfer::{create_offline_transfer, OfflineTransfer};
+pub use offline_transfer::{create_offline_transfer, create_unsigned_transaction, OfflineTransfer};
 pub use transfer::{CashNoteRedemption, Transfer};

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -104,11 +104,7 @@ pub fn create_unsigned_transfer(
         .try_fold(NanoTokens::zero(), |total, (amount, _, _)| {
             total.checked_add(*amount)
         })
-        .ok_or_else(|| {
-            Error::CashNoteReissueFailed(
-                "Overflow occurred while summing the amounts for the recipients.".to_string(),
-            )
-        })?;
+        .ok_or(Error::ExcessiveNanoValue)?;
 
     // We need to select the necessary number of cash_notes from those that we were passed.
     let (cash_notes_to_spend, change_amount) =

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -18,9 +18,10 @@ use super::{
 
 use crate::{
     calculate_royalties_fee,
+    cashnotes::UnsignedTransfer,
     transfers::{
-        create_offline_transfer, create_unsigned_transaction, offline_transfer_from_transaction,
-        OfflineTransfer, UnsignedTransfer,
+        create_offline_transfer, offline_transfer_from_transaction, CashNotesAndSecretKey,
+        OfflineTransfer,
     },
     CashNote, CashNoteRedemption, DerivationIndex, DerivedSecretKey, Hash, MainPubkey,
     MainSecretKey, NanoTokens, SignedSpend, Spend, Transaction, Transfer, UniquePubkey,
@@ -233,10 +234,7 @@ impl LocalWallet {
     /// once the updated wallet is stored to disk it is safe to drop the WalletExclusiveAccess
     pub fn available_cash_notes(
         &mut self,
-    ) -> Result<(
-        Vec<(CashNote, Option<DerivedSecretKey>, DerivationIndex)>,
-        WalletExclusiveAccess,
-    )> {
+    ) -> Result<(CashNotesAndSecretKey, WalletExclusiveAccess)> {
         trace!("Trying to lock wallet to get available cash_notes...");
         // lock and load from disk to make sure we're up to date and others can't modify the wallet concurrently
         let exclusive_access = self.lock()?;
@@ -250,11 +248,7 @@ impl LocalWallet {
             let held_cash_note = load_created_cash_note(id, &wallet_dir);
             if let Some(cash_note) = held_cash_note {
                 if let Ok(derived_key) = cash_note.derived_key(&self.key) {
-                    available_cash_notes.push((
-                        cash_note.clone(),
-                        Some(derived_key),
-                        cash_note.derivation_index,
-                    ));
+                    available_cash_notes.push((cash_note.clone(), Some(derived_key)));
                 } else {
                     warn!(
                         "Skipping CashNote {:?} because we don't have the key to spend it",
@@ -279,47 +273,8 @@ impl LocalWallet {
         to: Vec<(NanoTokens, MainPubkey)>,
         reason_hash: Option<Hash>,
     ) -> Result<UnsignedTransfer> {
-        let mut rng = &mut rand::rngs::OsRng;
-        // create a unique key for each output
-        let to_unique_keys: Vec<_> = to
-            .into_iter()
-            .map(|(amount, address)| (amount, address, DerivationIndex::random(&mut rng)))
-            .collect();
-
-        trace!("Trying to lock wallet to get available cash_notes...");
-        // lock and load from disk to make sure we're up to date and others can't modify the wallet concurrently
-        let exclusive_access = self.lock()?;
-        self.reload()?;
-        trace!("Wallet locked and loaded!");
-
-        // get the available cash_notes
-        let mut available_cash_notes = vec![];
-        let wallet_dir = self.watchonly_wallet.wallet_dir().to_path_buf();
-        for (id, _token) in self.watchonly_wallet.available_cash_notes().iter() {
-            if let Some(cash_note) = load_created_cash_note(id, &wallet_dir) {
-                available_cash_notes.push((cash_note.clone(), None, cash_note.derivation_index));
-            } else {
-                warn!("Skipping CashNote {:?} because we don't have it", id);
-            }
-        }
-        debug!(
-            "Available CashNotes for local send: {:#?}",
-            available_cash_notes
-        );
-
-        let reason_hash = reason_hash.unwrap_or_default();
-
-        let unsigned_transfer = create_unsigned_transaction(
-            available_cash_notes,
-            to_unique_keys,
-            self.address(),
-            reason_hash,
-        )?;
-
-        trace!("Releasing wallet lock"); // by dropping exclusive_access
-        std::mem::drop(exclusive_access);
-
-        Ok(unsigned_transfer)
+        self.watchonly_wallet
+            .build_unsigned_transaction(to, reason_hash)
     }
 
     /// Make a transfer and return all created cash_notes


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Jan 24 17:57 UTC
This pull request includes changes in multiple files. Here is a summary of the diff:

- The `local_store.rs` file now returns a tuple containing a `Vec` of `(CashNote, Option<DerivedSecretKey>)>` instead of `(Vec<(CashNote, DerivedSecretKey)>, WalletExclusiveAccess)` in the `available_cash_notes` function. It also adds the `build_unsigned_transaction` function.
- The `reissue.rs` file in the `sn_transfers/benches` directory has modifications in the `create_offline_transfer` and `derive_key` functions. The second element of the tuple parameter in the `create_offline_transfer` function is now wrapped in an `Option` type.
- The `offline_transfer.rs` file includes changes in the `TranferInputs` struct, `create_offline_transfer` function, addition of `build_unsigned_transaction` function, modification of the `select_inputs` function, addition of `create_transaction_builder_with` function, and addition of the `reason_hash` parameter in the `create_offline_transfer_with` function.
- The `builder.rs` file changes the type and parameter of `input_details` in `TransactionBuilder`, as well as the parameter types in the `add_input` and `add_inputs` methods.
- The `wallet.rs` file introduces changes related to the `Create` and `Transaction` commands, along with the addition of the `build_unsigned_transaction` and `receive` helper functions.
- The `main.rs` file adds a new arm in the match expression for the `Transaction` variant in the `WalletCmds` enum.
- The `mod.rs` file introduces the `build_unsigned_transaction` function in the `offline_transfer` module.
- The `genesis.rs` file modifies the `create_first_cash_note_from_key` method by adding an optional derived key as an argument in the `add_input` method.

Please let me know if you need any further assistance.
<!-- reviewpad:summarize:end --> 
