### PR TITLE
chore(cli): print the datamap's entire hex addr for public files

### DIFF
--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -291,6 +291,12 @@ async fn upload_files(
             // log uploaded file information
             println!("**************************************");
             println!("*          Uploaded Files            *");
+            if !make_data_public {
+                println!("*                                    *");
+                println!("*  These are not public by default.  *");
+                println!("*     Reupload with `-p` option      *");
+                println!("*      to publish the datamaps.      *");
+            }
             println!("**************************************");
             for (file_name, addr) in chunk_manager.verified_files() {
                 let hex_addr = addr.to_hex();

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -293,12 +293,13 @@ async fn upload_files(
             println!("*          Uploaded Files            *");
             println!("**************************************");
             for (file_name, addr) in chunk_manager.verified_files() {
+                let hex_addr = addr.to_hex();
                 if let Some(file_name) = file_name.to_str() {
-                    println!("\"{file_name}\" {addr:?}");
-                    info!("Uploaded {file_name} to {addr:?}");
+                    println!("\"{file_name}\" {hex_addr}");
+                    info!("Uploaded {file_name} to {hex_addr}");
                 } else {
-                    println!("\"{file_name:?}\" {addr:?}");
-                    info!("Uploaded {file_name:?} to {addr:?}");
+                    println!("\"{file_name:?}\" {hex_addr}");
+                    info!("Uploaded {file_name:?} to {hex_addr}");
                 }
             }
         } else {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jan 24 12:56 UTC
This pull request updates the CLI code to print the entire hex address of the datamap for public files that are uploaded. It modifies the `upload_files` function in the `sn_cli/src/subcommands/files/mod.rs` file to display the hex address instead of the regular address.
<!-- reviewpad:summarize:end --> 
