### PR TITLE
chore(node): reduce node default logging level

### DIFF
--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -333,17 +333,16 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
 
 fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, Option<WorkerGuard>)> {
     let logging_targets = vec![
-        // TODO: Reset to nice and clean defaults once we have a better idea of what we want
-        ("sn_networking".to_string(), Level::DEBUG),
-        ("safenode".to_string(), Level::TRACE),
-        ("sn_build_info".to_string(), Level::TRACE),
-        ("sn_logging".to_string(), Level::TRACE),
-        ("sn_node".to_string(), Level::TRACE),
-        ("sn_peers_acquisition".to_string(), Level::TRACE),
-        ("sn_protocol".to_string(), Level::TRACE),
-        ("sn_registers".to_string(), Level::TRACE),
-        ("sn_testnet".to_string(), Level::TRACE),
-        ("sn_transfers".to_string(), Level::TRACE),
+        ("sn_networking".to_string(), Level::INFO),
+        ("safenode".to_string(), Level::DEBUG),
+        ("sn_build_info".to_string(), Level::DEBUG),
+        ("sn_logging".to_string(), Level::DEBUG),
+        ("sn_node".to_string(), Level::DEBUG),
+        ("sn_peers_acquisition".to_string(), Level::DEBUG),
+        ("sn_protocol".to_string(), Level::DEBUG),
+        ("sn_registers".to_string(), Level::DEBUG),
+        ("sn_testnet".to_string(), Level::DEBUG),
+        ("sn_transfers".to_string(), Level::DEBUG),
     ];
 
     let output_dest = match &opt.log_output_dest {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jan 24 13:50 UTC
This pull request reduces the default logging level for the node. It updates the logging targets in the `init_logging` function in main.rs file. The logging levels for various modules have been changed from `TRACE` to `DEBUG` or `INFO`.
<!-- reviewpad:summarize:end --> 
