### PR TITLE
feat(node): only replicate new records or to new nodes

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -551,3 +551,99 @@ jobs:
               echo "We are logging an extremely large data"
               exit 1
             fi
+
+  replication_bench_with_heavy_upload:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    name: Replication bench with heaby upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: install ripgrep
+        shell: bash
+        run: sudo apt-get install -y ripgrep
+
+      - name: Download materials to create two 300MB test_files to be uploaded by client
+        shell: bash
+        run: |
+          mkdir test_data_1
+          cd test_data_1
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safe-qiWithListeners-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safenode-qiWithListeners-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safenode_rpc_client-qiWithListeners-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/faucet-qilesssubs-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safe-qilesssubs-x86_64.tar.gz
+          ls -l
+          cd ..
+          tar -cvzf test_data_1.tar.gz test_data_1
+          mkdir test_data_2
+          cd test_data_2
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safenode-qilesssubs-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safenode_rpc_client-qilesssubs-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/faucet-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safe-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safenode-DebugMem-x86_64.tar.gz
+          ls -l
+          cd ..
+          tar -cvzf test_data_2.tar.gz test_data_2
+          ls -l
+
+      - name: Build binaries
+        run: cargo build --release --bin safenode --bin safe --bin faucet
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ubuntu-latest
+          build: true
+
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
+
+      - name: Create and fund a wallet to pay for files storage
+        run: |
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 100000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
+          cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 5
+
+      - name: Start a client to upload first file
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_1.tar.gz" -r 0
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 60
+
+      - name: Wait for certain period
+        run: sleep 300
+
+      - name: Start a client to upload second file
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_2.tar.gz" -r 0
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 60
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_heavy_replicate_bench
+          platform: ubuntu-latest
+          build: true

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -565,6 +565,7 @@ impl NetworkBuilder {
             network_discovery: NetworkDiscovery::new(&peer_id),
             bootstrap_peers: Default::default(),
             live_connected_peers: Default::default(),
+            replicated_in_range_peers: Default::default(),
         };
 
         Ok((
@@ -614,6 +615,9 @@ pub struct SwarmDriver {
     // Peers that having live connection to. Any peer got contacted during kad network query
     // will have live connection established. And they may not appear in the RT.
     pub(crate) live_connected_peers: BTreeMap<ConnectionId, (PeerId, Instant)>,
+    // Peers within the range that we have repliated to,
+    // records the first time inserted into the map.
+    pub(crate) replicated_in_range_peers: HashMap<PeerId, Option<Instant>>,
 }
 
 impl SwarmDriver {

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -685,6 +685,10 @@ impl Network {
         self.send_swarm_cmd(SwarmCmd::GossipHandler)
     }
 
+    pub fn trigger_interval_replication(&self) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::TriggerIntervalReplication)
+    }
+
     // Helper to send SwarmCmd
     fn send_swarm_cmd(&self, cmd: SwarmCmd) -> Result<()> {
         let capacity = self.swarm_cmd_sender.capacity();

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -228,13 +228,15 @@ impl NodeRecordStore {
     /// Reset old entries `insert_time` to None
     pub(crate) fn reset_old_records(&mut self) {
         for val in self.records.values_mut() {
+            trace!("checking record {:?}", val.2);
             let shall_reset = if let Some(time) = val.2 {
-                time.elapsed() > Duration::from_secs(3600)
+                time.elapsed() > Duration::from_secs(60)
             } else {
                 false
             };
 
             if shall_reset {
+                trace!("Reset insert_time to None");
                 val.2 = None;
             }
         }

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 #![allow(clippy::mutable_key_type)] // for the Bytes in NetworkAddress
 
-use crate::record_store::{ClientRecordStore, NodeRecordStore};
+use crate::record_store::{ClientRecordStore, NodeRecordStore, RecordStoreEntryType};
 use libp2p::kad::{
     store::{RecordStore, Result},
     KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
@@ -98,10 +98,17 @@ impl UnifiedRecordStore {
     }
 
     #[allow(clippy::mutable_key_type)]
-    pub(crate) fn record_addresses_ref(&self) -> &HashMap<RecordKey, (NetworkAddress, RecordType)> {
+    pub(crate) fn record_addresses_ref(&self) -> &RecordStoreEntryType {
         match self {
             Self::Client(store) => store.record_addresses_ref(),
             Self::Node(store) => store.record_addresses_ref(),
+        }
+    }
+
+    pub(crate) fn reset_old_records(&mut self) {
+        match self {
+            Self::Client(_) => warn!("Calling reset_old_records at Client. This should not happen"),
+            Self::Node(store) => store.reset_old_records(),
         }
     }
 

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 #![allow(clippy::mutable_key_type)]
 
+use crate::record_store::RecordStoreEntryType;
+
 use libp2p::{
     kad::{RecordKey, K_VALUE},
     PeerId,
@@ -53,7 +55,7 @@ impl ReplicationFetcher {
         &mut self,
         holder: PeerId,
         incoming_keys: Vec<(NetworkAddress, RecordType)>,
-        locally_stored_keys: &HashMap<RecordKey, (NetworkAddress, RecordType)>,
+        locally_stored_keys: &RecordStoreEntryType,
     ) -> Vec<(PeerId, RecordKey)> {
         self.remove_stored_keys(locally_stored_keys);
 
@@ -176,12 +178,9 @@ impl ReplicationFetcher {
     }
 
     /// Remove keys that we hold already and no longer need to be replicated.
-    fn remove_stored_keys(
-        &mut self,
-        existing_keys: &HashMap<RecordKey, (NetworkAddress, RecordType)>,
-    ) {
+    fn remove_stored_keys(&mut self, existing_keys: &RecordStoreEntryType) {
         self.to_be_fetched.retain(|(key, t, _), _| {
-            if let Some((_addr, record_type)) = existing_keys.get(key) {
+            if let Some((_addr, record_type, _insert_time)) = existing_keys.get(key) {
                 // check the address only against similar record types
                 t != record_type
             } else {

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -242,7 +242,6 @@ impl Node {
 
                         let _handle = spawn(async move {
                             if let Err(err) = Self::try_interval_replication(network)
-                                .await
                             {
                                 error!("Error while triggering replication {err:?}");
                             }
@@ -296,7 +295,7 @@ impl Node {
                 let net_clone = self.network.clone();
                 self.record_metrics(Marker::IntervalReplicationTriggered);
                 let _handle = spawn(async move {
-                    if let Err(err) = Self::try_interval_replication(net_clone).await {
+                    if let Err(err) = Self::try_interval_replication(net_clone) {
                         error!("Error while triggering replication {err:?}");
                     }
                 });
@@ -308,7 +307,7 @@ impl Node {
                 let net = self.network.clone();
                 self.record_metrics(Marker::IntervalReplicationTriggered);
                 let _handle = spawn(async move {
-                    if let Err(e) = Self::try_interval_replication(net).await {
+                    if let Err(e) = Self::try_interval_replication(net) {
                         error!("Error while triggering replication {e:?}");
                     }
                 });

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -22,54 +22,8 @@ use tokio::task::{spawn, JoinHandle};
 
 impl Node {
     /// Sends _all_ record keys every interval to all peers.
-    pub(crate) async fn try_interval_replication(network: Network) -> Result<()> {
-        let start = std::time::Instant::now();
-        trace!("Try trigger interval replication started@{start:?}");
-        // Already contains self_peer_id
-        let mut closest_k_peers = network.get_closest_k_value_local_peers().await?;
-
-        // remove our peer id from the calculations here:
-        closest_k_peers.retain(|peer_id| peer_id != &network.peer_id);
-
-        // Only grab the closest nodes
-        let closest_k_peers = closest_k_peers
-            .into_iter()
-            // add some leeway to allow for divergent knowledge
-            .take(REPLICATE_RANGE)
-            .collect::<Vec<_>>();
-
-        trace!("Try trigger interval replication started@{start:?}, peers found_and_sorted, took: {:?}", start.elapsed());
-
-        let our_peer_id = network.peer_id;
-        let our_address = NetworkAddress::from_peer(our_peer_id);
-
-        #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-        let all_records = network.get_all_local_record_addresses().await?;
-
-        if !all_records.is_empty() {
-            debug!(
-                "Informing all peers of our records. {:?} peers will be informed",
-                closest_k_peers.len()
-            );
-            for peer_id in closest_k_peers {
-                trace!(
-                    "Sending a replication list of {} keys to {peer_id:?} ",
-                    all_records.len()
-                );
-                let request = Request::Cmd(Cmd::Replicate {
-                    holder: our_address.clone(),
-                    keys: all_records.clone(),
-                });
-
-                network.send_req_ignore_reply(request, peer_id)?;
-            }
-        }
-
-        trace!(
-            "Try trigger interval started@{start:?}, took {:?}",
-            start.elapsed()
-        );
-        Ok(())
+    pub(crate) fn try_interval_replication(network: Network) -> Result<()> {
+        Ok(network.trigger_interval_replication()?)
     }
 
     /// Get the Record from a peer or from the network without waiting.


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jan 24 15:53 UTC
This pull request includes the following changes:

1. In `NetworkBuilder` and `SwarmDriver` structs, a new field `replicated_in_range_peers` with default initialization has been added.
2. Changes to the `try_interval_replication` method in the `replication.rs` file, making it synchronous and simplifying the code.
3. Changes to the `node.rs` file, removing the `await` keyword after calling the `try_interval_replication` function.
4. Changes to the `record_store_api.rs` file, adding an import statement and implementing a new method `reset_old_records` in the `UnifiedRecordStore` struct.
5. Changes in the `replication_fetcher.rs` file, including import statement, modification of function signature, and refactoring of code for removing stored keys.
6. Changes to the `replication_fetcher.rs` file, adding import statement, new variant to `SwarmCmd` enum, and new method `try_interval_replication` in the `SwarmDriver` struct.
7. Changes to the `record_store.rs` file, including import statements, defining new type `RecordStoreEntryType`, adding methods, and updating struct fields.
8. Changes to the `Network` struct, adding a new public method `trigger_interval_replication`.

These changes introduce new features, make code optimizations, and enhance functionality in various files.
<!-- reviewpad:summarize:end --> 
