### PR TITLE
feat(network): move the kad::put_record_to inside PutRecordCfg

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -426,9 +426,10 @@ impl Client {
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::One,
             re_attempt: true,
+            use_put_record_to: Some(vec![payee]),
             verification,
         };
-        Ok(self.network.put_record_to(payee, record, &put_cfg).await?)
+        Ok(self.network.put_record(record, &put_cfg).await?)
     }
 
     /// Retrieve a `Chunk` from the kad network.
@@ -538,6 +539,7 @@ impl Client {
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::All,
             re_attempt: true,
+            use_put_record_to: None,
             verification: Some((VerificationKind::Network, verification_cfg)),
         };
         Ok(self.network.put_record(record, &put_cfg).await?)

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -398,6 +398,7 @@ impl ClientRegister {
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::All,
             re_attempt: true,
+            use_put_record_to: None,
             verification: Some((VerificationKind::Network, verification_cfg)),
         };
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -158,6 +158,9 @@ pub struct PutRecordCfg {
     pub put_quorum: Quorum,
     /// If set to true, we retry upto PUT_RETRY_ATTEMPTS times
     pub re_attempt: bool,
+    /// Use the `kad::put_record_to` to PUT the record only to the specified peers. If this option is set to None, we
+    /// will be using `kad::put_record` which would PUT the record to all the closest members of the record.
+    pub use_put_record_to: Option<Vec<PeerId>>,
     /// Enables verification after writing. The VerificationKind is used to determine the method to use.
     pub verification: Option<(VerificationKind, GetRecordCfg)>,
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Jan 24 20:22 UTC
This pull request moves the `kad::put_record_to` function inside the `PutRecordCfg` struct. It also updates the references to the function in the codebase. The changes include modifications in the `api.rs`, `register.rs`, `cmd.rs`, `driver.rs`, and `lib.rs` files. Overall, this patch improves the organization and structure of the code related to network record handling.
<!-- reviewpad:summarize:end --> 
