### PR TITLE
chore(cli): error if there is no file to upload

### DIFF
--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -121,6 +121,15 @@ impl ChunkManager {
                 }
             });
         let total_files = self.files_to_chunk.len();
+        if total_files == 0 {
+            if files_path.is_dir() {
+                bail!(
+                    "The directory specified for upload is empty. Please verify the provided path."
+                );
+            } else {
+                bail!("The provided file path is invalid. Please verify the path.");
+            }
+        }
 
         // resume the chunks from the artifacts dir
         if read_cache {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jan 24 10:28 UTC
This pull request adds an error message if there are no files to upload in the CLI.
<!-- reviewpad:summarize:end --> 
