### PR TITLE
feat(cli): store uploaded file metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,6 +4522,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rmp-serde",
+ "serde",
  "sn_build_info",
  "sn_client",
  "sn_logging",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -41,6 +41,7 @@ rand = "0.8.5"
 rayon = "1.8.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
 rmp-serde = "1.1.1"
+serde = { version = "1.0.133", features = [ "derive"]}
 sn_build_info = { path="../sn_build_info", version = "0.1.3" }
 sn_client = { path = "../sn_client", version = "0.99.38" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.31" }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jan 24 11:35 UTC
This pull request adds a new feature to the CLI tool. It modifies the chunk_manager.rs file to store uploaded file metadata. The patch also updates the Cargo.lock and Cargo.toml files by adding dependencies. Overall, the patch adds new functionality to store uploaded file metadata in the CLI tool.
<!-- reviewpad:summarize:end --> 
