### PR TITLE
feat: allow register CLI to create a public register writable to anyone

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly  # Needs nightly to distinguish between deps of different versions
+        uses: dtolnay/rust-toolchain@nightly # Needs nightly to distinguish between deps of different versions
         with:
           # we need rustfmt here while we have a build step
           components: rustfmt
@@ -47,7 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -57,15 +56,15 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
-      
+
       - shell: bash
         run: cargo clippy --all-targets --all-features -- -Dwarnings
-      
+
       - name: Check documentation
         # Deny certain `rustdoc` lints that are unwanted.
         # See https://doc.rust-lang.org/rustdoc/lints.html for lints that are 'warning' by default.
         run: RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps
-      
+
       - name: Check local-discovery is not a default feature
         shell: bash
         run: if [[ ! $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].features.default[]? | select(. == "local-discovery")') ]]; then echo "local-discovery is not a default feature in any package."; else echo "local-discovery is a default feature in at least one package." && exit 1; fi
@@ -74,7 +73,7 @@ jobs:
         run: cargo build --all-targets --all-features
 
   unit:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -87,7 +86,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Run CLI tests
         timeout-minutes: 25
         run: cargo test --release --package sn_cli
@@ -119,10 +118,10 @@ jobs:
           # this will speed up PR merge flows, while giving us a modicum
           # of proptesting
           # we do many more runs on the nightly run
-          PROPTEST_CASES: 50 
+          PROPTEST_CASES: 50
 
   e2e:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -179,20 +178,61 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Start a client to create a register
+      - name: Start a client to create a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register create -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
-      - name: Start a client to get a register
+      - name: Start a client to get a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Start a client to edit a register
+      - name: Start a client to edit a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao wood
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Start a client to create a register writable by anyone
+        id: register-address
+        run: echo "REGISTER_ADDRESS=$(cargo run --bin safe --release -- --log-output-dest=data-dir register create -n trycatch -p | grep "Address" | sed 's/.*Address=\(.*\)/\1/')" >> $GITHUB_OUTPUT
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Start a client to get a register writable by anyone (current client is the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n trycatch
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit a register writable by anyone (current client is the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n trycatch wood
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Delete client subdir to generate new client
+        shell: bash
+        run: rm -rf "${{ matrix.safe_path }}"/client
+
+      - name: Start a client to get a register writable by anyone (new client is not the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get ${{ steps.register-address.outputs.REGISTER_ADDRESS }}
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit a register writable by anyone (new client is not the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit ${{ steps.register-address.outputs.REGISTER_ADDRESS }} water
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Start a client to edit a register writable by owner only (expect failure since new client)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao water
         env:
           SN_LOG: "all"
         timeout-minutes: 10
@@ -207,7 +247,7 @@ jobs:
           build: true
 
   gossipsub:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Gossipsub E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -238,7 +278,7 @@ jobs:
           platform: ${{ matrix.os }}
           build: true
 
-      - name: Gossipsub - nodes to subscribe to topics, and publish messages 
+      - name: Gossipsub - nodes to subscribe to topics, and publish messages
         run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
         timeout-minutes: 20
 
@@ -252,7 +292,7 @@ jobs:
           build: true
 
   spend_test:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: spend tests against network
     runs-on: ${{ matrix.os }}
     strategy:
@@ -293,7 +333,7 @@ jobs:
           else
             echo "SAFE_PEERS has been set to $SAFE_PEERS"
           fi
-        
+
       # This should be first to avoid slow reward acceptance etc
       - name: execute the nodes rewards tests
         run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
@@ -312,7 +352,6 @@ jobs:
         env:
           SN_LOG: "all"
         timeout-minutes: 25
-
 
       - name: Stop the local network and upload logs
         if: always()
@@ -375,7 +414,7 @@ jobs:
           fi
 
       - name: Chunks data integrity during nodes churn
-        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture 
+        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
         env:
           TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
@@ -397,7 +436,7 @@ jobs:
         # get the counts, then the specific line, and then the digit count only
         # then check we have an expected level of restarts
         # TODO: make this use an env var, or relate to testnet size
-        run : |
+        run: |
           restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
@@ -410,7 +449,7 @@ jobs:
           fi
           node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
           echo "Node dir count is $node_count"
-         
+
         # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
         # if [ $restart_count -lt $node_count ]; then
         #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
@@ -423,7 +462,7 @@ jobs:
         # get the counts, then the specific line, and then the digit count only
         # then check we have an expected level of replication
         # TODO: make this use an env var, or relate to testnet size
-        run : |
+        run: |
           fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "Carried out $fetching_attempt_count fetching attempts"
@@ -446,108 +485,108 @@ jobs:
           fi
 
   verify_data_location_routing_table:
-      if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-      name: Verify data location and Routing Table
-      runs-on: ${{ matrix.os }}
-      strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              node_data_path: /home/runner/.local/share/safe/node
-              safe_path: /home/runner/.local/share/safe
-            - os: windows-latest
-              node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-              safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
-            - os: macos-latest
-              node_data_path: /Users/runner/Library/Application Support/safe/node
-              safe_path: /Users/runner/Library/Application Support/safe
-      steps:
-        - uses: actions/checkout@v4
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    name: Verify data location and Routing Table
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node_data_path: /home/runner/.local/share/safe/node
+            safe_path: /home/runner/.local/share/safe
+          - os: windows-latest
+            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
+          - os: macos-latest
+            node_data_path: /Users/runner/Library/Application Support/safe/node
+            safe_path: /Users/runner/Library/Application Support/safe
+    steps:
+      - uses: actions/checkout@v4
 
-        - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
 
-        - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
-        - name: Build binaries
-          run: cargo build --release --features local-discovery --bin safenode --bin faucet
-          timeout-minutes: 30
+      - name: Build binaries
+        run: cargo build --release --features local-discovery --bin safenode --bin faucet
+        timeout-minutes: 30
 
-        - name: Build data location and routing table tests
-          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run  
-          timeout-minutes: 30
+      - name: Build data location and routing table tests
+        run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run
+        timeout-minutes: 30
 
-        - name: Start a local network
-          uses: maidsafe/sn-local-testnet-action@main
-          with:
-            action: start
-            interval: 2000
-            node-path: target/release/safenode
-            faucet-path: target/release/faucet
-            platform: ${{ matrix.os }}
-            build: true
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ${{ matrix.os }}
+          build: true
 
-        - name: Check SAFE_PEERS was set
-          shell: bash
-          run: |
-            if [[ -z "$SAFE_PEERS" ]]; then
-              echo "The SAFE_PEERS variable has not been set"
-              exit 1
-            else
-              echo "SAFE_PEERS has been set to $SAFE_PEERS"
-            fi
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
 
-        - name: Verify the routing tables of the nodes
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
-          timeout-minutes: 5
-      
-        - name: Verify the location of the data on the network (4 * 5 mins)
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture 
-          env:
-            CHURN_COUNT: 3
-            SN_LOG: "all"
-          timeout-minutes: 30
+      - name: Verify the routing tables of the nodes
+        run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
+        timeout-minutes: 5
 
-        - name: Verify the routing tables of the nodes
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
-          timeout-minutes: 5
+      - name: Verify the location of the data on the network (4 * 5 mins)
+        run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
+        env:
+          CHURN_COUNT: 3
+          SN_LOG: "all"
+        timeout-minutes: 30
 
-        - name: Stop the local network and upload logs
-          if: always()
-          uses: maidsafe/sn-local-testnet-action@main
-          with:
-            action: stop
-            log_file_prefix: safe_test_logs_data_location
-            platform: ${{ matrix.os }}
-            build: true
+      - name: Verify the routing tables of the nodes
+        run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
+        timeout-minutes: 5
 
-        - name: Verify restart of nodes using rg
-          shell: bash
-          timeout-minutes: 1
-          # get the counts, then the specific line, and then the digit count only
-          # then check we have an expected level of restarts
-          # TODO: make this use an env var, or relate to testnet size
-          run : |
-            restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
-              rg "(\d+) matches" | rg "\d+" -o)
-            echo "Restart $restart_count nodes"
-            peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
-              rg "(\d+) matches" | rg "\d+" -o)
-            echo "PeerRemovedFromRoutingTable $peer_removed times"
-            if [ $peer_removed -lt $restart_count ]; then
-              echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
-              exit 1
-            fi
-            node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-            echo "Node dir count is $node_count"
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_data_location
+          platform: ${{ matrix.os }}
+          build: true
 
-        # Only error out after uploading the logs
-        - name: Don't log raw data
-          if: matrix.os != 'windows-latest' # causes error
-          shell: bash
-          timeout-minutes: 10
-          run: |
-            if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
-            then
-              echo "We are logging an extremely large data"
-              exit 1
-            fi
+      - name: Verify restart of nodes using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of restarts
+        # TODO: make this use an env var, or relate to testnet size
+        run: |
+          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Restart $restart_count nodes"
+          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "PeerRemovedFromRoutingTable $peer_removed times"
+          if [ $peer_removed -lt $restart_count ]; then
+            echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
+            exit 1
+          fi
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          echo "Node dir count is $node_count"
+
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,6 +4527,7 @@ dependencies = [
  "sn_logging",
  "sn_peers_acquisition",
  "sn_protocol",
+ "sn_registers",
  "sn_transfers",
  "tempfile",
  "tokio",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -44,6 +44,7 @@ rmp-serde = "1.1.1"
 sn_build_info = { path="../sn_build_info", version = "0.1.3" }
 sn_client = { path = "../sn_client", version = "0.99.37" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.31" }
+sn_registers = { path = "../sn_registers", version = "0.3.6" }
 sn_logging = { path = "../sn_logging", version = "0.2.16" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.1.13" }
 sn_protocol = { path = "../sn_protocol", version = "0.10.0" }

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -36,7 +36,7 @@ use sn_protocol::{
     },
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_registers::SignedRegister;
+use sn_registers::{Permissions, SignedRegister};
 use sn_transfers::{CashNote, CashNoteRedemption, MainPubkey, NanoTokens, Payment, SignedSpend};
 use std::{
     collections::{HashMap, HashSet},
@@ -342,10 +342,17 @@ impl Client {
         address: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        perms: Permissions,
     ) -> Result<(ClientRegister, NanoTokens, NanoTokens)> {
         info!("Instantiating a new Register replica with address {address:?}");
-        let (reg, mut total_cost, mut total_royalties) =
-            ClientRegister::create_online(self.clone(), address, wallet_client, false).await?;
+        let (reg, mut total_cost, mut total_royalties) = ClientRegister::create_online(
+            self.clone(),
+            address,
+            wallet_client,
+            false,
+            perms.clone(),
+        )
+        .await?;
 
         debug!("{address:?} Created in theorryyyyy");
         let reg_address = reg.address();
@@ -356,9 +363,14 @@ impl Client {
             while !stored {
                 info!("Register not completely stored on the network yet. Retrying...");
                 // this verify store call here ensures we get the record from Quorum::all
-                let (reg, top_up_cost, royalties_top_up) =
-                    ClientRegister::create_online(self.clone(), address, wallet_client, true)
-                        .await?;
+                let (reg, top_up_cost, royalties_top_up) = ClientRegister::create_online(
+                    self.clone(),
+                    address,
+                    wallet_client,
+                    true,
+                    perms.clone(),
+                )
+                .await?;
                 let reg_address = reg.address();
 
                 total_cost = total_cost

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -53,27 +53,15 @@ impl ClientRegister {
         Self::create_register(client, meta, Permissions::new_owner_only())
     }
 
-    /// Create a new public Register (Anybody can write to it) and send it so the Network.
-    /// This will optionally verify the Register was stored on the network.
-    pub async fn create_public_online(
-        client: Client,
-        meta: XorName,
-        wallet_client: &mut WalletClient,
-        verify_store: bool,
-    ) -> Result<Self> {
-        let mut reg = Self::create_register(client, meta, Permissions::new_anyone_can_write())?;
-        reg.sync(wallet_client, verify_store).await?;
-        Ok(reg)
-    }
-
     /// Create a new Register and send it to the Network.
     pub async fn create_online(
         client: Client,
         meta: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        perms: Permissions,
     ) -> Result<(Self, NanoTokens, NanoTokens)> {
-        let mut reg = Self::create_register(client, meta, Permissions::new_owner_only())?;
+        let mut reg = Self::create_register(client, meta, perms)?;
         let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store).await?;
         Ok((reg, storage_cost, royalties_fees))
     }

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_client::{Client, Error, WalletClient};
-use sn_registers::RegisterAddress;
+use sn_registers::{Permissions, RegisterAddress};
 use sn_transfers::LocalWallet;
 use xor_name::XorName;
 
@@ -77,7 +77,12 @@ async fn main() -> Result<()> {
         Err(_) => {
             println!("Register '{reg_nickname}' not found, creating it at {address}");
             let (register, _cost, _royalties_fees) = client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(
+                    meta,
+                    &mut wallet_client,
+                    true,
+                    Permissions::new_anyone_can_write(),
+                )
                 .await?;
 
             register

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -24,6 +24,7 @@ use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress, SpendAddress},
     NetworkAddress,
 };
+use sn_registers::Permissions;
 use sn_transfers::LocalWallet;
 use sn_transfers::{CashNote, MainSecretKey, NanoTokens};
 use std::{
@@ -349,7 +350,12 @@ fn create_registers_task(
             sleep(delay).await;
 
             match client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(
+                    meta,
+                    &mut wallet_client,
+                    true,
+                    Permissions::new_owner_only(),
+                )
                 .await
             {
                 Ok(_) => content

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -22,6 +22,7 @@ use sn_protocol::safenode_proto::{
     safe_node_client::SafeNodeClient, GossipsubSubscribeRequest, NodeEventsRequest,
     TransferNotifsFilterRequest,
 };
+use sn_registers::Permissions;
 use sn_transfers::{
     CashNoteRedemption, LocalWallet, MainSecretKey, NanoTokens, NETWORK_ROYALTIES_PK,
 };
@@ -84,7 +85,12 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
     let prev_rewards_balance = current_rewards_balance()?;
 
     let (_register, storage_cost, _royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            register_addr,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
     println!("Cost is {storage_cost:?}: {prev_rewards_balance:?}");
 
@@ -155,7 +161,12 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     println!("Paying for random Register address {register_addr:?} ...");
     let (_, storage_cost, royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            register_addr,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
     println!("Random Register created, paid {storage_cost}/{royalties_fees}");
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -20,6 +20,7 @@ use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress},
     NetworkAddress,
 };
+use sn_registers::Permissions;
 use sn_transfers::{MainPubkey, NanoTokens, PaymentQuote};
 use std::collections::BTreeMap;
 use tokio::time::{sleep, Duration};
@@ -283,7 +284,12 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
         .await?;
 
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, true)
+        .create_and_pay_for_register(
+            xor_name,
+            &mut wallet_client,
+            true,
+            Permissions::new_owner_only(),
+        )
         .await?;
 
     let retrieved_reg = client.get_register(address).await?;
@@ -337,7 +343,12 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
 
     // this should fail to store as the amount paid is not enough
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            xor_name,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
 
     sleep(Duration::from_secs(5)).await;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jan 24 19:25 UTC
This pull request includes various changes across multiple files:

1. In the "Cargo.toml" file, a new dependency, "sn_registers" with version "0.3.6", has been added.

2. In the "api.rs" file:
   - Import statements for `Permissions` and `SignedRegister` from the module `sn_registers` have been added.
   - The `create_online` function now includes a new parameter `perms` of type `Permissions`.
   - The `create_online` function calls have been modified to pass the `perms` argument.

3. In the "nodes_rewards.rs" file:
   - An import statement for the `Permissions` struct from the `sn_registers` module has been added.
   - The `nodes_rewards_for_storing_registers` function now includes an additional argument, `Permissions::new_owner_only()`, in the `create_and_pay_for_register` method call.
   - The `nodes_rewards_for_register_notifs_over_gossipsub` function now includes an additional argument, `Permissions::new_owner_only()`, in the `create_and_pay_for_register` method call.

4. In the "register.rs" file in the "sn_client/src" directory:
   - The `create_public_online` function has been removed.
   - The `create_online` function has been modified to include a new parameter, `perms` of type `Permissions`, to customize the permissions for register creation.
   - The `create_online` function now creates a register using the specified permissions instead of always using `Permissions::new_owner_only()`.

5. In the "register.rs" file:
   - The `sn_registers::Permissions` module has been imported.
   - A new command-line argument, `public`, has been added to the `Create` enum variant, allowing the creation of registers with public write access.
   - The `create_register` function now includes the `public` argument to determine the permissions for the register.
   - Depending on the value of the `public` argument, the register is assigned the appropriate permissions, either `Permissions::new_anyone_can_write()` or `Permissions::new_owner_only()`.
   - The address of the created register is printed to the console.

In summary, this pull request introduces changes to add a new dependency, modify function calls and introduce customizable permissions for register creation.
<!-- reviewpad:summarize:end --> 

Resolves #1106 