### PR TITLE
feat: allow register CLI to create a public register writable to anyone

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -122,12 +122,18 @@ jobs:
           PROPTEST_CASES: 50 
 
   e2e:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            safe_path: /home/runner/.local/share/safe
+          - os: windows-latest
+            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
+          - os: macos-latest
+            safe_path: /Users/runner/Library/Application Support/safe
     steps:
       - uses: actions/checkout@v4
 
@@ -179,20 +185,89 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Start a client to create a register
+      - name: Start a client to create a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register create -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 10
 
-      - name: Start a client to get a register
+      - name: Start a client to get a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n baobao
         env:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Start a client to edit a register
+      - name: Start a client to edit a register writable by the owner only
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao wood
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      ## Next two steps are same with a slight difference in the way they write to the output file (GITHUB_OUTPUT vs ENV:GITHUB_OUTPUT)
+
+      # runs on linux/mac
+      - name: Start a client to create a register writable by anyone
+        id: register-address
+        if: matrix.os != 'windows-latest' 
+        run: echo "$(cargo run --bin safe --release -- --log-output-dest=data-dir register create -n trycatch -p | rg REGISTER_ADDRESS )" >> $GITHUB_OUTPUT
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      # runs on windows
+      - name: Start a client to create a register writable by anyone
+        id: register-address-windows
+        if: matrix.os == 'windows-latest' 
+        run: echo "$(cargo run --bin safe --release -- --log-output-dest=data-dir register create -n trycatch -p | rg REGISTER_ADDRESS )" >> $ENV:GITHUB_OUTPUT
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Start a client to get a register writable by anyone (current client is the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n trycatch
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit a register writable by anyone (current client is the owner)
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n trycatch wood
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Delete client subdir to generate new client
+        shell: bash
+        run: rm -rf ${{ matrix.safe_path }}/client
+
+
+      ## Next four steps are same with a slight difference in the which output step they read from
+
+      # runs on linux/mac
+      - name: Start a client to get a register writable by anyone (new client is not the owner)
+        if: matrix.os != 'windows-latest' 
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get ${{ steps.register-address.outputs.REGISTER_ADDRESS }}
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit a register writable by anyone (new client is not the owner)
+        if: matrix.os != 'windows-latest'
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit ${{ steps.register-address.outputs.REGISTER_ADDRESS }} water
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      # runs on Windows
+      - name: Start a client to get a register writable by anyone (new client is not the owner)
+        if: matrix.os == 'windows-latest' 
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register get ${{ steps.register-address-windows.outputs.REGISTER_ADDRESS }}
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 2
+
+      - name: Start a client to edit a register writable by anyone (new client is not the owner)
+        if: matrix.os == 'windows-latest'
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit ${{ steps.register-address-windows.outputs.REGISTER_ADDRESS }} water
         env:
           SN_LOG: "all"
         timeout-minutes: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,6 +4533,7 @@ dependencies = [
  "sn_logging",
  "sn_peers_acquisition",
  "sn_protocol",
+ "sn_registers",
  "sn_transfers",
  "tempfile",
  "tokio",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0.133", features = [ "derive"]}
 sn_build_info = { path="../sn_build_info", version = "0.1.4" }
 sn_client = { path = "../sn_client", version = "0.101.1" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.35" }
+sn_registers = { path = "../sn_registers", version = "0.3.6" }
 sn_logging = { path = "../sn_logging", version = "0.2.16" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.2.0" }
 sn_protocol = { path = "../sn_protocol", version = "0.10.4" }

--- a/sn_cli/src/subcommands/register.rs
+++ b/sn_cli/src/subcommands/register.rs
@@ -11,6 +11,7 @@ use clap::Subcommand;
 use color_eyre::{eyre::WrapErr, Result, Section};
 use sn_client::{Client, Error as ClientError, WalletClient};
 use sn_protocol::storage::RegisterAddress;
+use sn_registers::Permissions;
 use sn_transfers::LocalWallet;
 use std::path::Path;
 use xor_name::XorName;
@@ -23,6 +24,11 @@ pub enum RegisterCmds {
         /// This is used along with your public key to derive the address of the register
         #[clap(name = "name", short = 'n')]
         name: String,
+
+        /// Create the register with public write access.
+        /// By default only the owner can write to the register.
+        #[clap(name = "public", short = 'p')]
+        public: bool,
     },
     Edit {
         /// The address of the register to edit.
@@ -56,8 +62,8 @@ pub(crate) async fn register_cmds(
     verify_store: bool,
 ) -> Result<()> {
     match cmds {
-        RegisterCmds::Create { name } => {
-            create_register(name, client, root_dir, verify_store).await?
+        RegisterCmds::Create { name, public } => {
+            create_register(name, public, client, root_dir, verify_store).await?
         }
         RegisterCmds::Edit {
             address,
@@ -74,6 +80,7 @@ pub(crate) async fn register_cmds(
 
 async fn create_register(
     name: String,
+    public: bool,
     client: &Client,
     root_dir: &Path,
     verify_store: bool,
@@ -88,21 +95,24 @@ async fn create_register(
     let mut wallet_client = WalletClient::new(client.clone(), wallet);
 
     let meta = XorName::from_content(name.as_bytes());
+    let perms = match public {
+        true => Permissions::new_anyone_can_write(),
+        false => Permissions::new_owner_only(),
+    };
     let (register, storage_cost, royalties_fees) = client
-        .create_and_pay_for_register(meta, &mut wallet_client, verify_store)
+        .create_and_pay_for_register(meta, &mut wallet_client, verify_store, perms)
         .await?;
 
     if storage_cost.is_zero() {
-        println!(
-            "Register '{name}' already exists at {}!",
-            register.address().to_hex()
-        );
+        println!("Register '{name}' already exists!",);
     } else {
         println!(
-            "Successfully created register '{name}' at {} for {storage_cost:?} (royalties fees: {royalties_fees:?})!",
-            register.address().to_hex()
+            "Successfully created register '{name}' for {storage_cost:?} (royalties fees: {royalties_fees:?})!",
         );
     }
+
+    println!("REGISTER_ADDRESS={}", register.address().to_hex());
+
     Ok(())
 }
 

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -36,7 +36,7 @@ use sn_protocol::{
     },
     NetworkAddress, PrettyPrintRecordKey,
 };
-use sn_registers::SignedRegister;
+use sn_registers::{Permissions, SignedRegister};
 use sn_transfers::{CashNote, CashNoteRedemption, MainPubkey, NanoTokens, Payment, SignedSpend};
 use std::{
     collections::{HashMap, HashSet},
@@ -342,10 +342,17 @@ impl Client {
         address: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        perms: Permissions,
     ) -> Result<(ClientRegister, NanoTokens, NanoTokens)> {
         info!("Instantiating a new Register replica with address {address:?}");
-        let (reg, mut total_cost, mut total_royalties) =
-            ClientRegister::create_online(self.clone(), address, wallet_client, false).await?;
+        let (reg, mut total_cost, mut total_royalties) = ClientRegister::create_online(
+            self.clone(),
+            address,
+            wallet_client,
+            false,
+            perms.clone(),
+        )
+        .await?;
 
         debug!("{address:?} Created in theorryyyyy");
         let reg_address = reg.address();
@@ -356,9 +363,14 @@ impl Client {
             while !stored {
                 info!("Register not completely stored on the network yet. Retrying...");
                 // this verify store call here ensures we get the record from Quorum::all
-                let (reg, top_up_cost, royalties_top_up) =
-                    ClientRegister::create_online(self.clone(), address, wallet_client, true)
-                        .await?;
+                let (reg, top_up_cost, royalties_top_up) = ClientRegister::create_online(
+                    self.clone(),
+                    address,
+                    wallet_client,
+                    true,
+                    perms.clone(),
+                )
+                .await?;
                 let reg_address = reg.address();
 
                 total_cost = total_cost

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -53,27 +53,15 @@ impl ClientRegister {
         Self::create_register(client, meta, Permissions::new_owner_only())
     }
 
-    /// Create a new public Register (Anybody can write to it) and send it so the Network.
-    /// This will optionally verify the Register was stored on the network.
-    pub async fn create_public_online(
-        client: Client,
-        meta: XorName,
-        wallet_client: &mut WalletClient,
-        verify_store: bool,
-    ) -> Result<Self> {
-        let mut reg = Self::create_register(client, meta, Permissions::new_anyone_can_write())?;
-        reg.sync(wallet_client, verify_store).await?;
-        Ok(reg)
-    }
-
     /// Create a new Register and send it to the Network.
     pub async fn create_online(
         client: Client,
         meta: XorName,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        perms: Permissions,
     ) -> Result<(Self, NanoTokens, NanoTokens)> {
-        let mut reg = Self::create_register(client, meta, Permissions::new_owner_only())?;
+        let mut reg = Self::create_register(client, meta, perms)?;
         let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store).await?;
         Ok((reg, storage_cost, royalties_fees))
     }

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_client::{Client, Error, WalletClient};
-use sn_registers::RegisterAddress;
+use sn_registers::{Permissions, RegisterAddress};
 use sn_transfers::LocalWallet;
 use xor_name::XorName;
 
@@ -77,7 +77,12 @@ async fn main() -> Result<()> {
         Err(_) => {
             println!("Register '{reg_nickname}' not found, creating it at {address}");
             let (register, _cost, _royalties_fees) = client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(
+                    meta,
+                    &mut wallet_client,
+                    true,
+                    Permissions::new_anyone_can_write(),
+                )
                 .await?;
 
             register

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -24,6 +24,7 @@ use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress, SpendAddress},
     NetworkAddress,
 };
+use sn_registers::Permissions;
 use sn_transfers::LocalWallet;
 use sn_transfers::{CashNote, MainSecretKey, NanoTokens};
 use std::{
@@ -349,7 +350,12 @@ fn create_registers_task(
             sleep(delay).await;
 
             match client
-                .create_and_pay_for_register(meta, &mut wallet_client, true)
+                .create_and_pay_for_register(
+                    meta,
+                    &mut wallet_client,
+                    true,
+                    Permissions::new_owner_only(),
+                )
                 .await
             {
                 Ok(_) => content

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -22,6 +22,7 @@ use sn_protocol::safenode_proto::{
     safe_node_client::SafeNodeClient, GossipsubSubscribeRequest, NodeEventsRequest,
     TransferNotifsFilterRequest,
 };
+use sn_registers::Permissions;
 use sn_transfers::{
     CashNoteRedemption, LocalWallet, MainSecretKey, NanoTokens, NETWORK_ROYALTIES_PK,
 };
@@ -84,7 +85,12 @@ async fn nodes_rewards_for_storing_registers() -> Result<()> {
     let prev_rewards_balance = current_rewards_balance()?;
 
     let (_register, storage_cost, _royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            register_addr,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
     println!("Cost is {storage_cost:?}: {prev_rewards_balance:?}");
 
@@ -155,7 +161,12 @@ async fn nodes_rewards_for_register_notifs_over_gossipsub() -> Result<()> {
 
     println!("Paying for random Register address {register_addr:?} ...");
     let (_, storage_cost, royalties_fees) = client
-        .create_and_pay_for_register(register_addr, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            register_addr,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
     println!("Random Register created, paid {storage_cost}/{royalties_fees}");
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -20,6 +20,7 @@ use sn_protocol::{
     storage::{ChunkAddress, RegisterAddress},
     NetworkAddress,
 };
+use sn_registers::Permissions;
 use sn_transfers::{MainPubkey, NanoTokens, PaymentQuote};
 use std::collections::BTreeMap;
 use tokio::time::{sleep, Duration};
@@ -281,7 +282,12 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
         .await?;
 
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, true)
+        .create_and_pay_for_register(
+            xor_name,
+            &mut wallet_client,
+            true,
+            Permissions::new_owner_only(),
+        )
         .await?;
 
     let retrieved_reg = client.get_register(address).await?;
@@ -335,7 +341,12 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
 
     // this should fail to store as the amount paid is not enough
     let (mut register, _cost, _royalties_fees) = client
-        .create_and_pay_for_register(xor_name, &mut wallet_client, false)
+        .create_and_pay_for_register(
+            xor_name,
+            &mut wallet_client,
+            false,
+            Permissions::new_owner_only(),
+        )
         .await?;
 
     sleep(Duration::from_secs(5)).await;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jan 24 22:32 UTC
This pull request includes changes in various files. Here is a summary of the changes:

1. In the file "nodes_rewards.rs":
- Imported the `Permissions` struct from the `sn_registers` module.
- Modified the `create_and_pay_for_register` function call by adding a new argument `Permissions::new_owner_only()`.
These changes involve using the `Permissions` struct and passing it as an argument to the `create_and_pay_for_register` function.

2. In the file "register.rs":
- Removed the `create_public_online` function.
- Modified the `create_online` function to accept a `perms` parameter of type `Permissions`.
- The `perms` parameter is used in `create_register` when creating the register.
These changes suggest a refactoring of the code related to creating and syncing registers in the client.

3. In the file "Cargo.lock":
- Added the "sn_registers" dependency.

4. In the file "data_with_churn.rs":
- Added an import statement for `Permissions` from the `sn_registers` module.
- Passed an additional argument `Permissions::new_owner_only()` to the `create_and_pay_for_register` function.
These changes seem to be related to enhancing security and permissions in the code.

5. In the file "registers.rs":
- Added an import statement for `Permissions` from the `sn_registers` module.
- Added the `Permissions::new_anyone_can_write()` as an additional parameter in the `create_and_pay_for_register` function call.
These changes indicate that the code now includes permissions for the register and allows anyone to write to it.

6. In the file "register.rs":
- Imported the `Permissions` struct from the `sn_registers` module.
- Added a new command line option `-p` or `--public` to create the register with public write access.
- Updated the `create_register` function to accept the `public` parameter and use it to determine the permissions of the register.
- Updated the `create_and_pay_for_register` function call to include the `perms` parameter.
- Print the address of the created register at the end.

7. In the file "Cargo.toml":
- Added a new dependency, "sn_registers", with version "0.3.6" in the "sn_cli" directory.

8. In the file "storage_payments.rs":
- Imported `sn_registers::Permissions`.
- Added additional arguments in the `create_and_pay_for_register` function call.
- Added creation of `Permissions::new_owner_only()`.
- Added additional arguments in the second `create_and_pay_for_register` function call.
These changes introduce the `Permissions` module, modify the function calls to `create_and_pay_for_register`, and add extra arguments to these function calls.

Let me know if you need any further assistance.
<!-- reviewpad:summarize:end --> 

Resolves issue #1106 