### PR TITLE
chore: Move replicate flow to driver

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -9,7 +9,8 @@
 use crate::{
     driver::{truncate_patch_version, PendingGetClosestType, SwarmDriver},
     error::{Error, Result},
-    multiaddr_is_global, multiaddr_strip_p2p, CLOSE_GROUP_SIZE,
+    multiaddr_is_global, multiaddr_strip_p2p, sort_peers_by_address, CLOSE_GROUP_SIZE,
+    REPLICATE_RANGE,
 };
 use bytes::Bytes;
 use core::fmt;
@@ -32,7 +33,7 @@ use libp2p::{
 };
 
 use sn_protocol::{
-    messages::{Cmd, CmdResponse, Query, Request, Response},
+    messages::{CmdResponse, Query, Request, Response},
     storage::RecordType,
     NetworkAddress, PrettyPrintRecordKey,
 };
@@ -108,11 +109,6 @@ pub enum MsgResponder {
 #[allow(clippy::large_enum_variant)]
 /// Events forwarded by the underlying Network; to be used by the upper layers
 pub enum NetworkEvent {
-    /// Incoming `Cmd` from a peer
-    CmdRequestReceived {
-        /// Cmd
-        cmd: Cmd,
-    },
     /// Incoming `Query` from a peer
     QueryRequestReceived {
         /// Query
@@ -161,9 +157,6 @@ pub enum NetworkEvent {
 impl Debug for NetworkEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            NetworkEvent::CmdRequestReceived { cmd, .. } => {
-                write!(f, "NetworkEvent::CmdRequestReceived({cmd:?})")
-            }
             NetworkEvent::QueryRequestReceived { query, .. } => {
                 write!(f, "NetworkEvent::QueryRequestReceived({query:?})")
             }
@@ -646,7 +639,8 @@ impl SwarmDriver {
                     // as we send that regardless of how we handle the request as its unimportant to the sender.
                     match request {
                         Request::Cmd(sn_protocol::messages::Cmd::Replicate { holder, keys }) => {
-                            trace!("Short circuit ReplicateOk response to peer {peer:?}");
+                            self.add_keys_to_replication_fetcher(holder, keys);
+
                             let response = Response::Cmd(
                                 sn_protocol::messages::CmdResponse::Replicate(Ok(())),
                             );
@@ -655,10 +649,6 @@ impl SwarmDriver {
                                 .request_response
                                 .send_response(channel, response)
                                 .map_err(|_| Error::InternalMsgChannelDropped)?;
-
-                            self.send_event(NetworkEvent::CmdRequestReceived {
-                                cmd: sn_protocol::messages::Cmd::Replicate { holder, keys },
-                            });
                         }
                         Request::Query(query) => {
                             self.send_event(NetworkEvent::QueryRequestReceived {
@@ -1101,6 +1091,125 @@ impl SwarmDriver {
 
             trace!("Removing outdated connection {connection_id:?} to {peer_id:?}");
             let _result = self.swarm.close_connection(connection_id);
+        }
+    }
+
+    fn add_keys_to_replication_fetcher(
+        &mut self,
+        sender: NetworkAddress,
+        incoming_keys: Vec<(NetworkAddress, RecordType)>,
+    ) {
+        let holder = if let Some(peer_id) = sender.as_peer_id() {
+            peer_id
+        } else {
+            warn!("Replication list sender is not a peer_id {sender:?}");
+            return;
+        };
+
+        trace!(
+            "Received replication list from {holder:?} of {} keys",
+            incoming_keys.len()
+        );
+
+        // accept replication requests from the K_VALUE peers away,
+        // giving us some margin for replication
+        let closest_k_peers = self.get_closest_k_value_local_peers();
+        if !closest_k_peers.contains(&holder) || holder == self.self_peer_id {
+            trace!("Holder {holder:?} is self or not in replication range.");
+            return;
+        }
+
+        // Only handle those non-exist and in close range keys
+        let keys_to_store =
+            self.select_non_existent_records_for_replications(&incoming_keys, &closest_k_peers);
+        if keys_to_store.is_empty() {
+            debug!("Empty keys to store after adding to");
+            return;
+        }
+
+        #[allow(clippy::mutable_key_type)]
+        let all_keys = self
+            .swarm
+            .behaviour_mut()
+            .kademlia
+            .store_mut()
+            .record_addresses_ref();
+        let keys_to_fetch = self
+            .replication_fetcher
+            .add_keys(holder, keys_to_store, all_keys);
+        if !keys_to_fetch.is_empty() {
+            self.send_event(NetworkEvent::KeysToFetchForReplication(keys_to_fetch));
+        } else {
+            trace!("no waiting keys to fetch from the network");
+        }
+    }
+
+    /// Checks suggested records against what we hold, so we only
+    /// enqueue what we do not have
+    fn select_non_existent_records_for_replications(
+        &mut self,
+        incoming_keys: &[(NetworkAddress, RecordType)],
+        closest_k_peers: &Vec<PeerId>,
+    ) -> Vec<(NetworkAddress, RecordType)> {
+        #[allow(clippy::mutable_key_type)]
+        let locally_stored_keys = self
+            .swarm
+            .behaviour_mut()
+            .kademlia
+            .store_mut()
+            .record_addresses_ref();
+        let non_existent_keys: Vec<_> = incoming_keys
+            .iter()
+            .filter(|(addr, record_type)| {
+                let key = addr.to_record_key();
+                let local = locally_stored_keys.get(&key);
+
+                // if we have a local value of matching record_type, we don't need to fetch it
+                if let Some((_, local_record_type)) = local {
+                    local_record_type != record_type
+                } else {
+                    true
+                }
+            })
+            .collect();
+
+        non_existent_keys
+            .into_iter()
+            .filter_map(|(key, record_type)| {
+                if self.is_in_close_range(key, closest_k_peers) {
+                    Some((key.clone(), record_type.clone()))
+                } else {
+                    // Reduce the log level as there will always be around 40% records being
+                    // out of the close range, as the sender side is using `CLOSE_GROUP_SIZE + 2`
+                    // to send our replication list to provide addressing margin.
+                    // Given there will normally be 6 nodes sending such list with interval of 5-10s,
+                    // this will accumulate to a lot of logs with the increasing records uploaded.
+                    trace!("not in close range for key {key:?}");
+                    None
+                }
+            })
+            .collect()
+    }
+
+    // A close target doesn't falls into the close peers range:
+    // For example, a node b11111X has an RT: [(1, b1111), (2, b111), (5, b11), (9, b1), (7, b0)]
+    // Then for a target bearing b011111 as prefix, all nodes in (7, b0) are its close_group peers.
+    // Then the node b11111X. But b11111X's close_group peers [(1, b1111), (2, b111), (5, b11)]
+    // are none among target b011111's close range.
+    // Hence, the ilog2 calculation based on close_range cannot cover such case.
+    // And have to sort all nodes to figure out whether self is among the close_group to the target.
+    fn is_in_close_range(&self, target: &NetworkAddress, all_peers: &Vec<PeerId>) -> bool {
+        if all_peers.len() <= REPLICATE_RANGE {
+            return true;
+        }
+
+        // Margin of 2 to allow our RT being bit lagging.
+        match sort_peers_by_address(all_peers, target, REPLICATE_RANGE) {
+            Ok(close_group) => close_group.contains(&&self.self_peer_id),
+            Err(err) => {
+                warn!("Could not get sorted peers for {target:?} with error {err:?}");
+                true
+            }
         }
     }
 }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -685,6 +685,10 @@ impl Network {
         self.send_swarm_cmd(SwarmCmd::GossipHandler)
     }
 
+    pub fn trigger_interval_replication(&self) -> Result<()> {
+        self.send_swarm_cmd(SwarmCmd::TriggerIntervalReplication)
+    }
+
     // Helper to send SwarmCmd
     fn send_swarm_cmd(&self, cmd: SwarmCmd) -> Result<()> {
         let capacity = self.swarm_cmd_sender.capacity();

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -633,16 +633,6 @@ impl Network {
             .map_err(|_e| Error::InternalMsgChannelDropped)
     }
 
-    // Add a list of keys of a holder to Replication Fetcher.
-    #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-    pub fn add_keys_to_replication_fetcher(
-        &self,
-        holder: PeerId,
-        keys: HashMap<NetworkAddress, RecordType>,
-    ) -> Result<()> {
-        self.send_swarm_cmd(SwarmCmd::AddKeysToReplicationFetcher { holder, keys })
-    }
-
     /// Send `Request` to the given `PeerId` and await for the response. If `self` is the recipient,
     /// then the `Request` is forwarded to itself and handled, and a corresponding `Response` is created
     /// and returned to itself. Hence the flow remains the same and there is no branching at the upper
@@ -696,20 +686,10 @@ impl Network {
         let cmd_sender = self.swarm_cmd_sender.clone();
 
         if capacity == 0 {
-            if matches!(cmd, SwarmCmd::AddKeysToReplicationFetcher { .. }) {
-                // we can safely drop AddKeysToReplicationFetcher
-                // it should be reattempted in a few seconds and if we can cope we'll do it.
-                warn!(
-                    "SwarmCmd channel is full. Dropping AddKeysToReplicationFetcher: {:?}",
-                    cmd
-                );
-                return Ok(());
-            } else {
-                error!(
-                    "SwarmCmd channel is full. Await capacity to send: {:?}",
-                    cmd
-                );
-            }
+            error!(
+                "SwarmCmd channel is full. Await capacity to send: {:?}",
+                cmd
+            );
         }
 
         // Spawn a task to send the SwarmCmd and keep this fn sync

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -242,7 +242,6 @@ impl Node {
 
                         let _handle = spawn(async move {
                             if let Err(err) = Self::try_interval_replication(network)
-                                .await
                             {
                                 error!("Error while triggering replication {err:?}");
                             }
@@ -296,7 +295,7 @@ impl Node {
                 let net_clone = self.network.clone();
                 self.record_metrics(Marker::IntervalReplicationTriggered);
                 let _handle = spawn(async move {
-                    if let Err(err) = Self::try_interval_replication(net_clone).await {
+                    if let Err(err) = Self::try_interval_replication(net_clone) {
                         error!("Error while triggering replication {err:?}");
                     }
                 });
@@ -308,7 +307,7 @@ impl Node {
                 let net = self.network.clone();
                 self.record_metrics(Marker::IntervalReplicationTriggered);
                 let _handle = spawn(async move {
-                    if let Err(e) = Self::try_interval_replication(net).await {
+                    if let Err(e) = Self::try_interval_replication(net) {
                         error!("Error while triggering replication {e:?}");
                     }
                 });

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -17,7 +17,6 @@ use sn_protocol::{
     storage::RecordType,
     NetworkAddress, PrettyPrintRecordKey,
 };
-use std::collections::HashMap;
 use tokio::task::{spawn, JoinHandle};
 
 impl Node {
@@ -165,7 +164,7 @@ impl Node {
             let our_peer_id = network.peer_id;
             let our_address = NetworkAddress::from_peer(our_peer_id);
             #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
-            let keys = HashMap::from([(data_addr.clone(), record_type.clone())]);
+            let keys = vec![(data_addr.clone(), record_type.clone())];
 
             for peer_id in sorted_based_on_addr {
                 trace!("Replicating fresh record {pretty_key:?} to {peer_id:?}");

--- a/sn_protocol/src/messages/cmd.rs
+++ b/sn_protocol/src/messages/cmd.rs
@@ -11,7 +11,6 @@ use crate::{storage::RecordType, NetworkAddress};
 use serde::{Deserialize, Serialize};
 // TODO: remove this dependency and define these types herein.
 pub use sn_transfers::Hash;
-use std::collections::HashMap;
 
 /// Data and CashNote cmds - recording spends or creating, updating, and removing data.
 ///
@@ -29,7 +28,7 @@ pub enum Cmd {
         /// Holder of the replication keys.
         holder: NetworkAddress,
         /// Keys of copy that shall be replicated.
-        keys: HashMap<NetworkAddress, RecordType>,
+        keys: Vec<(NetworkAddress, RecordType)>,
     },
 }
 
@@ -37,7 +36,7 @@ impl std::fmt::Debug for Cmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Cmd::Replicate { holder, keys } => {
-                let first_ten_keys: Vec<_> = keys.keys().take(10).collect();
+                let first_ten_keys: Vec<_> = keys.iter().take(10).collect();
                 f.debug_struct("Cmd::Replicate")
                     .field("holder", holder)
                     .field("keys_len", &keys.len())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jan 24 11:03 UTC
This pull request includes the following changes:

- The function `get_local_storecost` in the `Network` implementation now takes an additional parameter `key: RecordKey`.
- The code that previously called `get_local_storecost` has been updated to pass the `key` parameter.
- A new function `trigger_interval_replication` has been added to the `Network` implementation.
- The new function is used to trigger interval replication in the network.
- The function `try_interval_replication` in the file `replication.rs` has been modified to be synchronous and call `network.trigger_interval_replication()` instead of being asynchronous.
- The file `replication.rs` also includes a new implementation of `try_interval_replication`, replacing the previous implementation.
- The file diff in `.github/workflows/merge.yml` includes the addition of a new job called "replication_bench_with_heavy_upload" that performs a replication benchmark with heavy upload.
- The file diff includes changes in the import statements, method calls, and match arm handling in various files.

These changes simplify the code, improve code readability, and add support for triggering interval replication. Additionally, the `store_cost` function in `record_store.rs` has been updated to use the correct number of stored records for cost calculation and include the `stored_records` variable in the log message.
<!-- reviewpad:summarize:end --> 
