### PR TITLE
feat(cli): safe wallet create saves new key

### DIFF
--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -30,7 +30,7 @@ use sn_client::Client;
 use sn_logging::{metrics::init_metrics, LogBuilder, LogFormat};
 use sn_peers_acquisition::parse_peers_args;
 use sn_transfers::bls_secret_from_hex;
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 use tracing::Level;
 
 const CLIENT_KEY: &str = "clientkey";
@@ -152,4 +152,15 @@ fn get_client_data_dir_path() -> Result<PathBuf> {
     home_dirs.push("client");
     std::fs::create_dir_all(home_dirs.as_path())?;
     Ok(home_dirs)
+}
+
+fn get_stdin_response(prompt: &str) -> String {
+    println!("{prompt}");
+    let mut buffer = String::new();
+    let stdin = io::stdin();
+    if stdin.read_line(&mut buffer).is_err() {
+        // consider if error should process::exit(1) here
+        return "".to_string();
+    };
+    buffer
 }


### PR DESCRIPTION
This PR will save the new key if a key/wallet already exists when calling `safe wallet create <new_sk>`.

An existing wallet will be moved to a new directory (if it has existing funds, removed if it has no funds).

Before this pr:

```
ian@ian-desktop:~/.local/share/safe/client $ safe wallet address
8f459c4e801ffb6014f1a320c4435a336fdefa925f9f17ada40263241563b7cf20f586643b0dc2fb752652f46ec12eda

ian@ian-desktop:~/.local/share/safe/client $ safe wallet create 2eb5cb219147616b041c20920d82c6fc701356b67743ad4d670e8e3060d8e5ab
# expect this to report 0 balance for new wallet, but it uses the old wallet balance
Wallet created (balance 59.999796105) for main public key: 8935291af5674a4bab6d21f895ce19972fb2f6659f71e42c910b25faafebd4de2471596ebd40f50baec0ecd6ca95c309.

ian@ian-desktop:~/.local/share/safe/client $ safe wallet address
# expect it to be the new address, but it's the old one
8f459c4e801ffb6014f1a320c4435a336fdefa925f9f17ada40263241563b7cf20f586643b0dc2fb752652f46ec12eda
```

After this pr:

```
ian@ian-desktop:~/.local/share/safe/client $ safe wallet address
8f459c4e801ffb6014f1a320c4435a336fdefa925f9f17ada40263241563b7cf20f586643b0dc2fb752652f46ec12eda

ian@ian-desktop:~/.local/share/safe/client $ safe wallet create 2eb5cb219147616b041c20920d82c6fc701356b67743ad4d670e8e3060d8e5ab
Existing wallet has balance of 59.999796105. Replace with new wallet? [y/N]
y
# old wallet is moved and balance for new wallet is correct
Old wallet stored at /home/ian/.local/share/safe/client/wallet_8f459c4e80
Wallet created (balance 0.000000000) for main public key: 8935291af5674a4bab6d21f895ce19972fb2f6659f71e42c910b25faafebd4de2471596ebd40f50baec0ecd6ca95c309.

ian@ian-desktop:~/.local/share/safe/client $ safe wallet address
# new wallet is created
8935291af5674a4bab6d21f895ce19972fb2f6659f71e42c910b25faafebd4de2471596ebd40f50baec0ecd6ca95c309
```

On a related note, `LocalWallet::create_from_key` was added because there are many existing ways to load a wallet, none of which can be used to override the existing wallet stored to disk. The concept of 'load' and 'create' and 'use' are all co-mingled within the 'load' word. It would be good to consolidate a lot of very similar public apis, because I couldn't untangle the various potential semantic uses of these functions:

```text
pub fn load_from_main_key(root_dir: &Path, main_key: MainSecretKey) -> Result<Self>
pub fn load_from(root_dir: &Path) -> Result<Self>
pub fn try_load_from(root_dir: &Path) -> Result<Self>
pub fn load_from_path(wallet_dir: &Path, main_key: Option<MainSecretKey>) -> Result<Self>
fn load_from_path_and_key(wallet_dir: &Path, main_key: Option<MainSecretKey>) -> Result<Self>
```

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jan 24 02:47 UTC
This pull request introduces a new feature to the command-line interface (CLI). The feature allows the creation of a safe wallet to save a new key. The patch includes changes to the main.rs, wallet.rs, and local_store.rs files. In wallet.rs, the patch adds logic to check for an existing wallet with a balance and confirm whether to replace it with a new wallet. If confirmed, the existing wallet is removed, and a new wallet is created with the new key. The local_store.rs file includes changes to support the creation of a serialized wallet for a given path and main key, overwriting any existing wallet. Additionally, the clear() function is added to move all files for the current wallet to a new directory in case of clearing specific spends.
<!-- reviewpad:summarize:end --> 
