### PR TITLE
chore: get spend from network only require Majority

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -531,7 +531,7 @@ impl Client {
         };
 
         let verification_cfg = GetRecordCfg {
-            get_quorum: Quorum::All,
+            get_quorum: Quorum::Majority,
             re_attempt: true,
             target_record: record_to_verify,
             expected_holders,
@@ -554,7 +554,7 @@ impl Client {
             PrettyPrintRecordKey::from(&key)
         );
         let get_cfg = GetRecordCfg {
-            get_quorum: Quorum::All,
+            get_quorum: Quorum::Majority,
             re_attempt: true,
             target_record: None,
             expected_holders: Default::default(),

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -724,7 +724,11 @@ impl Node {
                             "Checking parent input at {:?} - {parent_cash_note_address:?}",
                             parent_input.unique_pubkey(),
                         );
-                        let parent = match self.network.get_spend(parent_cash_note_address).await {
+                        let parent = match self
+                            .network
+                            .try_get_spend(parent_cash_note_address)
+                            .await
+                        {
                             Ok(parent) => parent,
                             Err(err) => {
                                 error!("Error while getting parent spend {parent_cash_note_address:?} for cash_note addr {cash_note_addr:?}: {err:?}");
@@ -747,7 +751,7 @@ impl Node {
 
                 // check the network if any spend has happened for the same unique_pubkey
                 debug!("Check if any spend exist for the same unique_pubkey {cash_note_addr:?}");
-                let mut spends = match self.network.get_spend(cash_note_addr).await {
+                let mut spends = match self.network.try_get_spend(cash_note_addr).await {
                     Ok(spend) => {
                         debug!("Got spend from network for the same unique_pubkey");
                         vec![spend]

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -95,11 +95,11 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     // upload won't error out, only error out during verification.
     println!("Sending both transfers to the network...");
     let res = client
-        .send(transfer_to_2.all_spend_requests.iter(), false)
+        .send_spends(transfer_to_2.all_spend_requests.iter(), false)
         .await;
     assert!(res.is_ok());
     let res = client
-        .send(transfer_to_3.all_spend_requests.iter(), false)
+        .send_spends(transfer_to_3.all_spend_requests.iter(), false)
         .await;
     assert!(res.is_ok());
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jan 24 13:25 UTC
This pull request includes several changes to the codebase. 

In the sn_client/src/api.rs file:
- Line 531: The `get_quorum` field in the `GetRecordCfg` struct is changed from `Quorum::All` to `Quorum::Majority` to specify that only a majority of holders is required for the record.
- Line 554: The `get_quorum` field in the `GetRecordCfg` struct is changed from `Quorum::All` to `Quorum::Majority` to specify that only a majority of holders is required for the record.

In the sn_client/src/wallet.rs file:
- Line 92: The `send` method is renamed to `send_spends` to more accurately represent its purpose of sending spend requests to the network.
- Line 152: A comment is added to indicate that using the default `ExponentialBackoff` doesn't make sense in this context.
- Line 269: A comment is added to highlight the potential risk of repaying the whole bunch of spends to the chunks' store costs and royalty fees if any one of the payments fails to be put.
- Line 304: A comment is added to indicate that the storage payment transfer will be retried later if it was not successfully registered in the network.
- Line 331: The `send` method is renamed to `send_spends` to more accurately represent its purpose of sending spend requests to the network.

In the sn_networking/src/lib.rs file:
- Line 410: The `GetNetworkRecord` command now logs the record retrieval attempt and its results.
- Line 574: A comment is added to clarify that the `verify_chunk_existence` method carries out three re-attempts while the `get_record_from_network` method carries out only one re-attempt.

In the sn_networking/src/transfers.rs file:
- Line 26: The `get_quorum` field in the `GetRecordCfg` struct is changed from `Quorum::All` to `Quorum::Majority` to specify that only a majority of holders is required for the record.

In the sn_node/tests/sequential_transfers.rs file:
- Lines 95 and 98: The `send` method calls are changed to `send_spends` to more accurately represent their purpose of sending spend requests to the network.

Overall, this pull request includes changes related to modifying the `get_quorum` field in the `GetRecordCfg` struct, renaming the `send` method to `send_spends`, and adding comments for clarity.
<!-- reviewpad:summarize:end --> 
