### PR TITLE
feat(client): use futures stream to speed up downloads

### DIFF
--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -88,4 +88,7 @@ pub enum Error {
 
     #[error("The provided data map is empty")]
     EmptyDataMap,
+
+    #[error("Error occurred while assembling the downloaded chunks")]
+    FailedToAssembleDownloadedChunks,
 }

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -85,4 +85,7 @@ pub enum Error {
 
     #[error("Incorrect Download Option")]
     IncorrectDownloadOption,
+
+    #[error("The provided data map is empty")]
+    EmptyDataMap,
 }

--- a/sn_client/src/files/mod.rs
+++ b/sn_client/src/files/mod.rs
@@ -10,18 +10,13 @@ pub(crate) mod download;
 pub(crate) mod upload;
 
 use crate::{
-    chunks::{to_chunk, DataMapLevel, Error as ChunksError, SmallFile},
+    chunks::{to_chunk, Error as ChunksError, SmallFile},
     error::Result,
     Client, WalletClient,
 };
 use bytes::Bytes;
-use futures::{future::join_all, stream::FuturesOrdered, StreamExt};
-use itertools::Itertools;
 use libp2p::PeerId;
-use self_encryption::{
-    self, decrypt_full_set, ChunkInfo, DataMap, EncryptedChunk, StreamSelfDecryptor,
-    MIN_ENCRYPTABLE_BYTES,
-};
+use self_encryption::{self, MIN_ENCRYPTABLE_BYTES};
 use sn_protocol::{
     storage::{Chunk, ChunkAddress},
     NetworkAddress,
@@ -31,10 +26,8 @@ use std::{
     fs::{self, create_dir_all, File},
     io::{Read, Write},
     path::{Path, PathBuf},
-    time::Instant,
 };
 use tempfile::tempdir;
-use tokio::task;
 use tracing::trace;
 use xor_name::XorName;
 
@@ -72,41 +65,6 @@ impl FilesApi {
         let wallet = LocalWallet::load_from(path)?;
 
         Ok(WalletClient::new(self.client.clone(), wallet))
-    }
-
-    /// Read bytes from the network. The contents are spread across
-    /// multiple chunks in the network. This function invokes the self-encryptor and returns
-    /// the data that was initially stored.
-    ///
-    /// Takes `position` and `length` arguments which specify the start position
-    /// and the length of bytes to be read.
-    /// Passing `0` to position reads the data from the beginning,
-    /// and the `length` is just an upper limit.
-    pub async fn read_from(
-        &self,
-        address: ChunkAddress,
-        position: usize,
-        length: usize,
-        batch_size: usize,
-    ) -> Result<Bytes> {
-        trace!("Reading {length} bytes at: {address:?}, starting from position: {position}");
-        let chunk = self.client.get_chunk(address, false).await?;
-
-        // First try to deserialize a LargeFile, if it works, we go and seek it.
-        // If an error occurs, we consider it to be a SmallFile.
-        if let Ok(data_map) = self.unpack_chunk(chunk.clone(), batch_size).await {
-            return self.seek(data_map, position, length).await;
-        }
-
-        // The error above is ignored to avoid leaking the storage format detail of SmallFiles and LargeFiles.
-        // The basic idea is that we're trying to deserialize as one, and then the other.
-        // The cost of it is that some errors will not be seen without a refactor.
-        let mut bytes = chunk.value().clone();
-
-        let _ = bytes.split_to(position);
-        bytes.truncate(length);
-
-        Ok(bytes)
     }
 
     /// Tries to chunk the file, returning `(head_address, data_map_chunk, file_size, chunk_names)`
@@ -250,173 +208,6 @@ impl FilesApi {
         }
 
         Ok(NetworkAddress::ChunkAddress(head_address))
-    }
-
-    // Gets and decrypts chunks from the network using nothing else but the data map.
-    // If a downloaded path is given, the decrypted file will be written to the given path,
-    // by the decryptor directly.
-    // Otherwise, will assume the fetched content is a small one and return as bytes.
-    async fn read_all(
-        &self,
-        data_map: DataMap,
-        decrypted_file_path: Option<PathBuf>,
-        show_holders: bool,
-        batch_size: usize,
-    ) -> Result<Option<Bytes>> {
-        let mut decryptor = if let Some(path) = decrypted_file_path {
-            StreamSelfDecryptor::decrypt_to_file(Box::new(path), &data_map)?
-        } else {
-            let encrypted_chunks = self.try_get_chunks(data_map.infos()).await?;
-            let bytes = decrypt_full_set(&data_map, &encrypted_chunks)
-                .map_err(ChunksError::SelfEncryption)?;
-            return Ok(Some(bytes));
-        };
-
-        let expected_count = data_map.infos().len();
-        // let mut missing_chunks = Vec::new();
-        let mut ordered_read_futures = FuturesOrdered::new();
-        let now = Instant::now();
-
-        let mut index = 0;
-
-        for chunk_info in data_map.infos().iter() {
-            let dst_hash = chunk_info.dst_hash;
-            // The futures are executed concurrently,
-            // but the result is returned in the order in which they were inserted.
-            ordered_read_futures.push_back(async move {
-                (
-                    dst_hash,
-                    self.client
-                        .get_chunk(ChunkAddress::new(dst_hash), show_holders)
-                        .await,
-                )
-            });
-
-            if ordered_read_futures.len() >= batch_size || index + batch_size > expected_count {
-                while let Some((dst_hash, result)) = ordered_read_futures.next().await {
-                    let chunk = result.map_err(|error| {
-                        error!("Chunk missing {dst_hash:?} with {error:?}");
-                        ChunksError::ChunkMissing(dst_hash)
-                    })?;
-                    let encrypted_chunk = EncryptedChunk {
-                        index,
-                        content: chunk.value().clone(),
-                    };
-                    let _ = decryptor.next_encrypted(encrypted_chunk)?;
-
-                    index += 1;
-                    info!("Client (read all) download progress {index:?}/{expected_count:?}");
-                    println!("Client (read all) download progress {index:?}/{expected_count:?}");
-                }
-            }
-        }
-
-        let elapsed = now.elapsed();
-        println!("Client downloaded file in {elapsed:?}");
-
-        Ok(None)
-    }
-
-    /// Extracts a file DataMapLevel from a chunk.
-    /// If the DataMapLevel is not the first level mapping directly to the user's contents,
-    /// the process repeats itself until it obtains the first level DataMapLevel.
-    pub async fn unpack_chunk(&self, mut chunk: Chunk, batch_size: usize) -> Result<DataMap> {
-        loop {
-            match rmp_serde::from_slice(chunk.value()).map_err(ChunksError::Deserialisation)? {
-                DataMapLevel::First(data_map) => {
-                    return Ok(data_map);
-                }
-                DataMapLevel::Additional(data_map) => {
-                    let serialized_chunk = self
-                        .read_all(data_map, None, false, batch_size)
-                        .await?
-                        .expect("error encountered on reading additional datamap");
-                    chunk = rmp_serde::from_slice(&serialized_chunk)
-                        .map_err(ChunksError::Deserialisation)?;
-                }
-            }
-        }
-    }
-    // Gets a subset of chunks from the network, decrypts and
-    // reads `len` bytes of the data starting at given `pos` of original file.
-    async fn seek(&self, data_map: DataMap, pos: usize, len: usize) -> Result<Bytes> {
-        let info = self_encryption::seek_info(data_map.file_size(), pos, len);
-        let range = &info.index_range;
-        let all_infos = data_map.infos();
-
-        let encrypted_chunks = self
-            .try_get_chunks(
-                (range.start..range.end + 1)
-                    .clone()
-                    .map(|i| all_infos[i].clone())
-                    .collect_vec(),
-            )
-            .await?;
-
-        let bytes =
-            self_encryption::decrypt_range(&data_map, &encrypted_chunks, info.relative_pos, len)
-                .map_err(ChunksError::SelfEncryption)?;
-
-        Ok(bytes)
-    }
-
-    async fn try_get_chunks(&self, chunks_info: Vec<ChunkInfo>) -> Result<Vec<EncryptedChunk>> {
-        let expected_count = chunks_info.len();
-        let mut retrieved_chunks = vec![];
-
-        let mut tasks = Vec::new();
-        for chunk_info in chunks_info.clone().into_iter() {
-            let client = self.client.clone();
-            let task = task::spawn(async move {
-                let chunk = client
-                    .get_chunk(ChunkAddress::new(chunk_info.dst_hash), false)
-                    .await
-                    .map_err(|error| {
-                        error!("Chunk missing {:?} with {error:?}", chunk_info.dst_hash);
-                        ChunksError::ChunkMissing(chunk_info.dst_hash)
-                    })?;
-                Ok::<EncryptedChunk, ChunksError>(EncryptedChunk {
-                    index: chunk_info.index,
-                    content: chunk.value().clone(),
-                })
-            });
-            tasks.push(task);
-        }
-
-        // This swallowing of errors is basically a compaction into a single
-        // error saying "didn't get all chunks".
-        retrieved_chunks.extend(join_all(tasks).await.into_iter().flatten().flatten());
-
-        info!(
-            "Client download progress {:?}/{expected_count:?}",
-            retrieved_chunks.len()
-        );
-        println!(
-            "Client download progress {:?}/{expected_count:?}",
-            retrieved_chunks.len()
-        );
-
-        if expected_count > retrieved_chunks.len() {
-            let missing_chunks: Vec<XorName> = chunks_info
-                .iter()
-                .filter_map(|expected_info| {
-                    if retrieved_chunks.iter().any(|retrieved_chunk| {
-                        XorName::from_content(&retrieved_chunk.content) == expected_info.dst_hash
-                    }) {
-                        None
-                    } else {
-                        Some(expected_info.dst_hash)
-                    }
-                })
-                .collect();
-            Err(ChunksError::NotEnoughChunksRetrieved {
-                expected: expected_count,
-                retrieved: retrieved_chunks.len(),
-                missing_chunks,
-            })?
-        } else {
-            Ok(retrieved_chunks)
-        }
     }
 }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jan 24 18:39 UTC
This pull request contains the following changes:

In the `error.rs` file:
- Added a new variant `EmptyDataMap` to the `Error` enum. This variant represents the error of an empty data map being provided.

In the `sn_client/src/files/mod.rs` file:
- The `chunks` module is now importing only the `Error` type from the `self_encryption` module, instead of the `DataMapLevel` and `SmallFile` types.
- Removed the import of `futures::{future::join_all, stream::FuturesOrdered, StreamExt}`.
- Removed the import of `itertools::Itertools`.
- Modified the import of `self_encryption::{self, decrypt_full_set, ChunkInfo, DataMap, EncryptedChunk, StreamSelfDecryptor, MIN_ENCRYPTABLE_BYTES}`. Removed the `decrypt_full_set` function and types `ChunkInfo`, `DataMap`, `EncryptedChunk`, and `StreamSelfDecryptor`. Only the `MIN_ENCRYPTABLE_BYTES` constant remains.
- Removed the import of `std::time::Instant`.
- Removed the import of `tokio::task`.
- Removed the import of `tracing::trace`.
- Removed the import of `xor_name::XorName`.
- Removed several methods of the `FilesApi` implementation, including `read_from`, `read_all`, `unpack_chunk`, `seek`, and `try_get_chunks`.
<!-- reviewpad:summarize:end --> 
