### PR TITLE
feat(client): extra sleep between chunk verification

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -321,6 +321,13 @@ impl Network {
                 return Ok(());
             }
             warn!("The obtained {n_verified} verified proofs did not match the expected {expected_n_verified} verified proofs");
+            // Sleep to avoid firing queries too close to even choke the nodes further.
+            let waiting_time = if retry_attempts == 1 {
+                MIN_WAIT_BEFORE_READING_A_PUT
+            } else {
+                MIN_WAIT_BEFORE_READING_A_PUT + MIN_WAIT_BEFORE_READING_A_PUT
+            };
+            tokio::time::sleep(waiting_time).await;
         }
 
         Err(Error::FailedToVerifyChunkProof(chunk_address.clone()))

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -131,10 +131,10 @@ where
             *SpendAddress::from_unique_pubkey(&cash_note.unique_pubkey()).xorname();
         let unique_pubkey_file_name = format!("{}.cash_note", hex::encode(unique_pubkey_name));
 
-        debug!("Writing cash note to: {:?}", created_cash_notes_path);
         fs::create_dir_all(&created_cash_notes_path)?;
 
         let cash_note_file_path = created_cash_notes_path.join(unique_pubkey_file_name);
+        debug!("Writing cash note to: {cash_note_file_path:?}");
 
         let hex = cash_note
             .to_hex()


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jan 24 09:29 UTC
This pull request introduces a new feature to the client code. Specifically, it adds an extra sleep between chunk verification in the `sn_networking` module. This sleep is added to avoid firing queries too close together and potentially choking the nodes further. The waiting time is determined based on the number of retry attempts. Additionally, this patch includes a minor change in the `sn_transfers` module, where a debug message is added to indicate the path where the cash note is being written.
<!-- reviewpad:summarize:end --> 
