### PR TITLE
feat: error if file size smaller than MIN_ENCRYPTABLE_BYTES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -898,15 +898,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes",
  "fnv",
@@ -4365,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.28.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821b251d66af34fc754104e88cf4fbcf22d2671f59062bdcf480696cc3e58186"
+checksum = "8e9ca43227f2459c3bd7f827d672e9b21db86284f8f36014221a1827d0243b17"
 dependencies = [
  "aes",
  "bincode",
@@ -5079,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -5915,15 +5915,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5938,21 +5929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5987,12 +5963,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6002,12 +5972,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6023,12 +5987,6 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -6038,12 +5996,6 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6059,12 +6011,6 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -6077,12 +6023,6 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6092,12 +6032,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -33,7 +33,7 @@ prometheus-client = { version = "0.22", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "1.8.0"
 rmp-serde = "1.1.1"
-self_encryption = "~0.28.5"
+self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_networking = { path = "../sn_networking", version = "0.12.25" }
 sn_protocol = { path = "../sn_protocol", version = "0.10.5" }

--- a/sn_client/src/chunks/error.rs
+++ b/sn_client/src/chunks/error.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use self_encryption::MIN_ENCRYPTABLE_BYTES;
 use sn_protocol::PrettyPrintRecordKey;
 use std::io;
 use thiserror::Error;
@@ -38,11 +39,8 @@ pub enum Error {
     #[error("Cannot store empty file.")]
     EmptyFileProvided,
 
-    #[error(
-        "You might need to pad the `SmallFile` contents and then store it as a `LargeFile`, \
-        as the encryption has made it slightly too big ({0} bytes)"
-    )]
-    SmallFilePaddingNeeded(usize),
+    #[error("File is too small to be encrypted, it is less than {MIN_ENCRYPTABLE_BYTES} bytes")]
+    FileTooSmall,
 
     #[error(
         "The provided bytes ({size}) is too large to store as a `SmallFile` which maximum can be \

--- a/sn_client/src/chunks/mod.rs
+++ b/sn_client/src/chunks/mod.rs
@@ -10,38 +10,4 @@ mod error;
 mod pac_man;
 
 pub(crate) use self::error::{Error, Result};
-pub(crate) use pac_man::{encrypt_large, to_chunk, DataMapLevel};
-
-use bytes::Bytes;
-use self_encryption::MIN_ENCRYPTABLE_BYTES;
-
-/// Data of size more than 0 bytes less than [`MIN_ENCRYPTABLE_BYTES`] bytes.
-///
-/// A `SmallFile` cannot be self-encrypted, thus needs
-/// to be encrypted by the Client if they wish to.
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
-pub(crate) struct SmallFile {
-    bytes: Bytes,
-}
-
-impl SmallFile {
-    /// Enforces size > 0 and size < [`MIN_ENCRYPTABLE_BYTES`] bytes.
-    pub(crate) fn new(bytes: Bytes) -> Result<Self> {
-        if bytes.len() >= MIN_ENCRYPTABLE_BYTES {
-            Err(Error::TooLargeAsSmallFile {
-                size: bytes.len(),
-                maximum: MIN_ENCRYPTABLE_BYTES - 1,
-            })
-        } else if bytes.is_empty() {
-            Err(Error::EmptyFileProvided)
-        } else {
-            Ok(Self { bytes })
-        }
-    }
-
-    /// Returns the bytes.
-    pub(crate) fn bytes(&self) -> Bytes {
-        self.bytes.clone()
-    }
-}
+pub(crate) use pac_man::{encrypt_large, DataMapLevel};

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -47,7 +47,7 @@ tonic = { version = "0.6.2" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
-self_encryption = "~0.28.5"
+self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 sn_build_info = { path="../sn_build_info", version = "0.1.4" }
 sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.2.0" }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -15,7 +15,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
 rmp-serde = "1.1.1"
-self_encryption = "~0.28.5"
+self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 use xor_name::XorName;
 
 /// Arbitrary maximum size of a register entry.
-const MAX_REG_ENTRY_SIZE: usize = MIN_ENCRYPTABLE_BYTES / 3; // 1024 bytes
+const MAX_REG_ENTRY_SIZE: usize = MIN_ENCRYPTABLE_BYTES / 3 * 1024; // 1024 bytes
 
 /// Maximum number of entries of a register.
 const MAX_REG_NUM_ENTRIES: u16 = 1024;


### PR DESCRIPTION
fixes #1157

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Jan 24 15:48 UTC
This pull request fixes an issue where an error is thrown if the file size is smaller than `MIN_ENCRYPTABLE_BYTES`. The patch modifies the error message to display the actual file size and the minimum required size. The patch also removes unused code related to small files.
<!-- reviewpad:summarize:end --> 
