### PR TITLE
WIP: run nightly tests on a WAN network

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -1,6 +1,9 @@
 name: PR Benchmarks
 
-on: pull_request
+# on: pull_request
+on:
+  merge_group:
+    branches: [main]
 
 env:
   CARGO_INCREMENTAL: '0'

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -6,8 +6,8 @@ on:
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
     branches: [main]
-  pull_request:
-    branches: ["*"]
+  # pull_request:
+  #   branches: ["*"]
 
 env:
   SAFE_DATA_PATH: /home/runner/.local/share/safe

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,8 +6,8 @@ on:
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
     branches: [main]
-  pull_request:
-    branches: ["*"]
+  # pull_request:
+  #   branches: ["*"]
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+    env:
+      ansible-vault-password: ${{ secrets.SN_TESTNET_ANSIBLE_VAULT_PASSWORD }}
+      aws-access-key-id: ${{ secrets.SN_TESTNET_AWS_ACCESS_KEY_ID }}
+      aws-access-key-secret: ${{ secrets.SN_TESTNET_AWS_SECRET_ACCESS_KEY }}
+      do-token: ${{ secrets.SN_TESTNET_DO_PAT }}
+      ssh-secret-key: ${{ secrets.SN_TESTNET_SSH_KEY }}
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -55,12 +62,12 @@ jobs:
         uses: maidsafe/sn-testnet-action@main
         with:
           action: create
-          ansible-vault-password: ${{ secrets.SN_TESTNET_ANSIBLE_VAULT_PASSWORD }}
-          aws-access-key-id: ${{ secrets.SN_TESTNET_AWS_ACCESS_KEY_ID }}
-          aws-access-key-secret: ${{ secrets.SN_TESTNET_AWS_SECRET_ACCESS_KEY }}
+          ansible-vault-password: ${{ env.ansible-vault-password }}
+          aws-access-key-id: ${{ env.aws-access-key-id }}
+          aws-access-key-secret: ${{ env.aws-access-key-secret }}
           aws-region: eu-west-2
-          do-token: ${{ secrets.SN_TESTNET_DO_PAT }}
-          ssh-secret-key: ${{ secrets.SN_TESTNET_SSH_KEY }}
+          do-token: ${{ env.do-token }}
+          ssh-secret-key: ${{ env.ssh-secret-key }}
           security-group-id: sg-0d47df5b3f0d01e2a
           subnet-id: subnet-018f2ab26755df7f9
           node-count: 20

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,18 @@
 name: Nightly -- Full Network Tests
 
+# on:
+#   schedule:
+#     - cron:  '0 0 * * *'
+#   workflow_dispatch:
+
 on:
-  schedule:
-    - cron:  '0 0 * * *'
-  workflow_dispatch:
+  # tests must run for a PR to be valid and pass merge queue muster
+  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
+  # the merge run checks should show on master and enable this clear test/passing history
+  merge_group:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
     
 
 env:
@@ -11,6 +20,18 @@ env:
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
 
 jobs:
+  debug:
+    name: debug
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Get the branch name
+        run: echo "Branch name is ${{ github.event.pull_request.head.ref }}"
+      - name: Get the PR creator
+        run: echo "PR creator is ${{ github.actor }}"
+
   e2e:
     name: E2E tests
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,10 +53,23 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
+
+      - name: Test
+        env:
+          TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_SECRET: ${{ secrets.TEST_SECRET }}
+        run: |
+          echo ${#TEST_GITHUB_TOKEN}
+          echo ${#TEST_SECRET}
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
           
-      - name: Build safe
-        run: cargo build --release --bin safe
-        timeout-minutes: 30
+      # - name: Build safe
+      #   run: cargo build --release --bin safe
+      #   timeout-minutes: 30
 
       - name: Start a WAN network
         uses: maidsafe/sn-testnet-action@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -47,18 +47,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
           
-      - name: Build binaries
-        run: cargo build --release --bin safenode --bin safe --bin faucet
+      - name: Build safe
+        run: cargo build --release --bin safe
         timeout-minutes: 30
 
-      - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+      - name: Start a WAN network
+        uses: maidsafe/sn-testnet-action@main
         with:
-          action: start
-          interval: 2000
-          node-path: target/release/safenode
-          faucet-path: target/release/faucet
-          platform: ${{ matrix.os }}
+          action: create
+          ansible-vault-password: ${{ secrets.SN_TESTNET_ANSIBLE_VAULT_PASSWORD }}
+          aws-access-key-id: ${{ secrets.SN_TESTNET_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.SN_TESTNET_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          do-token: ${{ secrets.SN_TESTNET_DO_PAT }}
+          ssh-secret-key: ${{ secrets.SN_TESTNET_SSH_KEY }}
+          security-group-id: sg-0d47df5b3f0d01e2a
+          subnet-id: subnet-018f2ab26755df7f9
+          node-count: 20
+          vm-count: 1
+          provider: digital-ocean
+          testnet-name: NightlyE2E
+          # if we were to run on a PR, use the below
+          # custom-node-bin-org-name: ${{ github.actor }}"
+          # custom-node-bin-branch-name: ${{ github.event.pull_request.head.ref }}
+          # Prevent deployer from fetching the latest release. It contains the `network-contacts` feature turned on.
+          custom-node-bin-org-name: maidsafe
+          custom-node-bin-branch-name: main
 
       - name: Check contact peer
         shell: bash
@@ -96,418 +110,447 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 2
 
-      - name: Stop the local network and upload logs
+      - name: Fetch logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-testnet-action@wan_nightly
         with:
-          action: stop
-          log_file_prefix: safe_test_logs_e2e
-          platform: ${{ matrix.os }}
+          action: logs
+          ansible-vault-password: ${{ secrets.SN_TESTNET_ANSIBLE_VAULT_PASSWORD }}
+          aws-access-key-id: ${{ secrets.SN_TESTNET_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.SN_TESTNET_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          do-token: ${{ secrets.SN_TESTNET_DO_PAT }}
+          ssh-secret-key: ${{ secrets.SN_TESTNET_SSH_KEY }}
+          node-count: 20
+          vm-count: 1
+          provider: digital-ocean
+          testnet-name: NightlyE2E
+          custom-node-bin-org-name: maidsafe
+          custom-node-bin-branch-name: main
 
-      - name: post notification to slack on failure
-        if: ${{ failure() }}
-        uses: bryannice/gitactions-slack-notification@2.0.0
-        env:
-          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-          SLACK_TITLE: "Nightly E2E Test Run Failed"
 
-  full_unit:
-    name: Full Unit Tests (including proptests)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        continue-on-error: true
-
-      - name: Build unit tests before running
-        run: cargo test --release --lib --bins --no-run 
-        timeout-minutes: 30
-
-      - name: Run CLI tests
-        timeout-minutes: 25
-        run: cargo test --release --package sn_cli
-
-      - name: Run testnet tests
-        timeout-minutes: 25
-        run: cargo test --release --package sn_testnet
-
-      - name: Run client tests
-        timeout-minutes: 25
-        run: cargo test --release --package sn_client
-
-      - name: Run network tests
-        timeout-minutes: 25
-        run: cargo test --release -p sn_networking
-
-      - name: Run protocol tests
-        timeout-minutes: 25
-        run: cargo test --release -p sn_protocol
-
-      - name: Run transfers tests
-        timeout-minutes: 25
-        run: cargo test --release --package sn_transfers
-
-      - name: Run register tests
-        shell: bash
-        timeout-minutes: 50
-        env:
-          PROPTEST_CASES: 512
-        run: cargo test --release -p sn_registers
-
-      - name: post notification to slack on failure
-        if: ${{ failure() }}
-        uses: bryannice/gitactions-slack-notification@2.0.0
-        env:
-          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-          SLACK_TITLE: "Nightly Unit Test Run Failed"
-
-  gossipsub:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
-    name: Gossipsub E2E tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Build binaries
-        run: cargo build --release --bin safenode --bin faucet
-        timeout-minutes: 30
-
-      - name: Build gossipsub testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test msgs_over_gossipsub --no-run
-        timeout-minutes: 30
-
-      - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
-        with:
-          action: start
-          interval: 2000
-          node-path: target/release/safenode
-          faucet-path: target/release/faucet
-          platform: ${{ matrix.os }}
-
-      - name: Gossipsub - nodes to subscribe to topics, and publish messages 
-        run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
-        timeout-minutes: 20
-
-      - name: Stop the local network and upload logs
+      - name: Stop the WAN network
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-testnet-action@wan_nightly
         with:
-          action: stop
-          log_file_prefix: safe_test_logs_gossipsub_e2e
-          platform: ${{ matrix.os }}
+          action: destroy
+          ansible-vault-password: ${{ secrets.SN_TESTNET_ANSIBLE_VAULT_PASSWORD }}
+          aws-access-key-id: ${{ secrets.SN_TESTNET_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.SN_TESTNET_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          do-token: ${{ secrets.SN_TESTNET_DO_PAT }}
+          ssh-secret-key: ${{ secrets.SN_TESTNET_SSH_KEY }}
+          node-count: 20
+          vm-count: 1
+          provider: digital-ocean
+          testnet-name: NightlyE2E
+          custom-node-bin-org-name: maidsafe
+          custom-node-bin-branch-name: main
 
-  spend_test:
-    name: spend tests against network
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
+      # - name: post notification to slack on failure
+      #   if: ${{ failure() }}
+      #   uses: bryannice/gitactions-slack-notification@2.0.0
+      #   env:
+      #     SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+      #     SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+      #     SLACK_TITLE: "Nightly E2E Test Run Failed"
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+  # full_unit:
+  #   name: Full Unit Tests (including proptests)
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: Swatinem/rust-cache@v2
-        continue-on-error: true
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - name: Build binaries
-        run: cargo build --release --features=local-discovery --bin safenode --bin faucet
-        timeout-minutes: 30
+  #     - uses: Swatinem/rust-cache@v2
+  #       continue-on-error: true
 
-      - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
-        timeout-minutes: 30
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
+  #     - name: Build unit tests before running
+  #       run: cargo test --release --lib --bins --no-run 
+  #       timeout-minutes: 30
 
-      - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
-        with:
-          action: start
-          interval: 2000
-          node-path: target/release/safenode
-          faucet-path: target/release/faucet
-          platform: ${{ matrix.os }}
+  #     - name: Run CLI tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release --package sn_cli
 
-      # This should be first to avoid slow reward acceptance etc
-      - name: execute the nodes rewards tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
-          SN_LOG: "all"
-        timeout-minutes: 25
+  #     - name: Run testnet tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release --package sn_testnet
 
-      - name: execute the spend test
-        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
-          SN_LOG: "all"
-        timeout-minutes: 10
+  #     - name: Run client tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release --package sn_client
 
-      - name: execute the storage payment tests
-        run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1          
-        env:
-          CARGO_TARGET_DIR: "./transfer-target"
-          SN_LOG: "all"
-        timeout-minutes: 10
+  #     - name: Run network tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release -p sn_networking
 
-      - name: Small wait to allow reward receipt
-        run: sleep 30
-        timeout-minutes: 1
+  #     - name: Run protocol tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release -p sn_protocol
+
+  #     - name: Run transfers tests
+  #       timeout-minutes: 25
+  #       run: cargo test --release --package sn_transfers
+
+  #     - name: Run register tests
+  #       shell: bash
+  #       timeout-minutes: 50
+  #       env:
+  #         PROPTEST_CASES: 512
+  #       run: cargo test --release -p sn_registers
+
+  #     - name: post notification to slack on failure
+  #       if: ${{ failure() }}
+  #       uses: bryannice/gitactions-slack-notification@2.0.0
+  #       env:
+  #         SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+  #         SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+  #         SLACK_TITLE: "Nightly Unit Test Run Failed"
+
+  # gossipsub:
+  #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
+  #   name: Gossipsub E2E tests
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+
+  #     - name: Build binaries
+  #       run: cargo build --release --bin safenode --bin faucet
+  #       timeout-minutes: 30
+
+  #     - name: Build gossipsub testing executable
+  #       run: cargo test --release -p sn_node --features=local-discovery --test msgs_over_gossipsub --no-run
+  #       timeout-minutes: 30
+
+  #     - name: Start a local network
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: start
+  #         interval: 2000
+  #         node-path: target/release/safenode
+  #         faucet-path: target/release/faucet
+  #         platform: ${{ matrix.os }}
+
+  #     - name: Gossipsub - nodes to subscribe to topics, and publish messages 
+  #       run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
+  #       timeout-minutes: 20
+
+  #     - name: Stop the local network and upload logs
+  #       if: always()
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: stop
+  #         log_file_prefix: safe_test_logs_gossipsub_e2e
+  #         platform: ${{ matrix.os }}
+
+  # spend_test:
+  #   name: spend tests against network
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - uses: Swatinem/rust-cache@v2
+  #       continue-on-error: true
+
+  #     - name: Build binaries
+  #       run: cargo build --release --features=local-discovery --bin safenode --bin faucet
+  #       timeout-minutes: 30
+
+  #     - name: Build testing executable
+  #       run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
+  #       timeout-minutes: 30
+  #       env:
+  #         CARGO_TARGET_DIR: "./transfer-target"
+
+  #     - name: Start a local network
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: start
+  #         interval: 2000
+  #         node-path: target/release/safenode
+  #         faucet-path: target/release/faucet
+  #         platform: ${{ matrix.os }}
+
+  #     # This should be first to avoid slow reward acceptance etc
+  #     - name: execute the nodes rewards tests
+  #       run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
+  #       env:
+  #         CARGO_TARGET_DIR: "./transfer-target"
+  #         SN_LOG: "all"
+  #       timeout-minutes: 25
+
+  #     - name: execute the spend test
+  #       run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
+  #       env:
+  #         CARGO_TARGET_DIR: "./transfer-target"
+  #         SN_LOG: "all"
+  #       timeout-minutes: 10
+
+  #     - name: execute the storage payment tests
+  #       run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1          
+  #       env:
+  #         CARGO_TARGET_DIR: "./transfer-target"
+  #         SN_LOG: "all"
+  #       timeout-minutes: 10
+
+  #     - name: Small wait to allow reward receipt
+  #       run: sleep 30
+  #       timeout-minutes: 1
 
       
-      - name: Stop the local network and upload logs
-        if: always()
-        uses: maidsafe/sn-local-testnet-action@main
-        with:
-          action: stop
-          log_file_prefix: safe_test_logs_spend
-          platform: ${{ matrix.os }}
+  #     - name: Stop the local network and upload logs
+  #       if: always()
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: stop
+  #         log_file_prefix: safe_test_logs_spend
+  #         platform: ${{ matrix.os }}
 
-      - name: post notification to slack on failure
-        if: ${{ failure() }}
-        uses: bryannice/gitactions-slack-notification@2.0.0
-        env:
-          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-          SLACK_TITLE: "Nightly Spend Test Run Failed"
+  #     - name: post notification to slack on failure
+  #       if: ${{ failure() }}
+  #       uses: bryannice/gitactions-slack-notification@2.0.0
+  #       env:
+  #         SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+  #         SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+  #         SLACK_TITLE: "Nightly Spend Test Run Failed"
 
-  churn:
-    name: Network churning tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            node_data_path: /home/runner/.local/share/safe/node
-            safe_path: /home/runner/.local/share/safe
-          - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
-          - os: macos-latest
-            node_data_path: /Users/runner/Library/Application Support/safe/node
-            safe_path: /Users/runner/Library/Application Support/safe
-    steps:
-      - uses: actions/checkout@v4
+  # churn:
+  #   name: Network churning tests
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - os: ubuntu-latest
+  #           node_data_path: /home/runner/.local/share/safe/node
+  #           safe_path: /home/runner/.local/share/safe
+  #         - os: windows-latest
+  #           node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+  #           safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
+  #         - os: macos-latest
+  #           node_data_path: /Users/runner/Library/Application Support/safe/node
+  #           safe_path: /Users/runner/Library/Application Support/safe
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        continue-on-error: true
+  #     - uses: Swatinem/rust-cache@v2
+  #       continue-on-error: true
 
-      - name: Build binaries
-        run: cargo build --release --features local-discovery --bin safenode --bin faucet
-        timeout-minutes: 30
+  #     - name: Build binaries
+  #       run: cargo build --release --features local-discovery --bin safenode --bin faucet
+  #       timeout-minutes: 30
 
-      - name: Build churn tests 
-        run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
-        timeout-minutes: 30
+  #     - name: Build churn tests 
+  #       run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
+  #       timeout-minutes: 30
 
-      - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
-        with:
-          action: start
-          interval: 2000
-          node-path: target/release/safenode
-          faucet-path: target/release/faucet
-          platform: ${{ matrix.os }}
+  #     - name: Start a local network
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: start
+  #         interval: 2000
+  #         node-path: target/release/safenode
+  #         faucet-path: target/release/faucet
+  #         platform: ${{ matrix.os }}
 
-      - name: Chunks data integrity during nodes churn (during 10min) (in theory)
-        run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
-        env:
-          TEST_DURATION_MINS: 60
-          TEST_CHURN_CYCLES: 6
-          SN_LOG: "all"
-        timeout-minutes: 90
+  #     - name: Chunks data integrity during nodes churn (during 10min) (in theory)
+  #       run: cargo test --release -p sn_node --features="local-discovery" --test data_with_churn -- --nocapture
+  #       env:
+  #         TEST_DURATION_MINS: 60
+  #         TEST_CHURN_CYCLES: 6
+  #         SN_LOG: "all"
+  #       timeout-minutes: 90
       
-      - name: Verify restart of nodes using rg
-        shell: bash
-        timeout-minutes: 1
-        # get the counts, then the specific line, and then the digit count only
-        # then check we have an expected level of restarts
-        # TODO: make this use an env var, or relate to testnet size
-        run : |
-          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
-            rg "(\d+) matches" | rg "\d+" -o)
-          echo "Restart $restart_count nodes"
-          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
-            rg "(\d+) matches" | rg "\d+" -o)
-          echo "PeerRemovedFromRoutingTable $peer_removed times"
-          if [ $peer_removed -lt $restart_count ]; then
-            echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
-            exit 1
-          fi
-          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-          echo "Node dir count is $node_count"
+  #     - name: Verify restart of nodes using rg
+  #       shell: bash
+  #       timeout-minutes: 1
+  #       # get the counts, then the specific line, and then the digit count only
+  #       # then check we have an expected level of restarts
+  #       # TODO: make this use an env var, or relate to testnet size
+  #       run : |
+  #         restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+  #           rg "(\d+) matches" | rg "\d+" -o)
+  #         echo "Restart $restart_count nodes"
+  #         peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+  #           rg "(\d+) matches" | rg "\d+" -o)
+  #         echo "PeerRemovedFromRoutingTable $peer_removed times"
+  #         if [ $peer_removed -lt $restart_count ]; then
+  #           echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
+  #           exit 1
+  #         fi
+  #         node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+  #         echo "Node dir count is $node_count"
           
-        # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
-        # if [ $restart_count -lt $node_count ]; then
-        #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
-        #   exit 1
-        # fi
+  #       # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
+  #       # if [ $restart_count -lt $node_count ]; then
+  #       #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
+  #       #   exit 1
+  #       # fi
 
-      - name: Verify data replication using rg
-        shell: bash
-        timeout-minutes: 1
-        # get the counts, then the specific line, and then the digit count only
-        # then check we have an expected level of replication
-        # TODO: make this use an env var, or relate to testnet size
-        run : |
-          fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
-            rg "(\d+) matches" | rg "\d+" -o)
-          echo "Carried out $fetching_attempt_count fetching attempts"
-          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-          if [ $fetching_attempt_count -lt $node_count ]; then
-            echo "Replication fetching attempts of: $fetching_attempt_count is less than the node count of: $node_count"
-            exit 1
-          fi
+  #     - name: Verify data replication using rg
+  #       shell: bash
+  #       timeout-minutes: 1
+  #       # get the counts, then the specific line, and then the digit count only
+  #       # then check we have an expected level of replication
+  #       # TODO: make this use an env var, or relate to testnet size
+  #       run : |
+  #         fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
+  #           rg "(\d+) matches" | rg "\d+" -o)
+  #         echo "Carried out $fetching_attempt_count fetching attempts"
+  #         node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+  #         if [ $fetching_attempt_count -lt $node_count ]; then
+  #           echo "Replication fetching attempts of: $fetching_attempt_count is less than the node count of: $node_count"
+  #           exit 1
+  #         fi
 
-      - name: Stop the local network and upload logs
-        if: always()
-        uses: maidsafe/sn-local-testnet-action@main
-        with:
-          action: stop
-          log_file_prefix: safe_test_logs_churn
-          platform: ${{ matrix.os }}
+  #     - name: Stop the local network and upload logs
+  #       if: always()
+  #       uses: maidsafe/sn-local-testnet-action@main
+  #       with:
+  #         action: stop
+  #         log_file_prefix: safe_test_logs_churn
+  #         platform: ${{ matrix.os }}
       
-      - name: post notification to slack on failure
-        if: ${{ failure() }}
-        uses: bryannice/gitactions-slack-notification@2.0.0
-        env:
-          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-          SLACK_TITLE: "Nightly Churn Test Run Failed"
+  #     - name: post notification to slack on failure
+  #       if: ${{ failure() }}
+  #       uses: bryannice/gitactions-slack-notification@2.0.0
+  #       env:
+  #         SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+  #         SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+  #         SLACK_TITLE: "Nightly Churn Test Run Failed"
 
-      # Only error out after uploading the logs
-      - name: Don't log raw data
-        if: matrix.os != 'windows-latest' # causes error
-        shell: bash
-        timeout-minutes: 10
-        run: |
-          if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
-          then
-            echo "We are logging an extremely large data"
-            exit 1
-          fi
+  #     # Only error out after uploading the logs
+  #     - name: Don't log raw data
+  #       if: matrix.os != 'windows-latest' # causes error
+  #       shell: bash
+  #       timeout-minutes: 10
+  #       run: |
+  #         if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+  #         then
+  #           echo "We are logging an extremely large data"
+  #           exit 1
+  #         fi
 
-  verify_data_location_routing_table:
-      name: Verify data location and Routing Table
-      runs-on: ${{ matrix.os }}
-      strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              node_data_path: /home/runner/.local/share/safe/node
-              safe_path: /home/runner/.local/share/safe
-            - os: windows-latest
-              node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-              safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
-            - os: macos-latest
-              node_data_path: /Users/runner/Library/Application Support/safe/node
-              safe_path: /Users/runner/Library/Application Support/safe
-      steps:
-        - uses: actions/checkout@v4
+  # verify_data_location_routing_table:
+  #     name: Verify data location and Routing Table
+  #     runs-on: ${{ matrix.os }}
+  #     strategy:
+  #       matrix:
+  #         include:
+  #           - os: ubuntu-latest
+  #             node_data_path: /home/runner/.local/share/safe/node
+  #             safe_path: /home/runner/.local/share/safe
+  #           - os: windows-latest
+  #             node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+  #             safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
+  #           - os: macos-latest
+  #             node_data_path: /Users/runner/Library/Application Support/safe/node
+  #             safe_path: /Users/runner/Library/Application Support/safe
+  #     steps:
+  #       - uses: actions/checkout@v4
 
-        - name: Install Rust
-          uses: dtolnay/rust-toolchain@stable
+  #       - name: Install Rust
+  #         uses: dtolnay/rust-toolchain@stable
 
-        - uses: Swatinem/rust-cache@v2
-          continue-on-error: true
+  #       - uses: Swatinem/rust-cache@v2
+  #         continue-on-error: true
 
-        - name: Build binaries
-          run: cargo build --release --features local-discovery --bin safenode --bin faucet
-          timeout-minutes: 30
+  #       - name: Build binaries
+  #         run: cargo build --release --features local-discovery --bin safenode --bin faucet
+  #         timeout-minutes: 30
 
-        - name: Build data location and routing table tests
-          run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run
-          timeout-minutes: 30
+  #       - name: Build data location and routing table tests
+  #         run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run
+  #         timeout-minutes: 30
 
-        - name: Start a local network
-          uses: maidsafe/sn-local-testnet-action@main
-          with:
-            action: start
-            interval: 2000
-            node-path: target/release/safenode
-            faucet-path: target/release/faucet
-            platform: ${{ matrix.os }}
+  #       - name: Start a local network
+  #         uses: maidsafe/sn-local-testnet-action@main
+  #         with:
+  #           action: start
+  #           interval: 2000
+  #           node-path: target/release/safenode
+  #           faucet-path: target/release/faucet
+  #           platform: ${{ matrix.os }}
 
-        - name: Verify the Routing table of the nodes
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
-          timeout-minutes: 5
+  #       - name: Verify the Routing table of the nodes
+  #         run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
+  #         timeout-minutes: 5
 
-        - name: Verify the location of the data on the network
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
-          env:
-            SN_LOG: "all"
-          timeout-minutes: 90
+  #       - name: Verify the location of the data on the network
+  #         run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
+  #         env:
+  #           SN_LOG: "all"
+  #         timeout-minutes: 90
 
-        - name: Verify the routing tables of the nodes
-          run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
-          timeout-minutes: 5
+  #       - name: Verify the routing tables of the nodes
+  #         run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
+  #         timeout-minutes: 5
         
-        - name: Verify restart of nodes using rg
-          shell: bash
-          timeout-minutes: 1
-          # get the counts, then the specific line, and then the digit count only
-          # then check we have an expected level of restarts
-          # TODO: make this use an env var, or relate to testnet size
-          run : |
-            restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
-              rg "(\d+) matches" | rg "\d+" -o)
-            echo "Restart $restart_count nodes"
-            peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
-              rg "(\d+) matches" | rg "\d+" -o)
-            echo "PeerRemovedFromRoutingTable $peer_removed times"
-            if [ $peer_removed -lt $restart_count ]; then
-              echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
-              exit 1
-            fi
-            node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-            echo "Node dir count is $node_count"
+  #       - name: Verify restart of nodes using rg
+  #         shell: bash
+  #         timeout-minutes: 1
+  #         # get the counts, then the specific line, and then the digit count only
+  #         # then check we have an expected level of restarts
+  #         # TODO: make this use an env var, or relate to testnet size
+  #         run : |
+  #           restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+  #             rg "(\d+) matches" | rg "\d+" -o)
+  #           echo "Restart $restart_count nodes"
+  #           peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+  #             rg "(\d+) matches" | rg "\d+" -o)
+  #           echo "PeerRemovedFromRoutingTable $peer_removed times"
+  #           if [ $peer_removed -lt $restart_count ]; then
+  #             echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
+  #             exit 1
+  #           fi
+  #           node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+  #           echo "Node dir count is $node_count"
 
-        - name: Stop the local network and upload logs
-          if: always()
-          uses: maidsafe/sn-local-testnet-action@main
-          with:
-            action: stop
-            log_file_prefix: safe_test_logs_data_location
-            platform: ${{ matrix.os }}
+  #       - name: Stop the local network and upload logs
+  #         if: always()
+  #         uses: maidsafe/sn-local-testnet-action@main
+  #         with:
+  #           action: stop
+  #           log_file_prefix: safe_test_logs_data_location
+  #           platform: ${{ matrix.os }}
         
-        - name: post notification to slack on failure
-          if: ${{ failure() }}
-          uses: bryannice/gitactions-slack-notification@2.0.0
-          env:
-            SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-            SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
-            SLACK_TITLE: "Nightly Data Location Test Run Failed"
+  #       - name: post notification to slack on failure
+  #         if: ${{ failure() }}
+  #         uses: bryannice/gitactions-slack-notification@2.0.0
+  #         env:
+  #           SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+  #           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+  #           SLACK_TITLE: "Nightly Data Location Test Run Failed"
 
-        # Only error out after uploading the logs
-        - name: Don't log raw data
-          if: matrix.os != 'windows-latest' # causes error
-          shell: bash
-          timeout-minutes: 10
-          run: |
-            if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
-            then
-              echo "We are logging an extremely large data"
-              exit 1
-            fi
+  #       # Only error out after uploading the logs
+  #       - name: Don't log raw data
+  #         if: matrix.os != 'windows-latest' # causes error
+  #         shell: bash
+  #         timeout-minutes: 10
+  #         run: |
+  #           if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+  #           then
+  #             echo "We are logging an extremely large data"
+  #             exit 1
+  #           fi

--- a/sn_node/tests/common/client.rs
+++ b/sn_node/tests/common/client.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use eyre::{bail, Result};
+use eyre::{bail, OptionExt, Result};
 use lazy_static::lazy_static;
 use sn_client::{send, Client};
 use sn_peers_acquisition::parse_peer_addr;
@@ -41,7 +41,8 @@ pub fn get_wallet(root_dir: &Path) -> LocalWallet {
 /// else return the local node count
 pub fn get_node_count() -> usize {
     match DeploymentInventory::load() {
-        Ok(inventory) => inventory.rpc_endpoints.len(),
+        // -1 to exclude the genesis VM's node
+        Ok(inventory) => inventory.rpc_endpoints.len() - 1,
         Err(_) => LOCAL_NODE_COUNT,
     }
 }
@@ -51,7 +52,27 @@ pub fn get_node_count() -> usize {
 /// else generate local addresses for NODE_COUNT nodes
 pub fn get_all_rpc_addresses() -> Result<Vec<SocketAddr>> {
     match DeploymentInventory::load() {
-        Ok(inventory) => Ok(inventory.rpc_endpoints),
+        Ok(inventory) => {
+            // todo: don't filter out genesis here?
+            let genesis_ip = inventory
+                .vm_list
+                .iter()
+                .find_map(|(name, addr)| {
+                    if name.contains("genesis") {
+                        Some(*addr)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_eyre("Could not get the genesis VM's addr")?;
+
+            let addrs = inventory
+                .rpc_endpoints
+                .into_iter()
+                .filter(|addr| addr.ip() != genesis_ip)
+                .collect();
+            Ok(addrs)
+        }
         Err(_) => {
             let starting_port = match std::env::var("CHURN_TEST_START_PORT") {
                 Ok(val) => val.parse()?,
@@ -75,7 +96,7 @@ pub fn get_all_rpc_addresses() -> Result<Vec<SocketAddr>> {
 /// Else to the local network.
 pub async fn get_gossip_client() -> Client {
     match DeploymentInventory::load() {
-        Ok(inventory) => Droplet::get_gossip_client(inventory.peers).await,
+        Ok(inventory) => Droplet::get_gossip_client(&inventory).await,
         Err(_) => NonDroplet::get_gossip_client().await,
     }
 }
@@ -106,7 +127,7 @@ pub async fn get_gossip_client_and_wallet(
 ) -> Result<(Client, LocalWallet)> {
     match DeploymentInventory::load() {
         Ok(inventory) => {
-            let client = Droplet::get_gossip_client(inventory.peers).await;
+            let client = Droplet::get_gossip_client(&inventory).await;
             let local_wallet =
                 Droplet::get_funded_wallet(&client, root_dir, amount, inventory.faucet_address)
                     .await?;
@@ -192,12 +213,16 @@ impl NonDroplet {
 struct Droplet;
 impl Droplet {
     /// Create a new client and bootstrap from the provided safe_peers
-    pub async fn get_gossip_client(safe_peers: Vec<String>) -> Client {
+    pub async fn get_gossip_client(inventory: &DeploymentInventory) -> Client {
         let secret_key = bls::SecretKey::random();
 
         let mut bootstrap_peers = Vec::new();
-        for peer in safe_peers {
-            match parse_peer_addr(&peer) {
+        for peer in inventory
+            .peers
+            .iter()
+            .chain(vec![&inventory.genesis_multiaddr])
+        {
+            match parse_peer_addr(peer) {
                 Ok(peer) => bootstrap_peers.push(peer),
                 Err(err) => error!("Can't parse SAFE_PEERS {peer:?} with error {err:?}"),
             }

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -10,14 +10,11 @@
 mod common;
 
 use crate::common::{
-    client::{
-        get_all_rpc_addresses, get_gossip_client, get_gossip_client_and_wallet,
-        PAYING_WALLET_INITIAL_BALANCE,
-    },
+    client::{get_all_rpc_addresses, get_gossip_client_and_wallet, PAYING_WALLET_INITIAL_BALANCE},
     get_all_peer_ids, node_restart,
 };
 use assert_fs::TempDir;
-use eyre::{eyre, Result};
+use eyre::{eyre, Context, Result};
 use libp2p::{
     kad::{KBucketKey, RecordKey},
     PeerId,
@@ -28,7 +25,6 @@ use sn_logging::LogBuilder;
 use sn_networking::{sort_peers_by_key, CLOSE_GROUP_SIZE};
 use sn_protocol::{
     safenode_proto::{safe_node_client::SafeNodeClient, NodeInfoRequest, RecordAddressesRequest},
-    storage::ChunkAddress,
     NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
@@ -41,7 +37,6 @@ use std::{
 };
 use tonic::Request;
 use tracing::error;
-use xor_name::XorName;
 
 const CHUNK_SIZE: usize = 1024;
 
@@ -66,7 +61,7 @@ const CHURN_COUNT: u8 = 20;
 
 /// Default number of chunks that should be PUT to the network.
 // It can be overridden by setting the 'CHUNK_COUNT' env var.
-const CHUNK_COUNT: usize = 50;
+const CHUNK_COUNT: usize = 5;
 
 type NodeIndex = usize;
 type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
@@ -74,8 +69,6 @@ type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("verify_data_location");
-
-    query_content_task();
 
     let churn_count = if let Ok(str) = std::env::var("CHURN_COUNT") {
         str.parse::<u8>()?
@@ -126,7 +119,18 @@ async fn verify_data_location() -> Result<()> {
 
             // get the new PeerId for the current NodeIndex
             let endpoint = format!("https://{rpc_address}");
-            let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+            let mut attempts = 0;
+            let mut rpc_client = 'inside: loop {
+                if let Ok(rpc_client) = SafeNodeClient::connect(endpoint.clone()).await {
+                    break 'inside rpc_client;
+                }
+                println!("Could not connect to rpc {endpoint:?} after restarting. retrying");
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+                attempts += 1;
+                if attempts >= 10 {
+                    panic!("FAILED TO CONNECT even after retries");
+                }
+            };
             let response = rpc_client
                 .node_info(Request::new(NodeInfoRequest {}))
                 .await?;
@@ -138,29 +142,6 @@ async fn verify_data_location() -> Result<()> {
             verify_location(&all_peers, &node_rpc_address).await?;
         }
     }
-}
-
-// Spawns a task which periodically queries random content
-fn query_content_task() {
-    let _handle = tokio::spawn(async move {
-        let delay = Duration::from_millis(1);
-        loop {
-            // thread random rng
-            let mut rng = OsRng;
-            let client = get_gossip_client().await;
-            // let's choose a random content to query
-            let rando_addr = ChunkAddress::new(XorName::random(&mut rng));
-            tracing::trace!("Querying content {rando_addr:?}");
-
-            if let Err(error) = client.get_chunk(rando_addr, false).await {
-                tracing::error!(
-                    "Error querying content rando content (as expected) {rando_addr:?} : {error}"
-                );
-            }
-
-            tokio::time::sleep(delay).await;
-        }
-    });
 }
 
 fn print_node_close_groups(all_peers: &[PeerId]) {
@@ -189,7 +170,9 @@ async fn get_records_and_holders(node_rpc_addresses: &[SocketAddr]) -> Result<Re
 
     for (node_index, rpc_address) in node_rpc_addresses.iter().enumerate() {
         let endpoint = format!("https://{rpc_address}");
-        let mut rpc_client = SafeNodeClient::connect(endpoint).await?;
+        let mut rpc_client = SafeNodeClient::connect(endpoint).await.context(format!(
+            "Failed to connect to {rpc_address:?} during get_records_and_holders"
+        ))?;
 
         let records_response = rpc_client
             .record_addresses(Request::new(RecordAddressesRequest {}))
@@ -249,14 +232,16 @@ async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAd
                     .filter(|expected| !actual_holders.contains(expected))
                     .for_each(|expected| missing_peers.push(*expected));
 
-                error!(
-                    "Record {:?} is not stored by {missing_peers:?}",
-                    PrettyPrintRecordKey::from(key),
-                );
-                println!(
-                    "Record {:?} is not stored by {missing_peers:?}",
-                    PrettyPrintRecordKey::from(key),
-                );
+                if !missing_peers.is_empty() {
+                    error!(
+                        "Record {:?} is not stored by {missing_peers:?}",
+                        PrettyPrintRecordKey::from(key),
+                    );
+                    println!(
+                        "Record {:?} is not stored by {missing_peers:?}",
+                        PrettyPrintRecordKey::from(key),
+                    );
+                }
             }
 
             let mut failed_peers = Vec::new();
@@ -281,7 +266,7 @@ async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAd
             });
             println!("State of each node:");
             record_holders.iter().for_each(|(key, node_index)| {
-                println!("Record {key:?} is currently held by node indexes {node_index:?}");
+                println!("Record {key:?} is currently held by node indices {node_index:?}");
             });
             println!("Node index map:");
             all_peers
@@ -289,8 +274,10 @@ async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAd
                 .enumerate()
                 .for_each(|(idx, peer)| println!("{idx} : {peer:?}"));
             verification_attempts += 1;
-            println!("Sleeping before retrying verification");
-            tokio::time::sleep(REVERIFICATION_DELAY).await;
+            println!("Sleeping before retrying verification. {verification_attempts}/{VERIFICATION_ATTEMPTS}");
+            if verification_attempts < VERIFICATION_ATTEMPTS {
+                tokio::time::sleep(REVERIFICATION_DELAY).await;
+            }
         } else {
             // if successful, break out of the loop
             break;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jan 24 11:24 UTC
This pull request includes the following changes:

1. The `.github/workflows/memcheck.yml` file:
   - Modified the `on` section by commenting out the `pull_request` trigger.
   - No changes were made to the `env` section.

2. The `benchmark-prs.yml` file:
   - Changed the trigger for this workflow from `pull_request` to `merge_group` for branches equal to `main`.
   - Set the value of the `CARGO_INCREMENTAL` environment variable to `'0'`.

3. The `.github/workflows/merge.yml` file:
   - Commented out the `pull_request` event in the `on` section.
   - Added a comment explaining the purpose of the `merge_group` event.

4. The `Cargo.lock` file:
   - Updated packages: `async-lock` (from version 3.2.0 to 3.3.0), `console` (from version 0.15.7 to 0.15.8), `h2` (from version 0.3.22 to 0.3.23), and `termcolor` (from version 1.4.0 to 1.4.1).
   - Removed packages: `windows-sys` and `windows-targets`.

5. The `sn_node/tests/common/mod.rs` file:
   - Modified the import statement for `Result` from the `eyre` crate to include the `Context` trait.
   - Updated error handling in the `get_all_peer_ids` and `node_restart` functions using the `context` method from the `eyre` crate.
   - Removed certain lines related to `Chunks records` and `Registers records` with corresponding print statements.

6. The `client.rs` file:
   - Added an import statement for `OptionExt` from the `eyre` crate.
   - Modified the `get_node_count` function to subtract 1 from the length of `inventory.rpc_endpoints`.
   - Updated the `get_all_rpc_addresses` function to filter out the genesis node's address from `inventory.rpc_endpoints` and retrieve the genesis VM's IP address from `inventory.vm_list`.
   - Updated the `get_gossip_client` and `get_gossip_client_and_wallet` functions to replace the `safe_peers` argument with `inventory.peers`.
   - Revised the `Droplet` struct so that the `get_gossip_client` function takes a reference to `inventory` instead of `safe_peers`.

7. Changes in the file containing the `verify_data_location` test module:
   - Removed unused imports and reorganized the remaining imports.
   - Removed the `query_content_task` function.
   - Updated the value of `CHUNK_COUNT` from 50 to 5.
   - Updated the type alias `RecordHolders` to use `HashMap<RecordKey, HashSet<NodeIndex>>`.
   - Modified the `verify_data_location` async function by removing the call to `query_content_task`, changing the logic to retry connecting to the RPC client in case of failures, adding error handling for failed RPC client connections, removing the use of `ChunkAddress` and `XorName`, and removing tracing and logging statements.
   - Modified the `get_records_and_holders` async function by adding error handling for failed RPC client connections and removing the printing of error messages.
   - Modified the `verify_location` async function by updating the error message printing to only occur if missing peers are found, changing the printing of record holder node indices to include "indices" instead of "indexes," and adding a check to sleep before retrying verification based on the number of verification attempts.

Please review these changes in the file diff.
<!-- reviewpad:summarize:end --> 
