### PR TITLE
ci: use node manager for running local testnets

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -54,7 +54,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ubuntu-latest
-          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Start a local network
         env:
-          SN_LOG: all
+          SN_LOG: "all"
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: start
@@ -74,7 +74,6 @@ jobs:
           faucet-path: target/release/faucet
           platform: ubuntu-latest
           set-safe-peers: false
-          build: true
           join: true
 
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -153,7 +153,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
-          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -279,7 +278,6 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_e2e
           platform: ${{ matrix.os }}
-          build: true
 
   gossipsub:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
@@ -311,7 +309,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
-          build: true
 
       - name: Gossipsub - nodes to subscribe to topics, and publish messages 
         run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
@@ -324,7 +321,6 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_gossipsub_e2e
           platform: ${{ matrix.os }}
-          build: true
 
   spend_test:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')" 
@@ -357,7 +353,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
-          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -396,7 +391,6 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_spend
           platform: ${{ matrix.os }}
-          build: true
 
   churn:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
@@ -437,7 +431,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ${{ matrix.os }}
-          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -464,7 +457,6 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_churn
           platform: ${{ matrix.os }}
-          build: true
 
       - name: Verify restart of nodes using rg
         shell: bash
@@ -559,7 +551,6 @@ jobs:
             node-path: target/release/safenode
             faucet-path: target/release/faucet
             platform: ${{ matrix.os }}
-            build: true
 
         - name: Check SAFE_PEERS was set
           shell: bash
@@ -593,7 +584,6 @@ jobs:
             action: stop
             log_file_prefix: safe_test_logs_data_location
             platform: ${{ matrix.os }}
-            build: true
 
         - name: Verify restart of nodes using rg
           shell: bash
@@ -679,7 +669,6 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ubuntu-latest
-          build: true
 
       - name: Check SAFE_PEERS was set
         shell: bash
@@ -722,4 +711,3 @@ jobs:
           action: stop
           log_file_prefix: safe_test_logs_heavy_replicate_bench
           platform: ubuntu-latest
-          build: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
             target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
-      
-
-
       - uses: dtolnay/rust-toolchain@stable
       # It's quite slow to install just by building it, but here we need a cross-platform solution.
       - shell: bash
@@ -75,8 +72,6 @@ jobs:
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
 
     steps:
-
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.10.6"
 
 [features]
-test-utils=["dirs-next", "serde_json"]
+test-utils=[]
 
 [dependencies]
 bls = { package = "blsttc", version = "8.0.1" }
@@ -18,12 +18,12 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.2"
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
-dirs-next = { version = "~2.0.0", optional = true }
+dirs-next = "~2.0.0"
 hex = "~0.4.3"
 libp2p = { version="0.53", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-serde_json = {version = "1.0", optional = true }
+serde_json = "1.0"
 sha2 = "0.10.7"
 sn_transfers = { path = "../sn_transfers", version = "0.14.36" }
 sn_registers = { path = "../sn_registers", version = "0.3.7" }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -17,6 +17,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Error, Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 #[non_exhaustive]
 pub enum Error {
+    // ---------- Misc errors
+    #[error("Could not obtain user's data directory")]
+    UserDataDirectoryNotObtainable,
+
     // ---------- Chunk Proof errors
     #[error("Chunk does not exist {0:?}")]
     ChunkDoesNotExist(NetworkAddress),

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -13,6 +13,8 @@ extern crate tracing;
 pub mod error;
 /// Messages types
 pub mod messages;
+/// Data structures for node management.
+pub mod node_registry;
 /// RPC commands to node
 pub mod node_rpc;
 /// Storage types for spends, chunks and registers.

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::Error;
+use color_eyre::Result;
+use libp2p::{Multiaddr, PeerId};
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum NodeStatus {
+    /// The node service has been added but not started for the first time
+    Added,
+    /// Last time we checked the service was running
+    Running,
+    /// The node service has been stopped
+    Stopped,
+    /// The node service has been removed
+    Removed,
+}
+
+fn serialize_peer_id<S>(value: &Option<PeerId>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(peer_id) = value {
+        return serializer.serialize_str(&peer_id.to_string());
+    }
+    serializer.serialize_none()
+}
+
+fn deserialize_peer_id<'de, D>(deserializer: D) -> Result<Option<PeerId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    if let Some(peer_id_str) = s {
+        PeerId::from_str(&peer_id_str)
+            .map(Some)
+            .map_err(DeError::custom)
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Node {
+    pub genesis: bool,
+    pub version: String,
+    pub service_name: String,
+    pub user: String,
+    pub number: u16,
+    pub port: u16,
+    pub rpc_port: u16,
+    pub status: NodeStatus,
+    pub pid: Option<u32>,
+    #[serde(
+        serialize_with = "serialize_peer_id",
+        deserialize_with = "deserialize_peer_id"
+    )]
+    pub peer_id: Option<PeerId>,
+    pub data_dir_path: Option<PathBuf>,
+    pub log_dir_path: Option<PathBuf>,
+    pub safenode_path: Option<PathBuf>,
+}
+
+impl Node {
+    pub fn get_multiaddr(&self) -> Option<Multiaddr> {
+        if let Some(peer_id) = self.peer_id {
+            let peer = format!("/ip4/127.0.0.1/tcp/{}/p2p/{}", self.port, peer_id);
+            match peer.parse() {
+                Ok(p) => return Some(p),
+                Err(_) => return None,
+            }
+        }
+        None
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeRegistry {
+    pub save_path: PathBuf,
+    pub nodes: Vec<Node>,
+    pub faucet_pid: Option<u32>,
+}
+
+impl NodeRegistry {
+    pub fn save(&self) -> Result<()> {
+        let json = serde_json::to_string(self)?;
+        let mut file = std::fs::File::create(self.save_path.clone())?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(NodeRegistry {
+                save_path: path.to_path_buf(),
+                nodes: vec![],
+                faucet_pid: None,
+            });
+        }
+        let mut file = std::fs::File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let registry = serde_json::from_str(&contents)?;
+        Ok(registry)
+    }
+}
+
+pub fn get_local_node_registry_path() -> Result<PathBuf> {
+    let path = dirs_next::data_dir()
+        .ok_or_else(|| Error::UserDataDirectoryNotObtainable)?
+        .join("safe")
+        .join("local_node_registry.json");
+    Ok(path)
+}


### PR DESCRIPTION
- a857601f **ci: use node manager for running local testnets**

  The local testnet action now uses the node manager to launch local networks. The churn tests were
  updated to parse the node manager's inventory, which they use to restart nodes.

  The node registry from the node manager has been transferred to the `sn_protocol` crate to reduce
  duplication between `safe_network` and `sn-node-manager`, because they both need access to these
  data structures. The local network deployment inventory is represented using the node registry.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Jan 24 21:21 UTC
This pull request updates the CI configuration to use the node manager for running local testnets. The `SN_LOG` environment variable is set to "all", and the `maidsafe/sn-local-testnet-action` dependency is replaced with `jacderida/sn-local-testnet-action@node-manager`. The `action` parameter is set to "start" and the `interval` parameter is set to 2000.
<!-- reviewpad:summarize:end --> 
