### PR TITLE
refactor(record_store): emit swarm cmd directly after writing a record

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -456,13 +456,16 @@ impl SwarmDriver {
                     Err(err) => return Err(err.into()),
                 };
             }
-            SwarmCmd::AddLocalRecordAsStored { key, record_type } => self
-                .swarm
-                .behaviour_mut()
-                .kademlia
-                .store_mut()
-                .mark_as_stored(key, record_type),
+            SwarmCmd::AddLocalRecordAsStored { key, record_type } => {
+                trace!("Adding Record locally, for {key:?} and {record_type:?}");
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .mark_as_stored(key, record_type);
+            }
             SwarmCmd::RemoveFailedLocalRecord { key } => {
+                trace!("Removing Record locally, for {key:?}");
                 self.swarm.behaviour_mut().kademlia.store_mut().remove(&key)
             }
             SwarmCmd::RecordStoreHasKey { key, sender } => {

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -401,6 +401,7 @@ impl NetworkBuilder {
         };
 
         let (network_event_sender, network_event_receiver) = mpsc::channel(NETWORKING_CHANNEL_SIZE);
+        let (swarm_cmd_sender, swarm_cmd_receiver) = mpsc::channel(NETWORKING_CHANNEL_SIZE);
 
         // Kademlia Behaviour
         let kademlia = {
@@ -409,7 +410,8 @@ impl NetworkBuilder {
                     let node_record_store = NodeRecordStore::with_config(
                         peer_id,
                         store_cfg,
-                        Some(network_event_sender.clone()),
+                        network_event_sender.clone(),
+                        swarm_cmd_sender.clone(),
                     );
                     #[cfg(feature = "open-metrics")]
                     let node_record_store = node_record_store
@@ -541,7 +543,6 @@ impl NetworkBuilder {
 
         let swarm = Swarm::new(transport, behaviour, peer_id, swarm_config);
 
-        let (swarm_cmd_sender, swarm_cmd_receiver) = mpsc::channel(NETWORKING_CHANNEL_SIZE);
         let swarm_driver = SwarmDriver {
             swarm,
             self_peer_id: peer_id,

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -133,10 +133,6 @@ pub enum NetworkEvent {
     NatStatusChanged(NatStatus),
     /// Report unverified record
     UnverifiedRecord(Record),
-    /// Report failed write to cleanup record store
-    FailedToWrite(RecordKey),
-    /// Report a completed write so we can safely add this to the record store now
-    CompletedWrite((RecordKey, RecordType)),
     /// Gossipsub message received
     GossipsubMsgReceived {
         /// Topic the message was published on
@@ -185,17 +181,6 @@ impl Debug for NetworkEvent {
             NetworkEvent::UnverifiedRecord(record) => {
                 let pretty_key = PrettyPrintRecordKey::from(&record.key);
                 write!(f, "NetworkEvent::UnverifiedRecord({pretty_key:?})")
-            }
-            NetworkEvent::FailedToWrite(record_key) => {
-                let pretty_key = PrettyPrintRecordKey::from(record_key);
-                write!(f, "NetworkEvent::FailedToWrite({pretty_key:?})")
-            }
-            NetworkEvent::CompletedWrite((record_key, record_type)) => {
-                let pretty_key = PrettyPrintRecordKey::from(record_key);
-                write!(
-                    f,
-                    "NetworkEvent::CompletedWrite({pretty_key:?}, {record_type:?})"
-                )
             }
             NetworkEvent::GossipsubMsgReceived { topic, .. } => {
                 write!(f, "NetworkEvent::GossipsubMsgReceived({topic})")

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 #![allow(clippy::mutable_key_type)] // for the Bytes in NetworkAddress
 
-use crate::event::NetworkEvent;
+use crate::{cmd::SwarmCmd, event::NetworkEvent};
 use libp2p::{
     identity::PeerId,
     kad::{
@@ -43,8 +43,10 @@ pub struct NodeRecordStore {
     config: NodeRecordStoreConfig,
     /// A set of keys, each corresponding to a data `Record` stored on disk.
     records: HashMap<Key, (NetworkAddress, RecordType)>,
-    /// Currently only used to notify the record received via network put to be validated.
-    event_sender: Option<mpsc::Sender<NetworkEvent>>,
+    /// Send network events to the node layer.
+    network_event_sender: mpsc::Sender<NetworkEvent>,
+    /// Send cmds to the network layer. Used to interact with self in an async fashion.
+    swarm_cmd_sender: mpsc::Sender<SwarmCmd>,
     /// Distance range specify the acceptable range of record entry.
     /// None means accept all records.
     distance_range: Option<Distance>,
@@ -81,13 +83,15 @@ impl NodeRecordStore {
     pub fn with_config(
         local_id: PeerId,
         config: NodeRecordStoreConfig,
-        event_sender: Option<mpsc::Sender<NetworkEvent>>,
+        network_event_sender: mpsc::Sender<NetworkEvent>,
+        swarm_cmd_sender: mpsc::Sender<SwarmCmd>,
     ) -> Self {
         NodeRecordStore {
             local_key: KBucketKey::from(local_id),
             config,
             records: Default::default(),
-            event_sender,
+            network_event_sender,
+            swarm_cmd_sender,
             distance_range: None,
             #[cfg(feature = "open-metrics")]
             record_count_metric: None,
@@ -247,7 +251,7 @@ impl NodeRecordStore {
             let _ = metric.set(self.records.len() as i64);
         }
 
-        let cloned_event_sender = self.event_sender.clone();
+        let cloned_event_sender = self.network_event_sender.clone();
         tokio::spawn(async move {
             let event = match fs::write(&file_path, r.value) {
                 Ok(_) => {
@@ -263,13 +267,8 @@ impl NodeRecordStore {
                 }
             };
 
-            // This happens after the write to disk is complete
-            if let Some(event_sender) = cloned_event_sender {
-                if let Err(error) = event_sender.send(event).await {
-                    error!("SwarmDriver failed to send event w/  {error:?}");
-                }
-            } else {
-                error!("Record store doesn't have event_sender could not send write events for {record_key:?} {file_path:?}");
+            if let Err(error) = cloned_event_sender.send(event).await {
+                error!("SwarmDriver failed to send event w/  {error:?}");
             }
         });
 
@@ -390,19 +389,17 @@ impl RecordStore for NodeRecordStore {
         }
 
         trace!("Unverified Record {record_key:?} try to validate and store");
-        if let Some(event_sender) = self.event_sender.clone() {
-            // push the event off thread so as to be non-blocking
-            let _handle = tokio::spawn(async move {
-                if let Err(error) = event_sender
-                    .send(NetworkEvent::UnverifiedRecord(record))
-                    .await
-                {
-                    error!("SwarmDriver failed to send event: {}", error);
-                }
-            });
-        } else {
-            error!("Record store doesn't have event_sender setup");
-        }
+        let event_sender = self.network_event_sender.clone();
+        // push the event off thread so as to be non-blocking
+        let _handle = tokio::spawn(async move {
+            if let Err(error) = event_sender
+                .send(NetworkEvent::UnverifiedRecord(record))
+                .await
+            {
+                error!("SwarmDriver failed to send event: {}", error);
+            }
+        });
+
         Ok(())
     }
 
@@ -629,10 +626,13 @@ mod tests {
     async fn testing_thread(r: ArbitraryRecord) {
         let r = r.0;
         let (network_event_sender, mut network_event_receiver) = mpsc::channel(1);
+        let (swarm_cmd_sender, _) = mpsc::channel(1);
+
         let mut store = NodeRecordStore::with_config(
             PeerId::random(),
             Default::default(),
-            Some(network_event_sender),
+            network_event_sender,
+            swarm_cmd_sender,
         );
 
         let store_cost_before = store.store_cost();
@@ -709,7 +709,15 @@ mod tests {
             ..Default::default()
         };
         let self_id = PeerId::random();
-        let mut store = NodeRecordStore::with_config(self_id, store_config.clone(), None);
+        let (network_event_sender, _) = mpsc::channel(1);
+        let (swarm_cmd_sender, _) = mpsc::channel(1);
+
+        let mut store = NodeRecordStore::with_config(
+            self_id,
+            store_config.clone(),
+            network_event_sender,
+            swarm_cmd_sender,
+        );
         let mut stored_records: Vec<RecordKey> = vec![];
         let self_address = NetworkAddress::from_peer(self_id);
         for i in 0..100 {
@@ -809,7 +817,14 @@ mod tests {
             ..Default::default()
         };
         let self_id = PeerId::random();
-        let mut store = NodeRecordStore::with_config(self_id, store_config, None);
+        let (network_event_sender, _) = mpsc::channel(1);
+        let (swarm_cmd_sender, _) = mpsc::channel(1);
+        let mut store = NodeRecordStore::with_config(
+            self_id,
+            store_config,
+            network_event_sender,
+            swarm_cmd_sender,
+        );
 
         let mut stored_records: Vec<RecordKey> = vec![];
         let self_address = NetworkAddress::from_peer(self_id);

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -331,16 +331,6 @@ impl Node {
                     self.events_channel.broadcast(NodeEvent::BehindNat);
                 }
             }
-            NetworkEvent::FailedToWrite(key) => {
-                if let Err(e) = self.network.remove_failed_local_record(key) {
-                    error!("Failed to remove local record: {e:?}");
-                }
-            }
-            NetworkEvent::CompletedWrite((key, record_type)) => {
-                if let Err(e) = self.network.add_record_as_stored_locally(key, record_type) {
-                    error!("Failed to add local record as stored: {e:?}");
-                }
-            }
             NetworkEvent::ResponseReceived { res } => {
                 trace!("NetworkEvent::ResponseReceived {res:?}");
                 if let Err(err) = self.handle_response(res) {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jan 24 07:13 UTC
This pull request includes the following changes:

- The `FailedToWrite` variant was removed from the `NetworkEvent` enum.
- The `CompletedWrite` variant was removed from the `NetworkEvent` enum.
- Added logging statements for adding and removing records locally in `cmd.rs`.
- Refactored the code for adding a local record and marked it as stored in `cmd.rs`.
- Added a logging statement for removing a record locally in `cmd.rs`.
- A new channel `swarm_cmd_sender` and `swarm_cmd_receiver` have been added in `sn_networking/src/driver.rs`.
- The `network_event_sender` and `swarm_cmd_sender` are now passed as arguments to `NodeRecordStore::with_config()` in `sn_networking/src/driver.rs`.
- The import statement for `tokio::sync::mpsc` has been updated to include `Sender` as well.
- The functions `remove_failed_local_record` and `add_record_as_stored_locally` have been removed.
- The function `send_swarm_cmd` has been refactored to a separate function called `send_swarm_cmd`, and the logic for checking channel capacity and spawning a task to send the command has been moved to this new function.
- The function `is_record_key_present_locally` now returns a `Result` wrapped in `async`.
- The function `multiaddr_strip_p2p` has been added.
- The `mod tests` block has been added for unit tests.
- Lines 331-337 in `node.rs`: Code related to handling a `NetworkEvent::FailedToWrite` was removed.
- Lines 339-348 in `node.rs`: Code related to handling a `NetworkEvent::CompletedWrite` was removed.
- Lines 350-355 in `node.rs`: Code related to handling a `NetworkEvent::ResponseReceived` was modified.

These changes aim to improve the functionality, logging, and implementation details in the codebase.
<!-- reviewpad:summarize:end --> 
