### PR TITLE
chore: make `first` argument public

### DIFF
--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -34,7 +34,7 @@ pub struct PeersArgs {
     /// If this argument is used, any others will be ignored because they do not apply to the first
     /// node.
     #[clap(long)]
-    first: bool,
+    pub first: bool,
     /// Peer(s) to use for bootstrap, in a 'multiaddr' format containing the peer ID.
     ///
     /// A multiaddr looks like


### PR DESCRIPTION
This needs to be publicly accessible for applications like the node manager to be able to check if `--first` has been used.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jan 24 13:27 UTC
This pull request updates the `first` argument in the `PeersArgs` struct to be public. This change allows the application to check if the `--first` flag has been used.
<!-- reviewpad:summarize:end --> 
