### PR TITLE
fix(client): avoid dead lock with less chunks

### DIFF
--- a/sn_client/src/files/upload.rs
+++ b/sn_client/src/files/upload.rs
@@ -257,14 +257,6 @@ impl FilesUpload {
                 return Ok(());
             }
 
-            if chunks.is_empty() && !on_going_pay_for_chunk.is_empty() {
-                // Fire None to trigger a forced round of making leftover payments.
-                let paying_work_sender_clone = paying_work_sender.clone();
-                let _handle = tokio::spawn(async move {
-                    let _ = paying_work_sender_clone.send(None).await;
-                });
-            }
-
             while !chunks.is_empty()
                 && on_going_get_cost.len() < batch_size
                 && pending_to_pay.len() < batch_size
@@ -296,6 +288,14 @@ impl FilesUpload {
                     let _ = on_going_uploadings.insert(chunk_info.name);
                     self.spawn_upload_chunk_task(chunk_info, payee, upload_chunk_sender.clone());
                 }
+            }
+
+            if chunks.is_empty() && !on_going_pay_for_chunk.is_empty() {
+                // Fire None to trigger a forced round of making leftover payments.
+                let paying_work_sender_clone = paying_work_sender.clone();
+                let _handle = tokio::spawn(async move {
+                    let _ = paying_work_sender_clone.send(None).await;
+                });
             }
 
             let task_result = if let Some(result) = progress_tasks(


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jan 24 16:24 UTC
This pull request fixes a deadlock issue related to handling chunks in the client. The patch avoids the deadlock by triggering a forced round of making leftover payments when there are no more chunks to process.
<!-- reviewpad:summarize:end --> 
