### PR TITLE
chore: Expand heavy test and collect network handling times

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -171,6 +171,7 @@ jobs:
           unit: "MiB/s",
           value: ((if .throughput[0].unit == "KiB/s" then (.throughput[0].per_iteration / (1024*1024*1024)) else (.throughput[0].per_iteration / (1024*1024)) end) / (.mean.estimate / 1e9))
           })' > files-benchmark.json
+        timeout-minutes: 15
 
       - name: Confirming the number of files uploaded and downloaded during the benchmark test
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -666,6 +666,18 @@ jobs:
           cd ..
           tar -cvzf test_data_2.tar.gz test_data_2
           ls -l
+          mkdir test_data_3
+          cd test_data_3
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safenode_rpc_client-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/faucet-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safe-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safenode-DebugMem-x86_64.tar.gz
+          wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safenode_rpc_client-DebugMem-x86_64.tar.gz
+          ls -l
+          cd ..
+          tar -cvzf test_data_3.tar.gz test_data_3
+          ls -l
+          df
 
       - name: Build binaries
         run: cargo build --release --bin safenode --bin safe --bin faucet
@@ -705,14 +717,63 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 5
 
+      - name: Confirm the cash_notes files
+        run: |
+          pwd
+          ls $CLIENT_DATA_PATH/ -l
+          ls $CLIENT_DATA_PATH/wallet -l
+          ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+        env:
+          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
+        timeout-minutes: 10
+
       - name: Wait for certain period
         run: sleep 300
         timeout-minutes: 6
 
-      - name: Start a client to upload second file
+      - name: Use same client to upload second file
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_2.tar.gz" -r 0
         env:
           SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Wait for certain period
+        run: sleep 300
+        timeout-minutes: 6
+
+      # Start a different client to avoid local wallet slow down with more payments handled.
+      - name: Start a different client
+        run: |
+          pwd
+          mv $CLIENT_DATA_PATH $SAFE_DATA_PATH/client_first
+          ls -l $SAFE_DATA_PATH
+          ls -l $SAFE_DATA_PATH/client_first
+          mkdir $SAFE_DATA_PATH/client
+          ls -l $SAFE_DATA_PATH
+          mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
+          ls -l $CLIENT_DATA_PATH
+          cargo run --bin faucet --release -- --log-output-dest=data-dir send 100000000 $(cargo run --bin safe --release -- --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
+          cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
+        env:
+          SN_LOG: "all"
+          SAFE_DATA_PATH: /home/runner/.local/share/safe
+          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
+        timeout-minutes: 25
+
+      - name: Use second client to upload third file
+        run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_3.tar.gz" -r 0
+        env:
+          SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Confirm the cash_notes files
+        run: |
+          pwd
+          ls $CLIENT_DATA_PATH/ -l
+          ls $CLIENT_DATA_PATH/wallet -l
+          ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+        env:
+          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
         timeout-minutes: 10
 
       - name: Stop the local network and upload logs


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jan 24 09:28 UTC
This pull request adds two patches. 

The first patch expands the replication bench with a heavy upload test. It modifies the ".github/workflows/benchmark-prs.yml" and ".github/workflows/merge.yml" files. The changes include adding a timeout for the benchmark test, confirming the number of files uploaded and downloaded, and building binaries. It also includes additional steps to upload more test files, use a different client for uploading, and confirm the cash_notes files.

The second patch is a chore to collect node handling time statistics. It modifies the "sn_node/src/node.rs" file. The changes include adding event headers and recording the handling time for different network events in the Node struct.

<!-- reviewpad:summarize:end --> 
