### PR TITLE
fix: Avoid store outgoing cashnote to disk

### DIFF
--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -507,6 +507,11 @@ impl LocalWallet {
             );
             let start = Instant::now();
 
+            // Only the change_cash_note, i.e. the pay-in one, needs to be stored to disk.
+            //
+            // Paying out cash_note doesn't need to be stored into disk.
+            // As it is the transfer, that generated from it, to be sent out to network,
+            // and be stored within the unconfirmed_spends, and to be re-sent in case of failure.
             self.store_cash_notes_to_disk(&[cash_note])?;
             trace!(
                 "update_local_wallet completed store change cash_note to disk in {:?}",
@@ -517,9 +522,6 @@ impl LocalWallet {
         for request in transfer.all_spend_requests {
             self.unconfirmed_spend_requests.insert(request);
         }
-
-        // Store created CashNotes in a batch, improving IO performance
-        self.store_cash_notes_to_disk(&transfer.created_cash_notes)?;
 
         // store wallet to disk
         let start = Instant::now();

--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -33,6 +33,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     fs::File,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 const WALLET_DIR_NAME: &str = "wallet";
@@ -349,6 +350,8 @@ impl LocalWallet {
         let mut storage_cost = NanoTokens::zero();
         let mut royalties_fees = NanoTokens::zero();
 
+        let start = Instant::now();
+
         // create random derivation indexes for recipients
         let mut recipients_by_xor = BTreeMap::new();
         for (xorname, (main_pubkey, quote)) in price_map.iter() {
@@ -376,16 +379,35 @@ impl LocalWallet {
             .flat_map(|(node, roy)| vec![node, roy])
             .cloned()
             .collect();
+
+        trace!(
+            "local_send_storage_payment prepared in {:?}",
+            start.elapsed()
+        );
+
+        let start = Instant::now();
         let (available_cash_notes, exclusive_access) = self.available_cash_notes()?;
+        trace!(
+            "local_send_storage_payment fetched {} cashnotes in {:?}",
+            available_cash_notes.len(),
+            start.elapsed()
+        );
         debug!("Available CashNotes: {:#?}", available_cash_notes);
         let reason_hash = Default::default();
+        let start = Instant::now();
         let offline_transfer = create_offline_transfer(
             available_cash_notes,
             recipients,
             self.address(),
             reason_hash,
         )?;
+        trace!(
+            "local_send_storage_payment created offline_transfer with {} cashnotes in {:?}",
+            offline_transfer.created_cash_notes.len(),
+            start.elapsed()
+        );
 
+        let start = Instant::now();
         // cache transfer payments in the wallet
         let mut cashnotes_to_use: HashSet<CashNote> = offline_transfer
             .created_cash_notes
@@ -444,9 +466,19 @@ impl LocalWallet {
             self.watchonly_wallet
                 .insert_payment_transaction(*xorname, payment);
         }
+        trace!(
+            "local_send_storage_payment completed payments insertion in {:?}",
+            start.elapsed()
+        );
 
         // write all changes to local wallet
+        let start = Instant::now();
         self.update_local_wallet(offline_transfer, exclusive_access)?;
+        trace!(
+            "local_send_storage_payment completed local wallet update in {:?}",
+            start.elapsed()
+        );
+
         Ok((storage_cost, royalties_fees))
     }
 
@@ -467,19 +499,35 @@ impl LocalWallet {
             .mark_notes_as_spent(spent_unique_pubkeys.clone());
 
         if let Some(cash_note) = transfer.change_cash_note {
+            let start = Instant::now();
             self.watchonly_wallet.deposit(&[cash_note.clone()])?;
-            self.store_cash_notes_to_disk(&[cash_note])?;
-        }
+            trace!(
+                "update_local_wallet completed deposit change cash_note in {:?}",
+                start.elapsed()
+            );
+            let start = Instant::now();
 
-        // Store created CashNotes in a batch, improving IO performance
-        self.store_cash_notes_to_disk(&transfer.created_cash_notes)?;
+            self.store_cash_notes_to_disk(&[cash_note])?;
+            trace!(
+                "update_local_wallet completed store change cash_note to disk in {:?}",
+                start.elapsed()
+            );
+        }
 
         for request in transfer.all_spend_requests {
             self.unconfirmed_spend_requests.insert(request);
         }
 
+        // Store created CashNotes in a batch, improving IO performance
+        self.store_cash_notes_to_disk(&transfer.created_cash_notes)?;
+
         // store wallet to disk
+        let start = Instant::now();
         self.store(exclusive_access)?;
+        trace!(
+            "update_local_wallet completed store self wallet to disk in {:?}",
+            start.elapsed()
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jan 24 10:37 UTC
This pull request includes two patches. The first patch adds functionality to collect wallet handling time statistics in the client. It includes changes to the `wallet.rs` file in the `sn_client` module and the `local_store.rs` file in the `sn_transfers` module. The second patch fixes a bug in the client where paying-out cash_notes were unintentionally being stored into disk. This patch only modifies the `local_store.rs` file in the `sn_transfers` module.
<!-- reviewpad:summarize:end --> 
