### PR TITLE
test(CI): ensure no extra leftover cash_note or payment files

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
+        env:
+          SN_LOG: "all"
         with:
           action: start
           interval: 2000

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -784,12 +784,26 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 5
 
-      - name: Confirm the cash_notes files
+      - name: Ensure no leftover cash_notes and payment files
         run: |
+          expected_cash_notes_files="1"
+          expected_payment_files="0"
           pwd
           ls $CLIENT_DATA_PATH/ -l
           ls $CLIENT_DATA_PATH/wallet -l
           ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+          cash_note_files=$(ls $CLIENT_DATA_PATH/wallet/cash_notes | wc -l)
+          echo "Find $cash_note_files cash_note files"
+          if [ $expected_cash_notes_files -lt $cash_note_files ]; then
+            echo "Got too many cash_note files leftover: $cash_note_files"
+            exit 1
+          fi
+          ls $CLIENT_DATA_PATH/wallet/payments -l
+          payment_files=$(ls $CLIENT_DATA_PATH/wallet/payments | wc -l)
+          if [ $expected_payment_files -lt $payment_files ]; then
+            echo "Got too many payment files leftover: $payment_files"
+            exit 1
+          fi
         env:
           CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
         timeout-minutes: 10
@@ -802,6 +816,29 @@ jobs:
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_2.tar.gz" -r 0
         env:
           SN_LOG: "all"
+        timeout-minutes: 10
+
+      - name: Ensure no leftover cash_notes and payment files
+        run: |
+          expected_cash_notes_files="1"
+          expected_payment_files="0"
+          pwd
+          ls $CLIENT_DATA_PATH/ -l
+          ls $CLIENT_DATA_PATH/wallet -l
+          ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+          cash_note_files=$(find $CLIENT_DATA_PATH/wallet/cash_notes -type f | wc -l)
+          if (( $(echo "$cash_note_files > $expected_cash_notes_files" | bc -l) )); then
+            echo "Got too many cash_note files leftover: $cash_note_files"
+            exit 1
+          fi
+          ls $CLIENT_DATA_PATH/wallet/payments -l
+          payment_files=$(find $CLIENT_DATA_PATH/wallet/payments -type f | wc -l)
+          if (( $(echo "$payment_files > $expected_payment_files" | bc -l) )); then
+            echo "Got too many payment files leftover: $payment_files"
+            exit 1
+          fi
+        env:
+          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
         timeout-minutes: 10
 
       - name: Wait for certain period
@@ -833,12 +870,26 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 10
 
-      - name: Confirm the cash_notes files
+      - name: Ensure no leftover cash_notes and payment files
         run: |
+          expected_cash_notes_files="1"
+          expected_payment_files="0"
           pwd
           ls $CLIENT_DATA_PATH/ -l
           ls $CLIENT_DATA_PATH/wallet -l
           ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+          cash_note_files=$(ls $CLIENT_DATA_PATH/wallet/cash_notes | wc -l)
+          echo "Find $cash_note_files cash_note files"
+          if [ $expected_cash_notes_files -lt $cash_note_files ]; then
+            echo "Got too many cash_note files leftover: $cash_note_files"
+            exit 1
+          fi
+          ls $CLIENT_DATA_PATH/wallet/payments -l
+          payment_files=$(ls $CLIENT_DATA_PATH/wallet/payments | wc -l)
+          if [ $expected_payment_files -lt $payment_files ]; then
+            echo "Got too many payment files leftover: $payment_files"
+            exit 1
+          fi
         env:
           CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
         timeout-minutes: 10


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jan 24 14:39 UTC
This pull request updates the CI workflow file `merge.yml` to ensure that no extra leftover `cash_note` or payment files are present. It adds a new step that checks for the expected number of files in the `cash_notes` and `payments` directories and throws an error if there are more than expected. This helps maintain a clean and organized workspace.
<!-- reviewpad:summarize:end --> 
