### PR TITLE
fix(client): avoid deadlock during upload in case of error

### DIFF
--- a/sn_client/src/files/upload.rs
+++ b/sn_client/src/files/upload.rs
@@ -382,6 +382,15 @@ impl FilesUpload {
                             return Err(ClientError::SequentialUploadPaymentError);
                         }
                     }
+
+                    // In case of error, remove the entries from correspondent on_going_tasks list.
+                    // So that the overall upload flow can progress on to other work.
+                    for chunk_info in error_list.iter() {
+                        let _ = on_going_get_cost.remove(&chunk_info.name);
+                        let _ = on_going_pay_for_chunk.remove(&chunk_info.name);
+                        let _ = on_going_uploadings.remove(&chunk_info.name);
+                    }
+
                     self.failed_chunks.extend(error_list);
                 }
             }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jan 24 15:10 UTC
This pull request fixes a deadlock issue during the upload process in the client. In case of an error, the patch removes entries from the corresponding ongoing tasks list to allow the upload flow to progress.
<!-- reviewpad:summarize:end --> 
