### PR TITLE
chore: remove arg and env variable combination

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -55,10 +55,6 @@ jobs:
             rg '/ip4.*$' -m1 -o | rg '"' -r '')
           echo "SAFE_PEERS=$safe_peers" >> $GITHUB_ENV
 
-      - name: Set CHURN_TEST_START_PORT
-        run: |
-          echo "CHURN_TEST_START_PORT=12001" >> $GITHUB_ENV
-
       - name: Check SAFE_PEERS was set
         shell: bash
         run: echo "The SAFE_PEERS variable has been set to $SAFE_PEERS"


### PR DESCRIPTION
Our code was setup such that the `--peer` arguments and those defined using `SAFE_PEERS` were combined together to form one list. Now we use `clap` to parse one or the other.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Jan 24 21:47 UTC
This pull request removes the combination of `--peer` arguments and `SAFE_PEERS` environment variables to form a single peer list. It now uses `clap` to parse either one or the other.
<!-- reviewpad:summarize:end --> 
