### PR TITLE
chore(CI): check the home dir space

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -632,6 +632,11 @@ jobs:
         shell: bash
         run: sudo apt-get install -y ripgrep
 
+      - name: Check the home dir available space
+        run: |
+          df
+          du -sh /home/runner/
+
       - name: Download material, 2.34G
         shell: bash
         run: |
@@ -676,12 +681,18 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 30
 
+      - name: Check the home dir leftover space
+        run: |
+          df
+          du -sh /home/runner/
+
       - name: Confirm the cash_notes files
         run: |
           pwd
           ls $CLIENT_DATA_PATH/ -l
           ls $CLIENT_DATA_PATH/wallet -l
           ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+          ls $CLIENT_DATA_PATH/logs -l
         env:
           CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
         timeout-minutes: 10
@@ -691,7 +702,6 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_large_file_upload
           platform: ubuntu-latest
           build: true
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -681,6 +681,34 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 30
 
+      - name: Zip the client and nodes logs
+        if: always()
+        run: |
+          pwd
+          find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
+          find $CLIENT_DATA_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
+          ls -l
+        env:
+          NODE_DATA_PATH: /home/runner/.local/share/safe/node
+          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
+        timeout-minutes: 10
+
+      - name: Upload node logs
+        uses: actions/upload-artifact@main
+        with:
+          name: large_file_upload_node_logs
+          path: nodes_log_files.tar.gz
+        continue-on-error: true
+        if: always()
+
+      - name: Upload client logs
+        uses: actions/upload-artifact@main
+        with:
+          name: large_file_upload_client_logs
+          path: client_log_files.tar.gz
+        continue-on-error: true
+        if: always()
+
       - name: Check the home dir leftover space
         run: |
           df


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Jan 24 11:29 UTC
This pull request adds a check for available space in the home directory in the CI workflow. It includes the commands "df -h ~" to check the available space before and after downloading material. Additionally, it confirms the existence of the "cash_notes" files.
<!-- reviewpad:summarize:end --> 
