### PR TITLE
feat: initial webtransport-websys wasm setup

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -142,6 +142,21 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 30
 
+      - name: Check current files
+        run: ls -la
+      - name: Check safenode file
+        run: ls /home/runner/work/safe_network/safe_network/target/release
+        
+      - name: Check there was no restart issues
+        run: |
+          if rg 'Failed to execute hard-restart command' $NODE_DATA_PATH; then
+            echo "Restart issues detected"
+            exit 1
+          else
+            echo "No restart issues detected"
+          fi
+
+
       - name: Verify the routing tables of the nodes
         run: cargo test --release -p sn_node --test verify_routing_table -- --nocapture 
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,7 +4877,6 @@ dependencies = [
  "proptest",
  "rand",
  "rmp-serde",
- "self_encryption",
  "serde",
  "thiserror",
  "tiny-keccak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -4094,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4106,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,8 +1685,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1984,7 +1986,7 @@ dependencies = [
  "hyper",
  "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -4149,7 +4151,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4289,14 +4291,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring 0.16.20",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring 0.16.20",
- "sct",
- "webpki",
+ "sct 0.7.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -4308,7 +4323,7 @@ dependencies = [
  "log",
  "ring 0.17.7",
  "rustls-webpki",
- "sct",
+ "sct 0.7.1",
 ]
 
 [[package]]
@@ -4388,6 +4403,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
 
 [[package]]
 name = "sct"
@@ -4620,6 +4645,7 @@ dependencies = [
  "custom_debug",
  "eyre",
  "futures",
+ "getrandom",
  "hex",
  "itertools 0.11.0",
  "libp2p 0.53.2",
@@ -4699,6 +4725,7 @@ dependencies = [
  "custom_debug",
  "eyre",
  "futures",
+ "getrandom",
  "hyper",
  "itertools 0.11.0",
  "libp2p 0.53.2",
@@ -4821,6 +4848,7 @@ dependencies = [
  "crdts",
  "custom_debug",
  "dirs-next",
+ "getrandom",
  "hex",
  "libp2p 0.53.2",
  "prost 0.9.0",
@@ -5306,6 +5334,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -5375,6 +5414,7 @@ dependencies = [
  "prost 0.9.0",
  "prost-derive 0.9.0",
  "tokio",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.10",
  "tower",
@@ -5866,6 +5906,16 @@ checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "libp2p-swarm 0.44.1",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-webtransport-websys",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -2827,6 +2828,27 @@ dependencies = [
  "tokio",
  "tracing",
  "void",
+]
+
+[[package]]
+name = "libp2p-webtransport-websys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840b63681e3bedbdb3df3e4f2dd48e9a20d2c6714264829ab90c6fce8549d627"
+dependencies = [
+ "futures",
+ "js-sys",
+ "libp2p-core 0.41.2",
+ "libp2p-identity",
+ "libp2p-noise",
+ "multiaddr",
+ "multihash",
+ "send_wrapper",
+ "thiserror",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4407,6 +4429,15 @@ name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,5 @@ uninlined_format_args = "warn"
 unicode_not_nfc = "warn"
 unused_async = "warn"
 unwrap_used = "warn"
+
+

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -10,12 +10,17 @@ readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.102.6"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+
 [features]
 default=["quic"]
 local-discovery=["sn_networking/local-discovery"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 # required to pass on flag to node builds
 quic = ["sn_networking/quic"]
+webtransport-websys = ["sn_networking/webtransport-websys"]
 
 [dependencies]
 async-trait = "0.1"
@@ -52,3 +57,7 @@ libp2p-identity = { version="0.2.7", features = ["rand"] }
 
 [lints]
 workspace = true
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.12", features = ["js"] }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -20,7 +20,6 @@ local-discovery=["sn_networking/local-discovery"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 # required to pass on flag to node builds
 quic = ["sn_networking/quic"]
-webtransport-websys = ["sn_networking/webtransport-websys"]
 
 [dependencies]
 async-trait = "0.1"
@@ -61,3 +60,4 @@ workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
+sn_networking = { path = "../sn_networking", version = "0.12.32" }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -49,3 +49,8 @@ eyre = "0.6.8"
 
 [lints]
 workspace = true
+
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.12", features = ["js"] }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.12.35"
 default=[]
 local-discovery=["libp2p/mdns"]
 quic=["libp2p/quic"]
+webtransport-websys=["libp2p/webtransport-websys"]
 open-metrics=["libp2p/metrics", "prometheus-client", "hyper", "sysinfo"]
 
 [dependencies]

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.12.35"
 
 [features]
-default=[]
+default=["quic"]
 local-discovery=["libp2p/mdns"]
 quic=["libp2p/quic"]
-webtransport-websys=["libp2p/webtransport-websys"]
+tcp=["libp2p/tcp"]
 open-metrics=["libp2p/metrics", "prometheus-client", "hyper", "sysinfo"]
 
 [dependencies]
@@ -54,3 +54,5 @@ workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
+libp2p = { version="0.53", features = ["tokio", "dns", "kad", "macros", "request-response", "cbor","identify", "autonat", "noise", "tcp", "yamux", "gossipsub", "webtransport-websys"] }
+

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -26,14 +26,17 @@ use crate::{
     Network, CLOSE_GROUP_SIZE,
 };
 use futures::StreamExt;
-#[cfg(any(feature = "quic", feature = "webtransport-websys"))]
+#[cfg(not(feature = "tcp"))]
 use libp2p::core::muxing::StreamMuxerBox;
 #[cfg(feature = "local-discovery")]
 use libp2p::mdns;
-#[cfg(feature = "quic")]
-use libp2p::quic;
-#[cfg(feature = "webtransport-websys")]
-use libp2p::webtransport_websys;
+// default transports
+#[cfg(all(not(feature = "tcp"), not(target_arch = "wasm32")))]
+use libp2p::quic::{tokio::Transport as TokioTransport, Config as TransportConfig};
+#[cfg(feature = "tcp")]
+use libp2p::tcp::{tokio::Transport as TokioTransport, Config as TransportConfig};
+#[cfg(target_arch = "wasm32")]
+use libp2p::webtransport_websys::{Config as TransportConfig, Transport as TokioTransport};
 use libp2p::{
     autonat,
     identity::Keypair,
@@ -319,19 +322,23 @@ impl NetworkBuilder {
         )?;
 
         // Listen on the provided address
-        let listen_addr = listen_addr.ok_or(Error::ListenAddressNotProvided)?;
-        #[cfg(not(any(feature = "quic", feature = "webtransport-websys")))]
-        let listen_addr = Multiaddr::from(listen_addr.ip()).with(Protocol::Tcp(listen_addr.port()));
+        let listen_socket_addr = listen_addr.ok_or(Error::ListenAddressNotProvided)?;
+
+        // Flesh out the multiaddress
+        let listen_addr = Multiaddr::from(listen_socket_addr.ip());
 
         #[cfg(feature = "quic")]
-        let listen_addr = Multiaddr::from(listen_addr.ip())
-            .with(Protocol::Udp(listen_addr.port()))
+        let listen_addr = listen_addr
+            .with(Protocol::Udp(listen_socket_addr.port()))
             .with(Protocol::QuicV1);
 
-        #[cfg(feature = "webtransport-websys")]
-        let listen_addr = Multiaddr::from(listen_addr.ip())
-            .with(Protocol::Udp(listen_addr.port()))
+        #[cfg(target_arch = "wasm32")]
+        let listen_addr = listen_addr
+            .with(Protocol::Udp(listen_socket_addr.port()))
             .with(Protocol::WebTransport);
+
+        #[cfg(feature = "tcp")]
+        Multiaddr::from(listen_socket_addr.ip()).with(Protocol::Tcp(listen_socket_addr.port()));
 
         let _listener_id = swarm_driver
             .swarm
@@ -458,9 +465,13 @@ impl NetworkBuilder {
             libp2p::identify::Behaviour::new(cfg)
         };
 
-        // Transport
-        #[cfg(not(any(feature = "quic", feature = "webtransport-websys")))]
-        let mut transport = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default())
+        #[cfg(not(feature = "tcp"))]
+        let main_transport = TokioTransport::new(TransportConfig::new(&self.keypair))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .boxed();
+
+        #[cfg(feature = "tcp")]
+        let main_transport = TokioTransport::new(TransportConfig::default())
             .upgrade(libp2p::core::upgrade::Version::V1)
             .authenticate(
                 libp2p::noise::Config::new(&self.keypair)
@@ -468,17 +479,6 @@ impl NetworkBuilder {
             )
             .multiplex(libp2p::yamux::Config::default())
             .boxed();
-
-        #[cfg(feature = "quic")]
-        let mut transport = libp2p::quic::tokio::Transport::new(quic::Config::new(&self.keypair))
-            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .boxed();
-
-        #[cfg(feature = "webtransport-websys")]
-        let mut transport =
-            webtransport_websys::Transport::new(webtransport_websys::Config::new(&self.keypair))
-                .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn)))
-                .boxed();
 
         let gossipsub = if self.enable_gossip {
             // Gossipsub behaviour
@@ -516,11 +516,13 @@ impl NetworkBuilder {
 
         let gossipsub = Toggle::from(gossipsub);
 
-        if !self.local {
+        let transport = if !self.local {
             debug!("Preventing non-global dials");
-            // Wrap TCP or UDP in a transport that prevents dialing local addresses.
-            transport = libp2p::core::transport::global_only::Transport::new(transport).boxed();
-        }
+            // Wrap upper in a transport that prevents dialing local addresses.
+            libp2p::core::transport::global_only::Transport::new(main_transport).boxed()
+        } else {
+            main_transport
+        };
 
         // Disable AutoNAT if we are either running locally or a client.
         let autonat = if !self.local && !is_client {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -983,9 +983,15 @@ mod tests {
 
             // Execute for 50 iterations, which allows the test can be executed in normal CI runs.
             if iteration == 50 {
-                assert_eq!(0, empty_earned_nodes);
-                assert!((max_store_cost / min_store_cost) < 60);
-                assert!((max_earned / min_earned) < 800);
+                assert_eq!(0, empty_earned_nodes, "every node has earnt _something_");
+                assert!(
+                    (max_store_cost / min_store_cost) < 60,
+                    "store cost is balanced"
+                );
+                assert!(
+                    (max_earned / min_earned) < 800,
+                    "earning distribution is well balanced"
+                );
                 break;
             }
         }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -73,7 +73,7 @@ color-eyre = "0.6.2"
 [dev-dependencies]
 tempfile = "3.6.0"
 reqwest = { version="0.11.18", default-features=false, features = ["rustls"] }
-sn_protocol = { path = "../sn_protocol", version = "0.10.14", features = ["test-utils"]}
+sn_protocol = { path = "../sn_protocol", version = "0.10.14", features = ["test-utils", "rpc"]}
 
 [lints]
 workspace = true

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -502,6 +502,24 @@ fn start_new_node_process() {
     let args: Vec<String> = env::args().collect();
 
     info!("Original args are: {args:?}");
+    info!("Current exe is: {current_exe:?}");
+
+    // Convert current exe path to string, log an error and return if it fails
+    let current_exe = match current_exe.to_str() {
+        Some(s) => {
+            // remove "(deleted)" string from current exe path
+            if s.contains(" (deleted)") {
+                warn!("The current executable path contains ' (deleted)', which may lead to unexpected behavior. This has been removed from the exe location string");
+                s.replace(" (deleted)", "")
+            } else {
+                s.to_string()
+            }
+        }
+        None => {
+            error!("Failed to convert current executable path to string");
+            return;
+        }
+    };
 
     // Create a new Command instance to run the current executable
     let mut cmd = Command::new(current_exe);

--- a/sn_node_rpc_client/Cargo.toml
+++ b/sn_node_rpc_client/Cargo.toml
@@ -27,7 +27,7 @@ sn_client = { path = "../sn_client", version = "0.102.6" }
 sn_logging = { path = "../sn_logging", version = "0.2.16" }
 sn_node = { path = "../sn_node", version = "0.103.8" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.3" }
-sn_protocol = { path = "../sn_protocol", version = "0.10.14" }
+sn_protocol = { path = "../sn_protocol", version = "0.10.14", features=["rpc"] }
 sn_transfers = { path = "../sn_transfers", version = "0.14.40" }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -124,7 +124,7 @@ async fn get_network_contacts(args: &PeersArgs) -> Result<Vec<Multiaddr>> {
 pub fn parse_peer_addr(addr: &str) -> Result<Multiaddr> {
     // Parse valid IPv4 socket address, e.g. `1.2.3.4:1234`.
     if let Ok(addr) = addr.parse::<std::net::SocketAddrV4>() {
-        #[cfg(not(feature = "quic"))]
+        #[cfg(not(feature = "quic, webtransport-websys"))]
         // Turn the address into a `/ip4/<ip>/tcp/<port>` multiaddr.
         let multiaddr = Multiaddr::from(*addr.ip()).with(Protocol::Tcp(addr.port()));
         #[cfg(feature = "quic")]
@@ -132,6 +132,11 @@ pub fn parse_peer_addr(addr: &str) -> Result<Multiaddr> {
         let multiaddr = Multiaddr::from(*addr.ip())
             .with(Protocol::Udp(addr.port()))
             .with(Protocol::QuicV1);
+        #[cfg(feature = "webtransport-websys")]
+        // Turn the address into a `/ip4/<ip>/udp/<port>/webtransport-websys-v1` multiaddr.
+        let multiaddr = Multiaddr::from(*addr.ip())
+            .with(Protocol::Udp(addr.port()))
+            .with(Protocol::WebTransport);
         return Ok(multiaddr);
     }
 

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -36,7 +36,7 @@ tracing = { version = "~0.1.26" }
 # # watch out updating this, protoc compiler needs to be installed on all build systems
 # # arm builds + musl are very problematic
 prost = { version = "0.9" }
-tonic = { version = "0.6.2" }
+tonic = { version = "0.6.2", default-features = false, features = ["prost", "tls", "codegen"]}
 xor_name = "5.0.0"
 
 [build-dependencies]
@@ -46,3 +46,11 @@ tonic-build = { version = "~0.6.2" }
 
 [lints]
 workspace = true
+
+
+
+# wasm compilation
+[lib]
+crate-type = ["cdylib", "rlib"]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.12", features = ["js"] }

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -14,6 +14,7 @@ default = ["quic"]
 test-utils=[]
 quic=[]
 tcp=[]
+rpc=["tonic", "prost"]
 
 [dependencies]
 bls = { package = "blsttc", version = "8.0.1" }
@@ -35,8 +36,9 @@ tiny-keccak = { version = "~2.0.2", features = [ "sha3" ] }
 tracing = { version = "~0.1.26" }
 # # watch out updating this, protoc compiler needs to be installed on all build systems
 # # arm builds + musl are very problematic
-prost = { version = "0.9" }
-tonic = { version = "0.6.2", default-features = false, features = ["prost", "tls", "codegen"]}
+# prost and tonic are needed for the RPC server messages, not the underlying protocol
+prost = { version = "0.9" , optional=true }
+tonic = { version = "0.6.2", optional=true, default-features = false, features = ["prost", "tls", "codegen"]}
 xor_name = "5.0.0"
 
 [build-dependencies]

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -25,6 +25,7 @@ pub mod test_utils;
 
 // this includes code generated from .proto files
 #[allow(clippy::unwrap_used)]
+#[cfg(feature = "rpc")]
 pub mod safenode_proto {
     tonic::include_proto!("safenode_proto");
 }

--- a/sn_registers/Cargo.toml
+++ b/sn_registers/Cargo.toml
@@ -15,7 +15,6 @@ bls = { package = "blsttc", version = "8.0.1" }
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 hex = "~0.4.3"
 rmp-serde = "1.1.1"
-self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -12,13 +12,12 @@ use crate::{
 };
 
 use bls::{PublicKey, SecretKey, Signature};
-use self_encryption::MIN_ENCRYPTABLE_BYTES;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use xor_name::XorName;
 
 /// Arbitrary maximum size of a register entry.
-const MAX_REG_ENTRY_SIZE: usize = MIN_ENCRYPTABLE_BYTES / 3 * 1024; // 1024 bytes
+const MAX_REG_ENTRY_SIZE: usize = 1024;
 
 /// Maximum number of entries of a register.
 const MAX_REG_NUM_ENTRIES: u16 = 1024;

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -20,7 +20,6 @@ lazy_static = "~1.4.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
-tokio = { version = "1.32.0", features = ["macros", "rt"] }
 thiserror = "1.0.24"
 tiny-keccak = { version = "~2.0.2", features = [ "sha3" ] }
 tracing = { version = "~0.1.26" }
@@ -29,6 +28,7 @@ xor_name = "5.0.0"
 rayon = "1.8.0"
 
 [dev-dependencies]
+tokio = { version = "1.32.0", features = ["macros", "rt"] }
 criterion = "0.4.0"
 assert_fs = "1.0.0"
 eyre = "0.6.8"

--- a/sn_transfers/src/wallet/watch_only.rs
+++ b/sn_transfers/src/wallet/watch_only.rs
@@ -21,6 +21,7 @@ use crate::{
     transfers::create_unsigned_transfer, wallet::data_payments::PaymentDetails, CashNote,
     DerivationIndex, Hash, MainPubkey, NanoTokens, UniquePubkey, UnsignedTransfer,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use fs2::FileExt;
 use serde::Serialize;
 use std::{
@@ -296,6 +297,8 @@ impl WatchOnlyWallet {
             .write(true)
             .truncate(true)
             .open(lock)?;
+
+        #[cfg(not(target_arch = "wasm32"))]
         file.lock_exclusive()?;
         Ok(file)
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Jan 24 12:15 UTC
This pull request includes the following changes:

- In the `parse_peer_addr` function, some modifications have been made.
- Conditional compilations have been added for the `quic` and `webtransport-websys` features.
- For the `quic` feature, the `multiaddr` is created with the `QuicV1` protocol.
- For the `webtransport-websys` feature, the `multiaddr` is created with the `WebTransport` protocol.

In the `Cargo.toml` file, the following changes are present:

- The `tokio` dependency has been removed from the `dependencies` section and added to the `dev dependencies` section.
- The `[lib]` section has been added with `crate-type` set to `["cdylib", "rlib"]`.
- The `[target.'cfg(target_arch = "wasm32")'.dependencies]` section has been added with the `getrandom` dependency and its version set to `"0.2.12"` with the feature `"js"`.
- The `[dependencies]` section has been updated to include `webtransport-websys`.
- A blank line has been added at the end of the file.

In the `register.rs` file, the following changes are observed:

- The import `self_encryption::MIN_ENCRYPTABLE_BYTES` has been removed.
- The value of `MAX_REG_ENTRY_SIZE` has been changed from `MIN_ENCRYPTABLE_BYTES / 3 * 1024` to `1024`.
- The constant `MAX_REG_NUM_ENTRIES` remains unchanged.

The version of the `sn_protocol` dependency in the `Cargo.toml` file has been updated to include the "rpc" feature.

In the `lib.rs` file, the following change is present:

- The `#[cfg(feature = "rpc")]` attribute has been added to the module `safenode_proto` inside the `sn_protocol` library.

The changes in the `Cargo.toml` file include updates to the dependencies `self_encryption`, `bls`, `crdts`, `hex`, `rmp-serde`, `serde`, `thiserror`, and `tiny-keccak`.

In the `watch_only.rs` file, two changes have been made: 
- The import statement for the `fs2` crate has been added when the target architecture is not `wasm32`.
- A file lock has been added before opening a file for writing.

The `Cargo.toml` file now includes the dependencies `webtransport-websys`, `open-metrics`, `[lints]` section with `workspace` set to `true`, and `[target.'cfg(target_arch = "wasm32")'.dependencies]` section with the `getrandom` dependency.

The `driver.rs` file, in the `sn_networking` crate, has undergone several changes including conditional compilations for the `quic` and `webtransport-websys` features, updates to the listener address construction and transport setup based on feature flags.

Let me know if you need any further assistance!
<!-- reviewpad:summarize:end --> 
