### PR TITLE
fix(wallet): remove unconfirmed_spends file from disk when all confirmed

### DIFF
--- a/sn_transfers/src/wallet/local_store.rs
+++ b/sn_transfers/src/wallet/local_store.rs
@@ -10,7 +10,8 @@ use super::{
     keys::{get_main_key, store_new_keypair},
     wallet_file::{
         get_unconfirmed_spend_requests, load_cash_notes_from_disk, load_created_cash_note,
-        remove_cash_notes, store_created_cash_notes, store_unconfirmed_spend_requests,
+        remove_cash_notes, remove_unconfirmed_spend_requests, store_created_cash_notes,
+        store_unconfirmed_spend_requests,
     },
     watch_only::WatchOnlyWallet,
     Error, Result,
@@ -97,6 +98,14 @@ impl LocalWallet {
     /// Store unconfirmed_spend_requests to disk.
     pub fn store_unconfirmed_spend_requests(&mut self) -> Result<()> {
         store_unconfirmed_spend_requests(
+            self.watchonly_wallet.wallet_dir(),
+            self.unconfirmed_spend_requests(),
+        )
+    }
+
+    /// Remove unconfirmed_spend_requests from disk.
+    fn remove_unconfirmed_spend_requests(&mut self) -> Result<()> {
+        remove_unconfirmed_spend_requests(
             self.watchonly_wallet.wallet_dir(),
             self.unconfirmed_spend_requests(),
         )
@@ -206,6 +215,10 @@ impl LocalWallet {
         ) {
             warn!("Could not clean confirmed spent cash_notes due to {error:?}");
         }
+
+        // Also need to remove unconfirmed_spend_requests from disk if was pre-loaded.
+        let _ = self.remove_unconfirmed_spend_requests();
+
         self.unconfirmed_spend_requests = Default::default();
     }
 

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -100,6 +100,18 @@ pub(super) fn store_unconfirmed_spend_requests(
     Ok(())
 }
 
+/// Remove the `unconfirmed_spend_requests` from the specified path.
+pub(super) fn remove_unconfirmed_spend_requests(
+    wallet_dir: &Path,
+    _unconfirmed_spend_requests: &BTreeSet<SignedSpend>,
+) -> Result<()> {
+    let unconfirmed_spend_requests_path = wallet_dir.join(UNCONFRIMED_TX_NAME);
+
+    debug!("Removing unconfirmed_spend_requests from {unconfirmed_spend_requests_path:?}");
+    fs::remove_file(unconfirmed_spend_requests_path)?;
+    Ok(())
+}
+
 /// Returns `Some(Vec<SpendRequest>)` or None if file doesn't exist.
 pub(super) fn get_unconfirmed_spend_requests(
     wallet_dir: &Path,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Jan 24 12:18 UTC
This pull request fixes a bug in the wallet code. It removes the `unconfirmed_spends` file from disk when all spends are confirmed. This ensures that no unnecessary data is stored on the disk.
<!-- reviewpad:summarize:end --> 
