### PR TITLE
docs: new wallet client example

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -35,6 +35,26 @@ pub struct WalletClient {
 
 impl WalletClient {
     /// Create a new wallet client.
+    ///
+    /// # Arguments
+    /// * `client` - A instance of the struct [`sn_client::Client`](self::Client)
+    /// * `wallet` - An instance of the struct [`sn_transfers::LocalWallet`](self::LocalWallet)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sn_client::{Client, WalletClient, Error};
+    /// use tempfile::TempDir;
+    /// use bls::SecretKey;
+    /// use sn_transfers::{LocalWallet, MainSecretKey};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(),Error>{
+    /// let client = Client::new(SecretKey::random(), None, false, None).await?;
+    /// let tmp_path = TempDir::new()?.path().to_owned();
+    /// let mut wallet = LocalWallet::load_from_path(&tmp_path,Some(MainSecretKey::new(SecretKey::random())))?;
+    /// let mut wallet_client = WalletClient::new(client, wallet);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(client: Client, wallet: LocalWallet) -> Self {
         Self { client, wallet }
     }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 16 Jan 24 16:47 UTC
This pull request adds a new wallet client example to the documentation. The `WalletClient` struct now has a new `new()` method that takes an instance of the `sn_client::Client` struct and an instance of the `sn_transfers::LocalWallet` struct as arguments. The example code demonstrates how to use the `WalletClient` to create a new wallet client, utilizing the `Client` and `LocalWallet` structs.
<!-- reviewpad:summarize:end --> 
