### PR TITLE
feat: set quic as default transport

### DIFF
--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.102.1"
 
 [features]
-default=[]
+default=["quic"]
 local-discovery=["sn_networking/local-discovery"]
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
 # required to pass on flag to node builds

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.3.1"
 
 [features]
+default = ["quic"]
 # required to pass on flag to node builds
 quic = ["sn_client/quic"]
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -318,6 +318,7 @@ impl NetworkBuilder {
 
         // Listen on the provided address
         let listen_addr = listen_addr.ok_or(Error::ListenAddressNotProvided)?;
+
         #[cfg(not(feature = "quic"))]
         let listen_addr = Multiaddr::from(listen_addr.ip()).with(Protocol::Tcp(listen_addr.port()));
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -14,7 +14,7 @@ name = "safenode"
 path = "src/bin/safenode/main.rs"
 
 [features]
-default=["metrics"]
+default=["metrics", "quic"]
 local-discovery=["sn_networking/local-discovery"]
 otlp = ["sn_logging/otlp"]
 metrics = ["sn_logging/process-metrics"]

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -11,9 +11,11 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.2.2"
 
 [features]
-default = []
+default = ["quic"]
 local-discovery = []
 network-contacts = ["reqwest", "tokio", "url"]
+quic= []
+tcp = []
 
 [dependencies]
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -120,7 +120,7 @@ async fn get_network_contacts(args: &PeersArgs) -> Result<Vec<Multiaddr>> {
     get_bootstrap_peers_from_url(url).await
 }
 
-/// Parse strings like `1.2.3.4:1234` and `/ip4/1.2.3.4/tcp/1234` into a (TCP) multiaddr.
+/// Parse strings like `1.2.3.4:1234` and `/ip4/1.2.3.4/tcp/1234` into a multiaddr.
 pub fn parse_peer_addr(addr: &str) -> Result<Multiaddr> {
     // Parse valid IPv4 socket address, e.g. `1.2.3.4:1234`.
     if let Ok(addr) = addr.parse::<std::net::SocketAddrV4>() {
@@ -135,7 +135,7 @@ pub fn parse_peer_addr(addr: &str) -> Result<Multiaddr> {
         return Ok(multiaddr);
     }
 
-    // Parse any valid multiaddr string, e.g. `/ip4/1.2.3.4/tcp/1234/p2p/<peer_id>`.
+    // Parse any valid multiaddr string
     if let Ok(addr) = addr.parse::<Multiaddr>() {
         return Ok(addr);
     }

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -10,7 +10,10 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.10.9"
 
 [features]
+default = ["quic"]
 test-utils=[]
+quic=[]
+tcp=[]
 
 [dependencies]
 bls = { package = "blsttc", version = "8.0.1" }

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.3.22"
 
 [features]
 # required to pass on flag to node builds
+default = ["quic"]
 chaos = []
 statemap = []
 otlp = []

--- a/sn_testnet/src/lib.rs
+++ b/sn_testnet/src/lib.rs
@@ -539,8 +539,6 @@ mod test {
             .launch_genesis(vec!["--log-format".to_string(), "json".to_string()])
             .await?;
 
-        assert_eq!(format!("/ip4/127.0.0.1/tcp/11101/p2p/{peer_id}"), multiaddr);
-
         if !cfg!(feature = "quic") {
             assert_eq!(format!("/ip4/127.0.0.1/tcp/11101/p2p/{peer_id}"), multiaddr);
         } else {


### PR DESCRIPTION
BREADKING CHANGE: quic and tcp are not compatible

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jan 24 09:08 UTC
This pull request updates the default transport to use QUIC instead of TCP. This is a breaking change as QUIC and TCP are not compatible. The changes are made in the `sn_client` and `sn_node` Cargo.toml files, adding "quic" as a default feature.
<!-- reviewpad:summarize:end --> 
