### PR TITLE
feat: init for token supply server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.6",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +2973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3046,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -4360,6 +4412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4469,6 +4527,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -5232,6 +5301,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token_supplies"
+version = "0.1.0"
+dependencies = [
+ "dirs-next",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "warp",
+]
+
+[[package]]
 name = "tokio"
 version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,6 +5371,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5560,6 +5653,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5694,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -5684,6 +5805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,6 +5878,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "rustls-pemfile 1.0.4",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util 0.7.10",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "sn_registers",
     "sn_testnet",
     "sn_transfers",
+    "token_supplies",
 ]
 
 [workspace.lints.rust]

--- a/token_supplies/Cargo.toml
+++ b/token_supplies/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
+description = "Safe Network Token Supplies"
+# documentation = "https://docs.rs/sn_node"
+edition = "2021"
+homepage = "https://maidsafe.net"
+license = "GPL-3.0"
+name = "token_supplies"
+readme = "README.md"
+repository = "https://github.com/maidsafe/safe_network"
+version = "0.1.0"
+
+
+[dependencies]
+warp = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+dirs-next = "2.0"

--- a/token_supplies/README.md
+++ b/token_supplies/README.md
@@ -1,0 +1,15 @@
+# Maid Token Supply level server
+
+
+Rides atop the goodwill of https://emaid.online/api and caches results for `emaid` and `maid` tokens 
+in order to provide a simple API that websites can use to check the current supply levels easily.
+
+
+http://<address>:3030/maid
+
+and 
+
+http://<address>:3030/emaid
+
+Should both return _only_ the current supply level of the token in question.
+

--- a/token_supplies/src/main.rs
+++ b/token_supplies/src/main.rs
@@ -1,0 +1,92 @@
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::io::{self, Read};
+use tokio::time::{sleep, Duration};
+use warp::Filter;
+
+use dirs_next::home_dir;
+use std::path::PathBuf;
+
+fn data_file_path() -> PathBuf {
+    let mut path = home_dir().expect("Could not get home directory");
+    path.push(".safe_token_supplies");
+    fs::create_dir_all(&path).expect("Failed to create directory");
+    path.push("data.json");
+    path
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct ApiResponse {
+    maid_total_circulating_cap: u64,
+    omni_burned: u64,
+    smart_contract_minted: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct SharedData {
+    maid_supply: u64,
+    emaid_supply: u64,
+}
+
+async fn fetch_api_data() -> Result<ApiResponse, reqwest::Error> {
+    reqwest::get("https://emaid.online/api")
+        .await?
+        .json::<ApiResponse>()
+        .await
+}
+
+async fn scheduled_fetch() {
+    loop {
+        let api_result = fetch_api_data().await;
+        match api_result {
+            Ok(api_data) => {
+                let data = SharedData {
+                    maid_supply: api_data.maid_total_circulating_cap - api_data.omni_burned,
+                    emaid_supply: api_data.smart_contract_minted,
+                };
+                match write_to_file(&data) {
+                    Ok(()) => println!("Data written to file successfully"),
+                    Err(e) => eprintln!("Failed to write to file: {}", e),
+                }
+            }
+            Err(e) => eprintln!("Failed to fetch API data: {}", e),
+        }
+
+        sleep(Duration::from_secs(43200)).await; // Sleep for 12 hours
+    }
+}
+
+fn write_to_file(data: &SharedData) -> io::Result<()> {
+    let json = serde_json::to_string(data)?;
+    fs::write(data_file_path(), json)?;
+    Ok(())
+}
+
+fn read_from_file() -> io::Result<SharedData> {
+    let mut file = File::open(data_file_path())?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let data = serde_json::from_str(&contents)?;
+    Ok(data)
+}
+
+#[tokio::main]
+async fn main() {
+    tokio::spawn(async {
+        scheduled_fetch().await;
+    });
+
+    let maid_supply = warp::path!("maid").map(|| match read_from_file() {
+        Ok(data) => format!("{}", data.maid_supply),
+        Err(e) => format!("Error reading data: {e}"),
+    });
+
+    let emaid_supply = warp::path!("emaid").map(|| match read_from_file() {
+        Ok(data) => format!("{}", data.emaid_supply),
+        Err(e) => format!("Error reading data: {e}"),
+    });
+
+    warp::serve(maid_supply.or(emaid_supply))
+        .run(([0, 0, 0, 0], 3030))
+        .await;
+}


### PR DESCRIPTION
This gives us an endpoint to supply to market cap sites for existing supply levels

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Jan 24 08:50 UTC
This pull request includes the following changes:

1. The `Cargo.toml` file has been modified to add the new crate "token_supplies" as a member of the workspace. It also includes changes to package metadata and the addition of dependencies.

2. A new file called `README.md` has been added in the `token_supplies` directory. It describes a server that caches and provides supply levels for the `emaid` and `maid` tokens. The server exposes two endpoints: `http://<address>:3030/maid` and `http://<address>:3030/emaid`, which return the current supply levels for the respective tokens.

3. The file `main.rs` has been modified to add imports for various dependencies, define new structs and functions, and modify the `main()` function. These changes add functionality to fetch data from an API, write it to a file, and serve the data in response to requests.

4. The `Cargo.lock` file has been updated to include several new packages and their dependencies.

Please review the details provided in the individual summaries for more information on each file's changes. Let me know if you have any specific questions.
<!-- reviewpad:summarize:end --> 
