### PR TITLE
fix(ci): upload logs directly without zipping them first

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -681,33 +681,15 @@ jobs:
           SN_LOG: "all"
         timeout-minutes: 30
 
-      - name: Zip the client and nodes logs
+      - name: Upload client and node logs
         if: always()
-        run: |
-          pwd
-          find $NODE_DATA_PATH -iname '*.log*' | tar -zcvf nodes_log_files.tar.gz --files-from -
-          find $CLIENT_DATA_PATH -iname '*.log*' | tar -zcvf client_log_files.tar.gz --files-from -
-          ls -l
-        env:
-          NODE_DATA_PATH: /home/runner/.local/share/safe/node
-          CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
-        timeout-minutes: 10
-
-      - name: Upload node logs
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
           name: large_file_upload_node_logs
-          path: nodes_log_files.tar.gz
-        continue-on-error: true
-        if: always()
-
-      - name: Upload client logs
-        uses: actions/upload-artifact@main
-        with:
-          name: large_file_upload_client_logs
-          path: client_log_files.tar.gz
-        continue-on-error: true
-        if: always()
+          path: |
+            ~/.local/share/safe/node/*/logs/*.log*
+            ~/.local/share/safe/*/*/*.log*
+            ~/.local/share/safe/client/logs/*/*.log*
 
       - name: Check the home dir leftover space
         run: |


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jan 24 21:26 UTC
This pull request fixes the continuous integration workflow by uploading logs directly without zipping them first. It removes the step of zipping the client and node logs and instead uploads them as artifacts using the `upload-artifact` action. This improves the efficiency of the workflow and reduces unnecessary steps.
<!-- reviewpad:summarize:end --> 
