### PR TITLE
WIP: test sn-local-testnet-action new log upload change

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -47,7 +47,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         env:
           SN_LOG: "all"
         with:
@@ -216,7 +216,7 @@ jobs:
       
       - name: Stop the local network
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_benchmark

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -50,7 +50,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -112,7 +112,7 @@ jobs:
 
       - name: Stop the local network
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           platform: ubuntu-latest

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Start a local network
         env:
           SN_LOG: "all"
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -235,7 +235,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_memcheck

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -146,7 +146,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -273,7 +273,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_e2e
@@ -302,7 +302,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -316,7 +316,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_gossipsub_e2e
@@ -346,7 +346,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -386,7 +386,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_spend
@@ -424,7 +424,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -452,7 +452,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_churn
@@ -544,7 +544,7 @@ jobs:
           timeout-minutes: 30
 
         - name: Start a local network
-          uses: maidsafe/sn-local-testnet-action@main
+          uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
           with:
             action: start
             interval: 2000
@@ -579,7 +579,7 @@ jobs:
 
         - name: Stop the local network and upload logs
           if: always()
-          uses: maidsafe/sn-local-testnet-action@main
+          uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
           with:
             action: stop
             log_file_prefix: safe_test_logs_data_location
@@ -648,7 +648,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -727,7 +727,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           platform: ubuntu-latest
@@ -790,7 +790,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -934,7 +934,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_heavy_replicate_bench

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -77,7 +77,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_e2e
@@ -172,7 +172,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -186,7 +186,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_gossipsub_e2e
@@ -218,7 +218,7 @@ jobs:
           CARGO_TARGET_DIR: "./transfer-target"
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -255,7 +255,7 @@ jobs:
       
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_spend
@@ -302,7 +302,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: start
           interval: 2000
@@ -362,7 +362,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/sn-local-testnet-action@main
+        uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
         with:
           action: stop
           log_file_prefix: safe_test_logs_churn
@@ -421,7 +421,7 @@ jobs:
           timeout-minutes: 30
 
         - name: Start a local network
-          uses: maidsafe/sn-local-testnet-action@main
+          uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
           with:
             action: start
             interval: 2000
@@ -465,7 +465,7 @@ jobs:
 
         - name: Stop the local network and upload logs
           if: always()
-          uses: maidsafe/sn-local-testnet-action@main
+          uses: RolandSherwin/sn-local-testnet-action@simplify_log_upload
           with:
             action: stop
             log_file_prefix: safe_test_logs_data_location


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jan 24 22:01 UTC
This pull request contains a patch that introduces a new artifact upload option. It modifies several workflow files to use the `sn-local-testnet-action` action with the `simplify_log_upload` parameter. The patch also includes changes to start and stop a local network and upload logs in various jobs.
<!-- reviewpad:summarize:end --> 
