### PR TITLE
chore: include connected peers in node

### DIFF
--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -51,6 +51,39 @@ where
     }
 }
 
+fn serialize_connected_peers<S>(
+    connected_peers: &Option<Vec<PeerId>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match connected_peers {
+        Some(peers) => {
+            let peer_strs: Vec<String> = peers.iter().map(|p| p.to_string()).collect();
+            serializer.serialize_some(&peer_strs)
+        }
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_connected_peers<'de, D>(deserializer: D) -> Result<Option<Vec<PeerId>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vec: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    match vec {
+        Some(peer_strs) => {
+            let peers: Result<Vec<PeerId>, _> = peer_strs
+                .into_iter()
+                .map(|s| PeerId::from_str(&s).map_err(DeError::custom))
+                .collect();
+            peers.map(Some)
+        }
+        None => Ok(None),
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Node {
     pub genesis: bool,
@@ -70,6 +103,11 @@ pub struct Node {
     pub data_dir_path: Option<PathBuf>,
     pub log_dir_path: Option<PathBuf>,
     pub safenode_path: Option<PathBuf>,
+    #[serde(
+        serialize_with = "serialize_connected_peers",
+        deserialize_with = "deserialize_connected_peers"
+    )]
+    pub connected_peers: Option<Vec<PeerId>>,
 }
 
 impl Node {

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -139,6 +139,11 @@ pub struct NodeRegistry {
 
 impl NodeRegistry {
     pub fn save(&self) -> Result<()> {
+        let path = Path::new(&self.save_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
         let json = serde_json::to_string(self)?;
         let mut file = std::fs::File::create(self.save_path.clone())?;
         file.write_all(json.as_bytes())?;


### PR DESCRIPTION
- ecb7208e **chore: include connected peers in node**

  It's useful for the `status` command in the node manager to include the number of connected peers,
  and it may be useful at some later point to list the peers in a more detailed view.
 
- de4a506f **fix: create parent directories**

  When saving the node registry, it should create all the directories in its path.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jan 24 13:24 UTC
This pull request includes three patches:

1. The first patch is a chore that adds the functionality to include the number of connected peers in the `status` command of the node manager. It also prepares for listing the peers in a more detailed view in the future.

2. The second patch is a fix that ensures all parent directories are created when saving the node registry. Previously, only the final directory in the save path was created.

3. The third patch is a work in progress (WIP) that adds a backwards compatibility test in the CI workflow. This test is intended to ensure that the code remains compatible with previous versions.

Please review these patches and provide any necessary feedback or suggestions.
<!-- reviewpad:summarize:end --> 
