### PR TITLE
Unused get store cost ar addr

### DIFF
--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -36,8 +36,8 @@ impl WalletClient {
     /// Create a new wallet client.
     ///
     /// # Arguments
-    /// * `client` - A instance of the struct [`sn_client::Client`](self::Client)
-    /// * `wallet` - An instance of the struct [`sn_transfers::LocalWallet`](self::LocalWallet)
+    /// * `client` - A instance of the struct [`sn_client::Client`](Client)
+    /// * `wallet` - An instance of the struct [`sn_transfers::LocalWallet`](LocalWallet)
     ///
     /// # Example
     /// ```no_run
@@ -129,7 +129,7 @@ impl WalletClient {
     /// Get the payment detail from a given address within the network.
     ///
     /// # Arguments
-    /// * `address` - The [`NetworkAddress`](self::NetworkAddress).
+    /// * `address` - The [`NetworkAddress`](NetworkAddress).
     ///
     /// # Example
     /// ```no_run
@@ -172,7 +172,7 @@ impl WalletClient {
     /// Remove the payment for a given network address from disk.
     ///
     /// # Arguments
-    /// * `address` - The [`NetworkAddress`](self::NetworkAddress).
+    /// * `address` - The [`NetworkAddress`](NetworkAddress).
     ///
     /// # Example
     /// ```no_run

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -322,20 +322,6 @@ impl WalletClient {
         }
     }
 
-    /// Get storecost from the network.
-    /// # Arguments
-    /// * `address` - The [`NetworkAddress`](self::NetworkAddress).
-    /// # Returns
-    /// * [`MainPubkey`](sn_transfers::MainPubkey) of the node to pay and the price in NanoTokens.
-    //TODO: Unused(No usages found in all Places)
-    async fn get_store_cost_at_address(&self, address: NetworkAddress) -> WalletResult<PayeeQuote> {
-        self.client
-            .network
-            .get_store_costs_from_network(address)
-            .await
-            .map_err(|error| WalletError::CouldNotSendMoney(error.to_string()))
-    }
-
     /// Send tokens to nodes closest to the data we want to make storage payment for.
     ///
     /// The returned result is: ((storage_cost, royalties_fees), (payee_map, skipped_chunks))

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -322,12 +322,13 @@ impl WalletClient {
         }
     }
 
-    /// Get storecost from the network
-    /// Returns the MainPubkey of the node to pay and the price in NanoTokens
-    pub async fn get_store_cost_at_address(
-        &self,
-        address: NetworkAddress,
-    ) -> WalletResult<PayeeQuote> {
+    /// Get storecost from the network.
+    /// # Arguments
+    /// * `address` - The [`NetworkAddress`](self::NetworkAddress).
+    /// # Returns
+    /// * [`MainPubkey`](sn_transfers::MainPubkey) of the node to pay and the price in NanoTokens.
+    //TODO: Unused(No usages found in all Places)
+    async fn get_store_cost_at_address(&self, address: NetworkAddress) -> WalletResult<PayeeQuote> {
         self.client
             .network
             .get_store_costs_from_network(address)

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -12,7 +12,7 @@ use super::{error::Result, Client};
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use futures::{future::join_all, TryFutureExt};
 use libp2p::PeerId;
-use sn_networking::{GetRecordError, PayeeQuote};
+use sn_networking::GetRecordError;
 use sn_protocol::NetworkAddress;
 use sn_transfers::{
     CashNote, DerivationIndex, LocalWallet, MainPubkey, NanoTokens, Payment, PaymentQuote,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jan 24 15:31 UTC
This pull request includes two patches. 

The first patch updates the documentation in the wallet module. Specifically, it improves the documentation for the `get_payment_for_addr` and `remove_payment_for_addr` methods by providing examples and clarifying the argument descriptions. It also adds documentation for the `send_cash_note` method, including an example.

The second patch removes the `get_store_cost_at_address` method, as it is unused and no longer needed.
<!-- reviewpad:summarize:end --> 
