### PR TITLE
chore(node): reduce MAX_UNCOMPRESSED_LOG_FILES to 10

### DIFF
--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::{
 };
 
 const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
-const MAX_UNCOMPRESSED_LOG_FILES: usize = 100;
+const MAX_UNCOMPRESSED_LOG_FILES: usize = 10;
 const MAX_LOG_FILES: usize = 1000;
 // Everything is logged by default
 const ALL_SN_LOGS: &str = "all";


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Jan 24 15:18 UTC
This pull request reduces the MAX_UNCOMPRESSED_LOG_FILES constant from 100 to 10 in the `sn_logging/src/layers.rs` file.
<!-- reviewpad:summarize:end --> 
