### PR TITLE
chore(test): lift up the expectations within address sim test

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -985,11 +985,11 @@ mod tests {
             if iteration == 50 {
                 assert_eq!(0, empty_earned_nodes, "every node has earnt _something_");
                 assert!(
-                    (max_store_cost / min_store_cost) < 60,
+                    (max_store_cost / min_store_cost) < 100,
                     "store cost is balanced"
                 );
                 assert!(
-                    (max_earned / min_earned) < 800,
+                    (max_earned / min_earned) < 1000,
                     "earning distribution is well balanced"
                 );
                 break;


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jan 24 11:57 UTC
This pull request updates the expectations within the address simulation test in the `record_store.rs` file. The test now checks that the ratio of `max_store_cost / min_store_cost` is less than 100 and the ratio of `max_earned / min_earned` is less than 1000 after 50 iterations.
<!-- reviewpad:summarize:end --> 
