### PR TITLE
fix(node): add missing rpc feat for sn_protocol

### DIFF
--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -54,7 +54,7 @@ sn_peers_acquisition= { path="../sn_peers_acquisition", version = "0.2.4" }
 sn_client = { path = "../sn_client", version = "0.102.8" }
 sn_logging = { path = "../sn_logging", version = "0.2.17" }
 sn_networking = { path = "../sn_networking", version = "0.12.36" }
-sn_protocol = { path = "../sn_protocol", version = "0.11.0" }
+sn_protocol = { path = "../sn_protocol", version = "0.11.0", features = ["rpc"]}
 sn_registers = { path = "../sn_registers", version = "0.3.8" }
 sn_transfers = { path = "../sn_transfers", version = "0.14.41" }
 thiserror = "1.0.23"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jan 24 12:45 UTC
This pull request fixes an issue in the sn_node project by adding a missing RPC feature for the sn_protocol dependency in the Cargo.toml file.
<!-- reviewpad:summarize:end --> 
