### PR TITLE
fix(CI): correct regex pattern for long time handling

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -293,13 +293,13 @@ jobs:
         shell: bash
         run: |
           num_of_times=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long cmd handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total cmd long handling time is: $total_long_handling_ms ms"
@@ -308,13 +308,13 @@ jobs:
           total_long_handling=$(($total_long_handling_ms))
           total_num_of_times=$(($num_of_times))
           num_of_times=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long event handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total event long handling time is: $total_long_handling_ms ms"

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -214,13 +214,13 @@ jobs:
         shell: bash
         run: |
           num_of_times=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long cmd handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total cmd long handling time is: $total_long_handling_ms ms"
@@ -229,13 +229,13 @@ jobs:
           total_long_handling=$(($total_long_handling_ms))
           total_num_of_times=$(($num_of_times))
           num_of_times=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long event handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total event long handling time is: $total_long_handling_ms ms"

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -110,12 +110,14 @@ jobs:
       ### Stop Network      ###
       #########################
 
-      - name: Stop the local network
+      - name: Stop the local network and upload logs
         if: always()
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
           platform: ubuntu-latest
+          log_file_prefix: safe_test_logs_generate_bench_charts
+          build: true
 
       #########################
       ### Mem Analysis      ###

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -332,13 +332,13 @@ jobs:
         #   rg "SwarmCmd handled in [^m,µ,n]*s:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats
         run: |
           num_of_times=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long cmd handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmCmd handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total cmd long handling time is: $total_long_handling_ms ms"
@@ -347,13 +347,13 @@ jobs:
           total_long_handling=$(($total_long_handling_ms))
           total_num_of_times=$(($num_of_times))
           num_of_times=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -c --stats |
             rg "(\d+) matches" |
             rg "\d+" -o
           )
           echo "Number of long event handling times: $num_of_times"
           total_long_handling_ms=$(
-            rg "SwarmEvent handled in [^,]*ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
+            rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob safe.* -o --no-line-number --no-filename |
             awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
           )
           echo "Total event long handling time is: $total_long_handling_ms ms"


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jan 24 12:53 UTC
This pull request fixes the regex pattern used for handling long time in the CI. It corrects the pattern for both SwarmCmd and SwarmEvent handling in the benchmark-prs.yml, generate-benchmark-charts.yml, and memcheck.yml files. The patch ensures that the correct time values are captured and calculated when handling cmd and event times.
<!-- reviewpad:summarize:end --> 
