### PR TITLE
fix(CI): log in trace during generate bench chart run

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
+        env:
+          SN_LOG: "all"
         with:
           action: start
           interval: 2000


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jan 24 11:21 UTC
This pull request fixes an issue in the CI workflow related to logging in trace during the generation of benchmark charts. The patch adds an environment variable `SN_LOG` with the value "all", ensuring that all logs are captured. This change enables better analysis and troubleshooting during the benchmark chart generation process.
<!-- reviewpad:summarize:end --> 
