### PR TITLE
ci: add `safenode-manager` to the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,20 +128,20 @@ jobs:
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
           just package-release-assets "safe"
           just package-release-assets "safenode"
-          just package-release-assets "testnet"
           just package-release-assets "faucet"
           just package-release-assets "safenode_rpc_client"
+          just package-release-assets "safenode-manager"
           # The versioned assets are uploaded to both the release and S3 in this target.
           just upload-release-assets
           # Now repackage and upload the artifacts to S3 using 'latest' for the version.
           just package-release-assets "safe" "latest"
           just package-release-assets "safenode" "latest"
-          just package-release-assets "testnet" "latest"
           just package-release-assets "faucet" "latest"
           just package-release-assets "safenode_rpc_client" "latest"
+          just package-release-assets "safenode-manager" "latest"
           just upload-release-assets-to-s3 "safe"
           just upload-release-assets-to-s3 "safenode"
-          just upload-release-assets-to-s3 "testnet"
+          just upload-release-assets-to-s3 "safenode-manager"
           just upload-release-assets-to-s3 "faucet"
           just upload-release-assets-to-s3 "safenode_rpc_client"
       - name: post notification to slack on failure

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -53,3 +53,27 @@ name = "sn_transfers"
 changelog_update = true
 git_release_enable = false
 publish = true
+
+[[package]]
+name = "sn_testnet"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_faucet"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_node_rpc_client"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "token_supplies"
+changelog_update = true
+git_release_enable = false
+publish = true


### PR DESCRIPTION
The node manager is now added in to the release process. As with the other binaries, it will have a Github release and will be uploaded to S3.

A few crates are configured to prevent Github releases, but they will still have their binaries uploaded to S3. This is with the exception of `sn_testnet` which will not have its binaries uploaded anywhere because we're going to phase this crate out, in favour of the node manager.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jan 24 16:39 UTC
This pull request adds the `safenode-manager` to the release process. The node manager will now have a Github release and its binaries will be uploaded to S3. The patch also configures a few crates to prevent Github releases but still upload their binaries to S3, except for the `sn_testnet` crate which will no longer have its binaries uploaded anywhere.
<!-- reviewpad:summarize:end --> 
