### PR TITLE
Fixes broken links in main README   

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Data on the Safe Network is Decentralised, Autonomous, and  built atop of Ka
 
 ### For Users
 
-- [CLI](https://github.com/maidsafe/sn_cli/blob/master/README.md) The Command Line Interface, allowing users to interact with the network from their terminal.
+- [CLI](https://github.com/maidsafe/safe_network/blob/main/sn_cli/README.md) The Command Line Interface, allowing users to interact with the network from their terminal.
 - [Node](https://github.com/maidsafe/sn_node/blob/master/README.md) The backbone of the safe network. Nodes can be run on comoodity hardware and provide storage space and validation of transactions to the network.
 
 ### For Developers

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Data on the Safe Network is Decentralised, Autonomous, and  built atop of Ka
 ### For Users
 
 - [CLI](https://github.com/maidsafe/safe_network/blob/main/sn_cli/README.md) The Command Line Interface, allowing users to interact with the network from their terminal.
-- [Node](https://github.com/maidsafe//safe_network/blob/main/sn_node/README.md) The backbone of the safe network. Nodes can be run on comoodity hardware and provide storage space and validation of transactions to the network.
+- [Node](https://github.com/maidsafe//safe_network/blob/main/sn_node/README.md) The backbone of the safe network. Nodes can be run on commodity hardware and provide storage space and validation of transactions to the network.
 
 ### For Developers
 
@@ -58,7 +58,7 @@ Browser usage is highly experimental, but the wasm32 target for `sn_client` _sho
 - [Networking](https://github.com/maidsafe/safe_network/blob/main/sn_networking/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
 - [Protocol](https://github.com/maidsafe/safe_network/blob/main/sn_protocol/README.md) The protocol used by the safe network.
 - [Transfers](https://github.com/maidsafe/safe_network/blob/main/sn_transfers/README.md) The transfers crate, used to send and receive tokens on the network.
-- [Peers Acquisition](https://github.com/maidsafe/safe_network/blob/main/sn_peers_acqisition/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
+- [Peers Acquisition](https://github.com/maidsafe/safe_network/blob/main/sn_peers_acquisition/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
 - [Build Info](https://github.com/maidsafe/safe_network/blob/main/sn_build_info/README.md) Small helper used to get the build/commit versioning info for debug purposes.
 
 ## Run your MaidSafe Local Test Network in 4 easy Steps

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Browser usage is highly experimental, but the wasm32 target for `sn_client` _sho
 
 ### For the Technical
 
-- [Logging](https://github.com/maidsafe/sn_logging/README.md) The generalised logging crate used by the safe network (backed by the tracing crate).
-- [Metrics](https://github.com/maidsafe/sn_metrics/README.md) The metrics crate used by the safe network.
-- [Networking](https://github.com/maidsafe/sn_networking/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
-- [Protocol](https://github.com/maidsafe/sn_protocol/README.md) The protocol used by the safe network.
-- [Transfers](https://github.com/maidsafe/sn_transfers/README.md) The transfers crate, used to send and receive tokens on the network.
-- [Peers Acquisition](https://github.com/maidsafe/sn_peers_acqisition/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
-- [Build Info](https://github.com/maidsafe/sn_build_info/README.md) Small helper used to get the build/commit versioning info for debug purposes.
+- [Logging](https://github.com/maidsafe/safe_network/blob/main/sn_logging/README.md) The generalised logging crate used by the safe network (backed by the tracing crate).
+- [Metrics](https://github.com/maidsafe/safe_network/blob/main/sn_metrics/README.md) The metrics crate used by the safe network.
+- [Networking](https://github.com/maidsafe/safe_network/blob/main/sn_networking/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
+- [Protocol](https://github.com/maidsafe/safe_network/blob/main/sn_protocol/README.md) The protocol used by the safe network.
+- [Transfers](https://github.com/maidsafe/safe_network/blob/main/sn_transfers/README.md) The transfers crate, used to send and receive tokens on the network.
+- [Peers Acquisition](https://github.com/maidsafe/safe_network/blob/main/sn_peers_acqisition/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
+- [Build Info](https://github.com/maidsafe/safe_network/blob/main/sn_build_info/README.md) Small helper used to get the build/commit versioning info for debug purposes.
 
 ## Run your MaidSafe Local Test Network in 4 easy Steps
 Before you start, make sure to have **[Rust installed](https://www.rust-lang.org/learn/get-started)** and the latest version with `rustup update`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Data on the Safe Network is Decentralised, Autonomous, and  built atop of Ka
 
 ### For Developers
 
-- [Client](https://github.com/maidsafe/sn_client/blob/master/README.md) The client APIs allowing use of the SafeNetwork to users and developers.
+- [Client](https://github.com/maidsafe/safe_network/blob/main/sn_client/README.md) The client APIs allowing use of the SafeNetwork to users and developers.
 - [Registers](https://github.com/maidsafe/sn_registers/blob/master/README.md) The CRDT registers structures available on the network.
 - [Testnet](https://github.com/maidsafe/sn_testnet/blob/master/README.md) The testnet crate, used to set up a local network for development and testing.
 - [Faucet](https://github.com/maidsafe/sn_faucet/blob/master/README.md) The local faucet server, used to claim genesis and request tokens from the network.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Browser usage is highly experimental, but the wasm32 target for `sn_client` _sho
 ### For the Technical
 
 - [Logging](https://github.com/maidsafe/safe_network/blob/main/sn_logging/README.md) The generalised logging crate used by the safe network (backed by the tracing crate).
-- [Metrics](https://github.com/maidsafe/safe_network/blob/main/sn_metrics/README.md) The metrics crate used by the safe network.
+- [Metrics](https://github.com/maidsafe/safe_network/blob/main/metrics/README.md) The metrics crate used by the safe network.
 - [Networking](https://github.com/maidsafe/safe_network/blob/main/sn_networking/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
 - [Protocol](https://github.com/maidsafe/safe_network/blob/main/sn_protocol/README.md) The protocol used by the safe network.
 - [Transfers](https://github.com/maidsafe/safe_network/blob/main/sn_transfers/README.md) The transfers crate, used to send and receive tokens on the network.

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The Data on the Safe Network is Decentralised, Autonomous, and  built atop of Ka
 ### For Users
 
 - [CLI](https://github.com/maidsafe/safe_network/blob/main/sn_cli/README.md) The Command Line Interface, allowing users to interact with the network from their terminal.
-- [Node](https://github.com/maidsafe/sn_node/blob/master/README.md) The backbone of the safe network. Nodes can be run on comoodity hardware and provide storage space and validation of transactions to the network.
+- [Node](https://github.com/maidsafe//safe_network/blob/main/sn_node/README.md) The backbone of the safe network. Nodes can be run on comoodity hardware and provide storage space and validation of transactions to the network.
 
 ### For Developers
 
 - [Client](https://github.com/maidsafe/safe_network/blob/main/sn_client/README.md) The client APIs allowing use of the SafeNetwork to users and developers.
-- [Registers](https://github.com/maidsafe/sn_registers/blob/master/README.md) The CRDT registers structures available on the network.
-- [Testnet](https://github.com/maidsafe/sn_testnet/blob/master/README.md) The testnet crate, used to set up a local network for development and testing.
-- [Faucet](https://github.com/maidsafe/sn_faucet/blob/master/README.md) The local faucet server, used to claim genesis and request tokens from the network.
-- [Node RPC](https://github.com/maidsafe/sn_node_rpc_client/blob/master/README.md) The RPC server used by the nodes to expose API calls to the outside world.
+- [Registers](https://github.com/maidsafe/safe_network/blob/main/sn_registers/README.md) The CRDT registers structures available on the network.
+- [Testnet](https://github.com/maidsafe/safe_network/blob/main/sn_testnet/README.md) The testnet crate, used to set up a local network for development and testing.
+- [Faucet](https://github.com/maidsafe/safe_network/blob/main/sn_faucet/README.md) The local faucet server, used to claim genesis and request tokens from the network.
+- [Node RPC](https://github.com/maidsafe/safe_network/blob/main/sn_node_rpc_client/README.md) The RPC server used by the nodes to expose API calls to the outside world.
 
 #### Transport Protocols and Architectures
 
@@ -53,13 +53,13 @@ Browser usage is highly experimental, but the wasm32 target for `sn_client` _sho
 
 ### For the Technical
 
-- [Logging](https://github.com/maidsafe/sn_logging/blob/master/README.md) The generalised logging crate used by the safe network (backed by the tracing crate).
-- [Metrics](https://github.com/maidsafe/sn_metrics/blob/master/README.md) The metrics crate used by the safe network.
-- [Networking](https://github.com/maidsafe/sn_networking/blob/master/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
-- [Protocol](https://github.com/maidsafe/sn_protocol/blob/master/README.md) The protocol used by the safe network.
-- [Transfers](https://github.com/maidsafe/sn_transfers/blob/master/README.md) The transfers crate, used to send and receive tokens on the network.
-- [Peers Acquisition](https://github.com/maidsafe/sn_peers_acqisition/blob/master/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
-- [Build Info](https://github.com/maidsafe/sn_build_info/blob/master/README.md) Small helper used to get the build/commit versioning info for debug purposes.
+- [Logging](https://github.com/maidsafe/sn_logging/README.md) The generalised logging crate used by the safe network (backed by the tracing crate).
+- [Metrics](https://github.com/maidsafe/sn_metrics/README.md) The metrics crate used by the safe network.
+- [Networking](https://github.com/maidsafe/sn_networking/README.md) The networking layer, built atop libp2p which allows nodes and clients to communicate.
+- [Protocol](https://github.com/maidsafe/sn_protocol/README.md) The protocol used by the safe network.
+- [Transfers](https://github.com/maidsafe/sn_transfers/README.md) The transfers crate, used to send and receive tokens on the network.
+- [Peers Acquisition](https://github.com/maidsafe/sn_peers_acqisition/README.md) The peers peers acqisition crate, or: how the network layer discovers bootstrap peers.
+- [Build Info](https://github.com/maidsafe/sn_build_info/README.md) Small helper used to get the build/commit versioning info for debug purposes.
 
 ## Run your MaidSafe Local Test Network in 4 easy Steps
 Before you start, make sure to have **[Rust installed](https://www.rust-lang.org/learn/get-started)** and the latest version with `rustup update`


### PR DESCRIPTION
## Description
See issue 1232

many links in https://github.com/maidsafe/safe_network/blob/main/README.md were GitHub 404s

 <!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jan 24 04:40 UTC
This pull request updates the links in the README.md file to the correct locations for various components of the Safe Network. The updated links now point to the main branch instead of the master branch. This ensures that users and developers can access the correct documentation for each component. Additionally, some typos in the file have been fixed.
<!-- reviewpad:summarize:end --> 
