### PR TITLE
Improve Error Handling for Node Manager `add` and `start` Commands

### DIFF
--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -9,6 +9,7 @@
 use crate::config::create_owned_dir;
 use crate::helpers::download_and_extract_release;
 use crate::service::{ServiceConfig, ServiceControl};
+use crate::VerbosityLevel;
 use color_eyre::{eyre::eyre, Help, Result};
 use colored::Colorize;
 use libp2p::Multiaddr;
@@ -42,6 +43,7 @@ pub async fn add(
     node_registry: &mut NodeRegistry,
     service_control: &dyn ServiceControl,
     release_repo: Box<dyn SafeReleaseRepositoryInterface>,
+    verbosity: VerbosityLevel,
 ) -> Result<()> {
     if install_options.genesis {
         if let Some(count) = install_options.count {
@@ -188,11 +190,13 @@ pub async fn add(
         println!("Services Added:");
         for install in added_service_data.iter() {
             println!(" {} {}", "✓".green(), install.0);
-            println!("    - Safenode path: {}", install.1);
-            println!("    - Data path: {}", install.2);
-            println!("    - Log path: {}", install.3);
-            println!("    - Service port: {}", install.4);
-            println!("    - RPC port: {}", install.5);
+            if verbosity != VerbosityLevel::Minimal {
+                println!("    - Safenode path: {}", install.1);
+                println!("    - Data path: {}", install.2);
+                println!("    - Log path: {}", install.3);
+                println!("    - Service port: {}", install.4);
+                println!("    - RPC port: {}", install.5);
+            }
         }
         println!("[!] Note: newly added services have not been started");
     }
@@ -377,6 +381,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -467,6 +472,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
         )
         .await;
 
@@ -520,6 +526,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
         )
         .await;
 
@@ -711,6 +718,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -871,6 +879,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -1023,6 +1032,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -1149,6 +1159,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -1293,6 +1304,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
         )
         .await?;
 
@@ -1365,6 +1377,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
         )
         .await;
 
@@ -1434,6 +1447,7 @@ mod tests {
             &mut node_registry,
             &mock_service_control,
             Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
         )
         .await;
 
@@ -1488,6 +1502,7 @@ mod tests {
             &mut node_registry,
             &MockServiceControl::new(),
             Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
         )
         .await;
 

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -102,7 +102,7 @@ pub enum SubCmd {
         /// This option can be used to test a safenode binary that has been built from a forked
         /// branch and uploaded somewhere. A typical use case would be for a developer who launches
         /// a testnet to test some changes they have on a fork.
-        #[clap(long)]
+        #[clap(long, conflicts_with = "version")]
         url: Option<String>,
         /// The user the service should run as.
         ///
@@ -307,14 +307,6 @@ async fn main() -> Result<()> {
         } => {
             if !is_running_as_root() {
                 return Err(eyre!("The add command must run as the root user"));
-            }
-
-            if url.is_some() && version.is_some() {
-                return Err(
-                    eyre!("The url and version arguments are mutually exclusive").suggestion(
-                        "Please try again specifying either url or version, but not both.",
-                    ),
-                );
             }
 
             println!("=================================================");


### PR DESCRIPTION
- 28e22de1 **chore: version and url arguments conflict**

  Use `clap` to indicate that the `--version` and `--url` arguments are mutually exclusive rather than
  doing it manually.

- 2ae12061 **chore: improve error handling for `add` command**

  If there is an attempt to add many services, we will try adding all of them, even if there is an
  error at some point when one service is being added. The results will then be summarised at the end.
  If there were any failed services, we'll return an error, but the services that were added
  successfully will continue to be usable.

- 5f9694ce **chore: improve error handling for `start` command**

  As with the `add` command, the `start` command can apply to many services. It is also changed such
  that it will attempt to start every service, even if there are others that don't start. If any fail,
  the command will return an error, but the services that were started will remain usable.

  This behaviour is useful for the testnet deployment process.

- cbe3612d **chore: provide verbosity level**

  At the moment this only applies to two commands, namely `add` and `start`. This is because these are
  commands that are used during the testnet deployment process and they would benefit from having more
  minimal output.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jan 24 21:40 UTC
This pull request includes the following changes:

- Added an import statement for the crate `VerbosityLevel`.
- Added a new parameter `verbosity` of type `VerbosityLevel` to the function `start`.
- Added a conditional check for the `verbosity` parameter before printing a message in the `start` function.
- Added a conditional check for the `verbosity` parameter before printing two more messages in the `start` function.
- Updated the function `upgrade` to pass `VerbosityLevel::Normal` as the value for the `verbosity` parameter in the `start` function.
- Added a new enum `VerbosityLevel` with variants `Minimal`, `Normal`, and `Full`.
- Implemented a `From<u8>` trait for the `VerbosityLevel` enum to convert a u8 value to the corresponding enum variant.
- Added a `verbose` field to the `Cmd` struct, annotated with clap attributes to specify its behavior.
- Modified the `SubCmd::Add` variant by adding a check for verbosity level to print information about adding safenode services.
- Modified the `SubCmd::Start` variant by adding a check for verbosity level to print information about starting safenode services.
- Modified the `start` function to accept the `verbosity` parameter and added additional logic to handle different verbosity levels.
- Added a check to print information about failed services if any services failed to start.
- Updated the error message for failing to start one or more services to include additional information and a suggestion.

Please let me know if you have any questions regarding these changes.
<!-- reviewpad:summarize:end --> 
