### PR TITLE
fix(ci): specify custom CARGO_TARGET_DIR for nightly

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -130,11 +130,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo cache registry, index and build
         uses: actions/cache@v4.0.0
@@ -159,11 +158,10 @@ jobs:
           - { os: windows-latest }
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - shell: bash
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -374,8 +374,7 @@ jobs:
           platform: ${{ matrix.os }}
           build: true
 
-      - name: Gossipsub - nodes to subscribe to topics, and publish messages 
-        if: matrix.os == 'windows-latest'
+      - name: Gossipsub - nodes to subscribe to topics, and publish messages
         run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -170,6 +170,10 @@ jobs:
 
       - name: Build gossipsub testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test msgs_over_gossipsub --no-run
+        env:
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
 
       - name: Start a local network
@@ -184,6 +188,8 @@ jobs:
 
       - name: Gossipsub - nodes to subscribe to topics, and publish messages 
         run: cargo test --release -p sn_node --features local-discovery --test msgs_over_gossipsub -- --nocapture
+        env:
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 20
 
       - name: Stop the local network and upload logs
@@ -215,9 +221,11 @@ jobs:
 
       - name: Build testing executable
         run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test nodes_rewards --no-run
-        timeout-minutes: 30
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 30
 
       - name: Start a local network
         uses: maidsafe/sn-local-testnet-action@main
@@ -233,28 +241,27 @@ jobs:
       - name: execute the nodes rewards tests
         run: cargo test --release -p sn_node --features="local-discovery" --test nodes_rewards -- --nocapture --test-threads=1
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           SN_LOG: "all"
         timeout-minutes: 25
 
       - name: execute the spend test
         run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: execute the storage payment tests
         run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1          
         env:
-          CARGO_TARGET_DIR: "./transfer-target"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           SN_LOG: "all"
         timeout-minutes: 10
 
       - name: Small wait to allow reward receipt
         run: sleep 30
         timeout-minutes: 1
-
       
       - name: Stop the local network and upload logs
         if: always()
@@ -302,6 +309,10 @@ jobs:
 
       - name: Build churn tests 
         run: cargo test --release -p sn_node --features=local-discovery --test data_with_churn --no-run
+        env:
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
 
       - name: Start a local network
@@ -320,6 +331,7 @@ jobs:
           TEST_DURATION_MINS: 60
           TEST_CHURN_CYCLES: 6
           SN_LOG: "all"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 90
       
       - name: Verify restart of nodes using rg
@@ -422,6 +434,10 @@ jobs:
 
         - name: Build data location and routing table tests
           run: cargo test --release -p sn_node --features=local-discovery --test verify_data_location --test verify_routing_table --no-run
+          env:
+            # only set the target dir for windows to bypass the linker issue.
+            # happens if we build the node manager via testnet action
+            CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           timeout-minutes: 30
 
         - name: Start a local network
@@ -436,16 +452,21 @@ jobs:
 
         - name: Verify the Routing table of the nodes
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture
+          env:
+            CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           timeout-minutes: 5
 
         - name: Verify the location of the data on the network
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_data_location -- --nocapture
           env:
             SN_LOG: "all"
+            CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           timeout-minutes: 90
 
         - name: Verify the routing tables of the nodes
           run: cargo test --release -p sn_node --features="local-discovery" --test verify_routing_table -- --nocapture 
+          env:
+            CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           timeout-minutes: 5
         
         - name: Verify restart of nodes using rg


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jan 24 10:08 UTC
This pull request fixes an issue in the CI pipeline by specifying a custom CARGO_TARGET_DIR for the nightly workflow. The patch modifies the `.github/workflows/nightly.yml` file by adding environment variables `CARGO_TARGET_DIR` to the `Build gossipsub testing executable`, `Gossipsub - nodes to subscribe to topics, and publish messages`, `Build testing executable`, `execute the nodes rewards tests`, `execute the spend test`, `execute the storage payment tests`, `Build churn tests`, `Verify the Routing table of the nodes`, and `Verify the location of the data on the network` steps. These environment variables set the target directory for cargo build commands based on the operating system being used.
<!-- reviewpad:summarize:end --> 
