### PR TITLE
chore(manager): make VerbosityLevel a public type

### DIFF
--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -34,7 +34,7 @@ use std::str::FromStr;
 const DEFAULT_NODE_COUNT: u16 = 25;
 
 #[derive(Clone, PartialEq)]
-enum VerbosityLevel {
+pub enum VerbosityLevel {
     Minimal,
     Normal,
     Full,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jan 24 13:11 UTC
This pull request updates the `sn_node_manager` code by making the `VerbosityLevel` enum a public type.
<!-- reviewpad:summarize:end --> 
