### PR TITLE
refactor(manager): provide rpc address instead of rpc port

### DIFF
--- a/sn_node/tests/common/client.rs
+++ b/sn_node/tests/common/client.rs
@@ -13,10 +13,7 @@ use sn_peers_acquisition::parse_peer_addr;
 use sn_protocol::node_registry::{get_local_node_registry_path, NodeRegistry};
 use sn_protocol::test_utils::DeploymentInventory;
 use sn_transfers::{create_faucet_wallet, LocalWallet, NanoTokens, Transfer};
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::Path,
-};
+use std::{net::SocketAddr, path::Path};
 use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 use tracing::{error, info, warn};
@@ -92,7 +89,7 @@ pub fn get_all_rpc_addresses(skip_genesis_for_droplet: bool) -> Result<Vec<Socke
             let addresses = local_node_registry
                 .nodes
                 .iter()
-                .map(|n| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), n.rpc_port))
+                .map(|n| n.rpc_socket_addr)
                 .collect::<Vec<SocketAddr>>();
             Ok(addresses)
         }

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -112,7 +112,7 @@ pub async fn status(
     // Again confirm that services which are marked running are still actually running.
     // If they aren't we'll mark them as stopped.
     for node in &mut node_registry.nodes {
-        let rpc_client = RpcClient::new(&format!("https://127.0.0.1:{}", node.rpc_port));
+        let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
         if let NodeStatus::Running = node.status {
             if let Some(pid) = node.pid {
                 // First we can try the PID we have now. If there is still a process running with
@@ -171,7 +171,7 @@ pub async fn status(
                 node.peer_id.map_or("-".to_string(), |p| p.to_string())
             );
             println!("Port: {}", node.port);
-            println!("RPC Port: {}", node.rpc_port);
+            println!("RPC Socket: {}", node.rpc_socket_addr);
             println!(
                 "Multiaddr: {}",
                 node.get_multiaddr()
@@ -346,6 +346,9 @@ mod tests {
         NetworkInfo, NodeInfo, RecordAddress, Result as RpcResult, RpcActions,
     };
     use sn_protocol::node_registry::{Node, NodeStatus};
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -398,7 +401,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Added,
             pid: None,
             peer_id: None,
@@ -462,7 +465,7 @@ mod tests {
             user: "safe".to_string(),
             number: 2,
             port: 8082,
-            rpc_port: 8083,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8083),
             status: NodeStatus::Stopped,
             pid: Some(1001),
             peer_id: Some(PeerId::from_str(
@@ -528,7 +531,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Running,
             pid: Some(1000),
             peer_id: Some(PeerId::from_str(
@@ -585,7 +588,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Running,
             pid: Some(1000),
             peer_id: Some(PeerId::from_str(
@@ -634,7 +637,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Running,
             pid: Some(1000),
             peer_id: Some(PeerId::from_str(
@@ -676,7 +679,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Added,
             pid: None,
             peer_id: None,
@@ -715,7 +718,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Stopped,
             pid: None,
             peer_id: None,
@@ -759,7 +762,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Stopped,
             pid: None,
             peer_id: None,
@@ -798,7 +801,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Running,
             pid: Some(1000),
             peer_id: Some(PeerId::from_str(
@@ -846,7 +849,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Running,
             pid: Some(1000),
             peer_id: Some(PeerId::from_str(
@@ -897,7 +900,7 @@ mod tests {
             user: "safe".to_string(),
             number: 1,
             port: 8080,
-            rpc_port: 8081,
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
             status: NodeStatus::Stopped,
             pid: None,
             peer_id: None,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -36,7 +36,7 @@ pub struct ServiceConfig {
     pub name: String,
     pub node_port: u16,
     pub peers: Vec<Multiaddr>,
-    pub rpc_port: u16,
+    pub rpc_socket_addr: SocketAddr,
     pub safenode_path: PathBuf,
     pub service_user: String,
 }
@@ -190,7 +190,7 @@ impl ServiceControl for NodeServiceManager {
             OsString::from("--port"),
             OsString::from(config.node_port.to_string()),
             OsString::from("--rpc"),
-            OsString::from(format!("127.0.0.1:{}", config.rpc_port)),
+            OsString::from(config.rpc_socket_addr.to_string()),
             OsString::from("--root-dir"),
             OsString::from(config.data_dir_path.to_string_lossy().to_string()),
             OsString::from("--log-output-dest"),

--- a/sn_node_rpc_client/src/lib.rs
+++ b/sn_node_rpc_client/src/lib.rs
@@ -10,6 +10,7 @@ use sn_protocol::safenode_proto::{
     GossipsubUnsubscribeRequest, NetworkInfoRequest, NodeInfoRequest, RecordAddressesRequest,
     RestartRequest, StopRequest, UpdateRequest,
 };
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use tokio::time::Duration;
@@ -54,10 +55,15 @@ pub struct RpcClient {
 }
 
 impl RpcClient {
-    pub fn new(endpoint: &str) -> RpcClient {
-        RpcClient {
+    pub fn new(endpoint: &str) -> Self {
+        Self {
             endpoint: endpoint.to_string(),
         }
+    }
+
+    pub fn from_socket_addr(socket: SocketAddr) -> Self {
+        let endpoint = format!("https://{socket}");
+        Self { endpoint }
     }
 }
 

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -9,11 +9,13 @@
 use crate::Error;
 use color_eyre::Result;
 use libp2p::{Multiaddr, PeerId};
-use serde::de::Error as DeError;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    io::{Read, Write},
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum NodeStatus {
@@ -92,7 +94,7 @@ pub struct Node {
     pub user: String,
     pub number: u16,
     pub port: u16,
-    pub rpc_port: u16,
+    pub rpc_socket_addr: SocketAddr,
     pub status: NodeStatus,
     pub pid: Option<u32>,
     #[serde(


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jan 24 13:59 UTC
This pull request includes the following changes:

1. In `node_registry.rs`, the `rpc_port` field in the `Node` struct has been replaced with the `rpc_socket_addr` field of type `SocketAddr`. An import for `net::SocketAddr` has also been added.

2. In a different file, an import statement for `std::net::SocketAddr` has been added. Two new implementations for the `new` and `from_socket_addr` functions of the `RpcClient` struct have been added, which take an endpoint of type `SocketAddr`.

3. In `service.rs`, the `ServiceConfig` struct and the `NodeServiceManager` implementation have been modified. The `rpc_port` field in `ServiceConfig` has been replaced with `rpc_socket_addr` of type `SocketAddr`. The `--rpc` command line argument in the `NodeServiceManager` implementation has been updated to use `config.rpc_socket_addr.to_string()` instead of `config.rpc_port.to_string()`.

4. In `main.rs` file of the `sn_node_manager` project, multiple changes have been made, including module imports using glob syntax, renaming the `rpc_port` field to `rpc_address`, accepting an `Ipv4Addr` in the `port` field instead of a u16 port number. Some function calls have been updated to use the new `RpcClient::from_socket_addr` method, as well as changes in the `start`, `upgrade`, and related functions.

5. In `control.rs`, changes include replacing `RpcClient::new` with `RpcClient::from_socket_addr` method call, updating the `println!` statement to use `node.rpc_socket_addr`, and adding tests for `RpcClient::from_socket_addr` with different IP address values for `rpc_socket_addr`.

6. In `client.rs`, multiple import statements have been added or modified, including `parse_peer_addr` and `NodeRegistry` from `sn_protocol` module, `DeploymentInventory` from `sn_protocol::test_utils` module, `LocalWallet`, `NanoTokens`, and `Transfer` from `sn_transfers` module, and various imports from the `std::net` and `tokio` modules. The `get_all_rpc_addresses` function now uses `n.rpc_socket_addr` instead of creating `SocketAddr` using `Ipv4Addr`.

7. In a different file, changes have been made to import statements for `std::net` module, addition of `rpc_socket_addr` argument to `launch_node` function and its implementation, creating `rpc_socket_addr` using `Ipv4Addr::new` and `SocketAddr::new` functions in `run_network` function, using `RpcClient::from_socket_addr` instead of `RpcClient::new`, updating arguments in `run_node` function, adding `rpc_socket_addr` field in `Node` struct of `NodeRegistry`, using `RpcClient::from_socket_addr` instead of `RpcClient::new` in `validate_network` function, and updating arguments in unit tests.

These changes reflect various modifications in the code related to RPC communication, network configuration, and imports.

Please let me know if you need further details about any specific change.
<!-- reviewpad:summarize:end --> 
