### PR TITLE
chore(manager): use TcpListener to check free port

### DIFF
--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -14,9 +14,7 @@ path="src/main.rs"
 name="safenode-manager"
 
 [features]
-default = ["quic"]
-quic = []
-tcp = []
+default = []
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive", "env"]}

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
-/// 3
+/// 4
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -14,14 +14,13 @@ use service_manager::{
     ServiceInstallCtx, ServiceLabel, ServiceManager, ServiceStartCtx, ServiceStopCtx,
     ServiceUninstallCtx,
 };
-use std::net::SocketAddr;
-#[cfg(feature = "tcp")]
-use std::net::TcpListener as SocketBinder;
-#[cfg(not(feature = "tcp"))]
-use std::net::UdpSocket as SocketBinder;
-use std::path::PathBuf;
-use std::time::Duration;
-use std::{ffi::OsString, thread::sleep};
+use std::{
+    ffi::OsString,
+    net::{SocketAddr, TcpListener},
+    path::PathBuf,
+    thread::sleep,
+    time::Duration,
+};
 use sysinfo::{Pid, System, SystemExt};
 
 // The UDP port might fail to unbind even when dropped and this can cause the safenode process to throw errors.
@@ -154,7 +153,7 @@ impl ServiceControl for NodeServiceManager {
     }
 
     fn is_port_free(&self, port: u16) -> bool {
-        let socket = SocketBinder::bind(("127.0.0.1", port));
+        let socket = TcpListener::bind(("127.0.0.1", port));
         let is_free = socket.is_ok();
         drop(socket);
         // Sleep a little while to make sure that we've dropped the socket.
@@ -173,7 +172,7 @@ impl ServiceControl for NodeServiceManager {
     fn get_available_port(&self) -> Result<u16> {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-        let socket = SocketBinder::bind(addr)?;
+        let socket = TcpListener::bind(addr)?;
         let port = socket.local_addr()?.port();
         drop(socket);
         // Sleep a little while to make sure that we've dropped the socket.

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
-/// 4
+/// 5
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,6 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
+/// 1
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
-/// 1
+/// 2
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -18,13 +18,8 @@ use std::{
     ffi::OsString,
     net::{SocketAddr, TcpListener},
     path::PathBuf,
-    thread::sleep,
-    time::Duration,
 };
 use sysinfo::{Pid, System, SystemExt};
-
-// The UDP port might fail to unbind even when dropped and this can cause the safenode process to throw errors.
-const PORT_UNBINDING_DELAY: Duration = Duration::from_secs(3);
 
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
@@ -156,9 +151,6 @@ impl ServiceControl for NodeServiceManager {
         let socket = TcpListener::bind(("127.0.0.1", port));
         let is_free = socket.is_ok();
         drop(socket);
-        // Sleep a little while to make sure that we've dropped the socket.
-        // Without the delay, we may face 'Port already in use' error, when trying to re-use this port.
-        sleep(PORT_UNBINDING_DELAY);
 
         is_free
     }
@@ -175,9 +167,6 @@ impl ServiceControl for NodeServiceManager {
         let socket = TcpListener::bind(addr)?;
         let port = socket.local_addr()?.port();
         drop(socket);
-        // Sleep a little while to make sure that we've dropped the socket.
-        // Without the delay, we may face 'Port already in use' error, when trying to re-use this port.
-        sleep(PORT_UNBINDING_DELAY);
 
         Ok(port)
     }

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
-/// 2
+/// 3
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use sysinfo::{Pid, System, SystemExt};
 
-/// 5
+/// 6
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jan 24 14:36 UTC
This pull request updates the `sn_node_manager` module by using `TcpListener` instead of `SocketBinder` in the `service.rs` file. It also includes some changes to the `Cargo.toml` file.
<!-- reviewpad:summarize:end --> 
