### PR TITLE
fix(manager): obtain node listen addr using RPC

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -503,8 +503,11 @@ impl SwarmDriver {
                                     there_is_a_serious_issue = true
                                 }
                                 TransportError::Other(err) => {
-                                    let problematic_errors =
-                                        ["ConnectionRefused", "HostUnreachable"];
+                                    let problematic_errors = [
+                                        "ConnectionRefused",
+                                        "HostUnreachable",
+                                        "HandshakeTimedOut",
+                                    ];
                                     // It is really difficult to match this error, due to being eg:
                                     // Custom { kind: Other, error: Left(Left(Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) }
                                     // if we can match that, let's. But meanwhile we'll check the message

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -45,7 +45,7 @@ const CHUNK_SIZE: usize = 1024;
 // for the old peer to be removed from the routing table.
 // Replication is then kicked off to distribute the data to the new closest
 // nodes, hence verification has to be performed after this.
-const VERIFICATION_DELAY: Duration = Duration::from_secs(20);
+const VERIFICATION_DELAY: Duration = Duration::from_secs(60);
 
 /// Number of times to retry verification if it fails
 const VERIFICATION_ATTEMPTS: usize = 5;

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -14,9 +14,7 @@ path="src/main.rs"
 name="safenode-manager"
 
 [features]
-default = ["quic"]
-quic = []
-tcp = []
+default = []
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive", "env"]}

--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -27,6 +27,7 @@ pub struct AddServiceOptions {
     pub genesis: bool,
     pub local: bool,
     pub peers: Vec<Multiaddr>,
+    pub node_port: Option<u16>,
     pub rpc_address: Option<Ipv4Addr>,
     pub safenode_dir_path: PathBuf,
     pub service_data_dir_path: PathBuf,
@@ -59,6 +60,15 @@ pub async fn add(
         let genesis_node = node_registry.nodes.iter().find(|n| n.genesis);
         if genesis_node.is_some() {
             return Err(eyre!("A genesis node already exists"));
+        }
+    }
+
+    if install_options.count.is_some() && install_options.node_port.is_some() {
+        let count = install_options.count.unwrap();
+        if count > 1 {
+            return Err(eyre!(
+                "Custom node port can only be used when adding a single service"
+            ));
         }
     }
 
@@ -112,6 +122,7 @@ pub async fn add(
             genesis: install_options.genesis,
             log_dir_path: service_log_dir_path.clone(),
             name: service_name.clone(),
+            node_port: install_options.node_port,
             peers: install_options.peers.clone(),
             rpc_socket_addr,
             safenode_path: service_safenode_path.clone(),
@@ -317,6 +328,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode1")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
@@ -334,6 +346,7 @@ mod tests {
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
+                node_port: None,
                 peers: vec![],
                 rpc_address: None,
                 url: None,
@@ -425,6 +438,7 @@ mod tests {
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
+                node_port: None,
                 peers: vec![],
                 rpc_address: Some(custom_rpc_address),
                 url: None,
@@ -477,6 +491,7 @@ mod tests {
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
+                node_port: None,
                 peers: vec![],
                 rpc_address: Some(custom_rpc_address),
                 url: None,
@@ -579,6 +594,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode1")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
@@ -606,6 +622,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode2")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8083),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
@@ -633,6 +650,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode3")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8085),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode3"),
@@ -648,6 +666,7 @@ mod tests {
                 genesis: false,
                 count: Some(3),
                 peers: vec![],
+                node_port: None,
                 rpc_address: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
@@ -793,6 +812,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode1")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
@@ -808,6 +828,7 @@ mod tests {
                 genesis: false,
                 count: None,
                 peers: vec![],
+                node_port: None,
                 rpc_address: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
@@ -941,6 +962,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode2")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8083),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
@@ -956,6 +978,7 @@ mod tests {
                 genesis: false,
                 count: None,
                 peers: vec![],
+                node_port: None,
                 rpc_address: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
@@ -1063,6 +1086,7 @@ mod tests {
                     .to_path_buf()
                     .join("safenode1")
                     .join(SAFENODE_FILE_NAME),
+                node_port: None,
                 rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
@@ -1081,6 +1105,7 @@ mod tests {
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 peers: vec![],
+                node_port: None,
                 rpc_address: None,
                 url: Some(url.to_string()),
                 user: get_username(),
@@ -1115,6 +1140,199 @@ mod tests {
             Some(node_data_dir.to_path_buf().join("safenode1"))
         );
         assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
+        let tmp_data_dir = assert_fs::TempDir::new()?;
+        let node_reg_path = tmp_data_dir.child("node_reg.json");
+
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let mut node_registry = NodeRegistry {
+            save_path: node_reg_path.to_path_buf(),
+            nodes: vec![],
+            faucet_pid: None,
+        };
+        let latest_version = "0.96.4";
+        let temp_dir = assert_fs::TempDir::new()?;
+        let node_data_dir = temp_dir.child("data");
+        node_data_dir.create_dir_all()?;
+        let node_logs_dir = temp_dir.child("logs");
+        node_logs_dir.create_dir_all()?;
+        let safenode_download_path = temp_dir.child(SAFENODE_FILE_NAME);
+        safenode_download_path.write_binary(b"fake safenode bin")?;
+
+        let custom_port = 12000;
+
+        let mut seq = Sequence::new();
+
+        mock_release_repo
+            .expect_get_latest_version()
+            .times(1)
+            .returning(|_| Ok(latest_version.to_string()))
+            .in_sequence(&mut seq);
+
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(latest_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_download_path_clone = safenode_download_path.to_path_buf().clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                ))),
+                always(), // We will extract to a temporary directory
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_download_path_clone.clone()))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(12001))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(eq(ServiceConfig {
+                local: false,
+                genesis: false,
+                name: "safenode1".to_string(),
+                safenode_path: node_data_dir
+                    .to_path_buf()
+                    .join("safenode1")
+                    .join(SAFENODE_FILE_NAME),
+                node_port: Some(custom_port),
+                rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12001),
+                service_user: get_username(),
+                log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
+                data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
+                peers: vec![],
+            }))
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        add(
+            AddServiceOptions {
+                local: false,
+                genesis: false,
+                count: None,
+                safenode_dir_path: temp_dir.to_path_buf(),
+                service_data_dir_path: node_data_dir.to_path_buf(),
+                service_log_dir_path: node_logs_dir.to_path_buf(),
+                peers: vec![],
+                node_port: Some(custom_port),
+                rpc_address: Some(Ipv4Addr::new(127, 0, 0, 1)),
+                url: None,
+                user: get_username(),
+                version: None,
+            },
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+            VerbosityLevel::Normal,
+        )
+        .await?;
+
+        safenode_download_path.assert(predicate::path::missing());
+        node_data_dir.assert(predicate::path::is_dir());
+        node_logs_dir.assert(predicate::path::is_dir());
+
+        assert_eq!(node_registry.nodes.len(), 1);
+        assert_eq!(node_registry.nodes[0].version, latest_version);
+        assert_eq!(node_registry.nodes[0].service_name, "safenode1");
+        assert_eq!(node_registry.nodes[0].user, get_username());
+        assert_eq!(node_registry.nodes[0].number, 1);
+        assert_eq!(
+            node_registry.nodes[0].rpc_socket_addr,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12001)
+        );
+        assert_eq!(
+            node_registry.nodes[0].log_dir_path,
+            Some(node_logs_dir.to_path_buf().join("safenode1"))
+        );
+        assert_eq!(
+            node_registry.nodes[0].data_dir_path,
+            Some(node_data_dir.to_path_buf().join("safenode1"))
+        );
+        assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_node_should_return_error_if_custom_port_is_used_and_more_than_one_service_is_used(
+    ) -> Result<()> {
+        let tmp_data_dir = assert_fs::TempDir::new()?;
+        let node_reg_path = tmp_data_dir.child("node_reg.json");
+
+        let mut node_registry = NodeRegistry {
+            save_path: node_reg_path.to_path_buf(),
+            nodes: vec![],
+            faucet_pid: None,
+        };
+        let temp_dir = assert_fs::TempDir::new()?;
+        let node_data_dir = temp_dir.child("data");
+        node_data_dir.create_dir_all()?;
+        let node_logs_dir = temp_dir.child("logs");
+        node_logs_dir.create_dir_all()?;
+
+        let custom_port = 12000;
+
+        let result = add(
+            AddServiceOptions {
+                local: true,
+                genesis: false,
+                count: Some(3),
+                safenode_dir_path: temp_dir.to_path_buf(),
+                service_data_dir_path: node_data_dir.to_path_buf(),
+                service_log_dir_path: node_logs_dir.to_path_buf(),
+                peers: vec![],
+                node_port: Some(custom_port),
+                rpc_address: None,
+                url: None,
+                user: get_username(),
+                version: None,
+            },
+            &mut node_registry,
+            &MockServiceControl::new(),
+            Box::new(MockSafeReleaseRepository::new()),
+            VerbosityLevel::Normal,
+        )
+        .await;
+
+        match result {
+            Ok(_) => panic!("This test should result in an error"),
+            Err(e) => {
+                assert_eq!(
+                    format!("Custom node port can only be used when adding a single service"),
+                    e.to_string()
+                )
+            }
+        }
 
         Ok(())
     }

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -397,6 +397,15 @@ mod tests {
                 uptime: std::time::Duration::from_secs(1), // the service was just started
             })
         });
+        mock_rpc_client
+            .expect_network_info()
+            .times(1)
+            .returning(|| {
+                Ok(NetworkInfo {
+                    connected_peers: Vec::new(),
+                    listeners: Vec::new(),
+                })
+            });
 
         let mut node = Node {
             genesis: false,
@@ -461,6 +470,15 @@ mod tests {
                 uptime: std::time::Duration::from_secs(1),
             })
         });
+        mock_rpc_client
+            .expect_network_info()
+            .times(1)
+            .returning(|| {
+                Ok(NetworkInfo {
+                    connected_peers: Vec::new(),
+                    listeners: Vec::new(),
+                })
+            });
 
         let mut node = Node {
             genesis: false,

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -103,13 +103,6 @@ pub enum SubCmd {
         log_dir_path: Option<PathBuf>,
         #[command(flatten)]
         peers: PeersArgs,
-        /// Specify a port for the node to run on.
-        ///
-        /// If not used, a port will be selected at random.
-        ///
-        /// This option only applies when a single service is being added.
-        #[clap(long)]
-        port: Option<u16>,
         /// Specify an Ipv4Addr for the node's RPC service to run on. The ports are assigned automatically.
         ///
         /// If not used, the localhost will be used with a random port.
@@ -321,7 +314,6 @@ async fn main() -> Result<()> {
             local,
             log_dir_path,
             peers,
-            port,
             rpc_address,
             url,
             user,
@@ -354,7 +346,6 @@ async fn main() -> Result<()> {
                     genesis: peers.first,
                     count,
                     peers: get_peers_from_args(peers).await?,
-                    port,
                     rpc_address,
                     safenode_dir_path: service_data_dir_path.clone(),
                     service_data_dir_path,

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -106,6 +106,13 @@ pub enum SubCmd {
         /// Specify an Ipv4Addr for the node's RPC service to run on. The ports are assigned automatically.
         ///
         /// If not used, the localhost will be used with a random port.
+        /// Specify a port for the node to run on.
+        ///
+        /// If not used, a port will be selected at random.
+        ///
+        /// This option only applies when a single service is being added.
+        #[clap(long)]
+        port: Option<u16>,
         #[clap(long)]
         rpc_address: Option<Ipv4Addr>,
         /// Provide a safenode binary using a URL.
@@ -314,6 +321,7 @@ async fn main() -> Result<()> {
             local,
             log_dir_path,
             peers,
+            port,
             rpc_address,
             url,
             user,
@@ -346,6 +354,7 @@ async fn main() -> Result<()> {
                     genesis: peers.first,
                     count,
                     peers: get_peers_from_args(peers).await?,
+                    node_port: port,
                     rpc_address,
                     safenode_dir_path: service_data_dir_path.clone(),
                     service_data_dir_path,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -50,7 +50,6 @@ pub trait ServiceControl {
     fn create_service_user(&self, username: &str) -> Result<()>;
     fn get_available_port(&self) -> Result<u16>;
     fn install(&self, config: ServiceConfig) -> Result<()>;
-    fn is_port_free(&self, port: u16) -> bool;
     fn is_service_process_running(&self, pid: u32) -> bool;
     fn start(&self, service_name: &str) -> Result<()>;
     fn stop(&self, service_name: &str) -> Result<()>;
@@ -148,17 +147,6 @@ impl ServiceControl for NodeServiceManager {
     #[cfg(target_os = "windows")]
     fn create_service_user(&self, _username: &str) -> Result<()> {
         Ok(())
-    }
-
-    fn is_port_free(&self, port: u16) -> bool {
-        let socket = TcpListener::bind(("127.0.0.1", port));
-        let is_free = socket.is_ok();
-        drop(socket);
-        // Sleep a little while to make sure that we've dropped the socket.
-        // Without the delay, we may face 'Port already in use' error, when trying to re-use this port.
-        sleep(PORT_UNBINDING_DELAY);
-
-        is_free
     }
 
     fn is_service_process_running(&self, pid: u32) -> bool {

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -34,7 +34,6 @@ pub struct ServiceConfig {
     pub local: bool,
     pub log_dir_path: PathBuf,
     pub name: String,
-    pub node_port: u16,
     pub peers: Vec<Multiaddr>,
     pub rpc_socket_addr: SocketAddr,
     pub safenode_path: PathBuf,
@@ -187,8 +186,6 @@ impl ServiceControl for NodeServiceManager {
         let label: ServiceLabel = config.name.parse()?;
         let manager = <dyn ServiceManager>::native()?;
         let mut args = vec![
-            OsString::from("--port"),
-            OsString::from(config.node_port.to_string()),
             OsString::from("--rpc"),
             OsString::from(config.rpc_socket_addr.to_string()),
             OsString::from("--root-dir"),

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -31,6 +31,7 @@ pub struct ServiceConfig {
     pub local: bool,
     pub log_dir_path: PathBuf,
     pub name: String,
+    pub node_port: Option<u16>,
     pub peers: Vec<Multiaddr>,
     pub rpc_socket_addr: SocketAddr,
     pub safenode_path: PathBuf,
@@ -196,6 +197,10 @@ impl ServiceControl for NodeServiceManager {
         }
         if config.local {
             args.push(OsString::from("--local"));
+        }
+        if let Some(node_port) = config.node_port {
+            args.push(OsString::from("--port"));
+            args.push(OsString::from(node_port.to_string()));
         }
 
         if !config.peers.is_empty() {

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -15,10 +15,7 @@ use service_manager::{
     ServiceUninstallCtx,
 };
 use std::net::SocketAddr;
-#[cfg(feature = "tcp")]
-use std::net::TcpListener as SocketBinder;
-#[cfg(not(feature = "tcp"))]
-use std::net::UdpSocket as SocketBinder;
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{ffi::OsString, thread::sleep};
@@ -153,7 +150,7 @@ impl ServiceControl for NodeServiceManager {
     }
 
     fn is_port_free(&self, port: u16) -> bool {
-        let socket = SocketBinder::bind(("127.0.0.1", port));
+        let socket = TcpListener::bind(("127.0.0.1", port));
         let is_free = socket.is_ok();
         drop(socket);
         // Sleep a little while to make sure that we've dropped the socket.
@@ -172,7 +169,7 @@ impl ServiceControl for NodeServiceManager {
     fn get_available_port(&self) -> Result<u16> {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-        let socket = SocketBinder::bind(addr)?;
+        let socket = TcpListener::bind(addr)?;
         let port = socket.local_addr()?.port();
         drop(socket);
         // Sleep a little while to make sure that we've dropped the socket.

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -93,7 +93,6 @@ pub struct Node {
     pub service_name: String,
     pub user: String,
     pub number: u16,
-    pub port: u16,
     pub rpc_socket_addr: SocketAddr,
     pub status: NodeStatus,
     pub pid: Option<u32>,
@@ -102,6 +101,7 @@ pub struct Node {
         deserialize_with = "deserialize_peer_id"
     )]
     pub peer_id: Option<PeerId>,
+    pub listen_addr: Option<Vec<Multiaddr>>,
     pub data_dir_path: Option<PathBuf>,
     pub log_dir_path: Option<PathBuf>,
     pub safenode_path: Option<PathBuf>,
@@ -110,29 +110,6 @@ pub struct Node {
         deserialize_with = "deserialize_connected_peers"
     )]
     pub connected_peers: Option<Vec<PeerId>>,
-}
-
-impl Node {
-    pub fn get_multiaddr(&self) -> Option<Multiaddr> {
-        if let Some(peer_id) = self.peer_id {
-            let start_addr = Multiaddr::from(std::net::Ipv4Addr::LOCALHOST);
-            // default
-            let addr = if cfg!(any(feature = "websockets", target_arch = "wasm32")) {
-                start_addr
-                    .with(libp2p::multiaddr::Protocol::Tcp(self.port))
-                    .with(libp2p::multiaddr::Protocol::Ws("/".into()))
-            } else {
-                start_addr
-                    .with(libp2p::multiaddr::Protocol::Udp(self.port))
-                    .with(libp2p::multiaddr::Protocol::QuicV1)
-            };
-
-            let peer = addr.with(libp2p::multiaddr::Protocol::P2p(peer_id));
-
-            return Some(peer);
-        }
-        None
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Jan 24 10:01 UTC
This pull request includes the following changes:

- `control.rs`:
  - Imported the `Protocol` struct from the `libp2p::multiaddr` module.
  - Added code to retrieve the network info and update the listen addresses of the node.
  - Removed printing of the `port` and `multiaddr` fields in the `status` function.
  - Added printing of the `listen_addr` field in the `status` function.
  - Removed the `port` field from the `Node` struct in the tests module.
  These changes primarily involve adding functionality to retrieve and update the listen addresses of the node and making adjustments to the code in the tests module.

- Other files:
  - Import `Protocol` from `libp2p::multiaddr`.
  - Remove the unused `port` parameter from the `launch_node` function in the `Launcher` trait.
  - Rename the `peers` parameter in the `launch_node` function to `bootstrap_peers`.
  - Replace uses of the `port` parameter in the `launch_node` function with the `rpc_socket_addr` parameter.
  - Replace uses of the `peers` parameter in the `launch_node` function with the `bootstrap_peers` parameter.
  - Remove the `port` parameter from the `run_node` function.
  - Rename the `peer` parameter in the `run_node` function to `bootstrap_peers`.
  - Replace uses of the `port` parameter in the `run_node` function with the `rpc_socket_addr` parameter.
  - Update calls to the `launch_node` function in the `run_network` function.
  - Update calls to the `run_node` function in the `run_network` function.
  - Update the initialization of the `Node` struct in the `run_node` function to include the `listen_addr` field.
  - Fix the `run_node` function test by updating the expectations for the `launch_node` function call.

- `service_config.rs`:
  - The `node_port` field has been removed from the `ServiceConfig` struct.
  - The `--port` argument has been removed from the `args` vector in the `NodeServiceManager` implementation.

- `main.rs`:
  - The `port` option has been removed from the `SubCmd` enum.
  - The `port` field has been removed from the `SubCmd::Add` variant.
  - The `port` field has been removed from the `main` function.

- `node_registry.rs`:
  - Removed the `port` field from the `Node` struct.
  - Added the `listen_addr` field of type `Option<Vec<Multiaddr>>` to the `Node` struct.
  - Removed the `get_multiaddr` method from the `Node` implementation.

These changes seem to be related to adding, removing, and updating network addressing configuration for the nodes in the codebase.
<!-- reviewpad:summarize:end --> 
