### PR TITLE
fix(client): error out on verify_chunk_store

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -476,6 +476,7 @@ impl Client {
             .await
         {
             error!("Failed to verify the existence of chunk {address:?} with err {err:?}");
+            return Err(err.into());
         }
 
         Ok(())


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Jan 24 13:33 UTC
This pull request fixes an issue in the client code where there was no error handling for the verification of a chunk store. The patch adds error handling and returns the error if the verification fails.
<!-- reviewpad:summarize:end --> 
