### PR TITLE
ci: build node manager on local network start

### DIFF
--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -59,6 +59,7 @@ jobs:
           node-path: target/release/safenode
           faucet-path: target/release/faucet
           platform: ubuntu-latest
+          build: true
 
       - name: Create and fund a wallet to pay for files storage
         run: |


### PR DESCRIPTION
This is required until we update the Github Action to pull the latest release of the node manager. This couldn't be done initially because we were moving the releases to the `safe_network` repository, but it should be doable now.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Jan 24 15:11 UTC
This pull request updates the CI workflow to build the node manager on local network start. This is necessary until the Github Action is updated to pull the latest release of the node manager.
<!-- reviewpad:summarize:end --> 
