### PR TITLE
fix(network): refactor cfg to allow get_record reattempts

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -105,7 +105,7 @@ const IDENTIFY_PROTOCOL_STR: &str = concat!("safe/", env!("CARGO_PKG_VERSION"));
 const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 
 /// Time before a Kad query times out if no response is received
-const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(25);
+const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(10);
 
 // Protocol support shall be downward compatible for patch only version update.
 // i.e. versions of `A.B.X` shall be considered as a same protocol of `A.B`

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -92,7 +92,7 @@ pub const fn close_group_majority() -> usize {
 }
 
 /// Max duration for all GET attempts
-const MAX_GET_RETRY_DURATION_MS: u64 = 6800;
+const MAX_GET_RETRY_DURATION_MS: u64 = 60000;
 
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_GET_RETRY_DURATION: Duration = Duration::from_millis(MAX_GET_RETRY_DURATION_MS);

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -373,9 +373,9 @@ async fn spawn_royalties_payment_client_listener(
     let handle = tokio::spawn(async move {
         let mut count = 0;
 
-        // if expected royalties is 0 or 1 we'll wait for 20s as a minimum,
-        // otherwise we'll wait for 10s per expected royalty
-        let secs = std::cmp::max(40, expected_royalties as u64 * 15);
+        // if expected royalties is 0 or 1 we'll wait for 300s as a minimum,
+        // otherwise we'll wait for 60s per expected royalty
+        let secs = std::cmp::max(300, expected_royalties as u64 * 60);
         let duration = Duration::from_secs(secs);
         info!("Awaiting transfers notifs for {duration:?}...");
         if timeout(duration, async {


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Jan 24 16:54 UTC
This pull request refactors the `cfg` to allow for reattempts of the `get_record` function. The timeout for Kad queries has been reduced from 25 seconds to 10 seconds. Additionally, the maximum duration for all GET attempts has been increased from 6.8 seconds to 60 seconds.
<!-- reviewpad:summarize:end --> 
