### PR TITLE
chore(rpc): add retry during initial connection and better error logging

### DIFF
--- a/sn_node_rpc_client/src/error.rs
+++ b/sn_node_rpc_client/src/error.rs
@@ -13,4 +13,6 @@ pub enum Error {
     TonicStatusError(#[from] tonic::Status),
     #[error(transparent)]
     TonicTransportError(#[from] tonic::transport::Error),
+    #[error("Could not connect to the RPC endpoint {0:?}")]
+    RpcEndpointConnectionFailure(tonic::transport::Error),
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Jan 24 17:37 UTC
This pull request adds retry functionality during the initial connection to the RPC endpoint and improves error logging. It modifies the RpcClient struct to include the MAX_CONNECTION_RETRY_ATTEMPTS and CONNECTION_RETRY_DELAY_SEC constants. It also introduces the connect_with_retry method which attempts to connect to the RPC endpoint with retry logic. The node_info, network_info, record_addresses, gossipsub_subscribe, gossipsub_unsubscribe, gossipsub_publish, node_restart, node_stop, and node_update methods of the RpcClient struct now use the connect_with_retry method to establish the RPC connection. Additionally, error logging is added to handle connection failures and display appropriate error messages.
<!-- reviewpad:summarize:end --> 
