### PR TITLE
feat(faucet): create distributions for maid addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "ecies"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f43496fc04523aa716c5dd76133cb6d7c81eb213375684d06a8b1683f8bc1e"
+dependencies = [
+ "aes-gcm",
+ "getrandom",
+ "hkdf",
+ "libsecp256k1",
+ "once_cell",
+ "parking_lot",
+ "rand_core",
+ "sha2",
+ "typenum",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3136,51 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64 0.13.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -4846,6 +4909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,9 +5217,13 @@ dependencies = [
  "clap 4.4.18",
  "color-eyre",
  "dirs-next",
+ "ecies",
+ "hex",
  "indicatif",
  "minreq",
+ "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sn_client",
  "sn_logging",

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -24,9 +24,13 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.2"
 dirs-next = "~2.0.0"
+ecies = { version="0.2.6", default-features = false, features = ["pure"] }
+hex = "0.4.3"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 minreq = { version = "2.11.0", features = ["https-rustls"], optional = true}
+rmp-serde = "1.1.2"
 serde = { version = "1.0.193", features = ["derive"] }
+serde_bytes = "0.11.12"
 serde_json = "1.0.108"
 sn_client = { path = "../sn_client", version = "0.102.22" }
 sn_logging = { path = "../sn_logging", version = "0.2.18" }

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.37"
 
 [features]
 default = []
-distribution = ["bitcoin", "minreq"]
+distribution = ["bitcoin", "minreq", "ecies", "serde_bytes"]
 
 [[bin]]
 path="src/main.rs"
@@ -24,13 +24,13 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.2"
 dirs-next = "~2.0.0"
-ecies = { version="0.2.6", default-features = false, features = ["pure"] }
+ecies = { version="0.2.6", default-features = false, features = ["pure"], optional = true }
 hex = "0.4.3"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 minreq = { version = "2.11.0", features = ["https-rustls"], optional = true}
 rmp-serde = "1.1.2"
 serde = { version = "1.0.193", features = ["derive"] }
-serde_bytes = "0.11.12"
+serde_bytes = { version = "0.11.12", optional = true }
 serde_json = "1.0.108"
 sn_client = { path = "../sn_client", version = "0.102.22" }
 sn_logging = { path = "../sn_logging", version = "0.2.18" }

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.37"
 
 [features]
 default = []
-distribition = ["bitcoin", "minreq"]
+distribution = ["bitcoin", "minreq"]
 
 [[bin]]
 path="src/main.rs"

--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -16,14 +16,6 @@ use std::path::{self, Path, PathBuf};
 use tiny_http::{Response, Server};
 use tracing::{debug, error, trace};
 
-#[derive(Serialize, Deserialize)]
-struct Distribution {
-    #[serde(with = "serde_bytes")]
-    transfer: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    encrypted_secret_key: Vec<u8>,
-}
-
 /// Run the faucet server.
 ///
 /// This will listen on port 8000 and send a transfer of tokens as response to any GET request.
@@ -73,9 +65,11 @@ async fn startup_server(client: &Client) -> Result<()> {
         // Each distribution takes about 500ms to create, so for thousands of
         // initial distributions this takes many minutes. This is run in the
         // background instead of blocking the server from starting.
-        tokio::spawn(
-            token_distribution::distribute_from_maid_to_tokens(client.clone(), balances, keys)
-        );
+        tokio::spawn(token_distribution::distribute_from_maid_to_tokens(
+            client.clone(),
+            balances,
+            keys,
+        ));
     }
     let server =
         Server::http("0.0.0.0:8000").map_err(|err| eyre!("Failed to start server: {err}"))?;

--- a/sn_faucet/src/token_distribution.rs
+++ b/sn_faucet/src/token_distribution.rs
@@ -8,7 +8,8 @@
 
 use color_eyre::eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
-use sn_transfers::NanoTokens;
+use sn_transfers::{MainPubkey, NanoTokens};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::{collections::HashMap, path::PathBuf};
 use tracing::{debug, error, info, trace};
@@ -46,6 +47,15 @@ fn get_pubkeys_data_dir_path() -> Result<PathBuf> {
         .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
         .join("safe_snapshot")
         .join("pubkeys");
+    std::fs::create_dir_all(dir.clone())?;
+    Ok(dir.to_path_buf())
+}
+
+fn get_distributions_data_dir_path() -> Result<PathBuf> {
+    let dir = dirs_next::data_dir()
+        .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
+        .join("safe_snapshot")
+        .join("distributions");
     std::fs::create_dir_all(dir.clone())?;
     Ok(dir.to_path_buf())
 }
@@ -224,4 +234,126 @@ fn save_address_pk(address: &str, pk_hex: &str) -> Result<()> {
     let addr_path = get_pubkeys_data_dir_path()?.join(address);
     std::fs::write(addr_path, pk_hex)?;
     Ok(())
+}
+
+async fn distribute_from_maid_to_tokens(
+    client: &Client,
+    snapshot: Snapshot,
+    pubkeys: HashMap<MaidAddress, MaidPubkey>,
+) {
+    for (addr, amount) in snapshot {
+        // check if this snapshot address has a pubkey
+        if !pubkeys.contains_key(&addr) {
+            continue;
+        }
+        let maid_pk = &pubkeys[&addr];
+        let _ = create_distribution(client, &addr, maid_pk, amount).await;
+    }
+}
+
+async fn create_distribution(
+    client: &Client,
+    addr: &MaidAddress,
+    maid_pk: &MaidPubkey,
+    amount: NanoTokens,
+) -> Result<String> {
+    // validate the pk and the address match
+    // because we can't be sure if this addr:pk pair has been pre-verified
+    // and we don't want to encrypt using the wrong pubkey for the address
+    if !maid_pk_matches_address(addr, maid_pk) {
+        let msg = format!("Not creating distribution for mismatched addr:pk {addr} {maid_pk}");
+        info!(msg);
+        return Err(eyre!(msg));
+    }
+    // check if this distribution has already been created
+    let root = get_distributions_data_dir_path()?;
+    let dist_path = root.join(addr);
+    if dist_path.exists() {
+        let dist_hex = match std::fs::read_to_string(dist_path.clone()) {
+            Ok(content) => content,
+            Err(err) => {
+                let msg = format!(
+                    "Error reading distribution file {}: {}",
+                    dist_path.display(),
+                    err
+                );
+                info!(msg);
+                return Err(eyre!(msg));
+            }
+        };
+        return Ok(dist_hex);
+    }
+    info!(
+        "Distributing {} to {} using pubkey {}",
+        amount, addr, maid_pk
+    );
+    // create a new random secret key to transfer this distribution to
+    let dist_sk = bls::SecretKey::random();
+    let dist_pk = MainPubkey(dist_sk.public_key()).to_hex();
+    // create a transfer to this new distribution key
+    let transfer_hex = match send_tokens(client, &amount.to_string(), &dist_pk).await {
+        Ok(t) => t,
+        Err(err) => {
+            let msg = format!("Failed send for {addr}: {err}");
+            info!(msg);
+            return Err(eyre!(msg));
+        }
+    };
+    let transfer = match hex::decode(transfer_hex) {
+        Ok(t) => t,
+        Err(err) => {
+            let msg = format!("Failed to decode transfer to {addr}: {err}");
+            info!(msg);
+            return Err(eyre!(msg));
+        }
+    };
+    // encrypt the secret key using the maid pubkey
+    let dist_sk_bytes = dist_sk.to_bytes();
+    let maid_pk_bytes = match hex::decode(maid_pk) {
+        Ok(b) => b,
+        Err(err) => {
+            let msg = format!("Failed to decode maid pk {maid_pk}: {err}");
+            info!(msg);
+            return Err(eyre!(msg));
+        }
+    };
+    let enc_dist_sk = match ecies::encrypt(&maid_pk_bytes, &dist_sk_bytes) {
+        Ok(ct) => ct,
+        Err(err) => {
+            let msg = format!("Failed to encrypt secret key for {addr}: {err}");
+            info!(msg);
+            return Err(eyre!(msg));
+        }
+    };
+    // create the distribution
+    let dist = Distribution {
+        transfer,
+        encrypted_secret_key: enc_dist_sk,
+    };
+    // serialize the distribution using message pack
+    let dist_bytes = match rmp_serde::to_vec_named(&dist) {
+        Ok(b) => b,
+        Err(err) => {
+            let msg = format!("Failed to encode distribution for {addr}: {err}");
+            info!(msg);
+            return Err(eyre!(msg));
+        }
+    };
+    let dist_hex = hex::encode(dist_bytes);
+    // save the distribution
+    match std::fs::write(dist_path.clone(), dist_hex.clone()) {
+        Ok(_) => {}
+        Err(err) => {
+            let msg = format!(
+                "Failed to write distribution to file {}: {}",
+                dist_path.display(),
+                err
+            );
+            info!(msg);
+            info!("The distribution hex that failed to write to file:");
+            info!(dist_hex);
+            return Err(eyre!(msg));
+        }
+    };
+    Ok(dist_hex)
 }


### PR DESCRIPTION
This PR changes the faucet startup process. At startup the faucet creates distributions of tokens using the snapshot of maid addresses + balances + public keys.

Each distribution is a combination of a transfer (from the faucet) and an encrypted secret key (randomly generated) that enables that transfer to be spent. The maid owner can decrypt the secret key using their maid private key, which is then used as a wallet key for spending the transfer.

Distributions created by the faucet are saved to `$HOME/.local/share/safe_snapshot/distributions/<address>` and contain the messagepack-encoded hex for the distribution.

Note:

* This doesn't enable access to the distributions yet, this is to be done in future work by exposing a faucet server endpoint that returns the distribution for a particular maid address. I'm trying to keep each PR relatively small.

* The startup process for the faucet server has become much longer while it creates these distributions. Creating 1200 initial distributions took about 11 minutes.
    * Should we move this into a separate thread and have it run in the background?
    * Should we have a feature flag for local testnets that doesn't use the 'live' snapshot list and uses a fake test-only list of a single address?

Future work will be:

* allow users to fetch their distribution from the cli for their maid address, and automatically send that distribution to their wallet.

* enable the faucet to receive new maid address+publickey pairs and create new distributions on the fly for those.

* expose the full snapshot and distribution list to enable audit of the process. Need to explore what an audit would require.

* find a simple / automatic way to retain address + publickeys that have been submitted while the faucet is running, stored in [maid_address_pubkeys.csv](https://github.com/maidsafe/safe_network/raw/main/sn_faucet/maid_address_pubkeys.csv) for future use.

* consider adding a test maid address to this so we can test the claim process easily.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jan 24 03:07 UTC
This pull request includes changes to the Cargo.lock, Cargo.toml, and faucet_server.rs files. It updates dependencies and adds new ones, including "ecies", "libsecp256k1", "libsecp256k1-core", "libsecp256k1-gen-ecmult", "libsecp256k1-gen-genmult", "rmp-serde", and "serde_bytes". It also adds structs and functions related to distributing tokens to addresses using public and secret keys.
<!-- reviewpad:summarize:end --> 
