### PR TITLE
feat(client): adding Folders API and CLI cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The folders storage capability can be demonstrated by uploading folders to the l
 
 Upload a directory:
 ```bash
-cargo run --bin safe --features local-discovery -- files upload <dir-path>
+cargo run --bin safe --features local-discovery -- folders upload <dir-path>
 ```
 
 After it finishes uploading the complete directory, with files and sub-directories, it will show the address where the main directory can be pulled from.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ Now download the files again:
 cargo run --bin safe --features local-discovery -- files download
 ```
 
+### Folders
+
+The folders storage capability can be demonstrated by uploading folders to the local network, then retrieving them.
+
+Upload a directory:
+```bash
+cargo run --bin safe --features local-discovery -- files upload <dir-path>
+```
+
+After it finishes uploading the complete directory, with files and sub-directories, it will show the address where the main directory can be pulled from.
+
+Now download the folders, optionally providing a target directory name:
+```bash
+cargo run --bin safe --features local-discovery -- folders download <address> [dir name]
+```
+
 ### Token Transfers
 
 Use your local wallet to demonstrate sending tokens and receiving transfers.

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -16,6 +16,7 @@ use crate::{
     cli::Opt,
     subcommands::{
         files::files_cmds,
+        folders::folders_cmds,
         gossipsub::gossipsub_cmds,
         register::register_cmds,
         wallet::{
@@ -153,6 +154,9 @@ async fn main() -> Result<()> {
         }
         SubCmd::Files(cmds) => {
             files_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+        }
+        SubCmd::Folders(cmds) => {
+            folders_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
         }
         SubCmd::Register(cmds) => {
             register_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -428,7 +428,7 @@ impl ChunkManager {
         Ok(self.get_chunks())
     }
 
-    /// Returns an iterator over the list of chunked files which belong to the provided path
+    /// Returns an iterator over the list of chunked files
     pub(crate) fn iter_chunked_files(&mut self) -> impl Iterator<Item = &ChunkedFile> {
         self.chunks.values()
     }

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -48,6 +48,7 @@ impl PathXorName {
 /// Info about a file that has been chunked
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub(crate) struct ChunkedFile {
+    pub file_path: PathBuf,
     pub file_name: OsString,
     pub head_chunk_address: ChunkAddress,
     pub chunks: BTreeSet<(XorName, PathBuf)>,
@@ -93,7 +94,6 @@ impl ChunkManager {
         read_cache: bool,
         include_data_maps: bool,
     ) -> Result<()> {
-        println!("Starting to chunk {files_path:?} now.");
         let now = Instant::now();
         // clean up
         self.files_to_chunk = Default::default();
@@ -200,6 +200,7 @@ impl ChunkManager {
 
                         let chunked_file = ChunkedFile {
                             head_chunk_address,
+                            file_path: path.to_owned(),
                             file_name: original_file_name.clone(),
                             chunks: chunks.into_iter().collect(),
                             data_map
@@ -277,13 +278,18 @@ impl ChunkManager {
         let resumed = self
             .files_to_chunk
             .par_iter()
-            .filter_map(|(original_file_name, path_xor, _)| {
+            .filter_map(|(original_file_name, path_xor, original_file_path)| {
                 // if this folder exists, and if we find chunks under this, we upload them.
                 let file_chunks_dir = artifacts_dir.join(&path_xor.0);
                 if !file_chunks_dir.exists() {
                     return None;
                 }
-                Self::read_file_chunks_dir(file_chunks_dir, path_xor, original_file_name.clone())
+                Self::read_file_chunks_dir(
+                    file_chunks_dir,
+                    path_xor,
+                    original_file_path.clone(),
+                    original_file_name.clone(),
+                )
             })
             .collect::<BTreeMap<_, _>>();
 
@@ -422,6 +428,11 @@ impl ChunkManager {
         Ok(self.get_chunks())
     }
 
+    /// Returns an iterator over the list of chunked files which belong to the provided path
+    pub(crate) fn iter_chunked_files(&mut self) -> impl Iterator<Item = &ChunkedFile> {
+        self.chunks.values()
+    }
+
     // Try to read the chunks from `file_chunks_dir`
     // Returns the ChunkedFile if the metadata file exists
     // file_chunks_dir: artifacts_dir/path_xor
@@ -430,6 +441,7 @@ impl ChunkManager {
     fn read_file_chunks_dir(
         file_chunks_dir: PathBuf,
         path_xor: &PathXorName,
+        original_file_path: PathBuf,
         original_file_name: OsString,
     ) -> Option<(PathXorName, ChunkedFile)> {
         let mut file_chunk_address: Option<ChunkAddress> = None;
@@ -478,6 +490,7 @@ impl ChunkManager {
                 Some((
                     path_xor.clone(),
                     ChunkedFile {
+                        file_path: original_file_path,
                         file_name: original_file_name,
                         head_chunk_address,
                         chunks,
@@ -503,6 +516,7 @@ impl ChunkManager {
         let metadata: (ChunkAddress, Option<Bytes>) = rmp_serde::from_slice(&metadata)
             .map_err(|err| error!("Failed to deserialize metadata with err {err:?}"))
             .ok()?;
+
         Some(metadata)
     }
 
@@ -714,9 +728,13 @@ mod tests {
 
         // 2. the folder should exists, but chunk removed
         let file_chunks_dir = manager.artifacts_dir.join(&path_xor.0);
-        let (path_xor_from_dir, chunked_file_from_dir) =
-            ChunkManager::read_file_chunks_dir(file_chunks_dir, &path_xor, chunked_file.file_name)
-                .expect("Folder and metadata should be present");
+        let (path_xor_from_dir, chunked_file_from_dir) = ChunkManager::read_file_chunks_dir(
+            file_chunks_dir,
+            &path_xor,
+            chunked_file.file_path,
+            chunked_file.file_name,
+        )
+        .expect("Folder and metadata should be present");
         assert_eq!(chunked_file_from_dir.chunks.len(), total_chunks - 1);
         assert_eq!(chunked_file_from_dir.head_chunk_address, file_xor_addr);
         assert_eq!(path_xor_from_dir, path_xor);
@@ -755,6 +773,7 @@ mod tests {
             let (path_xor_from_dir, chunked_file_from_dir) = ChunkManager::read_file_chunks_dir(
                 file_chunks_dir,
                 path_xor,
+                chunked_file.file_path.clone(),
                 chunked_file.file_name.to_owned(),
             )
             .expect("Folder and metadata should be present");

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -42,7 +42,7 @@ use xor_name::XorName;
 const DOWNLOAD_FOLDER: &str = "safe_files";
 
 /// Subdir for storing uploaded file into
-const UPLOADED_FILES: &str = "uploaded_files";
+pub(crate) const UPLOADED_FILES: &str = "uploaded_files";
 
 #[derive(Parser, Debug)]
 pub enum FilesCmds {
@@ -532,7 +532,7 @@ fn format_elapsed_time(elapsed_time: std::time::Duration) -> String {
     }
 }
 
-async fn download_file(
+pub(crate) async fn download_file(
     files_api: FilesApi,
     xor_name: XorName,
     // original file name and optional datamap chunk

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -253,7 +253,7 @@ pub(crate) async fn files_cmds(
 
 /// Given a file or directory, upload either the file or all the files in the directory. Optionally
 /// verify if the data was stored successfully.
-async fn upload_files(
+pub(crate) async fn upload_files(
     files_path: PathBuf,
     make_data_public: bool,
     client: &Client,
@@ -272,7 +272,9 @@ async fn upload_files(
     if files_api.wallet()?.balance().is_zero() {
         bail!("The wallet is empty. Cannot upload any files! Please transfer some funds into the wallet");
     }
+
     let mut chunk_manager = ChunkManager::new(&root_dir);
+    println!("Starting to chunk {files_path:?} now.");
     chunk_manager.chunk_path(&files_path, true, make_data_public)?;
 
     // Return early if we already uploaded them

--- a/sn_cli/src/subcommands/folders.rs
+++ b/sn_cli/src/subcommands/folders.rs
@@ -1,0 +1,158 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::files::{upload_files, ChunkManager};
+
+use sn_client::{Client, FolderEntry, FoldersApi, BATCH_SIZE, MAX_UPLOAD_RETRIES};
+use sn_registers::RegisterAddress;
+
+use clap::Parser;
+use color_eyre::Result;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+use walkdir::WalkDir;
+
+#[derive(Parser, Debug)]
+pub enum FoldersCmds {
+    Upload {
+        /// The location of the file(s) to upload for creating the folder on the network.
+        ///
+        /// Can be a file or a directory.
+        #[clap(name = "path", value_name = "PATH")]
+        path: PathBuf,
+        /// The batch_size to split chunks into parallel handling batches
+        /// during payment and upload processing.
+        #[clap(long, default_value_t = BATCH_SIZE, short='b')]
+        batch_size: usize,
+        /// Should the file be made accessible to all. (This is irreversible)
+        #[clap(long, name = "make_public", default_value = "false", short = 'p')]
+        make_public: bool,
+        /// The retry_count for retrying failed chunks
+        /// during payment and upload processing.
+        #[clap(long, default_value_t = MAX_UPLOAD_RETRIES, short = 'r')]
+        max_retries: usize,
+    },
+    Download {
+        /// The hex address of a folder.
+        #[clap(name = "address")]
+        folder_addr: String,
+        /// The name to apply to the downloaded folder.
+        #[clap(name = "target name")]
+        folder_name: String,
+        /// The batch_size for parallel downloading
+        #[clap(long, default_value_t = BATCH_SIZE , short='b')]
+        batch_size: usize,
+    },
+}
+
+pub(crate) async fn folders_cmds(
+    cmds: FoldersCmds,
+    client: &Client,
+    root_dir: &Path,
+    verify_store: bool,
+) -> Result<()> {
+    match cmds {
+        FoldersCmds::Upload {
+            path,
+            batch_size,
+            max_retries,
+            make_public,
+        } => {
+            upload_files(
+                path.clone(),
+                make_public,
+                client,
+                root_dir.to_path_buf(),
+                verify_store,
+                batch_size,
+                max_retries,
+            )
+            .await?;
+
+            let mut chunk_manager = ChunkManager::new(root_dir);
+            chunk_manager.chunk_path(&path, true, make_public)?;
+
+            let mut dirs_paths = BTreeMap::<PathBuf, FoldersApi>::new();
+            for (dir_path, parent, dir_name) in WalkDir::new(&path)
+                .into_iter()
+                .filter_entry(|e| e.file_type().is_dir())
+                .flatten()
+                .filter(|e| e.depth() > 0)
+                .filter_map(|e| {
+                    e.path()
+                        .parent()
+                        .zip(e.file_name().to_str())
+                        .map(|(p, n)| (e.path().to_path_buf(), p.to_owned(), n.to_owned()))
+                })
+            {
+                let curr_folder_addr = *dirs_paths
+                    .entry(dir_path)
+                    .or_insert(FoldersApi::new(client.clone(), root_dir))
+                    .address();
+
+                let parent_folder = dirs_paths
+                    .entry(parent)
+                    .or_insert(FoldersApi::new(client.clone(), root_dir));
+                parent_folder.add_folder(dir_name, curr_folder_addr)?;
+            }
+
+            for chunked_file in chunk_manager.iter_chunked_files() {
+                if let (Some(file_name), Some(parent)) = (
+                    chunked_file.file_name.to_str(),
+                    chunked_file.file_path.parent(),
+                ) {
+                    if let Some(folder) = dirs_paths.get_mut(parent) {
+                        folder.add_file(file_name.to_string(), chunked_file.head_chunk_address)?;
+                    }
+                }
+            }
+
+            // TODO: sync Folders concurrently
+            for (path, mut folder) in dirs_paths {
+                let address = folder.sync(verify_store).await?;
+                println!(
+                    "Folder (for {}) synced with the network at: {}",
+                    path.display(),
+                    address.to_hex()
+                );
+            }
+        }
+        FoldersCmds::Download {
+            folder_addr,
+            folder_name,
+            batch_size,
+        } => {
+            let address =
+                RegisterAddress::from_hex(&folder_addr).expect("Failed to parse Folder address");
+
+            let download_dir = dirs_next::download_dir().unwrap_or(root_dir.to_path_buf());
+            let downloaded_folder_path = download_dir.join(folder_name);
+            println!(
+                "Downloading onto {downloaded_folder_path:?} from {} with batch-size {batch_size}",
+                address.to_hex()
+            );
+            debug!(
+                "Downloading onto {downloaded_folder_path:?} from {}",
+                address.to_hex()
+            );
+
+            let folders_api = FoldersApi::retrieve(client.clone(), root_dir, address).await?;
+            println!("Entries in downloaded Folder:");
+            folders_api
+                .files()?
+                .iter()
+                .for_each(|(file_name, folder_entry)| match folder_entry {
+                    FolderEntry::File(addr) => println!("file- {file_name}: {addr:?}"),
+                    FolderEntry::Folder(addr) => println!("subfolder- {file_name}: {addr}"),
+                });
+        }
+    };
+    Ok(())
+}

--- a/sn_cli/src/subcommands/folders.rs
+++ b/sn_cli/src/subcommands/folders.rs
@@ -53,8 +53,8 @@ pub enum FoldersCmds {
         #[clap(name = "address")]
         folder_addr: String,
         /// The name to apply to the downloaded folder.
-        #[clap(name = "target name")]
-        folder_name: Option<String>,
+        #[clap(name = "target folder name")]
+        folder_name: String,
         /// The batch_size for parallel downloading
         #[clap(long, default_value_t = BATCH_SIZE , short='b')]
         batch_size: usize,
@@ -124,11 +124,7 @@ pub(crate) async fn folders_cmds(
                 RegisterAddress::from_hex(&folder_addr).expect("Failed to parse Folder address");
 
             let download_dir = dirs_next::download_dir().unwrap_or(root_dir.to_path_buf());
-            let download_folder_path = if let Some(name) = folder_name {
-                download_dir.join(name)
-            } else {
-                download_dir
-            };
+            let download_folder_path = download_dir.join(folder_name);
             println!(
                 "Downloading onto {download_folder_path:?} from {} with batch-size {batch_size}",
                 address.to_hex()

--- a/sn_cli/src/subcommands/folders.rs
+++ b/sn_cli/src/subcommands/folders.rs
@@ -6,15 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::files::{upload_files, ChunkManager};
+use super::files::{download_file, upload_files, ChunkManager, UploadedFile, UPLOADED_FILES};
 
-use sn_client::{Client, FolderEntry, FoldersApi, BATCH_SIZE, MAX_UPLOAD_RETRIES};
+use sn_client::{Client, FilesApi, FolderEntry, FoldersApi, BATCH_SIZE, MAX_UPLOAD_RETRIES};
+use sn_protocol::storage::{Chunk, ChunkAddress};
 use sn_registers::RegisterAddress;
 
 use clap::Parser;
 use color_eyre::Result;
 use std::{
     collections::BTreeMap,
+    fs::create_dir_all,
     path::{Path, PathBuf},
 };
 use walkdir::WalkDir;
@@ -45,7 +47,7 @@ pub enum FoldersCmds {
         folder_addr: String,
         /// The name to apply to the downloaded folder.
         #[clap(name = "target name")]
-        folder_name: String,
+        folder_name: Option<String>,
         /// The batch_size for parallel downloading
         #[clap(long, default_value_t = BATCH_SIZE , short='b')]
         batch_size: usize,
@@ -76,6 +78,7 @@ pub(crate) async fn folders_cmds(
             )
             .await?;
 
+            println!("Uploading folders hierarchy...");
             let mut chunk_manager = ChunkManager::new(root_dir);
             chunk_manager.chunk_path(&path, true, make_public)?;
 
@@ -133,26 +136,96 @@ pub(crate) async fn folders_cmds(
                 RegisterAddress::from_hex(&folder_addr).expect("Failed to parse Folder address");
 
             let download_dir = dirs_next::download_dir().unwrap_or(root_dir.to_path_buf());
-            let downloaded_folder_path = download_dir.join(folder_name);
+            let download_folder_path = if let Some(name) = folder_name {
+                download_dir.join(name)
+            } else {
+                download_dir
+            };
             println!(
-                "Downloading onto {downloaded_folder_path:?} from {} with batch-size {batch_size}",
+                "Downloading onto {download_folder_path:?} from {} with batch-size {batch_size}",
                 address.to_hex()
             );
             debug!(
-                "Downloading onto {downloaded_folder_path:?} from {}",
+                "Downloading onto {download_folder_path:?} from {}",
                 address.to_hex()
             );
 
-            let folders_api = FoldersApi::retrieve(client.clone(), root_dir, address).await?;
-            println!("Entries in downloaded Folder:");
-            folders_api
-                .files()?
-                .iter()
-                .for_each(|(file_name, folder_entry)| match folder_entry {
-                    FolderEntry::File(addr) => println!("file- {file_name}: {addr:?}"),
-                    FolderEntry::Folder(addr) => println!("subfolder- {file_name}: {addr}"),
-                });
+            let mut files_to_download = vec![];
+            let mut folders_to_download =
+                vec![("".to_string(), address, download_folder_path.clone())];
+
+            while let Some((name, folder_addr, target_path)) = folders_to_download.pop() {
+                if !name.is_empty() {
+                    println!(
+                        "Downloading Folder '{name}' from {}",
+                        hex::encode(folder_addr.xorname())
+                    );
+                }
+                download_folder(
+                    root_dir,
+                    client,
+                    &target_path,
+                    folder_addr,
+                    &mut files_to_download,
+                    &mut folders_to_download,
+                )
+                .await?;
+            }
+
+            let files_api: FilesApi = FilesApi::new(client.clone(), download_folder_path);
+            let uploaded_files_path = root_dir.join(UPLOADED_FILES);
+            for (file_name, addr, path) in files_to_download {
+                // try to read the data_map if it exists locally.
+                let expected_data_map_location = uploaded_files_path.join(addr.to_hex());
+                let local_data_map = UploadedFile::read(&expected_data_map_location)
+                    .map(|uploaded_file_metadata| {
+                        uploaded_file_metadata.data_map.map(|bytes| Chunk {
+                            address: ChunkAddress::new(*addr.xorname()),
+                            value: bytes,
+                        })
+                    })
+                    .unwrap_or(None);
+
+                download_file(
+                    files_api.clone(),
+                    *addr.xorname(),
+                    (file_name.into(), local_data_map),
+                    &path,
+                    false,
+                    batch_size,
+                )
+                .await;
+            }
         }
     };
+    Ok(())
+}
+
+async fn download_folder(
+    root_dir: &Path,
+    client: &Client,
+    target_path: &Path,
+    folder_addr: RegisterAddress,
+    files_to_download: &mut Vec<(String, ChunkAddress, PathBuf)>,
+    folders_to_download: &mut Vec<(String, RegisterAddress, PathBuf)>,
+) -> Result<()> {
+    create_dir_all(target_path)?;
+    let folders_api = FoldersApi::retrieve(client.clone(), root_dir, folder_addr).await?;
+
+    for (file_name, folder_entry) in folders_api.entries()?.into_iter() {
+        match folder_entry {
+            FolderEntry::File(file_addr) => {
+                files_to_download.push((file_name, file_addr, target_path.to_path_buf()))
+            }
+            FolderEntry::Folder(subfolder_addr) => {
+                folders_to_download.push((
+                    file_name.clone(),
+                    subfolder_addr,
+                    target_path.join(file_name),
+                ));
+            }
+        }
+    }
+
     Ok(())
 }

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 pub(crate) mod files;
+pub(crate) mod folders;
 pub(crate) mod gossipsub;
 pub(crate) mod register;
 pub(crate) mod wallet;
@@ -27,6 +28,9 @@ pub(super) enum SubCmd {
     #[clap(name = "files", subcommand)]
     /// Commands for file management
     Files(files::FilesCmds),
+    #[clap(name = "folders", subcommand)]
+    /// Commands for folders management
+    Folders(folders::FoldersCmds),
     #[clap(name = "register", subcommand)]
     /// Commands for register management
     Register(register::RegisterCmds),

--- a/sn_client/src/folders.rs
+++ b/sn_client/src/folders.rs
@@ -96,12 +96,12 @@ impl FoldersApi {
         })
     }
 
-    /// Returns the list of files of this Folder
-    pub fn files(&self) -> Result<Vec<(String, FolderEntry)>> {
-        let mut files = vec![];
+    /// Returns the list of entries of this Folder
+    pub fn entries(&self) -> Result<Vec<(String, FolderEntry)>> {
+        let mut entries = vec![];
         for (_, entry) in self.register.read() {
-            files.push(rmp_serde::from_slice(&entry)?)
+            entries.push(rmp_serde::from_slice(&entry)?)
         }
-        Ok(files)
+        Ok(entries)
     }
 }

--- a/sn_client/src/folders.rs
+++ b/sn_client/src/folders.rs
@@ -1,0 +1,107 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{error::Result, Client, ClientRegister, WalletClient};
+
+use sn_protocol::storage::{ChunkAddress, RegisterAddress};
+use sn_transfers::HotWallet;
+use xor_name::XorName;
+
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+/// Folder Entry representing either a file or subfolder.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum FolderEntry {
+    File(ChunkAddress),
+    Folder(RegisterAddress),
+}
+
+/// Folders APIs.
+#[derive(Clone)]
+pub struct FoldersApi {
+    client: Client,
+    wallet_dir: PathBuf,
+    register: ClientRegister,
+}
+
+impl FoldersApi {
+    /// Create FoldersApi instance.
+    pub fn new(client: Client, wallet_dir: &Path) -> Self {
+        let mut rng = rand::thread_rng();
+        let register = ClientRegister::create(client.clone(), XorName::random(&mut rng));
+        Self {
+            client,
+            wallet_dir: wallet_dir.to_path_buf(),
+            register,
+        }
+    }
+
+    /// Return the address of the Folder (Register address) on the network
+    pub fn address(&self) -> &RegisterAddress {
+        self.register.address()
+    }
+
+    /// Create a new WalletClient from the directory set.
+    pub fn wallet(&self) -> Result<WalletClient> {
+        let path = self.wallet_dir.as_path();
+        let wallet = HotWallet::load_from(path)?;
+
+        Ok(WalletClient::new(self.client.clone(), wallet))
+    }
+
+    /// Add provided file as entry of this Folder (locally).
+    pub fn add_file(&mut self, name: String, address: ChunkAddress) -> Result<()> {
+        let entry = (name, FolderEntry::File(address));
+        self.register
+            .write_atop(&rmp_serde::to_vec(&entry)?, &BTreeSet::default())?;
+        Ok(())
+    }
+
+    /// Add subfolder as entry of this Folder (locally).
+    pub fn add_folder(&mut self, name: String, address: RegisterAddress) -> Result<()> {
+        let entry = (name, FolderEntry::Folder(address));
+        self.register
+            .write_atop(&rmp_serde::to_vec(&entry)?, &BTreeSet::default())?;
+        Ok(())
+    }
+
+    /// Sync local Folder with the network.
+    pub async fn sync(&mut self, verify_store: bool) -> Result<RegisterAddress> {
+        let mut wallet_client = self.wallet()?;
+        self.register.sync(&mut wallet_client, verify_store).await?;
+
+        Ok(*self.register.address())
+    }
+
+    /// Download a copy of the Folder from the network.
+    pub async fn retrieve(
+        client: Client,
+        wallet_dir: &Path,
+        address: RegisterAddress,
+    ) -> Result<Self> {
+        let register = ClientRegister::retrieve(client.clone(), address).await?;
+        Ok(Self {
+            client,
+            wallet_dir: wallet_dir.to_path_buf(),
+            register,
+        })
+    }
+
+    /// Returns the list of files of this Folder
+    pub fn files(&self) -> Result<Vec<(String, FolderEntry)>> {
+        let mut files = vec![];
+        for (_, entry) in self.register.read() {
+            files.push(rmp_serde::from_slice(&entry)?)
+        }
+        Ok(files)
+    }
+}

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -16,6 +16,7 @@ mod error;
 mod event;
 mod faucet;
 mod files;
+mod folders;
 mod register;
 mod wallet;
 
@@ -29,6 +30,7 @@ pub use self::{
         upload::{FileUploadEvent, FilesUpload},
         FilesApi, BATCH_SIZE,
     },
+    folders::{FolderEntry, FoldersApi},
     register::ClientRegister,
     wallet::{broadcast_signed_spends, send, StoragePaymentResult, WalletClient},
 };

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -37,21 +37,19 @@ pub struct ClientRegister {
 
 impl ClientRegister {
     /// Central helper func to create a client register
-    fn create_register(client: Client, meta: XorName, perms: Permissions) -> Result<Self> {
+    fn create_register(client: Client, meta: XorName, perms: Permissions) -> Self {
         let public_key = client.signer_pk();
 
         let register = Register::new(public_key, meta, perms);
-        let reg = Self {
+        Self {
             client,
             register,
             ops: LinkedList::new(),
-        };
-
-        Ok(reg)
+        }
     }
 
     /// Create a new Register Locally.
-    pub fn create(client: Client, meta: XorName) -> Result<Self> {
+    pub fn create(client: Client, meta: XorName) -> Self {
         Self::create_register(client, meta, Permissions::new_owner_only())
     }
 
@@ -63,7 +61,7 @@ impl ClientRegister {
         verify_store: bool,
         perms: Permissions,
     ) -> Result<(Self, NanoTokens, NanoTokens)> {
-        let mut reg = Self::create_register(client, meta, perms)?;
+        let mut reg = Self::create_register(client, meta, perms);
         let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store).await?;
         Ok((reg, storage_cost, royalties_fees))
     }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{Client, Error, Result, WalletClient};
+use crate::{wallet::StoragePaymentResult, Client, Error, Result, WalletClient};
 
 use bls::PublicKey;
 use libp2p::{
@@ -62,7 +62,7 @@ impl ClientRegister {
         perms: Permissions,
     ) -> Result<(Self, NanoTokens, NanoTokens)> {
         let mut reg = Self::create_register(client, meta, perms);
-        let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store).await?;
+        let (storage_cost, royalties_fees) = reg.sync(wallet_client, verify_store, None).await?;
         Ok((reg, storage_cost, royalties_fees))
     }
 
@@ -158,10 +158,12 @@ impl ClientRegister {
 
     /// Sync this Register with the replicas on the network.
     /// This will optionally verify the stored Register on the network is the same as the local one.
+    /// If payment info is provided it won't try to make the payment.
     pub async fn sync(
         &mut self,
         wallet_client: &mut WalletClient,
         verify_store: bool,
+        mut payment_info: Option<(Payment, PeerId)>,
     ) -> Result<(NanoTokens, NanoTokens)> {
         let addr = *self.address();
         debug!("Syncing Register at {addr:?}!");
@@ -192,43 +194,24 @@ impl ClientRegister {
                 };
 
                 // Let's check if the user has already paid for this address first
-                let net_addr = sn_protocol::NetworkAddress::RegisterAddress(addr);
-                // Let's make the storage payment
-                let storage_payment_result = wallet_client
-                    .pay_for_storage(std::iter::once(net_addr.clone()))
-                    .await?;
-                storage_cost = storage_payment_result.storage_cost;
-                royalties_fees = storage_payment_result.royalty_fees;
-                let cost = storage_cost
-                    .checked_add(royalties_fees)
-                    .ok_or(Error::TotalPriceTooHigh)?;
+                if payment_info.is_none() {
+                    let net_addr = sn_protocol::NetworkAddress::RegisterAddress(addr);
+                    let payment_result = self.make_payment(wallet_client, &net_addr).await?;
+                    storage_cost = payment_result.storage_cost;
+                    royalties_fees = payment_result.royalty_fees;
 
-                println!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");
-                info!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");
+                    // Get payment proofs needed to publish the Register
+                    let payment = wallet_client.get_payment_for_addr(&net_addr)?;
+                    let payee = payment_result
+                        .payee_map
+                        .get(&net_addr)
+                        .ok_or(Error::PayeeNotFound(net_addr))?;
 
-                if let Err(err) = wallet_client.store_local_wallet() {
-                    warn!("Failed to store wallet with cached payment proofs: {err:?}");
-                    println!("Failed to store wallet with cached payment proofs: {err:?}");
-                } else {
-                    println!(
-                    "Successfully stored wallet with cached payment proofs, and new balance {}.",
-                    wallet_client.balance()
-                );
-                    info!(
-                    "Successfully stored wallet with cached payment proofs, and new balance {}.",
-                    wallet_client.balance()
-                );
+                    debug!("payments found: {payment:?}");
+                    payment_info = Some((payment, *payee));
                 }
 
-                // Get payment proofs needed to publish the Register
-                let payment = wallet_client.get_payment_for_addr(&net_addr)?;
-                let payee = storage_payment_result
-                    .payee_map
-                    .get(&net_addr)
-                    .ok_or(Error::PayeeNotFound(net_addr))?;
-
-                debug!("payments found: {payment:?}");
-                self.publish_register(cmd, Some((payment, *payee)), verify_store)
+                self.publish_register(cmd, payment_info, verify_store)
                     .await?;
                 self.register.clone()
             }
@@ -304,6 +287,41 @@ impl ClientRegister {
     }
 
     // ********* Private helpers  *********
+
+    // Make a storage payment for the provided network address
+    async fn make_payment(
+        &self,
+        wallet_client: &mut WalletClient,
+        net_addr: &NetworkAddress,
+    ) -> Result<StoragePaymentResult> {
+        // Let's make the storage payment
+        let payment_result = wallet_client
+            .pay_for_storage(std::iter::once(net_addr.clone()))
+            .await?;
+        let cost = payment_result
+            .storage_cost
+            .checked_add(payment_result.royalty_fees)
+            .ok_or(Error::TotalPriceTooHigh)?;
+
+        println!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");
+        info!("Successfully made payment of {cost} for a Register (At a cost per record of {cost:?}.)");
+
+        if let Err(err) = wallet_client.store_local_wallet() {
+            warn!("Failed to store wallet with cached payment proofs: {err:?}");
+            println!("Failed to store wallet with cached payment proofs: {err:?}");
+        } else {
+            println!(
+                "Successfully stored wallet with cached payment proofs, and new balance {}.",
+                wallet_client.balance()
+            );
+            info!(
+                "Successfully stored wallet with cached payment proofs, and new balance {}.",
+                wallet_client.balance()
+            );
+        }
+
+        Ok(payment_result)
+    }
 
     /// Publish a `Register` command on the network.
     /// If `verify_store` is true, it will verify the Register was stored on the network.

--- a/sn_node/examples/registers.rs
+++ b/sn_node/examples/registers.rs
@@ -147,7 +147,7 @@ async fn main() -> Result<()> {
         // Sync with network after a delay
         println!("Syncing with SAFE in {delay:?}...");
         sleep(delay).await;
-        reg_replica.sync(&mut wallet_client, true).await?;
+        reg_replica.sync(&mut wallet_client, true, None).await?;
         println!("synced!");
     }
 }

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -295,7 +295,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
     let random_entry = rng.gen::<[u8; 32]>().to_vec();
 
     register.write(&random_entry)?;
-    register.sync(&mut wallet_client, true).await?;
+    register.sync(&mut wallet_client, true, None).await?;
 
     let retrieved_reg = client.get_register(address).await?;
 
@@ -357,9 +357,9 @@ async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
 
     sleep(Duration::from_secs(5)).await;
     assert!(matches!(
-    register.sync(&mut wallet_client, false).await,
-            Err(ClientError::Protocol(ProtocolError::RegisterNotFound(addr))) if *addr == address
-        ));
+        register.sync(&mut wallet_client, false, None).await,
+        Err(ClientError::Protocol(ProtocolError::RegisterNotFound(addr))) if *addr == address
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jan 24 20:48 UTC
This pull request includes the following changes across multiple files:

- In the `subcommands/mod.rs` file, a new module `folders` has been added, along with the necessary command handling for the `SubCmd::Folders` variant.

- In the `subcommands/mod.rs` file, the `FoldersApi` trait has been imported.

- In the `subcommands/folders.rs` file, the implementation of the `FoldersApi` struct has been added. The struct provides APIs for interacting with folders and includes methods such as `new`, `wallet`, and `upload`.

- In the `folders.rs` file, the implementation of the `FoldersCmds` enum has been added, which includes variants for `Upload` and `Download` operations.

- In the `folders.rs` file, helper functions `upload_folder` and `download_folder` have been implemented to handle the actual upload and download operations.

- In the `api.rs` file, a blank line has been added at line 62, and there is an additional comment for instantiating a new client.

Please review the changes in the diff for any potential issues or improvements.
<!-- reviewpad:summarize:end --> 
