### PR TITLE
fix(cli): chunk manager to return error if fs operation fails

### DIFF
--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -29,9 +29,6 @@ use xor_name::XorName;
 const CHUNK_ARTIFACTS_DIR: &str = "chunk_artifacts";
 const METADATA_FILE: &str = "metadata";
 
-/// Subdir for storing uploaded file into
-pub(crate) const UPLOADED_FILES: &str = "uploaded_files";
-
 // The unique hex encoded hash(path)
 // This allows us to uniquely identify if a file has been chunked or not.
 // An alternative to use instead of filename as it might not be unique
@@ -367,30 +364,13 @@ impl ChunkManager {
                     chunked_file.head_chunk_address,
                 ));
 
-                // write the data_map addr and or data_map to the UPLOADED_FILES dir
-                let filename_hex = chunked_file.head_chunk_address.to_hex();
-
-                // ensure self.root_dir.join(UPLOADED_FILES) exists
-                let uploaded_files = self.root_dir.join(UPLOADED_FILES);
-                if !uploaded_files.exists() {
-                    if let Err(error) = fs::create_dir_all(&uploaded_files) {
-                        error!("Failed to create {uploaded_files:?} because {error:?}");
-                    }
-                }
-
-                let uploaded_file_path = uploaded_files.join(&filename_hex);
-
-                warn!(
-                    "Marking {uploaded_file_path:?} as completed for chunked_file {:?}",
-                    chunked_file
-                );
-
                 let uploaded_file_metadata = UploadedFile {
                     filename: chunked_file.file_name,
                     data_map: chunked_file.data_map,
                 };
                 // errors are logged by write()
-                let _result = uploaded_file_metadata.write(&uploaded_file_path);
+                let _result =
+                    uploaded_file_metadata.write(&self.root_dir, &chunked_file.head_chunk_address);
             }
         }
         Ok(())

--- a/sn_cli/src/subcommands/files/mod.rs
+++ b/sn_cli/src/subcommands/files/mod.rs
@@ -290,10 +290,10 @@ async fn upload_files(
             }
             println!("**************************************");
 
-            if chunk_manager.verified_files().is_empty() {
+            if chunk_manager.completed_files().is_empty() {
                 println!("chunk_manager doesn't have any verified_files, nor any failed_chunks to re-upload.");
             }
-            for (file_name, addr) in chunk_manager.verified_files() {
+            for (file_name, addr) in chunk_manager.completed_files() {
                 let hex_addr = addr.to_hex();
                 if let Some(file_name) = file_name.to_str() {
                     println!("\"{file_name}\" {hex_addr}");
@@ -363,7 +363,7 @@ async fn upload_files(
         // terminates with an error. This race condition can happen as we bail on `upload_result` before we await the
         // handler.
         if !upload_terminated_with_error {
-            for file_name in chunk_manager.unverified_files() {
+            for file_name in chunk_manager.incomplete_files() {
                 if let Some(file_name) = file_name.to_str() {
                     println!("Unverified file \"{file_name}\", suggest to re-upload again.");
                     info!("Unverified {file_name}");
@@ -383,7 +383,7 @@ async fn upload_files(
                 println!("*      to publish the datamaps.      *");
             }
             println!("**************************************");
-            for (file_name, addr) in chunk_manager.verified_files() {
+            for (file_name, addr) in chunk_manager.completed_files() {
                 let hex_addr = addr.to_hex();
                 if let Some(file_name) = file_name.to_str() {
                     println!("\"{file_name}\" {hex_addr}");

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -101,7 +101,7 @@ pub enum Error {
     #[error("Transport Error")]
     TransportError(#[from] TransportError<std::io::Error>),
 
-    #[error("SnProtocol Error")]
+    #[error("SnProtocol Error: {0}")]
     ProtocolError(#[from] sn_protocol::error::Error),
 
     #[error("Transfer Error {0}.")]


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Feb 24 06:01 UTC
This pull request includes the following changes:

- The variant `ProtocolError` of the `Error` enum in the file `error.rs` has been modified to include a formatted error message.
- The file diff of `error.rs` involves improving error handling and error message formatting in the code.
- The diff summary of other files includes changes related to improving error handling, file upload functionality, and logging.

Overall, this pull request focuses on enhancing error handling, error messages, file uploads, and logging in the codebase.
<!-- reviewpad:summarize:end --> 
