### PR TITLE
fix: node manager `status` permissions error

### DIFF
--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -697,24 +697,6 @@ async fn main() -> Result<()> {
             fail,
             json,
         } => {
-            let mut node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
-            if !node_registry.nodes.is_empty() {
-                if !json {
-                    println!("=================================================");
-                    println!("                Safenode Services                ");
-                    println!("=================================================");
-                }
-                status(
-                    &mut node_registry,
-                    &NodeServiceManager {},
-                    details,
-                    json,
-                    fail,
-                )
-                .await?;
-                node_registry.save()?;
-            }
-
             let mut local_node_registry = NodeRegistry::load(&get_local_node_registry_path()?)?;
             if !local_node_registry.nodes.is_empty() {
                 if !json {
@@ -731,6 +713,25 @@ async fn main() -> Result<()> {
                 )
                 .await?;
                 local_node_registry.save()?;
+                return Ok(());
+            }
+
+            let mut node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
+            if !node_registry.nodes.is_empty() {
+                if !json {
+                    println!("=================================================");
+                    println!("                Safenode Services                ");
+                    println!("=================================================");
+                }
+                status(
+                    &mut node_registry,
+                    &NodeServiceManager {},
+                    details,
+                    json,
+                    fail,
+                )
+                .await?;
+                node_registry.save()?;
             }
 
             Ok(())
@@ -930,17 +931,6 @@ async fn main() -> Result<()> {
             Ok(())
         }
     }
-}
-
-#[cfg(unix)]
-fn is_running_as_root() -> bool {
-    users::get_effective_uid() == 0
-}
-
-#[cfg(windows)]
-fn is_running_as_root() -> bool {
-    // The Windows implementation for this will be much more complex.
-    true
 }
 
 async fn get_bin_path(


### PR DESCRIPTION
A user reported an issue in the `status` command resulting in an error. The `status` command actually attempts to report on two different things: installed services and a local network. It first tried to report on the status of services, and in the process, it attempts to create the `/var/safenode-manager` directory if it does not exist, because that's where the node registry file is stored. So, if you ran the command as a non-root user, it would result in a permissions error. The error didn't occur on on my machine because it happened to be the case that I had already created that directory.

I've now changed the command so that it will first query whether a local network exists, then return if that is the case, without trying to query for installed services. In the case of no local network, when a query is made for installed services, the command will run without root access.

## Description

reviewpad:summary 
