### PR TITLE
chore: improvements from dev feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4949,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "sn-releases"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb737feba172449d8fa5ab6470c014c25f94b971fd7773043308335efdc77c0"
+checksum = "0fd09c844c16b72f6a34a090f642a9685d48f86345f67d607586900a93c0fd47"
 dependencies = [
  "async-trait",
  "chrono",

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -40,7 +40,7 @@ service-manager = "0.5.1"
 sn_node_rpc_client =  { path = "../sn_node_rpc_client", version = "0.4.35" } 
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.4" }
 sn_protocol = { path = "../sn_protocol", version = "0.12.4" }
-sn-releases = "0.1.6"
+sn-releases = "0.1.7"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }
 uuid = { version = "1.5.0", features = ["v4"] }

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -22,6 +22,9 @@ pub enum UpgradeResult {
     Error(String),
 }
 
+// macOS seems to require this delay to be in seconds rather than milliseconds.
+const RPC_START_UP_DELAY_MS: u64 = 3000;
+
 pub async fn start(
     node: &mut Node,
     service_control: &dyn ServiceControl,
@@ -47,7 +50,7 @@ pub async fn start(
     service_control.start(&node.service_name)?;
 
     // Give the node a little bit of time to start before initiating the node info query.
-    service_control.wait(3);
+    service_control.wait(RPC_START_UP_DELAY_MS);
     let node_info = rpc_client.node_info().await?;
     let network_info = rpc_client.network_info().await?;
     node.listen_addr = Some(
@@ -384,7 +387,7 @@ mod tests {
             .returning(|_| Ok(()));
         mock_service_control
             .expect_wait()
-            .with(eq(3))
+            .with(eq(3000))
             .times(1)
             .returning(|_| ());
         mock_rpc_client.expect_node_info().times(1).returning(|| {
@@ -457,7 +460,7 @@ mod tests {
             .returning(|_| Ok(()));
         mock_service_control
             .expect_wait()
-            .with(eq(3))
+            .with(eq(3000))
             .times(1)
             .returning(|_| ());
         mock_rpc_client.expect_node_info().times(1).returning(|| {

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -18,13 +18,8 @@ use std::{
     ffi::OsString,
     net::{SocketAddr, TcpListener},
     path::PathBuf,
-    thread::sleep,
-    time::Duration,
 };
 use sysinfo::{Pid, System, SystemExt};
-
-// The UDP port might fail to unbind even when dropped and this can cause the safenode process to throw errors.
-const PORT_UNBINDING_DELAY: Duration = Duration::from_secs(3);
 
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
@@ -163,9 +158,6 @@ impl ServiceControl for NodeServiceManager {
         let socket = TcpListener::bind(addr)?;
         let port = socket.local_addr()?.port();
         drop(socket);
-        // Sleep a little while to make sure that we've dropped the socket.
-        // Without the delay, we may face 'Port already in use' error, when trying to re-use this port.
-        sleep(PORT_UNBINDING_DELAY);
 
         Ok(port)
     }
@@ -278,6 +270,6 @@ impl ServiceControl for NodeServiceManager {
     ///
     /// This is wrapped mainly just for unit testing.
     fn wait(&self, delay: u64) {
-        std::thread::sleep(std::time::Duration::from_secs(delay));
+        std::thread::sleep(std::time::Duration::from_millis(delay));
     }
 }


### PR DESCRIPTION
Reduce the start up time for the local network by removing the wait in the `get_available_port` function. This function is now only being used to select ports for the RPC service, so it shouldn't be subject to the same problems we had with the node when it switched over to Quic.

Also, the `--clean` argument on the run command has been extended to kill any existing local network.

## Description

reviewpad:summary 
