### PR TITLE
ci: temporary debugging output for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-2
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+      RUST_LOG: debug
 
     steps:
       - uses: actions/checkout@v4
@@ -124,21 +125,33 @@ jobs:
       - name: publish and release
         shell: bash
         run: |
+          df -h
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+          df -h
           just package-release-assets "safe"
+          df -h
           just package-release-assets "safenode"
+          df -h
           just package-release-assets "faucet"
+          df -h
           just package-release-assets "safenode_rpc_client"
+          df -h
           just package-release-assets "safenode-manager"
           # The versioned assets are uploaded to both the release and S3 in this target.
           just upload-release-assets
+          df -h
           # Now repackage and upload the artifacts to S3 using 'latest' for the version.
           just package-release-assets "safe" "latest"
+          df -h
           just package-release-assets "safenode" "latest"
+          df -h
           just package-release-assets "faucet" "latest"
+          df -h
           just package-release-assets "safenode_rpc_client" "latest"
+          df -h
           just package-release-assets "safenode-manager" "latest"
+          df -h
           just upload-release-assets-to-s3 "safe"
           just upload-release-assets-to-s3 "safenode"
           just upload-release-assets-to-s3 "safenode-manager"


### PR DESCRIPTION
Something is causing the build agent to run out of space. I have a suspicion it's possible that it's something to do with how `release-plz` determines changes in the crates, and it could be struggling because the number of crates in our workspace has grown.

The first thing is to enable debugging output, because I seen some `debug!` usage in the `release-plz` codebase. Hoping maybe that could provide some clues if it is `release-plz` that is causing the disk usage.

If not, each step has output to display the disk usage, which hopefully may give us other clues.

This commit can be reverted when we have solved the issue.

## Description

reviewpad:summary 
