### PR TITLE
ci: use a different disk for the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-2
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
-      RUST_LOG: debug
 
     steps:
       - uses: actions/checkout@v4
@@ -125,33 +124,21 @@ jobs:
       - name: publish and release
         shell: bash
         run: |
-          df -h
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
-          df -h
           just package-release-assets "safe"
-          df -h
           just package-release-assets "safenode"
-          df -h
           just package-release-assets "faucet"
-          df -h
           just package-release-assets "safenode_rpc_client"
-          df -h
           just package-release-assets "safenode-manager"
           # The versioned assets are uploaded to both the release and S3 in this target.
           just upload-release-assets
-          df -h
           # Now repackage and upload the artifacts to S3 using 'latest' for the version.
           just package-release-assets "safe" "latest"
-          df -h
           just package-release-assets "safenode" "latest"
-          df -h
           just package-release-assets "faucet" "latest"
-          df -h
           just package-release-assets "safenode_rpc_client" "latest"
-          df -h
           just package-release-assets "safenode-manager" "latest"
-          df -h
           just upload-release-assets-to-s3 "safe"
           just upload-release-assets-to-s3 "safenode"
           just upload-release-assets-to-s3 "safenode-manager"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.11/release-plz-x86_64-unknown-linux-gnu.tar.gz
+  RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.43/release-plz-x86_64-unknown-linux-gnu.tar.gz
   JUST_BIN_URL: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
@@ -72,11 +72,6 @@ jobs:
       GH_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: "0"
-          token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
-        
       - uses: actions/download-artifact@master
         with:
           name: safe_network-x86_64-pc-windows-msvc
@@ -101,10 +96,15 @@ jobs:
         with:
           name: safe_network-aarch64-unknown-linux-musl
           path: artifacts/aarch64-unknown-linux-musl/release
-      - shell: bash
+      - name: manually checkout repository
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          sudo mkdir /mnt/safe_network
+          sudo chown runner:runner /mnt/safe_network
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          echo "${{ secrets.VERSION_BUMP_COMMIT_PAT }}" | git credential approve
+          git config --global credential.helper store
+          git clone --depth=1 https://github.com/maidsafe/safe_network /mnt/safe_network
       # It's possible to `cargo install` these tools, but it's very slow to compile on GHA infra.
       # Therefore we just pull some binaries from the Github Releases.
       - name: install tools
@@ -125,7 +125,12 @@ jobs:
         shell: bash
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          cd /mnt/safe_network
+
+          df -h
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+          df -h
+
           just package-release-assets "safe"
           just package-release-assets "safenode"
           just package-release-assets "faucet"


### PR DESCRIPTION
- c5752a02 **Revert "ci: temporary debugging output for release process"**

  This reverts commit 9e32aa47e00f725b854c9b51fc9b377512dab769.

- 06efde89 **ci: use a different disk for the release process**

  For reasons not yet determined, the publishing process undertaken by `release-plz` is using up 20GB
  of disk space, which results in the root file system on the Github Actions build agent being filled
  up during the process, since the disk only has 20GB of free space.

  It turns out there's another disk at `/mnt`, which has over 60GB of space, so we should be able to
  run the release process from there, until we can resolve the problem with `release-plz`.

  I tested the manual checkout on the merge workflow just to make sure it worked ok.

## Description

reviewpad:summary 
