### PR TITLE
ci: re-add disk space debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,10 @@ jobs:
         shell: bash
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          df -h
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+          df -h
+
           just package-release-assets "safe"
           just package-release-assets "safenode"
           just package-release-assets "faucet"


### PR DESCRIPTION
I would still like to monitor how much disk space `release-plz` is using just to see if upgrading to the new version has likely solved the problem we were having.

## Description

reviewpad:summary 
