### PR TITLE
feat: force and upgrade by url or version

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -146,8 +146,8 @@ jobs:
       - shell: bash
         run: cargo test --release --bin safenode-manager
 
-  node-manager-integration-tests:
-    name: node manager integration tests
+  node-manager-e2e-tests:
+    name: node manager e2e tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -169,7 +169,7 @@ jobs:
           ${{ matrix.elevated }} rustup default stable
           ${{ matrix.elevated }} cargo test --package sn-node-manager --release --test e2e -- --nocapture
 
-      # A simple test seemed to confirm that the Powershell step runs as admin by default.
+      # Powershell step runs as admin by default.
       - name: run integration test in powershell
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -181,6 +181,54 @@ jobs:
           $env:PATH += ";$env:GITHUB_WORKSPACE\bin"
 
           cargo test --release --package sn-node-manager --test e2e -- --nocapture
+
+  # Each upgrade test needs its own VM, otherwise they will interfere with each other.
+  node-manager-upgrade-tests:
+    name: node manager upgrade tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, elevated: sudo env PATH="$PATH", test: upgrade_to_latest_version }
+          - { os: ubuntu-latest, elevated: sudo env PATH="$PATH", test: force_upgrade_when_two_binaries_have_the_same_version }
+          - { os: ubuntu-latest, elevated: sudo env PATH="$PATH", test: force_downgrade_to_a_previous_version }
+          - { os: ubuntu-latest, elevated: sudo env PATH="$PATH", test: upgrade_from_older_version_to_specific_version }
+          - { os: macos-latest, elevated: sudo, test: upgrade_to_latest_version }
+          - { os: macos-latest, elevated: sudo, test: force_upgrade_when_two_binaries_have_the_same_version }
+          - { os: macos-latest, elevated: sudo, test: force_downgrade_to_a_previous_version }
+          - { os: macos-latest, elevated: sudo, test: upgrade_from_older_version_to_specific_version }
+          - { os: windows-latest, test: upgrade_to_latest_version }
+          - { os: windows-latest, test: force_upgrade_when_two_binaries_have_the_same_version }
+          - { os: windows-latest, test: force_downgrade_to_a_previous_version }
+          - { os: windows-latest, test: upgrade_from_older_version_to_specific_version }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - shell: bash
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: |
+          ${{ matrix.elevated }} rustup default stable
+          ${{ matrix.elevated }} cargo test --package sn-node-manager --release \
+            --test upgrades ${{ matrix.test }} -- --nocapture
+
+      # Powershell step runs as admin by default.
+      - name: run integration test in powershell
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          curl -L -o WinSW.exe $env:WINSW_URL
+
+          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\bin"
+          Move-Item -Path WinSW.exe -Destination "$env:GITHUB_WORKSPACE\bin"
+          $env:PATH += ";$env:GITHUB_WORKSPACE\bin"
+
+          cargo test --package sn-node-manager --release `
+            --test upgrades ${{ matrix.test }} -- --nocapture
 
   e2e:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,6 +4885,7 @@ dependencies = [
  "mockall",
  "nix 0.27.1",
  "predicates 2.1.5",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -55,4 +55,5 @@ assert_fs = "1.0.13"
 assert_matches = "1.5.0"
 async-trait = "0.1"
 mockall = "0.11.3"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 predicates = "2.0"

--- a/sn_node_manager/tests/upgrades.rs
+++ b/sn_node_manager/tests/upgrades.rs
@@ -1,0 +1,290 @@
+// Copyright (C) 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use assert_cmd::Command;
+use color_eyre::{eyre::eyre, Result};
+use serde_json::Value;
+use sn_releases::{ReleaseType, SafeReleaseRepositoryInterface};
+
+const CI_USER: &str = "runner";
+
+/// These tests need to execute as the root user.
+///
+/// They are intended to run on a CI-based environment with a fresh build agent because they will
+/// create real services and user accounts, and will not attempt to clean themselves up.
+///
+/// Each test also needs to run in isolation, otherwise they will interfere with each other.
+///
+/// If you run them on your own dev machine, do so at your own risk!
+
+#[tokio::test]
+async fn upgrade_to_latest_version() -> Result<()> {
+    let mut cmd = Command::cargo_bin("safenode-manager")?;
+    cmd.arg("add")
+        .arg("--user")
+        .arg(CI_USER)
+        .arg("--count")
+        .arg("3")
+        .arg("--peer")
+        .arg("/ip4/127.0.0.1/udp/46091/p2p/12D3KooWAWnbQLxqspWeB3M8HB3ab3CSj6FYzsJxEG9XdVnGNCod")
+        .arg("--version")
+        .arg("0.98.27")
+        .assert()
+        .success();
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some("0.98.27")),
+        "Services were not correctly initialised"
+    );
+
+    let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+    let latest_version = release_repo
+        .get_latest_version(&ReleaseType::Safenode)
+        .await?;
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    let output = cmd
+        .arg("upgrade")
+        .arg("--do-not-start")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output = std::str::from_utf8(&output)?;
+    println!("upgrade command output:");
+    println!("{output}");
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(&latest_version)),
+        "Not all services were updated to the latest version"
+    );
+
+    Ok(())
+}
+
+/// This scenario may seem pointless, but forcing a change for a binary with the same version will
+/// be required for the backwards compatibility test; the binary will be different, it will just
+/// have the same version.
+#[tokio::test]
+async fn force_upgrade_when_two_binaries_have_the_same_version() -> Result<()> {
+    let version = "0.98.27";
+
+    let mut cmd = Command::cargo_bin("safenode-manager")?;
+    cmd.arg("add")
+        .arg("--user")
+        .arg(CI_USER)
+        .arg("--count")
+        .arg("3")
+        .arg("--peer")
+        .arg("/ip4/127.0.0.1/udp/46091/p2p/12D3KooWAWnbQLxqspWeB3M8HB3ab3CSj6FYzsJxEG9XdVnGNCod")
+        .arg("--version")
+        .arg(version)
+        .assert()
+        .success();
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(version)),
+        "Services were not correctly initialised"
+    );
+
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    let output = cmd
+        .arg("upgrade")
+        .arg("--do-not-start")
+        .arg("--force")
+        .arg("--version")
+        .arg(version)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output = std::str::from_utf8(&output)?;
+    println!("upgrade command output:");
+    println!("{output}");
+
+    assert!(output.contains(&format!(
+        "Forced safenode1 version change from {version} to {version}"
+    )));
+    assert!(output.contains(&format!(
+        "Forced safenode2 version change from {version} to {version}"
+    )));
+    assert!(output.contains(&format!(
+        "Forced safenode3 version change from {version} to {version}"
+    )));
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(version)),
+        "Not all services were updated to the latest version"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn force_downgrade_to_a_previous_version() -> Result<()> {
+    let initial_version = "0.104.15";
+    let downgrade_version = "0.104.10";
+
+    let mut cmd = Command::cargo_bin("safenode-manager")?;
+    cmd.arg("add")
+        .arg("--user")
+        .arg(CI_USER)
+        .arg("--count")
+        .arg("3")
+        .arg("--peer")
+        .arg("/ip4/127.0.0.1/udp/46091/p2p/12D3KooWAWnbQLxqspWeB3M8HB3ab3CSj6FYzsJxEG9XdVnGNCod")
+        .arg("--version")
+        .arg(initial_version)
+        .assert()
+        .success();
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(initial_version)),
+        "Services were not correctly initialised"
+    );
+
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    let output = cmd
+        .arg("upgrade")
+        .arg("--do-not-start")
+        .arg("--force")
+        .arg("--version")
+        .arg(downgrade_version)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output = std::str::from_utf8(&output)?;
+    println!("upgrade command output:");
+    println!("{output}");
+
+    assert!(output.contains(&format!(
+        "Forced safenode1 version change from {initial_version} to {downgrade_version}"
+    )));
+    assert!(output.contains(&format!(
+        "Forced safenode2 version change from {initial_version} to {downgrade_version}"
+    )));
+    assert!(output.contains(&format!(
+        "Forced safenode3 version change from {initial_version} to {downgrade_version}"
+    )));
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(downgrade_version)),
+        "Not all services were updated to the latest version"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn upgrade_from_older_version_to_specific_version() -> Result<()> {
+    let initial_version = "0.104.10";
+    let upgrade_version = "0.104.14";
+
+    let mut cmd = Command::cargo_bin("safenode-manager")?;
+    cmd.arg("add")
+        .arg("--user")
+        .arg(CI_USER)
+        .arg("--count")
+        .arg("3")
+        .arg("--peer")
+        .arg("/ip4/127.0.0.1/udp/46091/p2p/12D3KooWAWnbQLxqspWeB3M8HB3ab3CSj6FYzsJxEG9XdVnGNCod")
+        .arg("--version")
+        .arg(initial_version)
+        .assert()
+        .success();
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(initial_version)),
+        "Services were not correctly initialised"
+    );
+
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    let output = cmd
+        .arg("upgrade")
+        .arg("--do-not-start")
+        .arg("--version")
+        .arg(upgrade_version)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output = std::str::from_utf8(&output)?;
+    println!("upgrade command output:");
+    println!("{output}");
+
+    assert!(output.contains(&format!(
+        "safenode1 upgraded from {initial_version} to {upgrade_version}"
+    )));
+    assert!(output.contains(&format!(
+        "safenode2 upgraded from {initial_version} to {upgrade_version}"
+    )));
+    assert!(output.contains(&format!(
+        "safenode3 upgraded from {initial_version} to {upgrade_version}"
+    )));
+
+    let services = get_service_status().await?;
+    assert!(
+        services
+            .iter()
+            .all(|service| service["version"].as_str() == Some(upgrade_version)),
+        "Not all services were updated to the latest version"
+    );
+
+    Ok(())
+}
+
+async fn get_service_status() -> Result<Vec<Value>> {
+    let mut cmd = Command::cargo_bin("safenode-manager")?;
+    let output = cmd
+        .arg("status")
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output = std::str::from_utf8(&output)?;
+    println!("status command output:");
+    println!("{output}");
+
+    let services: Vec<Value> = match serde_json::from_str(output) {
+        Ok(json) => json,
+        Err(e) => return Err(eyre!("Failed to parse JSON output: {:?}", e)),
+    };
+    Ok(services)
+}

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{error::Result as ProtocolResult, Error};
+use crate::Error;
 use color_eyre::Result;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
@@ -115,18 +115,18 @@ pub struct Node {
 
 impl Node {
     /// Returns the UDP port from our node's listen address.
-    pub fn get_safenode_port(&self) -> ProtocolResult<u16> {
+    pub fn get_safenode_port(&self) -> Option<u16> {
         // assuming the listening addr contains /ip4/127.0.0.1/udp/56215/quic-v1/p2p/<peer_id>
         if let Some(multi_addrs) = &self.listen_addr {
             for addr in multi_addrs {
                 for protocol in addr.iter() {
                     if let Protocol::Udp(port) = protocol {
-                        return Ok(port);
+                        return Some(port);
                     }
                 }
             }
         }
-        Err(Error::CouldNotObtainPortFromMultiAddr)
+        None
     }
 }
 


### PR DESCRIPTION
  Three new arguments are added to the `upgrade` command: `--force`, `--url` and `--version`.

  The `--url` and `--version` arguments provide two different sources for the upgrade, as opposed to
  just upgrading to the latest version. With `--url`, a custom binary can be provided, which will be
  used for the backwards compatibility test. The `--version` flag enables upgrading to a specific
  version rather than the latest. Both of these can be used with the `--force` flag to downgrade to an
  arbitrary version or to accept an upgrade from a binary with the same version, the latter of which
  will again be used in the backwards compatibility test.

  Integration tests provide coverage of these new features. Each of the tests really needs to run on
  its own machine, otherwise they interfere with each other, and tests can't make assumptions about
  how many services there are. So we add twelve additional jobs to the merge workflow here, which is
  for four tests on three operating systems. However, these tests should run pretty quickly.

  The `stop` command was modified such that it will no longer return an error if the service is in the
  `ADDED` state, i.e., it has not been started before. This enables us to test the upgrade process
  without initially starting the service, which could introduce complications. The `get_safenode_port`
  function was also changed to return an `Option` rather than a `Result` for the same reason.

## Description

reviewpad:summary 
