### PR TITLE
feat(faucet): api endpoint to return distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5031,6 +5031,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
+ "url",
 ]
 
 [[package]]

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -40,6 +40,7 @@ tiny_http = { version="0.12", features = ["ssl-rustls"] }
 tokio = { version = "1.32.0", features = ["parking_lot", "rt"] }
 tracing = { version = "~0.1.26" }
 tracing-core = "0.1.30"
+url = "2.5.0"
 
 [lints]
 workspace = true

--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -12,9 +12,11 @@ use crate::{claim_genesis, send_tokens};
 use color_eyre::eyre::{eyre, Result};
 use sn_client::Client;
 use sn_transfers::{HotWallet, NanoTokens};
-use std::path::{self, Path, PathBuf};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use tiny_http::{Response, Server};
 use tracing::{debug, error, trace};
+use url::Url;
 
 /// Run the faucet server.
 ///
@@ -58,16 +60,18 @@ pub async fn restart_faucet_server(client: &Client) -> Result<()> {
 }
 
 async fn startup_server(client: &Client) -> Result<()> {
+    #[allow(unused)]
+    let mut balances = HashMap::<String, NanoTokens>::new();
     #[cfg(feature = "distribution")]
     {
-        let balances = token_distribution::load_maid_snapshot()?;
+        balances = token_distribution::load_maid_snapshot()?;
         let keys = token_distribution::load_maid_pubkeys()?;
         // Each distribution takes about 500ms to create, so for thousands of
         // initial distributions this takes many minutes. This is run in the
         // background instead of blocking the server from starting.
         tokio::spawn(token_distribution::distribute_from_maid_to_tokens(
             client.clone(),
-            balances,
+            balances.clone(),
             keys,
         ));
     }
@@ -90,25 +94,83 @@ async fn startup_server(client: &Client) -> Result<()> {
             request.url(),
             request.headers()
         );
-        let key = request.url().trim_matches(path::is_separator);
-
-        match send_tokens(client, "100", key).await {
-            Ok(transfer) => {
-                println!("Sent tokens to {key}");
-                debug!("Sent tokens to {key}");
-                let response = Response::from_string(transfer);
-                let _ = request.respond(response).map_err(|err| {
-                    eprintln!("Failed to send response: {err}");
-                    error!("Failed to send response: {err}");
-                });
-            }
+        // There are two paths available in the faucet.
+        //
+        // http://<ip>/<wallet_hex_key>
+        // which sends a fixed amount to that key.
+        //
+        // http://<ip>/distribution?address=<addr>&publickey=<pkhex>
+        // which returns the distribution for that maid address
+        //
+        // tiny_http request.url() excludes host, ie is only the path.
+        // https://docs.rs/tiny_http/latest/tiny_http/struct.Request.html#method.url
+        // Returns the resource requested by the client.
+        let request_url = format!("http://127.0.0.1:8000{}", request.url());
+        let url = match Url::parse(&request_url) {
+            Ok(u) => u,
             Err(err) => {
-                eprintln!("Failed to send tokens to {key}: {err}");
-                error!("Failed to send tokens to {key}: {err}");
-                let response = Response::from_string(format!("Failed to send tokens: {err}"));
+                let response = Response::from_string(format!("Invalid url: {err}"));
+                let _ = request
+                    .respond(response.with_status_code(400))
+                    .map_err(|err| eprintln!("Failed to get distribution: {err}"));
+                continue;
+            }
+        };
+        if url.path() == "/distribution" {
+            // if distribution feature is enabled, return the distribution for
+            // this address
+            #[cfg(feature = "distribution")]
+            {
+                match token_distribution::handle_distribution_req(client, url, balances.clone())
+                    .await
+                {
+                    Ok(distribution) => {
+                        let response = Response::from_string(distribution);
+                        let _ = request.respond(response).map_err(|err| {
+                            eprintln!("Failed to send response: {err}");
+                            error!("Failed to send response: {err}");
+                        });
+                    }
+                    Err(err) => {
+                        eprintln!("Failed to get distribution: {err}");
+                        error!("Failed to get distribution: {err}");
+                        let response =
+                            Response::from_string(format!("Failed to get distribution: {err}"));
+                        let _ = request
+                            .respond(response.with_status_code(500))
+                            .map_err(|err| eprintln!("Failed to get distribution: {err}"));
+                    }
+                }
+            }
+            // if distribution feature not enabled then return an error
+            #[cfg(not(feature = "distribution"))]
+            {
+                let response = Response::from_string(format!("Distribution feature disabled"));
                 let _ = request
                     .respond(response.with_status_code(500))
                     .map_err(|err| eprintln!("Failed to send response: {err}"));
+            }
+        } else {
+            // issue a fixed amount of tokens to the wallet key
+            let key = url.path().trim_start_matches('/');
+            match send_tokens(client, "100", key).await {
+                Ok(transfer) => {
+                    println!("Sent tokens to {key}");
+                    debug!("Sent tokens to {key}");
+                    let response = Response::from_string(transfer);
+                    let _ = request.respond(response).map_err(|err| {
+                        eprintln!("Failed to send response: {err}");
+                        error!("Failed to send response: {err}");
+                    });
+                }
+                Err(err) => {
+                    eprintln!("Failed to send tokens to {key}: {err}");
+                    error!("Failed to send tokens to {key}: {err}");
+                    let response = Response::from_string(format!("Failed to send tokens: {err}"));
+                    let _ = request
+                        .respond(response.with_status_code(500))
+                        .map_err(|err| eprintln!("Failed to send response: {err}"));
+                }
             }
         }
     }


### PR DESCRIPTION
The server sends 100 tokens for the endpoint:
`http://<ip>/<bls_hex_pubkey>`

This adds a new (additional) endpoint to distribute to maid addresses:
`http://<ip>/distribution?address=<maid_address>&pkhex=<pkhex>`

Calling the new endpoint will return an existing distribution for that maidsafecoin address, or create a new distribution if needed.

This enables distributions to be fetched from the faucet, but there still needs to be integration into the cli which is future work to try to keep each PR relatively small and manageable.

Future faucet related work:

* update cli `safe wallet get-faucet` to be able to fetch distributions
* change the default amount issued by the faucet from 100 to something smaller (any suggestions?)
* potentially move away from `tiny_http` for the faucet server to something that has better security and rate limiting options

## Description

reviewpad:summary 
