### PR TITLE
Revert "ci: re-add disk space debugging"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,10 +125,7 @@ jobs:
         shell: bash
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          df -h
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
-          df -h
-
           just package-release-assets "safe"
           just package-release-assets "safenode"
           just package-release-assets "faucet"


### PR DESCRIPTION
This reverts commit dd05850e841efb7dd870828fb754b237a2fae731.

With the newer version of `release-plz` we have about 5GB to spare at the end of the publishing process:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   68G  5.0G  94% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

## Description

reviewpad:summary 
