### PR TITLE
fix(manager): restart nodes with the same safenode port

### DIFF
--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -24,7 +24,7 @@ pub struct AddServiceOptions {
     pub count: Option<u16>,
     pub genesis: bool,
     pub local: bool,
-    pub peers: Vec<Multiaddr>,
+    pub bootstrap_peers: Vec<Multiaddr>,
     pub node_port: Option<u16>,
     pub rpc_address: Option<Ipv4Addr>,
     pub safenode_bin_path: PathBuf,
@@ -116,7 +116,7 @@ pub async fn add(
             log_dir_path: service_log_dir_path.clone(),
             name: service_name.clone(),
             node_port: install_options.node_port,
-            peers: install_options.peers.clone(),
+            bootstrap_peers: install_options.bootstrap_peers.clone(),
             rpc_socket_addr,
             safenode_path: service_safenode_path.clone(),
             service_user: install_options.user.clone(),
@@ -259,6 +259,7 @@ mod tests {
         let mut node_registry = NodeRegistry {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
 
@@ -286,7 +287,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -301,7 +302,7 @@ mod tests {
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 node_port: None,
-                peers: vec![],
+                bootstrap_peers: vec![],
                 rpc_address: None,
                 url: None,
                 user: get_username(),
@@ -370,6 +371,7 @@ mod tests {
                 )),
                 connected_peers: None,
             }],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
 
@@ -393,7 +395,7 @@ mod tests {
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 node_port: None,
-                peers: vec![],
+                bootstrap_peers: vec![],
                 rpc_address: Some(custom_rpc_address),
                 url: None,
                 user: get_username(),
@@ -423,6 +425,7 @@ mod tests {
         let mut node_registry = NodeRegistry {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
 
@@ -447,7 +450,7 @@ mod tests {
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 node_port: None,
-                peers: vec![],
+                bootstrap_peers: vec![],
                 rpc_address: Some(custom_rpc_address),
                 url: None,
                 user: get_username(),
@@ -477,6 +480,7 @@ mod tests {
         let mut node_registry = NodeRegistry {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
 
@@ -514,7 +518,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -542,7 +546,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -570,7 +574,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode3"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode3"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -580,7 +584,7 @@ mod tests {
                 local: false,
                 genesis: false,
                 count: Some(3),
-                peers: vec![],
+                bootstrap_peers: vec![],
                 node_port: None,
                 rpc_address: None,
                 safenode_bin_path: safenode_download_path.to_path_buf(),
@@ -681,6 +685,7 @@ mod tests {
                 )),
                 connected_peers: None,
             }],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
         let temp_dir = assert_fs::TempDir::new()?;
@@ -714,7 +719,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -724,7 +729,7 @@ mod tests {
                 local: false,
                 genesis: false,
                 count: None,
-                peers: vec![],
+                bootstrap_peers: vec![],
                 node_port: None,
                 rpc_address: None,
                 safenode_bin_path: safenode_download_path.to_path_buf(),
@@ -773,6 +778,7 @@ mod tests {
         let mut node_registry = NodeRegistry {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
         let latest_version = "0.96.4";
@@ -810,7 +816,7 @@ mod tests {
                 service_user: get_username(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
-                peers: vec![],
+                bootstrap_peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -824,7 +830,7 @@ mod tests {
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
-                peers: vec![],
+                bootstrap_peers: vec![],
                 node_port: Some(custom_port),
                 rpc_address: Some(Ipv4Addr::new(127, 0, 0, 1)),
                 url: None,
@@ -872,6 +878,7 @@ mod tests {
         let mut node_registry = NodeRegistry {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![],
+            bootstrap_peers: vec![],
             faucet_pid: None,
         };
         let latest_version = "0.96.4";
@@ -892,7 +899,7 @@ mod tests {
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
-                peers: vec![],
+                bootstrap_peers: vec![],
                 node_port: Some(custom_port),
                 rpc_address: None,
                 url: None,

--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -134,6 +134,7 @@ pub async fn add(
 
                 node_registry.nodes.push(Node {
                     genesis: install_options.genesis,
+                    local: install_options.local,
                     service_name,
                     user: install_options.user.clone(),
                     number: node_number,
@@ -355,6 +356,7 @@ mod tests {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![Node {
                 genesis: true,
+                local: false,
                 service_name: "safenode1".to_string(),
                 user: "safe".to_string(),
                 number: 1,
@@ -669,6 +671,7 @@ mod tests {
             save_path: node_reg_path.to_path_buf(),
             nodes: vec![Node {
                 genesis: true,
+                local: false,
                 service_name: "safenode1".to_string(),
                 user: "safe".to_string(),
                 number: 1,

--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -144,9 +144,9 @@ pub async fn add(
                     listen_addr: None,
                     pid: None,
                     peer_id: None,
-                    log_dir_path: Some(service_log_dir_path.clone()),
-                    data_dir_path: Some(service_data_dir_path.clone()),
-                    safenode_path: Some(service_safenode_path),
+                    log_dir_path: service_log_dir_path.clone(),
+                    data_dir_path: service_data_dir_path.clone(),
+                    safenode_path: service_safenode_path,
                     connected_peers: None,
                 });
                 // We save the node registry for each service because it's possible any number of
@@ -332,11 +332,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[0].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode1"))
+            node_logs_dir.to_path_buf().join("safenode1")
         );
         assert_eq!(
             node_registry.nodes[0].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode1"))
+            node_data_dir.to_path_buf().join("safenode1")
         );
         assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
 
@@ -366,11 +366,9 @@ mod tests {
                 listen_addr: None,
                 pid: None,
                 peer_id: None,
-                log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-                data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-                safenode_path: Some(PathBuf::from(
-                    "/var/safenode-manager/services/safenode1/safenode",
-                )),
+                log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+                data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+                safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
                 connected_peers: None,
             }],
             bootstrap_peers: vec![],
@@ -614,11 +612,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[0].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode1"))
+            node_logs_dir.to_path_buf().join("safenode1")
         );
         assert_eq!(
             node_registry.nodes[0].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode1"))
+            node_data_dir.to_path_buf().join("safenode1")
         );
         assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
         assert_eq!(node_registry.nodes[1].version, latest_version);
@@ -631,11 +629,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[1].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode2"))
+            node_logs_dir.to_path_buf().join("safenode2")
         );
         assert_eq!(
             node_registry.nodes[1].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode2"))
+            node_data_dir.to_path_buf().join("safenode2")
         );
         assert_matches!(node_registry.nodes[1].status, NodeStatus::Added);
         assert_eq!(node_registry.nodes[2].version, latest_version);
@@ -648,11 +646,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[2].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode3"))
+            node_logs_dir.to_path_buf().join("safenode3")
         );
         assert_eq!(
             node_registry.nodes[2].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode3"))
+            node_data_dir.to_path_buf().join("safenode3")
         );
         assert_matches!(node_registry.nodes[2].status, NodeStatus::Added);
 
@@ -681,11 +679,9 @@ mod tests {
                 pid: None,
                 peer_id: None,
                 listen_addr: None,
-                log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-                data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-                safenode_path: Some(PathBuf::from(
-                    "/var/safenode-manager/services/safenode1/safenode",
-                )),
+                log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+                data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+                safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
                 connected_peers: None,
             }],
             bootstrap_peers: vec![],
@@ -760,11 +756,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[1].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode2"))
+            node_logs_dir.to_path_buf().join("safenode2")
         );
         assert_eq!(
             node_registry.nodes[1].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode2"))
+            node_data_dir.to_path_buf().join("safenode2")
         );
         assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
 
@@ -861,11 +857,11 @@ mod tests {
         );
         assert_eq!(
             node_registry.nodes[0].log_dir_path,
-            Some(node_logs_dir.to_path_buf().join("safenode1"))
+            node_logs_dir.to_path_buf().join("safenode1")
         );
         assert_eq!(
             node_registry.nodes[0].data_dir_path,
-            Some(node_data_dir.to_path_buf().join("safenode1"))
+            node_data_dir.to_path_buf().join("safenode1")
         );
         assert_matches!(node_registry.nodes[0].status, NodeStatus::Added);
 

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -187,24 +187,9 @@ pub async fn status(
                 "PID: {}",
                 node.pid.map_or("-".to_string(), |p| p.to_string())
             );
-            println!(
-                "Data path: {}",
-                node.data_dir_path
-                    .as_ref()
-                    .map_or("-".to_string(), |p| p.to_string_lossy().to_string())
-            );
-            println!(
-                "Log path: {}",
-                node.log_dir_path
-                    .as_ref()
-                    .map_or("-".to_string(), |p| p.to_string_lossy().to_string())
-            );
-            println!(
-                "Bin path: {}",
-                node.safenode_path
-                    .as_ref()
-                    .map_or("-".to_string(), |p| p.to_string_lossy().to_string())
-            );
+            println!("Data path: {}", node.data_dir_path.to_string_lossy());
+            println!("Log path: {}", node.log_dir_path.to_string_lossy());
+            println!("Bin path: {}", node.safenode_path.to_string_lossy());
             println!(
                 "Connected peers: {}",
                 node.connected_peers
@@ -279,17 +264,8 @@ pub async fn remove(
     service_control.uninstall(&node.service_name)?;
 
     if !keep_directories {
-        std::fs::remove_dir_all(node.data_dir_path.as_ref().ok_or_else(|| {
-            eyre!("The data directory should be set before the node is removed")
-        })?)?;
-        std::fs::remove_dir_all(
-            node.log_dir_path.as_ref().ok_or_else(|| {
-                eyre!("The log directory should be set before the node is removed")
-            })?,
-        )?;
-        node.data_dir_path = None;
-        node.log_dir_path = None;
-        node.safenode_path = None;
+        std::fs::remove_dir_all(&node.data_dir_path)?;
+        std::fs::remove_dir_all(&node.log_dir_path)?;
     }
 
     node.status = NodeStatus::Removed;
@@ -312,12 +288,7 @@ pub async fn upgrade(
     }
 
     stop(node, service_control).await?;
-    std::fs::copy(
-        upgraded_safenode_path,
-        node.safenode_path
-            .as_ref()
-            .ok_or_else(|| eyre!("Unable to obtain safenode path for current node"))?,
-    )?;
+    std::fs::copy(upgraded_safenode_path, &node.safenode_path)?;
     start(node, service_control, rpc_client, VerbosityLevel::Normal).await?;
     node.version = latest_version.to_string();
 
@@ -421,11 +392,9 @@ mod tests {
             pid: None,
             listen_addr: None,
             peer_id: None,
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
         start(
@@ -497,11 +466,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWAAqZWsjhdZTX7tniJ7Dwye3nEbp1dx1wE96sbgL51obs",
             )?),
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
         start(
@@ -564,11 +531,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
             )?),
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
         start(
@@ -622,11 +587,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
             )?),
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
         start(
@@ -672,11 +635,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
             )?),
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: Some(vec![PeerId::from_str(
                 "12D3KooWKbV9vUmZQdHmTwrQqHrqAQpM7GUWHJXeK1xLeh2LVpuc",
             )?]),
@@ -713,11 +674,9 @@ mod tests {
             pid: None,
             listen_addr: None,
             peer_id: None,
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
 
@@ -753,11 +712,9 @@ mod tests {
             pid: None,
             peer_id: None,
             listen_addr: None,
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
 
@@ -798,19 +755,15 @@ mod tests {
             pid: None,
             peer_id: None,
             listen_addr: None,
-            log_dir_path: Some(log_dir.to_path_buf()),
-            data_dir_path: Some(data_dir.to_path_buf()),
-            safenode_path: Some(safenode_bin.to_path_buf()),
+            log_dir_path: log_dir.to_path_buf(),
+            data_dir_path: data_dir.to_path_buf(),
+            safenode_path: safenode_bin.to_path_buf(),
             connected_peers: None,
         };
 
         remove(&mut node, &mock_service_control, false).await?;
 
-        assert_eq!(node.data_dir_path, None);
-        assert_eq!(node.log_dir_path, None);
-        assert_eq!(node.safenode_path, None);
         assert_matches!(node.status, NodeStatus::Removed);
-
         log_dir.assert(predicate::path::missing());
         data_dir.assert(predicate::path::missing());
 
@@ -840,11 +793,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
             )?),
-            log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
-            data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
-            safenode_path: Some(PathBuf::from(
-                "/var/safenode-manager/services/safenode1/safenode",
-            )),
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
             connected_peers: None,
         };
 
@@ -889,9 +840,9 @@ mod tests {
             peer_id: Some(PeerId::from_str(
                 "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
             )?),
-            log_dir_path: Some(log_dir.to_path_buf()),
-            data_dir_path: Some(data_dir.to_path_buf()),
-            safenode_path: Some(safenode_bin.to_path_buf()),
+            log_dir_path: log_dir.to_path_buf(),
+            data_dir_path: data_dir.to_path_buf(),
+            safenode_path: safenode_bin.to_path_buf(),
             connected_peers: None,
         };
 
@@ -939,16 +890,16 @@ mod tests {
             pid: None,
             peer_id: None,
             listen_addr: None,
-            log_dir_path: Some(log_dir.to_path_buf()),
-            data_dir_path: Some(data_dir.to_path_buf()),
-            safenode_path: Some(safenode_bin.to_path_buf()),
+            log_dir_path: log_dir.to_path_buf(),
+            data_dir_path: data_dir.to_path_buf(),
+            safenode_path: safenode_bin.to_path_buf(),
             connected_peers: None,
         };
 
         remove(&mut node, &mock_service_control, true).await?;
 
-        assert_eq!(node.data_dir_path, Some(data_dir.to_path_buf()));
-        assert_eq!(node.log_dir_path, Some(log_dir.to_path_buf()));
+        assert_eq!(node.data_dir_path, data_dir.to_path_buf());
+        assert_eq!(node.log_dir_path, log_dir.to_path_buf());
         assert_matches!(node.status, NodeStatus::Removed);
 
         log_dir.assert(predicate::path::is_dir());

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -6,8 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::service::ServiceControl;
-use crate::VerbosityLevel;
+use crate::{service::ServiceControl, VerbosityLevel};
 use color_eyre::{eyre::eyre, Help, Result};
 use colored::Colorize;
 use libp2p::multiaddr::Protocol;
@@ -412,6 +411,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -485,6 +485,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 2".to_string(),
             user: "safe".to_string(),
@@ -551,6 +552,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -608,6 +610,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -657,6 +660,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -699,6 +703,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -738,6 +743,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -782,6 +788,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -821,6 +828,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -869,6 +877,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -920,6 +929,7 @@ mod tests {
 
         let mut node = Node {
             genesis: false,
+            local: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),

--- a/sn_node_manager/src/local.rs
+++ b/sn_node_manager/src/local.rs
@@ -139,15 +139,13 @@ pub fn kill_network(node_registry: &NodeRegistry, keep_directories: bool) -> Res
         }
 
         if !keep_directories {
-            // The data directory must be set for a running node.
             // At this point we don't allow path overrides, so deleting the data directory will clear
             // the log directory also.
-            let data_dir_path = node.data_dir_path.as_ref().unwrap();
-            std::fs::remove_dir_all(data_dir_path)?;
+            std::fs::remove_dir_all(&node.data_dir_path)?;
             println!(
                 "  {} Removed {}",
                 "✓".green(),
-                data_dir_path.to_string_lossy()
+                node.data_dir_path.to_string_lossy()
             );
         }
     }
@@ -315,9 +313,9 @@ pub async fn run_node(
         pid: Some(node_info.pid),
         listen_addr: Some(listen_addrs),
         peer_id: Some(peer_id),
-        log_dir_path: Some(node_info.log_path),
-        data_dir_path: Some(node_info.data_path),
-        safenode_path: Some(launcher.get_safenode_path()),
+        log_dir_path: node_info.log_path,
+        data_dir_path: node_info.data_path,
+        safenode_path: launcher.get_safenode_path(),
     })
 }
 
@@ -470,20 +468,17 @@ mod tests {
         assert_eq!(node.service_name, "safenode-local1");
         assert_eq!(
             node.data_dir_path,
-            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}")))
+            PathBuf::from(format!("~/.local/share/safe/{peer_id}"))
         );
         assert_eq!(
             node.log_dir_path,
-            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs")))
+            PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs"))
         );
         assert_eq!(node.number, 1);
         assert_eq!(node.pid, Some(1000));
         assert_eq!(node.rpc_socket_addr, rpc_socket_addr);
         assert_eq!(node.status, NodeStatus::Running);
-        assert_eq!(
-            node.safenode_path,
-            Some(PathBuf::from("/usr/local/bin/safenode"))
-        );
+        assert_eq!(node.safenode_path, PathBuf::from("/usr/local/bin/safenode"));
 
         Ok(())
     }

--- a/sn_node_manager/src/local.rs
+++ b/sn_node_manager/src/local.rs
@@ -304,6 +304,8 @@ pub async fn run_node(
     Ok(Node {
         connected_peers,
         genesis: run_options.genesis,
+        // not read for local network.
+        local: true,
         service_name: format!("safenode-local{}", run_options.number),
         user: get_username()?,
         number: run_options.number,

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -387,27 +387,12 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let is_genesis = peers.first;
-            let bootstrap_peers = get_peers_from_args(peers).await?;
-            //  store the bootstrap peers
-            {
-                let new_bootstrap_peers: Vec<_> = bootstrap_peers
-                    .clone()
-                    .into_iter()
-                    .filter(|peer| !node_registry.bootstrap_peers.contains(peer))
-                    .collect();
-                if !new_bootstrap_peers.is_empty() {
-                    node_registry.bootstrap_peers.extend(new_bootstrap_peers);
-                    node_registry.save()?;
-                }
-            }
-
             add(
                 AddServiceOptions {
                     local,
-                    genesis: is_genesis,
+                    genesis: peers.first,
                     count,
-                    bootstrap_peers,
+                    bootstrap_peers: get_peers_from_args(peers).await?,
                     node_port: port,
                     rpc_address,
                     safenode_bin_path: safenode_download_path,

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -845,6 +845,7 @@ async fn main() -> Result<()> {
                 let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                 let result = upgrade(
                     node,
+                    node_registry.bootstrap_peers.clone(),
                     &safenode_download_path,
                     &latest_version,
                     &NodeServiceManager {},
@@ -879,6 +880,7 @@ async fn main() -> Result<()> {
                 let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                 let result = upgrade(
                     node,
+                    node_registry.bootstrap_peers.clone(),
                     &safenode_download_path,
                     &latest_version,
                     &NodeServiceManager {},
@@ -902,6 +904,7 @@ async fn main() -> Result<()> {
                     let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                     let result = upgrade(
                         node,
+                        node_registry.bootstrap_peers.clone(),
                         &safenode_download_path,
                         &latest_version,
                         &NodeServiceManager {},

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -387,12 +387,27 @@ async fn main() -> Result<()> {
             )
             .await?;
 
+            let is_genesis = peers.first;
+            let bootstrap_peers = get_peers_from_args(peers).await?;
+            //  store the bootstrap peers
+            {
+                let new_bootstrap_peers: Vec<_> = bootstrap_peers
+                    .clone()
+                    .into_iter()
+                    .filter(|peer| !node_registry.bootstrap_peers.contains(peer))
+                    .collect();
+                if !new_bootstrap_peers.is_empty() {
+                    node_registry.bootstrap_peers.extend(new_bootstrap_peers);
+                    node_registry.save()?;
+                }
+            }
+
             add(
                 AddServiceOptions {
                     local,
-                    genesis: peers.first,
+                    genesis: is_genesis,
                     count,
-                    peers: get_peers_from_args(peers).await?,
+                    bootstrap_peers,
                     node_port: port,
                     rpc_address,
                     safenode_bin_path: safenode_download_path,

--- a/sn_node_manager/src/service.rs
+++ b/sn_node_manager/src/service.rs
@@ -29,7 +29,7 @@ pub struct ServiceConfig {
     pub log_dir_path: PathBuf,
     pub name: String,
     pub node_port: Option<u16>,
-    pub peers: Vec<Multiaddr>,
+    pub bootstrap_peers: Vec<Multiaddr>,
     pub rpc_socket_addr: SocketAddr,
     pub safenode_path: PathBuf,
     pub service_user: String,
@@ -185,9 +185,9 @@ impl ServiceControl for NodeServiceManager {
             args.push(OsString::from(node_port.to_string()));
         }
 
-        if !config.peers.is_empty() {
+        if !config.bootstrap_peers.is_empty() {
             let peers_str = config
-                .peers
+                .bootstrap_peers
                 .iter()
                 .map(|peer| peer.to_string())
                 .collect::<Vec<_>>()

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     // ---------- Misc errors
     #[error("Could not obtain user's data directory")]
     UserDataDirectoryNotObtainable,
+    #[error("Could not obtain port from MultiAddr")]
+    CouldNotObtainPortFromMultiAddr,
     #[error("Could not parse RetryStrategy")]
     ParseRetryStrategyError,
 

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -103,9 +103,9 @@ pub struct Node {
     )]
     pub peer_id: Option<PeerId>,
     pub listen_addr: Option<Vec<Multiaddr>>,
-    pub data_dir_path: Option<PathBuf>,
-    pub log_dir_path: Option<PathBuf>,
-    pub safenode_path: Option<PathBuf>,
+    pub data_dir_path: PathBuf,
+    pub log_dir_path: PathBuf,
+    pub safenode_path: PathBuf,
     #[serde(
         serialize_with = "serialize_connected_peers",
         deserialize_with = "deserialize_connected_peers"

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -89,6 +89,7 @@ where
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Node {
     pub genesis: bool,
+    pub local: bool,
     pub version: String,
     pub service_name: String,
     pub user: String,

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -116,6 +116,7 @@ pub struct Node {
 pub struct NodeRegistry {
     pub save_path: PathBuf,
     pub nodes: Vec<Node>,
+    pub bootstrap_peers: Vec<Multiaddr>,
     pub faucet_pid: Option<u32>,
 }
 
@@ -137,6 +138,7 @@ impl NodeRegistry {
             return Ok(NodeRegistry {
                 save_path: path.to_path_buf(),
                 nodes: vec![],
+                bootstrap_peers: vec![],
                 faucet_pid: None,
             });
         }
@@ -151,6 +153,7 @@ impl NodeRegistry {
             return Ok(NodeRegistry {
                 save_path: path.to_path_buf(),
                 nodes: vec![],
+                bootstrap_peers: vec![],
                 faucet_pid: None,
             });
         }


### PR DESCRIPTION
## Description
This PR tries to set the `safenode port` to the same value when we run `upgrade`.

When we initially start a service based network, the `--port` field of the `safenode` is used when we manually add one node at a time. But when using the `deployer`, we do not do that, but instead set the `node_count`. This would mean that `port` is automatically assigned by the safenode.

Now during the upgrade process, we would want to re-use the same port, else we'd be causing a massive churn. So here is the high level overview on how to achieve this: 

1. Get the node port via the `node's listen addr`.
2. Supply this `port` to the service definition. I.e, add in the `--port` arg.

 The 2nd point would mean that we will be editing the `service definition` file to add the args. But I could not find any functions inside the `service manager` crate that would allow me to do that.
Thus, I resorted to `overwriting the entire service definition file` with all the same args that we used during the initial startup. To acheive this, I had to edit the `NodeRegistry` to add in extra fields like `bootstrap_peers`, `local` etc., for us to provide the `--peers` and `--local` args in this overwritten service definition file.
