### PR TITLE
fix: check if redeemed cns are already spent

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -965,7 +965,7 @@ jobs:
         run: ~/safe --log-output-dest=data-dir files upload "ubuntu-16.04.7-desktop-amd64.iso" --retry-strategy quick
         env:
           SN_LOG: "all"
-        timeout-minutes: 30
+        timeout-minutes: 45
 
       - name: Stop the local network and upload logs
         if: always()
@@ -1080,7 +1080,7 @@ jobs:
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./test_data_1.tar.gz" --retry-strategy quick
         env:
           SN_LOG: "all"
-        timeout-minutes: 5
+        timeout-minutes: 10
 
       - name: Ensure no leftover cash_notes and payment files
         run: |

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -123,9 +123,8 @@ pub enum Error {
     InCorrectRecordHeader,
 
     // ---------- Transfer Errors
-    #[error("Failed to get transfer parent spend")]
-    FailedToGetTransferParentSpend,
-
+    #[error("Failed to get spend: {0}")]
+    FailedToGetSpend(String),
     #[error("Transfer is invalid: {0}")]
     InvalidTransfer(String),
 

--- a/sn_node/tests/nodes_rewards.rs
+++ b/sn_node/tests/nodes_rewards.rs
@@ -378,8 +378,8 @@ mod tests {
             let mut count = 0;
 
             // if expected royalties is 0 or 1 we'll wait for 300s as a minimum,
-            // otherwise we'll wait for 60s per expected royalty
-            let secs = std::cmp::max(300, expected_royalties as u64 * 60);
+            // otherwise we'll wait for 120s per expected royalty
+            let secs = std::cmp::max(300, expected_royalties as u64 * 120);
             let duration = Duration::from_secs(secs);
             info!("Awaiting transfers notifs for {duration:?}...");
             if timeout(duration, async {


### PR DESCRIPTION
## Description

Issue originally identified by @iancoleman: redeeming Transfers doesn't check if the redeemed CashNotes where already spent (by us) or not. 

This PR fixes this. 