### PR TITLE
feat(manager): set env variable for the nodes

### DIFF
--- a/sn_node_manager/src/add_service.rs
+++ b/sn_node_manager/src/add_service.rs
@@ -20,6 +20,7 @@ use std::{
     path::PathBuf,
 };
 
+/// This is just a set of config parameters that is used inside the `add()` function.
 pub struct AddServiceOptions {
     pub count: Option<u16>,
     pub genesis: bool,
@@ -34,6 +35,7 @@ pub struct AddServiceOptions {
     pub url: Option<String>,
     pub user: String,
     pub version: String,
+    pub env_variables: Option<Vec<(String, String)>>,
 }
 
 /// Install safenode as a service.
@@ -135,6 +137,7 @@ pub async fn add(
             rpc_socket_addr,
             safenode_path: service_safenode_path.clone(),
             service_user: install_options.user.clone(),
+            env_variables: install_options.env_variables.clone(),
         });
 
         match result {
@@ -304,6 +307,10 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
                 bootstrap_peers: vec![],
+                env_variables: Some(vec![
+                    ("SN_LOG".to_owned(), "all".to_owned()),
+                    ("RUST_LOG".to_owned(), "libp2p=debug".to_owned()),
+                ]),
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -323,6 +330,10 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: Some(vec![
+                    ("SN_LOG".to_owned(), "all".to_owned()),
+                    ("RUST_LOG".to_owned(), "libp2p=debug".to_owned()),
+                ]),
             },
             &mut node_registry,
             &mock_service_control,
@@ -415,6 +426,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -470,6 +482,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -534,6 +547,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
                 bootstrap_peers: vec![],
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -562,6 +576,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
                 bootstrap_peers: vec![],
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -590,6 +605,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode3"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode3"),
                 bootstrap_peers: vec![],
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -609,6 +625,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -722,6 +739,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
                 bootstrap_peers: new_peers.clone(),
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -741,6 +759,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -839,6 +858,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
                 bootstrap_peers: vec![],
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -858,6 +878,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -936,6 +957,7 @@ mod tests {
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
                 bootstrap_peers: vec![],
+                env_variables: None,
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -955,6 +977,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &mock_service_control,
@@ -1024,6 +1047,7 @@ mod tests {
                 url: None,
                 user: get_username(),
                 version: latest_version.to_string(),
+                env_variables: None,
             },
             &mut node_registry,
             &MockServiceControl::new(),

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -280,7 +280,8 @@ pub async fn remove(
 
 pub async fn upgrade(
     node: &mut Node,
-    bootstrap_peers: Vec<Multiaddr>,
+    bootstrap_peers: &[Multiaddr],
+    env_variables: &Option<Vec<(String, String)>>,
     upgraded_safenode_path: &PathBuf,
     latest_version: &Version,
     service_control: &dyn ServiceControl,
@@ -302,12 +303,12 @@ pub async fn upgrade(
         genesis: node.genesis,
         name: node.service_name.clone(),
         node_port: Some(node.get_safenode_port()?),
-        bootstrap_peers,
+        bootstrap_peers: bootstrap_peers.to_owned(),
         rpc_socket_addr: node.rpc_socket_addr,
         log_dir_path: node.log_dir_path.clone(),
         safenode_path: node.safenode_path.clone(),
         service_user: node.user.clone(),
-        env_variables: None,
+        env_variables: env_variables.clone(),
     })?;
 
     start(node, service_control, rpc_client, VerbosityLevel::Normal).await?;

--- a/sn_node_manager/src/control.rs
+++ b/sn_node_manager/src/control.rs
@@ -307,6 +307,7 @@ pub async fn upgrade(
         log_dir_path: node.log_dir_path.clone(),
         safenode_path: node.safenode_path.clone(),
         service_user: node.user.clone(),
+        env_variables: None,
     })?;
 
     start(node, service_control, rpc_client, VerbosityLevel::Normal).await?;

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -119,10 +119,11 @@ pub enum SubCmd {
         ///
         /// If not set, the RPC server is run locally.
         rpc_address: Option<Ipv4Addr>,
-        /// Provide the environmental variable that is set for the safenode service.
+        /// Provide environment variables for the safenode service.
         ///
         /// This is useful to set the safenode's log levels. Each variable should be comma separated without any space.
-        /// Example usage `--env SN_LOG=all,RUST_LOG=libp2p=debug`
+        ///
+        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
         #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables)]
         env_variables: Option<Vec<(String, String)>>,
         /// Provide a safenode binary using a URL.
@@ -341,10 +342,12 @@ pub enum SubCmd {
         /// The name of the service to upgrade
         #[clap(long, conflicts_with = "peer_id")]
         service_name: Option<String>,
-        /// Provide the environmental variable that is set for the safenode service.
+        /// Provide environment variables for the safenode service. This will override the values set during the Add
+        /// command.
         ///
         /// This is useful to set the safenode's log levels. Each variable should be comma separated without any space.
-        /// Example usage `--env SN_LOG=all,RUST_LOG=libp2p=debug`
+        ///
+        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
         #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables)]
         env_variables: Option<Vec<(String, String)>>,
     },

--- a/sn_node_manager/src/main.rs
+++ b/sn_node_manager/src/main.rs
@@ -837,7 +837,8 @@ async fn main() -> Result<()> {
                 let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                 let result = upgrade(
                     node,
-                    node_registry.bootstrap_peers.clone(),
+                    &node_registry.bootstrap_peers,
+                    &node_registry.environment_variables,
                     &safenode_download_path,
                     &latest_version,
                     &NodeServiceManager {},
@@ -872,7 +873,8 @@ async fn main() -> Result<()> {
                 let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                 let result = upgrade(
                     node,
-                    node_registry.bootstrap_peers.clone(),
+                    &node_registry.bootstrap_peers,
+                    &node_registry.environment_variables,
                     &safenode_download_path,
                     &latest_version,
                     &NodeServiceManager {},
@@ -896,7 +898,8 @@ async fn main() -> Result<()> {
                     let rpc_client = RpcClient::from_socket_addr(node.rpc_socket_addr);
                     let result = upgrade(
                         node,
-                        node_registry.bootstrap_peers.clone(),
+                        &node_registry.bootstrap_peers,
+                        &node_registry.environment_variables,
                         &safenode_download_path,
                         &latest_version,
                         &NodeServiceManager {},

--- a/sn_protocol/src/node_registry.rs
+++ b/sn_protocol/src/node_registry.rs
@@ -135,6 +135,7 @@ pub struct NodeRegistry {
     pub save_path: PathBuf,
     pub nodes: Vec<Node>,
     pub bootstrap_peers: Vec<Multiaddr>,
+    pub environment_variables: Option<Vec<(String, String)>>,
     pub faucet_pid: Option<u32>,
 }
 
@@ -157,6 +158,7 @@ impl NodeRegistry {
                 save_path: path.to_path_buf(),
                 nodes: vec![],
                 bootstrap_peers: vec![],
+                environment_variables: None,
                 faucet_pid: None,
             });
         }
@@ -172,6 +174,7 @@ impl NodeRegistry {
                 save_path: path.to_path_buf(),
                 nodes: vec![],
                 bootstrap_peers: vec![],
+                environment_variables: None,
                 faucet_pid: None,
             });
         }


### PR DESCRIPTION
- This PR adds an option to set environmental variables during the `add/upgrade` commands.
- During the upgrade process:
	- if the env variable arg is provided, we write that into the service definition file, overwriting any previous values.
	- if the env variable arg is not provided, we will be re-using the previous value that was provided during `add`. To achieve this, we will have to store the `environment_variables` into the `NodeRegistry` file. Thus added a new field there.

