### PR TITLE
feat(registers): expose MerkleReg and add register_inspect example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,8 @@ version = "7.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387808c885b79055facbd4b2e806a683fe1bc37abc7dfa5fea1974ad2d4137b0"
 dependencies = [
+ "num",
+ "quickcheck",
  "serde",
  "tiny-keccak",
 ]
@@ -3403,6 +3405,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3427,17 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3431,6 +3458,30 @@ checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4975,6 +5026,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "console_error_panic_hook",
+ "crdts",
  "custom_debug",
  "eyre",
  "futures",

--- a/README.md
+++ b/README.md
@@ -247,6 +247,42 @@ hi Alice, this is Bob!
 ```
 Alice will see Bob's message when she either enters a blank line or writes another message herself.
 
+### Inspect a Register
+
+A second example, `register_inspect` allows you to view its structure and content. To use this with the above example you again provide the address of the register. For example:
+
+```
+cargo run --example register_inspect --features=local-discovery -- --reg-address 50f4c9d55aa1f4fc19149a86e023cd189e509519788b4ad8625a1ce62932d1938cf4242e029cada768e7af0123a98c25973804d84ad397ca65cb89d6580d04ff07e5b196ea86f882b925be6ade06fc8d
+```
+After printing a summary of the register, this example will display
+the structure of the register each time you press Enter, including the following:
+
+```
+Enter a blank line to print the latest register structure (or 'Q' <Enter> to quit)
+
+Syncing with SAFE...
+synced!
+======================
+Root (Latest) Node(s):
+[ 0] Node("4eadd9"..) Entry("[alice]: this is alice 3")
+[ 3] Node("f05112"..) Entry("[bob]: this is bob 3")
+======================
+Register Structure:
+(In general, earlier nodes are more indented)
+[ 0] Node("4eadd9"..) Entry("[alice]: this is alice 3")
+  [ 1] Node("f5afb2"..) Entry("[alice]: this is alice 2")
+    [ 2] Node("7693eb"..) Entry("[alice]: hello this is alice")
+[ 3] Node("f05112"..) Entry("[bob]: this is bob 3")
+  [ 4] Node("8c3cce"..) Entry("[bob]: this is bob 2")
+    [ 5] Node("c7f9fc"..) Entry("[bob]: this is bob 1")
+    [ 1] Node("f5afb2"..) Entry("[alice]: this is alice 2")
+      [ 2] Node("7693eb"..) Entry("[alice]: hello this is alice")
+======================
+```
+Each increase in indentation shows the children of the node above.
+The numbers in square brackets are just to make it easier to see
+where a node occurs more than once.
+
 ### RPC
 
 The node manager launches each node process with a remote procedure call (RPC) service. The workspace has a client binary that can be used to run commands against these services.

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
+crdts = "7.3.2"
 custom_debug = "~0.5.0"
 futures = "~0.3.13"
 hex = "~0.4.3"

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -284,6 +284,7 @@ impl ClientRegister {
     }
 
     /// Access the underlying MerkleReg (e.g. for access to history)
+    /// NOTE: This API is unstable and may be removed in the future
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
         self.register.merkle_reg()
     }

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -20,6 +20,8 @@ use sn_protocol::{
     storage::{try_serialize_record, RecordKind, RetryStrategy},
     NetworkAddress,
 };
+
+use crdts::merkle_reg::MerkleReg;
 use sn_registers::{Entry, EntryHash, Permissions, Register, RegisterAddress, SignedRegister};
 use sn_transfers::{NanoTokens, Payment};
 use std::collections::{BTreeSet, HashSet, LinkedList};
@@ -279,6 +281,11 @@ impl ClientRegister {
     ) -> Result<()> {
         self.write_atop(entry, children)?;
         self.push(verify_store).await
+    }
+
+    /// Access the underlying MerkleReg (e.g. for access to history)
+    pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
+        &self.register.merkle_reg()
     }
 
     // ********* Private helpers  *********

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -285,7 +285,7 @@ impl ClientRegister {
 
     /// Access the underlying MerkleReg (e.g. for access to history)
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
-        &self.register.merkle_reg()
+        self.register.merkle_reg()
     }
 
     // ********* Private helpers  *********

--- a/sn_node/examples/register_inspect.rs
+++ b/sn_node/examples/register_inspect.rs
@@ -1,0 +1,214 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::io;
+use std::collections::HashMap;
+use crdts::merkle_reg::{MerkleReg, Node, Hash};
+
+use sn_client::{Client, WalletClient};
+use sn_registers::{Permissions, RegisterAddress, Entry};
+use sn_transfers::HotWallet;
+use xor_name::XorName;
+
+use bls::SecretKey;
+use clap::Parser;
+use color_eyre::{
+    eyre::{eyre, Result, WrapErr},
+    Help,
+};
+
+#[derive(Parser, Debug)]
+#[clap(name = "register inspect cli")]
+struct Opt {
+    // Create register and give it a nickname (first user)
+    #[clap(long, default_value = "")]
+    reg_nickname: String,
+
+    // Get existing register with given network address (any other user)
+    #[clap(long, default_value = "", conflicts_with = "reg_nickname")]
+    reg_address: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opt = Opt::parse();
+    let mut reg_nickname = opt.reg_nickname;
+    let reg_address_string = opt.reg_address;
+
+    // let's build a random secret key to sign our Register ops
+    let signer = SecretKey::random();
+
+    println!("Starting SAFE client...");
+    let client = Client::new(signer, None, false, None, None).await?;
+    println!("SAFE client signer public key: {:?}", client.signer_pk());
+
+    // The address of the register to be displayed
+    let mut meta = XorName::from_content(reg_nickname.as_bytes());
+    let reg_address = if !reg_nickname.is_empty() {
+        meta = XorName::from_content(reg_nickname.as_bytes());
+        RegisterAddress::new(meta, client.signer_pk())
+    } else {
+        reg_nickname = format!("{reg_address_string:<6}...");
+        RegisterAddress::from_hex(&reg_address_string)
+            .wrap_err("cannot parse hex register address")?
+    };
+
+    // Loading a local wallet (for ClientRegister::sync()).
+    // The wallet can have ZERO balance in this example,
+    // but the ClientRegister::sync() API requires a wallet and will
+    // create the register if not found even though we don't want that.
+    //
+    // The only want to avoid unwanted creation of a Register seems to
+    // be to supply an empty wallet.
+    // TODO Follow the issue about this: https://github.com/maidsafe/safe_network/issues/1308
+    let root_dir = dirs_next::data_dir()
+        .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
+        .join("safe")
+        .join("client");
+
+    let wallet = HotWallet::load_from(&root_dir)
+        .wrap_err("Unable to read wallet file in {root_dir:?}")
+        .suggestion(
+            "If you have an old wallet file, it may no longer be compatible. Try removing it",
+        )?;
+
+    let mut wallet_client = WalletClient::new(client.clone(), wallet);
+
+    println!("Retrieving Register '{reg_nickname}' from SAFE");
+    let mut reg_replica = match client.get_register(reg_address).await {
+        Ok(register) => {
+            println!(
+                "Register '{reg_nickname}' found at {:?}!",
+                register.address(),
+            );
+            register
+        }
+        Err(_) => {
+            println!("Register '{reg_nickname}' not found, creating it at {reg_address}");
+            let (register, _cost, _royalties_fees) = client
+                .create_and_pay_for_register(
+                    meta,
+                    &mut wallet_client,
+                    true,
+                    Permissions::new_anyone_can_write(),
+                )
+                .await?;
+
+            register
+        }
+    };
+    println!("Register address: {:?}", reg_replica.address().to_hex());
+    println!("Register owned by: {:?}", reg_replica.owner());
+    println!("Register permissions: {:?}", reg_replica.permissions());
+
+    // Repeatedly display of the register structure on command
+    loop {
+        println!();
+        println!(
+            "Current total number of items in Register: {}",
+            reg_replica.size()
+        );
+        println!("Latest value (more than one if concurrent writes were made):");
+        println!("--------------");
+        for (_, entry) in reg_replica.read().into_iter() {
+            println!("{}", String::from_utf8(entry)?);
+        }
+        println!("--------------");
+
+        if prompt_user() {
+            return Ok(());
+        }
+
+        // Sync with network after a delay
+        println!("Syncing with SAFE...");
+        reg_replica.sync(&mut wallet_client, true, None).await?;
+        let merkle_reg = reg_replica.merkle_reg();
+        let content = merkle_reg.read();
+        println!("synced!");
+
+        // Show the Register structure
+
+        // Index nodes to make it easier to see where a
+        // node appears multiple times in the output.
+        // Note: it isn't related to the order of insertion
+        // which is hard to determine.
+        let mut index: usize = 0;
+        let mut node_ordering: HashMap<Hash,usize> = HashMap::new();
+        for (_hash, node) in content.hashes_and_nodes() {
+            index_node_and_descendants(&node, &mut index, &mut node_ordering, &merkle_reg);
+        };
+
+        println!("======================");
+        println!("Root (Latest) Node(s):");
+        for node in content.nodes() {
+            let _ = print_node(0, &node, &node_ordering);
+        };
+
+        println!("======================");
+        println!("Register Structure:");
+        println!("(In general, earlier nodes are more indented)");
+        let mut indents = 0;
+        for (_hash, node) in content.hashes_and_nodes() {
+            print_node_and_descendants(&mut indents, &node, &mut node_ordering, &merkle_reg);
+        };
+
+        println!("======================");
+    }
+}
+
+
+fn index_node_and_descendants(node: &Node<Entry>, index: &mut usize, node_ordering: &mut HashMap<Hash,usize>, merkle_reg: &MerkleReg<Entry>) {
+    let node_hash = node.hash().clone();
+    if node_ordering.get(&node_hash).is_none() {
+        node_ordering.insert(node_hash.clone(), *index);
+        *index += 1;
+    }
+
+    for child_hash in node.children.iter() {
+        if let Some(child_node) = merkle_reg.node(*child_hash) {
+            index_node_and_descendants(&child_node, index, node_ordering, &merkle_reg);
+        } else {
+            println!("ERROR looking up hash of child");
+        }
+    }
+}
+
+fn print_node_and_descendants(indents: &mut usize, node: &Node<Entry>, node_ordering: &HashMap<Hash,usize>, merkle_reg: &MerkleReg<Entry>) {
+    let _ = print_node(*indents, &node, &node_ordering);
+
+    *indents += 1;
+    for child_hash in node.children.iter() {
+        if let Some(child_node) = merkle_reg.node(*child_hash) {
+            print_node_and_descendants(indents, &child_node, node_ordering, &merkle_reg);
+        }
+    }
+    *indents -= 1;
+}
+
+fn print_node(indents: usize, node: &Node<Entry>, node_ordering: &HashMap<Hash,usize>) -> Result<()> {
+    let order = match node_ordering.get(&node.hash()) {
+        Some(order) => format!("{order}"),
+        None => String::new()
+    };
+    let indentation = "  ".repeat(indents);
+    println!("{indentation}[{:>2}] Node({:?}..) Entry({:?})", order, hex::encode(node.hash()[0..3].to_vec()), String::from_utf8(node.value.clone())?);
+    Ok(())
+}
+
+fn prompt_user() -> bool {
+    let mut input_text = String::new();
+    println!();
+    println!("Enter a blank line to print the latest register structure (or 'Q' <Enter> to quit)");
+    io::stdin()
+        .read_line(&mut input_text)
+        .expect("Failed to read text from stdin");
+
+    let string = input_text.trim().to_string();
+
+    return string.contains("Q") || string.contains("q")
+}

--- a/sn_node/examples/register_inspect.rs
+++ b/sn_node/examples/register_inspect.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::io;
+use crdts::merkle_reg::{Hash, MerkleReg, Node};
 use std::collections::HashMap;
-use crdts::merkle_reg::{MerkleReg, Node, Hash};
+use std::io;
 
 use sn_client::{Client, WalletClient};
-use sn_registers::{Permissions, RegisterAddress, Entry};
+use sn_registers::{Entry, Permissions, RegisterAddress};
 use sn_transfers::HotWallet;
 use xor_name::XorName;
 
@@ -138,16 +138,16 @@ async fn main() -> Result<()> {
         // Note: it isn't related to the order of insertion
         // which is hard to determine.
         let mut index: usize = 0;
-        let mut node_ordering: HashMap<Hash,usize> = HashMap::new();
+        let mut node_ordering: HashMap<Hash, usize> = HashMap::new();
         for (_hash, node) in content.hashes_and_nodes() {
             index_node_and_descendants(&node, &mut index, &mut node_ordering, &merkle_reg);
-        };
+        }
 
         println!("======================");
         println!("Root (Latest) Node(s):");
         for node in content.nodes() {
             let _ = print_node(0, &node, &node_ordering);
-        };
+        }
 
         println!("======================");
         println!("Register Structure:");
@@ -155,14 +155,18 @@ async fn main() -> Result<()> {
         let mut indents = 0;
         for (_hash, node) in content.hashes_and_nodes() {
             print_node_and_descendants(&mut indents, &node, &mut node_ordering, &merkle_reg);
-        };
+        }
 
         println!("======================");
     }
 }
 
-
-fn index_node_and_descendants(node: &Node<Entry>, index: &mut usize, node_ordering: &mut HashMap<Hash,usize>, merkle_reg: &MerkleReg<Entry>) {
+fn index_node_and_descendants(
+    node: &Node<Entry>,
+    index: &mut usize,
+    node_ordering: &mut HashMap<Hash, usize>,
+    merkle_reg: &MerkleReg<Entry>,
+) {
     let node_hash = node.hash().clone();
     if node_ordering.get(&node_hash).is_none() {
         node_ordering.insert(node_hash.clone(), *index);
@@ -178,7 +182,12 @@ fn index_node_and_descendants(node: &Node<Entry>, index: &mut usize, node_orderi
     }
 }
 
-fn print_node_and_descendants(indents: &mut usize, node: &Node<Entry>, node_ordering: &HashMap<Hash,usize>, merkle_reg: &MerkleReg<Entry>) {
+fn print_node_and_descendants(
+    indents: &mut usize,
+    node: &Node<Entry>,
+    node_ordering: &HashMap<Hash, usize>,
+    merkle_reg: &MerkleReg<Entry>,
+) {
     let _ = print_node(*indents, &node, &node_ordering);
 
     *indents += 1;
@@ -190,13 +199,22 @@ fn print_node_and_descendants(indents: &mut usize, node: &Node<Entry>, node_orde
     *indents -= 1;
 }
 
-fn print_node(indents: usize, node: &Node<Entry>, node_ordering: &HashMap<Hash,usize>) -> Result<()> {
+fn print_node(
+    indents: usize,
+    node: &Node<Entry>,
+    node_ordering: &HashMap<Hash, usize>,
+) -> Result<()> {
     let order = match node_ordering.get(&node.hash()) {
         Some(order) => format!("{order}"),
-        None => String::new()
+        None => String::new(),
     };
     let indentation = "  ".repeat(indents);
-    println!("{indentation}[{:>2}] Node({:?}..) Entry({:?})", order, hex::encode(node.hash()[0..3].to_vec()), String::from_utf8(node.value.clone())?);
+    println!(
+        "{indentation}[{:>2}] Node({:?}..) Entry({:?})",
+        order,
+        hex::encode(node.hash()[0..3].to_vec()),
+        String::from_utf8(node.value.clone())?
+    );
     Ok(())
 }
 
@@ -210,5 +228,5 @@ fn prompt_user() -> bool {
 
     let string = input_text.trim().to_string();
 
-    return string.contains("Q") || string.contains("q")
+    return string.contains("Q") || string.contains("q");
 }

--- a/sn_node/examples/register_inspect.rs
+++ b/sn_node/examples/register_inspect.rs
@@ -140,13 +140,13 @@ async fn main() -> Result<()> {
         let mut index: usize = 0;
         let mut node_ordering: HashMap<Hash, usize> = HashMap::new();
         for (_hash, node) in content.hashes_and_nodes() {
-            index_node_and_descendants(&node, &mut index, &mut node_ordering, &merkle_reg);
+            index_node_and_descendants(node, &mut index, &mut node_ordering, merkle_reg);
         }
 
         println!("======================");
         println!("Root (Latest) Node(s):");
         for node in content.nodes() {
-            let _ = print_node(0, &node, &node_ordering);
+            let _ = print_node(0, node, &node_ordering);
         }
 
         println!("======================");
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
         println!("(In general, earlier nodes are more indented)");
         let mut indents = 0;
         for (_hash, node) in content.hashes_and_nodes() {
-            print_node_and_descendants(&mut indents, &node, &mut node_ordering, &merkle_reg);
+            print_node_and_descendants(&mut indents, node, &node_ordering, merkle_reg);
         }
 
         println!("======================");
@@ -167,15 +167,15 @@ fn index_node_and_descendants(
     node_ordering: &mut HashMap<Hash, usize>,
     merkle_reg: &MerkleReg<Entry>,
 ) {
-    let node_hash = node.hash().clone();
+    let node_hash = node.hash();
     if node_ordering.get(&node_hash).is_none() {
-        node_ordering.insert(node_hash.clone(), *index);
+        node_ordering.insert(node_hash, *index);
         *index += 1;
     }
 
     for child_hash in node.children.iter() {
         if let Some(child_node) = merkle_reg.node(*child_hash) {
-            index_node_and_descendants(&child_node, index, node_ordering, &merkle_reg);
+            index_node_and_descendants(child_node, index, node_ordering, merkle_reg);
         } else {
             println!("ERROR looking up hash of child");
         }
@@ -188,12 +188,12 @@ fn print_node_and_descendants(
     node_ordering: &HashMap<Hash, usize>,
     merkle_reg: &MerkleReg<Entry>,
 ) {
-    let _ = print_node(*indents, &node, &node_ordering);
+    let _ = print_node(*indents, node, node_ordering);
 
     *indents += 1;
     for child_hash in node.children.iter() {
         if let Some(child_node) = merkle_reg.node(*child_hash) {
-            print_node_and_descendants(indents, &child_node, node_ordering, &merkle_reg);
+            print_node_and_descendants(indents, child_node, node_ordering, merkle_reg);
         }
     }
     *indents -= 1;
@@ -212,7 +212,7 @@ fn print_node(
     println!(
         "{indentation}[{:>2}] Node({:?}..) Entry({:?})",
         order,
-        hex::encode(node.hash()[0..3].to_vec()),
+        hex::encode(&node.hash()[0..3]),
         String::from_utf8(node.value.clone())?
     );
     Ok(())
@@ -228,5 +228,5 @@ fn prompt_user() -> bool {
 
     let string = input_text.trim().to_string();
 
-    return string.contains("Q") || string.contains("q");
+    string.contains('Q') || string.contains('q')
 }

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -114,6 +114,7 @@ impl RegisterCrdt {
     }
 
     /// Access the underlying MerkleReg (e.g. for access to history)
+    /// NOTE: This API is unstable and may be removed in the future
     pub(crate) fn merkle_reg(&self) -> &MerkleReg<Entry> {
         &self.data
     }

--- a/sn_registers/src/reg_crdt.rs
+++ b/sn_registers/src/reg_crdt.rs
@@ -112,6 +112,11 @@ impl RegisterCrdt {
             .map(|(hash, node)| (EntryHash(hash), node.value.clone()))
             .collect()
     }
+
+    /// Access the underlying MerkleReg (e.g. for access to history)
+    pub(crate) fn merkle_reg(&self) -> &MerkleReg<Entry> {
+        &self.data
+    }
 }
 
 #[cfg(test)]

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -131,6 +131,7 @@ impl SignedRegister {
     }
 
     /// Access the underlying MerkleReg (e.g. for access to history)
+    /// NOTE: This API is unstable and may be removed in the future
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
         self.base_register.merkle_reg()
     }
@@ -261,6 +262,7 @@ impl Register {
     }
 
     /// Access the underlying MerkleReg (e.g. for access to history)
+    /// NOTE: This API is unstable and may be removed in the future
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
         self.crdt.merkle_reg()
     }

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -132,7 +132,7 @@ impl SignedRegister {
 
     /// Access the underlying MerkleReg (e.g. for access to history)
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
-        &self.base_register.merkle_reg()
+        self.base_register.merkle_reg()
     }
 }
 
@@ -262,7 +262,7 @@ impl Register {
 
     /// Access the underlying MerkleReg (e.g. for access to history)
     pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
-        &self.crdt.merkle_reg()
+        self.crdt.merkle_reg()
     }
 
     // Private helper to check the given Entry's size is within define limit,

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -11,8 +11,8 @@ use crate::{
     RegisterOp,
 };
 
-use crdts::merkle_reg::MerkleReg;
 use bls::{PublicKey, SecretKey, Signature};
+use crdts::merkle_reg::MerkleReg;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use xor_name::XorName;

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -11,6 +11,7 @@ use crate::{
     RegisterOp,
 };
 
+use crdts::merkle_reg::MerkleReg;
 use bls::{PublicKey, SecretKey, Signature};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -127,6 +128,11 @@ impl SignedRegister {
         self.base_register.check_register_op(&op)?;
         self.ops.insert(op);
         Ok(())
+    }
+
+    /// Access the underlying MerkleReg (e.g. for access to history)
+    pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
+        &self.base_register.merkle_reg()
     }
 }
 
@@ -252,6 +258,11 @@ impl Register {
         } else {
             Err(Error::AccessDenied(requester))
         }
+    }
+
+    /// Access the underlying MerkleReg (e.g. for access to history)
+    pub fn merkle_reg(&self) -> &MerkleReg<Entry> {
+        &self.crdt.merkle_reg()
     }
 
     // Private helper to check the given Entry's size is within define limit,


### PR DESCRIPTION
## Description

Exposes the MerkleReg of RegisterCrdt in all Safe Register types to allow examination of the structure and history of changes to a register.

Adds a `register_inspect` example which displays nodes and their children for a register in a live network.

reviewpad:summary 
