### PR TITLE
feat(networking): add candidate addr as external

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -533,17 +533,19 @@ impl SwarmDriver {
                 event_string = "Dialing";
                 trace!("Dialing {peer_id:?} on {connection_id:?}");
             }
-            SwarmEvent::NewExternalAddrCandidate { address }
-                if !self.swarm.external_addresses().any(|addr| addr == &address) =>
-            {
+            SwarmEvent::NewExternalAddrCandidate { address } => {
                 event_string = "NewExternalAddrCandidate";
-                info!(%address, "external address: new candidate");
 
-                // Identify will let us know when we have a candidate. (Peers will tell us what address they see us as.)
-                // We manually confirm this to be our externally reachable address, though in theory it's possible we
-                // are not actually reachable. (Peers can lie to us.) This is a good enough heuristic for now.
-                // Setting this will also switch kad to server mode if it's not already in it.
-                self.swarm.add_external_address(address);
+                if !self.swarm.external_addresses().any(|addr| addr == &address) && !self.is_client
+                {
+                    info!(%address, "external address: new candidate");
+
+                    // Identify will let us know when we have a candidate. (Peers will tell us what address they see us as.)
+                    // We manually confirm this to be our externally reachable address, though in theory it's possible we
+                    // are not actually reachable. (Peers can lie to us.) This is a good enough heuristic for now.
+                    // Setting this will also switch kad to server mode if it's not already in it.
+                    self.swarm.add_external_address(address);
+                }
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 event_string = "ExternalAddrConfirmed";

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -533,7 +533,9 @@ impl SwarmDriver {
                 event_string = "Dialing";
                 trace!("Dialing {peer_id:?} on {connection_id:?}");
             }
-            SwarmEvent::NewExternalAddrCandidate { address } => {
+            SwarmEvent::NewExternalAddrCandidate { address }
+                if !self.swarm.external_addresses().any(|addr| addr == &address) =>
+            {
                 event_string = "NewExternalAddrCandidate";
                 info!(%address, "external address: new candidate");
 

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -533,6 +533,24 @@ impl SwarmDriver {
                 event_string = "Dialing";
                 trace!("Dialing {peer_id:?} on {connection_id:?}");
             }
+            SwarmEvent::NewExternalAddrCandidate { address } => {
+                event_string = "NewExternalAddrCandidate";
+                info!(%address, "external address: new candidate");
+
+                // Identify will let us know when we have a candidate. (Peers will tell us what address they see us as.)
+                // We manually confirm this to be our externally reachable address, though in theory it's possible we
+                // are not actually reachable. (Peers can lie to us.) This is a good enough heuristic for now.
+                // Setting this will also switch kad to server mode if it's not already in it.
+                self.swarm.add_external_address(address);
+            }
+            SwarmEvent::ExternalAddrConfirmed { address } => {
+                event_string = "ExternalAddrConfirmed";
+                info!(%address, "external address: confirmed");
+            }
+            SwarmEvent::ExternalAddrExpired { address } => {
+                event_string = "ExternalAddrExpired";
+                info!(%address, "external address: expired");
+            }
             other => {
                 event_string = "Other";
 


### PR DESCRIPTION
Previously AutoNAT would automatically add external addresses for us
when they were confirmed to be reachable by our peers. AutoNAT
unfortunately is broken with UDP/QUIC, so after we disabled AutoNAT,
our public addresses weren't implicitely added anymore to our external
addr list.

With this PR, we add all candidates as external. These candidates
currently come from `identify`, which is our peers telling us what they
see us as. Normally, we should confirm these addresses with something
like AutoNAT. But overzealously adding candidates shouldn't
neccessarily cause harm.

By setting the external address, `kad` is switched to server mode. Which
allows us to participate in the network.
