### PR TITLE
feat(folders): keep track of local changes to Folders

### DIFF
--- a/sn_cli/src/subcommands/acc_packet.rs
+++ b/sn_cli/src/subcommands/acc_packet.rs
@@ -8,6 +8,7 @@
 
 use super::files::{download_file, ChunkManager};
 
+use serde::{Deserialize, Serialize};
 use sn_client::{Client, FilesApi, FolderEntry, FoldersApi, Metadata, WalletClient};
 use sn_protocol::storage::{Chunk, ChunkAddress, RegisterAddress, RetryStrategy};
 use sn_transfers::HotWallet;
@@ -22,31 +23,55 @@ use color_eyre::{
 use std::{
     collections::BTreeMap,
     ffi::OsString,
-    fs::create_dir_all,
+    fs::{create_dir_all, File},
+    io::Write,
     path::{Path, PathBuf},
 };
 use tokio::task::JoinSet;
 use walkdir::{DirEntry, WalkDir};
+use xor_name::{XorName, XOR_NAME_LEN};
 
 // Name of hidden folder where tracking information and metadata is locally kept.
 const SAFE_TRACKING_CHANGES_DIR: &str = ".safe";
+
+// Subfolder where files metadata will be cached
+const METADATA_CACHE_DIR: &str = "metadata";
+
+// Name of the file where metadata about root folder is locally kept.
+const ROOT_FOLDER_METADATA_FILENAME: &str = "root_folder.xorname";
+
+// Information stored locally to keep track of local changes to files/folders.
+// TODO: to make file changes discovery more efficient, add more info like file size and last modified timestamp.
+#[derive(Debug, Serialize, Deserialize)]
+struct MetadataTrackingInfo {
+    file_path: PathBuf,
+    meta_xorname: XorName,
+    metadata: Metadata,
+}
 
 pub struct AccountPacket {
     client: Client,
     wallet_dir: PathBuf,
     files_dir: PathBuf,
+    meta_dir: PathBuf,
+    tracking_info_dir: PathBuf,
 }
 
 impl AccountPacket {
     /// Create AccountPacket instance.
     pub fn new(client: Client, wallet_dir: &Path, path: &Path) -> Result<Self> {
-        create_dir_all(path)?;
         let files_dir = path.to_path_buf().canonicalize()?;
+        let tracking_info_dir = files_dir.join(SAFE_TRACKING_CHANGES_DIR);
+        let meta_dir = tracking_info_dir.join(METADATA_CACHE_DIR);
+        create_dir_all(&meta_dir)
+            .map_err(|err| eyre!("The path provided needs to be a directory: {err}"))?;
 
         Ok(Self {
             client,
             wallet_dir: wallet_dir.to_path_buf(),
             files_dir,
+            meta_dir,
+            tracking_info_dir,
         })
     }
 
@@ -54,20 +79,21 @@ impl AccountPacket {
     /// Once they have been added, they can be compared against their remote versions on the network
     /// using the `status` method, and/or push all changes to the network with `sync` method.
     pub async fn add_all_files(&mut self, options: FilesUploadOptions) -> Result<RegisterAddress> {
-        // for now we use the same root folder as the wallet dir for storing chunks artifacts
-        let mut chunk_manager = ChunkManager::new(&self.wallet_dir);
+        let mut chunk_manager = ChunkManager::new(&self.tracking_info_dir);
         chunk_manager.chunk_with_iter(self.iter_only_files(), true, options.make_data_public)?;
 
-        let mut folders = self.build_folders_hierarchy()?;
+        let mut folders = self.build_folders_hierarchy(true)?;
 
         // add chunked files to the corresponding Folders
         for chunked_file in chunk_manager.iter_chunked_files() {
             if let Some(parent) = chunked_file.file_path.parent() {
                 if let Some(folder) = folders.get_mut(parent) {
-                    let (_metadata, _meta_xorname) = folder.add_file(
+                    let (metadata, meta_xorname) = folder.add_file(
                         chunked_file.file_name.clone(),
                         chunked_file.head_chunk_address,
                     )?;
+
+                    self.store_tracking_info(&chunked_file.file_path, metadata, meta_xorname)?;
                 }
             }
         }
@@ -77,6 +103,7 @@ impl AccountPacket {
             .get(&self.files_dir)
             .map(|folder| *folder.address())
             .ok_or(eyre!("Failed to obtain main Folder network address"))?;
+        self.store_root_folder_tracking_info(root_dir_address.xorname())?;
 
         self.pay_and_upload_folders(folders, options).await?;
 
@@ -110,7 +137,7 @@ impl AccountPacket {
         }
 
         let files_api: FilesApi = FilesApi::new(self.client.clone(), download_path.to_path_buf());
-        let uploaded_files_path = self.wallet_dir.join(UPLOADED_FILES);
+        let uploaded_files_path = self.tracking_info_dir.join(UPLOADED_FILES);
         for (file_name, addr, path) in files_to_download {
             // try to read the data_map if it exists locally.
             let expected_data_map_location = uploaded_files_path.join(addr.to_hex());
@@ -138,10 +165,134 @@ impl AccountPacket {
         Ok(())
     }
 
+    /// Generate a report with differences found in local files/folders in comparison with their versions stored on the network.
+    pub fn status(&mut self) -> Result<()> {
+        let root_folder_xorname = self.read_root_folder_xorname()?;
+        let mut curr_folders = BTreeMap::<PathBuf, FoldersApi>::new();
+        curr_folders.insert(
+            PathBuf::new(),
+            FoldersApi::with_xorname(self.client.clone(), &self.wallet_dir, root_folder_xorname)?,
+        );
+
+        for entry in WalkDir::new(&self.meta_dir)
+            .into_iter()
+            .flatten()
+            .filter(|e| e.file_type().is_file() && e.file_name() != ROOT_FOLDER_METADATA_FILENAME)
+        {
+            let path = entry.path();
+            let bytes = std::fs::read(path).map_err(|err| {
+                eyre!("Error while reading the tracking info from {path:?}: {err}")
+            })?;
+            let tracking_info: MetadataTrackingInfo =
+                rmp_serde::from_slice(&bytes).map_err(|err| {
+                    eyre!("Error while deserializing tracking info from {path:?}: {err}")
+                })?;
+
+            println!(">> INFO {tracking_info:?}");
+
+            /*let curr_folder_addr = *curr_folders
+            .entry(tracking_info.clone())
+            .or_insert(FoldersApi::with_xorname(
+                self.client.clone(),
+                &self.wallet_dir,
+                tracking_info.meta_xorname,
+            )?)
+            .address();*/
+        }
+
+        /*
+        let make_public = false;
+        let mut chunk_manager = ChunkManager::new(&self.tracking_info_dir);
+        chunk_manager.chunk_with_iter(self.iter_only_files(), true, make_public)?;
+
+        let mut folders = self.build_folders_hierarchy(false)?;
+
+        // add chunked files to the corresponding Folders
+        for chunked_file in chunk_manager.iter_chunked_files() {
+            if let Some(parent) = chunked_file.file_path.parent() {
+                if let Some(folder) = folders.get_mut(parent) {
+                    println!(
+                        ">> FILE {:?} -> {}",
+                        chunked_file.file_path,
+                        hex::encode(chunked_file.head_chunk_address.xorname())
+                    );
+                    let (_metadata, meta_xorname) = folder.add_file(
+                        chunked_file.file_name.clone(),
+                        chunked_file.head_chunk_address,
+                    )?;
+
+                    let metadata_file = self.meta_dir.join(hex::encode(meta_xorname));
+                    if metadata_file.exists() {
+                        println!(
+                            "META FOUND for {:?} >> {metadata_file:?}",
+                            chunked_file.file_name
+                        );
+                    } else {
+                        println!(
+                            "NOT FOUND for {:?} >> {metadata_file:?}",
+                            chunked_file.file_name
+                        );
+                    }
+                }
+            }
+        }
+        */
+
+        Ok(())
+    }
+
     // Private helpers
 
+    // Store tracking info in a file to keep track of any changes made to the source file/folder
+    fn store_tracking_info(
+        &self,
+        src_path: &Path,
+        metadata: Metadata,
+        meta_xorname: XorName,
+    ) -> Result<()> {
+        let metadata_file_path = self.meta_dir.join(hex::encode(meta_xorname));
+        let mut meta_file = File::create(metadata_file_path)?;
+
+        let file_path = src_path
+            .to_path_buf()
+            .canonicalize()?
+            .strip_prefix(&self.files_dir)?
+            .to_path_buf();
+        let tracking_info = MetadataTrackingInfo {
+            file_path,
+            meta_xorname,
+            metadata,
+        };
+
+        meta_file.write_all(&rmp_serde::to_vec(&tracking_info)?)?;
+
+        Ok(())
+    }
+
+    // Store tracking info about the root folder in a file to keep track of any changes made
+    fn store_root_folder_tracking_info(&self, root_folder_xorname: XorName) -> Result<()> {
+        let path = self.meta_dir.join(ROOT_FOLDER_METADATA_FILENAME);
+        let mut meta_file = File::create(path)?;
+        meta_file.write_all(hex::encode(root_folder_xorname).as_bytes())?;
+
+        Ok(())
+    }
+
+    fn read_root_folder_xorname(&self) -> Result<XorName> {
+        let path = self.meta_dir.join(ROOT_FOLDER_METADATA_FILENAME);
+        let bytes = std::fs::read(&path)
+            .map_err(|err| eyre!("Error while reading the tracking info from {path:?}: {err}"))?;
+
+        let mut xorname = [0; XOR_NAME_LEN];
+        xorname.copy_from_slice(&hex::decode(bytes)?);
+        Ok(XorName(xorname))
+    }
+
     // Build Folders hierarchy from the set files dir
-    fn build_folders_hierarchy(&self) -> Result<BTreeMap<PathBuf, FoldersApi>> {
+    fn build_folders_hierarchy(
+        &self,
+        store_tracking_info: bool,
+    ) -> Result<BTreeMap<PathBuf, FoldersApi>> {
         let mut folders = BTreeMap::new();
         for (dir_path, depth, parent, dir_name) in self.iter_only_dirs().filter_map(|entry| {
             entry.path().parent().map(|parent| {
@@ -162,8 +313,12 @@ impl AccountPacket {
                 let parent_folder = folders
                     .entry(parent)
                     .or_insert(FoldersApi::new(self.client.clone(), &self.wallet_dir)?);
-                let (_metadata, _meta_xorname) =
+                let (metadata, meta_xorname) =
                     parent_folder.add_folder(dir_name, curr_folder_addr)?;
+
+                if store_tracking_info {
+                    self.store_tracking_info(&dir_path, metadata, meta_xorname)?;
+                }
             }
         }
 
@@ -198,7 +353,7 @@ impl AccountPacket {
             self.files_dir.clone(),
             &self.client,
             self.wallet_dir.clone(),
-            self.wallet_dir.clone(),
+            self.tracking_info_dir.clone(),
             options.clone(),
         )
         .await?;

--- a/sn_cli/src/subcommands/files/chunk_manager.rs
+++ b/sn_cli/src/subcommands/files/chunk_manager.rs
@@ -228,7 +228,7 @@ impl ChunkManager {
                             file_path: path.to_owned(),
                             file_name: original_file_name.clone(),
                             chunks: chunks.into_iter().collect(),
-                            data_map
+                            data_map: Some(data_map.value)
                         };
                         Ok((path_xor.clone(), chunked_file))
                     }
@@ -390,6 +390,7 @@ impl ChunkManager {
             // todo: should we remove the entry? ig so
             if let Some(chunked_file) = self.chunks.remove(path_xor) {
                 trace!("removed {path_xor:?} from chunks list");
+
                 self.completed_files.push((
                     chunked_file.file_name.clone(),
                     chunked_file.head_chunk_address,

--- a/sn_cli/src/subcommands/folders.rs
+++ b/sn_cli/src/subcommands/folders.rs
@@ -59,6 +59,12 @@ pub enum FoldersCmds {
         #[clap(long, default_value_t = RetryStrategy::Quick, short = 'r', help = "Sets the retry strategy on download failure. Options: 'quick' for minimal effort, 'balanced' for moderate effort, or 'persistent' for maximum effort.")]
         retry_strategy: RetryStrategy,
     },
+    /// Report any differences found in local files/folders in comparison with their versions stored on the network.
+    Status {
+        /// Can be a file or a directory.
+        #[clap(name = "path", value_name = "PATH")]
+        path: PathBuf,
+    },
 }
 
 pub(crate) async fn folders_cmds(
@@ -118,6 +124,11 @@ pub(crate) async fn folders_cmds(
                     retry_strategy,
                 )
                 .await?;
+        }
+        FoldersCmds::Status { path } => {
+            let mut acc_packet = AccountPacket::new(client.clone(), root_dir, &path)?;
+
+            acc_packet.status()?;
         }
     }
     Ok(())

--- a/sn_cli/src/subcommands/folders.rs
+++ b/sn_cli/src/subcommands/folders.rs
@@ -17,7 +17,6 @@ use clap::Parser;
 use color_eyre::{eyre::eyre, Result};
 use std::{
     ffi::OsString,
-    fs::create_dir_all,
     path::{Path, PathBuf},
 };
 
@@ -106,7 +105,6 @@ pub(crate) async fn folders_cmds(
 
             let download_dir = dirs_next::download_dir().unwrap_or(root_dir.to_path_buf());
             let download_folder_path = download_dir.join(folder_name.clone());
-            create_dir_all(&download_folder_path)?;
             println!(
                 "Downloading onto {download_folder_path:?} from {} with batch-size {batch_size}",
                 address.to_hex()
@@ -116,20 +114,18 @@ pub(crate) async fn folders_cmds(
                 address.to_hex()
             );
 
-            let acc_packet =
-                AccountPacket::from_path(client.clone(), root_dir, &download_folder_path)?;
-            acc_packet
-                .download_folders(
-                    address,
-                    folder_name,
-                    &download_folder_path,
-                    batch_size,
-                    retry_strategy,
-                )
-                .await?;
+            let _acc_packet = AccountPacket::retrieve_folders(
+                client,
+                root_dir,
+                address,
+                &download_folder_path,
+                batch_size,
+                retry_strategy,
+            )
+            .await?;
         }
         FoldersCmds::Status { path } => {
-            let acc_packet = AccountPacket::from_path(client.clone(), root_dir, &path)?;
+            let mut acc_packet = AccountPacket::from_path(client.clone(), root_dir, &path)?;
 
             acc_packet.status().await?;
         }

--- a/sn_client/src/folders.rs
+++ b/sn_client/src/folders.rs
@@ -58,6 +58,12 @@ impl FoldersApi {
         Self::create(client, wallet_dir, register)
     }
 
+    /// Create FoldersApi instance with a provided XorName.
+    pub fn with_xorname(client: Client, wallet_dir: &Path, xorname: XorName) -> Result<Self> {
+        let register = ClientRegister::create(client.clone(), xorname);
+        Self::create(client, wallet_dir, register)
+    }
+
     /// Return the address of the Folder (Register address) on the network
     pub fn address(&self) -> &RegisterAddress {
         self.register.address()

--- a/sn_client/src/folders.rs
+++ b/sn_client/src/folders.rs
@@ -27,14 +27,14 @@ use std::{
 };
 
 /// Folder Entry representing either a file or subfolder.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum FolderEntry {
     File(ChunkAddress),
     Folder(RegisterAddress),
 }
 
 /// Metadata to be stored on a Chunk, linked from and belonging to Registers' entries.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Metadata {
     pub name: String,
     pub content: FolderEntry,
@@ -52,15 +52,12 @@ pub struct FoldersApi {
 
 impl FoldersApi {
     /// Create FoldersApi instance.
-    pub fn new(client: Client, wallet_dir: &Path) -> Result<Self> {
+    pub fn new(client: Client, wallet_dir: &Path, xorname: Option<XorName>) -> Result<Self> {
         let mut rng = rand::thread_rng();
-        let register = ClientRegister::create(client.clone(), XorName::random(&mut rng));
-        Self::create(client, wallet_dir, register)
-    }
-
-    /// Create FoldersApi instance with a provided XorName.
-    pub fn with_xorname(client: Client, wallet_dir: &Path, xorname: XorName) -> Result<Self> {
-        let register = ClientRegister::create(client.clone(), xorname);
+        let register = ClientRegister::create(
+            client.clone(),
+            xorname.unwrap_or_else(|| XorName::random(&mut rng)),
+        );
         Self::create(client, wallet_dir, register)
     }
 
@@ -150,27 +147,26 @@ impl FoldersApi {
     }
 
     /// Returns the list of entries of this Folder
-    pub async fn entries(&mut self) -> Result<Vec<Metadata>> {
+    pub async fn entries(&mut self) -> Result<Vec<(XorName, Metadata)>> {
         let mut entries = vec![];
         for (_, entry) in self.register.read() {
             let mut xorname = [0; XOR_NAME_LEN];
             xorname.copy_from_slice(&entry);
-            let metadata_addr = XorName(xorname);
-            let metadata = match self.metadata.get(&metadata_addr) {
+            let meta_xorname = XorName(xorname);
+            let metadata = match self.metadata.get(&meta_xorname) {
                 Some((metadata, _)) => metadata.clone(),
                 None => {
                     // retrieve metadata Chunk from network
                     let chunk = self
                         .client
-                        .get_chunk(ChunkAddress::new(metadata_addr), false, None)
+                        .get_chunk(ChunkAddress::new(meta_xorname), false, None)
                         .await?;
                     let metadata: Metadata = rmp_serde::from_slice(chunk.value())?;
-                    self.metadata
-                        .insert(metadata_addr, (metadata.clone(), None));
+                    self.metadata.insert(meta_xorname, (metadata.clone(), None));
                     metadata
                 }
             };
-            entries.push(metadata);
+            entries.push((meta_xorname, metadata));
         }
         Ok(entries)
     }


### PR DESCRIPTION
Example output from `folders status` cmd:
```
$ safe folders status ~/myfolder
...
🔗 Connected to the Network
Chunking 5 files...
Looking for local changes made to files/folders...
- New file: "~/myfolder/fileX.txt"
- New folder: "~/myfolder/newdir"
- File content changed: "~/myfolder/file1.txt"
- New file: "~/myfolder/newdir/newfile.txt"
- File removed: "~/myfolder/.hidden/hidden.txt"
- Folder removed: "~/myfolder/subdir2/dir22"
- File removed along with its folder: "~/myfolder/subdir2/dir22/file3.txt"

Changes found to local files/folders: 7
```

## Description

reviewpad:summary 
