### PR TITLE
feat(cli): claim from snapshot using get-faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4898,6 +4898,8 @@ dependencies = [
 name = "sn_cli"
 version = "0.89.81"
 dependencies = [
+ "base64 0.21.7",
+ "bitcoin",
  "blsttc",
  "bytes",
  "chrono",
@@ -4978,6 +4980,7 @@ name = "sn_faucet"
 version = "0.3.81"
 dependencies = [
  "assert_fs",
+ "base64 0.21.7",
  "bitcoin",
  "blsttc",
  "clap 4.5.1",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -20,12 +20,15 @@ harness = false
 
 [features]
 default = ["metrics"]
+distribution = ["base64", "bitcoin"]
 local-discovery=["sn_client/local-discovery", "sn_peers_acquisition/local-discovery"]
 metrics = ["sn_logging/process-metrics"]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
 open-metrics = ["sn_client/open-metrics"]
 
 [dependencies]
+base64 = { version = "0.21.7", optional = true }
+bitcoin = { version = "0.31.0", optional = true}
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.5.0"

--- a/sn_cli/src/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/subcommands/wallet/hot_wallet.rs
@@ -73,6 +73,12 @@ pub enum WalletCmds {
         /// The http url of the faucet to get tokens from.
         #[clap(name = "url")]
         url: String,
+        /// The maidsafecoin address to claim. Leave blank to receive a fixed
+        /// amount of tokens.
+        maid_address: Option<String>,
+        /// A signature of the safe wallet address, made by the maidsafecoin
+        /// address.
+        signature: Option<String>,
     },
     /// Send a transfer.
     ///
@@ -179,7 +185,7 @@ pub(crate) async fn wallet_cmds_without_client(cmds: &WalletCmds, root_dir: &Pat
                     return Ok(());
                 }
                 // remove existing wallet
-                let new_location = HotWallet::clear(root_dir)?;
+                let new_location = HotWallet::stash(root_dir)?;
                 println!("Old wallet stored at {}", new_location.display());
             }
             // Create the new wallet with the new key
@@ -205,7 +211,11 @@ pub(crate) async fn wallet_cmds(
     match cmds {
         WalletCmds::Send { amount, to } => send(amount, to, client, root_dir, verify_store).await,
         WalletCmds::Receive { file, transfer } => receive(transfer, file, client, root_dir).await,
-        WalletCmds::GetFaucet { url } => get_faucet(root_dir, client, url.clone()).await,
+        WalletCmds::GetFaucet {
+            url,
+            maid_address,
+            signature,
+        } => get_faucet(root_dir, client, url.clone(), maid_address, signature).await,
         WalletCmds::Audit { dot, royalties } => audit(client, dot, royalties, root_dir).await,
         WalletCmds::Verify {
             spend_address,

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.81"
 
 [features]
 default = []
-distribution = ["bitcoin", "minreq"]
+distribution = ["base64", "bitcoin", "minreq"]
 
 [[bin]]
 path="src/main.rs"
@@ -20,6 +20,7 @@ name="faucet"
 
 [dependencies]
 assert_fs = "1.0.0"
+base64 = { version = "0.21.7", optional = true }
 bitcoin = { version = "0.31.0", features = ["rand-std", "base64"], optional = true }
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/sn_transfers/src/wallet/hot_wallet.rs
+++ b/sn_transfers/src/wallet/hot_wallet.rs
@@ -183,15 +183,31 @@ impl HotWallet {
     }
 
     /// Moves all files for the current wallet, including keys and cashnotes
-    /// to directory root_dir/wallet_<short_address>
-    pub fn clear(root_dir: &Path) -> Result<PathBuf> {
+    /// to directory root_dir/wallet_ADDRESS
+    pub fn stash(root_dir: &Path) -> Result<PathBuf> {
         let wallet = HotWallet::load_from(root_dir)?;
         let wallet_dir = root_dir.join(WALLET_DIR_NAME);
-        let addr_short = &format!("{:?}", wallet.address())[0..10];
-        let new_name = format!("{WALLET_DIR_NAME}_{addr_short}");
+        let addr_hex = &format!("{:?}", wallet.address());
+        let new_name = format!("{WALLET_DIR_NAME}_{addr_hex}");
         let moved_dir = root_dir.join(new_name);
         let _ = std::fs::rename(wallet_dir, moved_dir.clone());
         Ok(moved_dir)
+    }
+
+    /// Moves a previously stashed wallet to the root wallet directory.
+    pub fn unstash(root_dir: &Path, addr_hex: &str) -> Result<()> {
+        let cleared_name = format!("{WALLET_DIR_NAME}_{addr_hex}");
+        let cleared_dir = root_dir.join(cleared_name);
+        let wallet_dir = root_dir.join(WALLET_DIR_NAME);
+        std::fs::rename(cleared_dir, wallet_dir.clone())?;
+        Ok(())
+    }
+
+    /// Removes all files for the current wallet, including keys and cashnotes
+    pub fn remove(root_dir: &Path) -> Result<()> {
+        let wallet_dir = root_dir.join(WALLET_DIR_NAME);
+        std::fs::remove_dir_all(wallet_dir)?;
+        Ok(())
     }
 
     /// To remove a specific spend from the requests, if eg, we see one spend is _bad_


### PR DESCRIPTION
This introduces a second way to get tokens from the faucet using the cli

`safe wallet get-faucet <url>`
Retains the existing fixed amount of tokens into the current wallet.
    
`safe wallet get-faucet <url> <maid_address> <signature>`
Receives a transfer from the maid snapshot for the amount of maid owned
by that address. The signature is a bitcoin signature by the maid
address with the message as the hex encoded safe wallet address that
will receive the transfer.

This uses the current safe wallet as the recipient.

It also introduces a few helpers for wallet management, not currently used by the cli but will be handy to include in future commands `safe wallet stash` and `safe wallet unstash <address>`

* `stash` - moves the current wallet into a new directory `wallet_<address>`
* `unstash` - moves the stashed wallet for the given address to the `wallet` directory - need to double check behavior for overwriting the existing wallet here (or not).
* `remove` - deletes the current wallet stored in `wallet` directory

These helpers arose for two main reasons

* there's no way to create an in-memory only wallet, mainly because of the dependency on `cash_notes` and `payments` files to make the wallet work correctly, so it's very common to move wallets around
* the backup for most blockchain systems is just the keys (usually via mnemonics) but this isn't enough to create a backup of a safe wallet, so these helpers are a starting point for backing up wallets.

## Description

reviewpad:summary 
