### PR TITLE
feat: remove use of client passed by iter uploader and estimate

### DIFF
--- a/sn_cli/src/subcommands/acc_packet.rs
+++ b/sn_cli/src/subcommands/acc_packet.rs
@@ -667,7 +667,6 @@ impl AccountPacket {
             .iterate_upload(
                 self.iter_only_files(),
                 self.files_dir.clone(),
-                &self.client,
                 options.clone(),
             )
             .await?;

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -104,7 +104,11 @@ pub(crate) async fn files_cmds(
         FilesCmds::Estimate {
             path,
             make_data_public,
-        } => estimate::estimate_cost(path, make_data_public, client, root_dir).await?,
+        } => {
+            estimate::Estimator::new(chunk_manager, files_api)
+                .estimate_cost(path, make_data_public, root_dir)
+                .await?
+        }
         FilesCmds::Upload {
             file_path,
             batch_size,
@@ -115,7 +119,6 @@ pub(crate) async fn files_cmds(
                 .iterate_upload(
                     WalkDir::new(&file_path).into_iter().flatten(),
                     file_path,
-                    client,
                     FilesUploadOptions {
                         make_data_public,
                         verify_store,
@@ -123,7 +126,7 @@ pub(crate) async fn files_cmds(
                         retry_strategy,
                     },
                 )
-                .await
+                .await?
         }
         FilesCmds::Download {
             file_name,
@@ -234,7 +237,7 @@ pub(crate) async fn files_cmds(
                 }
             }
         }
-    };
+    }
     Ok(())
 }
 

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -98,7 +98,7 @@ pub(crate) async fn files_cmds(
     verify_store: bool,
 ) -> Result<()> {
     let files_api = FilesApi::build(client.clone(), root_dir.to_path_buf())?;
-    let chunk_manager = ChunkManager::new(&root_dir.clone());
+    let chunk_manager = ChunkManager::new(root_dir);
 
     match cmds {
         FilesCmds::Estimate {

--- a/sn_cli/src/subcommands/files/estimate.rs
+++ b/sn_cli/src/subcommands/files/estimate.rs
@@ -40,9 +40,10 @@ impl Estimator {
             .as_nano();
 
         for (chunk_address, _location) in self.chunk_manager.get_chunks() {
+            let c = self.files_api.clone();
+
             tokio::spawn(async move {
-                let (_peer, _cost, quote) = self
-                    .files_api
+                let (_peer, _cost, quote) = c
                     .wallet()
                     .expect("estimate_cost: Wallet error.")
                     .get_store_cost_at_address(NetworkAddress::from_chunk_address(

--- a/sn_cli/src/subcommands/files/iterative_uploader.rs
+++ b/sn_cli/src/subcommands/files/iterative_uploader.rs
@@ -5,7 +5,7 @@ use indicatif::ProgressBar;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use sn_client::transfers::{Error as TransfersError, NanoTokens, WalletError};
-use sn_client::{Client, Error as ClientError, Error, FileUploadEvent, FilesApi, FilesUpload};
+use sn_client::{Error as ClientError, Error, FileUploadEvent, FilesApi, FilesUpload};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -35,7 +35,6 @@ impl IterativeUploader {
         mut self,
         entries_iter: impl Iterator<Item = DirEntry>,
         files_path: PathBuf,
-        _client: &Client,
         options: FilesUploadOptions,
     ) -> Result<()> {
         let FilesUploadOptions {

--- a/sn_cli/src/subcommands/files/iterative_uploader.rs
+++ b/sn_cli/src/subcommands/files/iterative_uploader.rs
@@ -35,7 +35,7 @@ impl IterativeUploader {
         mut self,
         entries_iter: impl Iterator<Item = DirEntry>,
         files_path: PathBuf,
-        client: &Client,
+        _client: &Client,
         options: FilesUploadOptions,
     ) -> Result<()> {
         let FilesUploadOptions {
@@ -64,7 +64,11 @@ impl IterativeUploader {
                 chunks.len()
             );
 
-            let failed_chunks = client.verify_uploaded_chunks(&chunks, batch_size).await?;
+            let failed_chunks = self
+                .files_api
+                .client()
+                .verify_uploaded_chunks(&chunks, batch_size)
+                .await?;
 
             // mark the non-failed ones as completed
             self.chunk_manager.mark_completed(

--- a/sn_cli/src/subcommands/files/upload.rs
+++ b/sn_cli/src/subcommands/files/upload.rs
@@ -1,14 +1,11 @@
+use std::ffi::OsString;
+use std::path::Path;
+
 use bytes::Bytes;
 use color_eyre::Result;
 use serde::Deserialize;
-use sn_client::protocol::storage::{ChunkAddress, RetryStrategy};
-use sn_client::{Client, FilesApi};
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
-use crate::subcommands::files::iterative_uploader::IterativeUploader;
-use crate::subcommands::files::ChunkManager;
+use sn_client::protocol::storage::{ChunkAddress, RetryStrategy};
 
 /// Subdir for storing uploaded file into
 pub(crate) const UPLOADED_FILES: &str = "uploaded_files";
@@ -77,25 +74,4 @@ impl UploadedFile {
         })?;
         Ok(metadata)
     }
-}
-
-/// Given a file or directory, upload either the file or all the files in the directory. Optionally
-/// verify if the data was stored successfully.
-pub async fn upload_files(
-    files_path: PathBuf,
-    client: &Client,
-    root_dir: PathBuf,
-    options: FilesUploadOptions,
-) -> Result<()> {
-    let files_api = FilesApi::build(client.clone(), root_dir.clone())?;
-    let chunk_manager = ChunkManager::new(&root_dir.clone());
-
-    IterativeUploader::new(chunk_manager, files_api)
-        .iterate_upload(
-            WalkDir::new(&files_path).into_iter().flatten(),
-            files_path,
-            client,
-            options,
-        )
-        .await
 }


### PR DESCRIPTION
## Description

- client is passed as a param but so too goes the files api which also contains client. We can therefore remove client and use the client inside of files api instead.
- Chunk manager and files api can be passed into estimate and upload.

That's mostly it 👍 

----------------------------------------------------

Looking a little more at files api, there are functions that invole the use of chunks a lot, and a function that is only used elsewhere. If you factored these functions into scope you may not have much of a need for files api (sn_client/src/files.rs). Perhaps a good refactor could take care of this.
