### PR TITLE
chore(api): make logging::Error public

### DIFF
--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -12,13 +12,15 @@ mod layers;
 #[cfg(feature = "process-metrics")]
 pub mod metrics;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use layers::TracingLayers;
 use std::path::PathBuf;
 use tracing::info;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_core::{dispatcher::DefaultGuard, Level};
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
+
+pub use error::Error;
 
 #[derive(Debug, Clone)]
 pub enum LogOutputDest {


### PR DESCRIPTION
it's public in other crates, it makes error handling easier.

## Description

reviewpad:summary 
