### PR TITLE
feat: support a port range on the `add` command

### DIFF
--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -8,7 +8,10 @@
 
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Result};
-use sn_node_manager::{cmd, VerbosityLevel};
+use sn_node_manager::{
+    add_services::config::{parse_port_range, PortRange},
+    cmd, VerbosityLevel,
+};
 use sn_peers_acquisition::PeersArgs;
 use std::{net::Ipv4Addr, path::PathBuf};
 
@@ -65,11 +68,15 @@ pub enum SubCmd {
         log_dir_path: Option<PathBuf>,
         #[command(flatten)]
         peers: PeersArgs,
-        /// Specify a port for the node to run on. If not used, a port will be selected at random.
+        /// Specify a port for the safenode service(s).
         ///
-        /// This option only applies when a single service is being added.
-        #[clap(long)]
-        port: Option<u16>,
+        /// If not used, ports will be selected at random.
+        ///
+        /// If multiple services are being added and this argument is used, you must specify a
+        /// range. For example, '12000-12004'. The length of the range must match the number of
+        /// services, which in this case would be 5. The range must also go from lower to higher.
+        #[clap(long, value_parser = parse_port_range)]
+        port: Option<PortRange>,
         #[clap(long)]
         /// Specify an Ipv4Addr for the node's RPC server to run on.
         ///

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -10,7 +10,10 @@
 
 use super::{download_and_get_upgrade_bin_path, is_running_as_root, print_upgrade_summary};
 use crate::{
-    add_services::{add_node, config::AddNodeServiceOptions},
+    add_services::{
+        add_node,
+        config::{AddNodeServiceOptions, PortRange},
+    },
     config,
     helpers::download_and_extract_release,
     status_report, ServiceManager, VerbosityLevel,
@@ -36,7 +39,7 @@ pub async fn add(
     local: bool,
     log_dir_path: Option<PathBuf>,
     peers: PeersArgs,
-    port: Option<u16>,
+    port: Option<PortRange>,
     rpc_address: Option<Ipv4Addr>,
     url: Option<String>,
     user: Option<String>,


### PR DESCRIPTION
Previously we would not allow a custom port to be specified if more than one service was being
added. However, without autonat, people still need to open ports manually on their router, so the
node services they add will need to match this port range. Without the ability to specify a range,
they'd need to add the services one by one.

## Description

reviewpad:summary 
