### PR TITLE
fix: attach binaries to node manager release

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -216,7 +216,7 @@ upload-github-release-assets:
   binary_crates=(
     "sn_cli"
     "sn_node"
-    "sn_node_manager"
+    "sn-node-manager"
     "sn_faucet"
     "sn_node_rpc_client"
   )

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,6 +14,19 @@ git_release_enable = false
 publish = true
 
 [[package]]
+name = "sn_cli"
+changelog_update = true
+publish = true
+changelog_include = [
+    "sn_client",
+    "sn_networking",
+    "sn_transfers",
+    "sn_registers",
+    "sn_peers_acquisition",
+    "sn_protocol",
+]
+
+[[package]]
 name = "sn_client"
 changelog_update = true
 git_release_enable = false
@@ -27,17 +40,28 @@ changelog_include = [
 ]
 
 [[package]]
-name = "sn_cli"
+name = "sn_faucet"
 changelog_update = true
+git_release_enable = false
 publish = true
-changelog_include = [
-    "sn_client",
-    "sn_networking",
-    "sn_transfers",
-    "sn_registers",
-    "sn_peers_acquisition",
-    "sn_protocol",
-]
+
+[[package]]
+name = "sn_logging"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
+name = "sn_metrics"
+changelog_update = true
+git_release_enable = false
+publish = false
+
+[[package]]
+name = "sn_networking"
+changelog_update = true
+git_release_enable = false
+publish = true
 
 [[package]]
 name = "sn_node"
@@ -52,13 +76,7 @@ changelog_include = [
 ]
 
 [[package]]
-name = "sn_logging"
-changelog_update = true
-git_release_enable = false
-publish = true
-
-[[package]]
-name = "sn_networking"
+name = "sn_node_rpc_client"
 changelog_update = true
 git_release_enable = false
 publish = true
@@ -82,31 +100,13 @@ git_release_enable = false
 publish = true
 
 [[package]]
+name = "sn_service_management"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
 name = "sn_transfers"
-changelog_update = true
-git_release_enable = false
-publish = true
-
-[[package]]
-name = "sn_faucet"
-changelog_update = true
-git_release_enable = false
-publish = true
-
-[[package]]
-name = "sn_node_rpc_client"
-changelog_update = true
-git_release_enable = false
-publish = true
-
-[[package]]
-name = "sn_metrics"
-changelog_update = true
-git_release_enable = false
-publish = false
-
-[[package]]
-name = "token_supplies"
 changelog_update = true
 git_release_enable = false
 publish = true
@@ -116,3 +116,9 @@ name = "test_utils"
 changelog_update = true
 git_release_enable = false
 publish = false
+
+[[package]]
+name = "token_supplies"
+changelog_update = true
+git_release_enable = false
+publish = true


### PR DESCRIPTION
The crate name was specified as `sn_node_manager` rather than `sn-node-manager`.

Also disable the `sn_service_management` crate from being released on Github. At the same time I arranged the crates in the config file alphabetically, just because it makes them a bit easier to find.

## Description

reviewpad:summary 
