### PR TITLE
fix(client): old uploads should not fail due to updating quotes

### DIFF
--- a/sn_client/src/uploader/mod.rs
+++ b/sn_client/src/uploader/mod.rs
@@ -370,6 +370,7 @@ enum TaskResult {
         xorname: XorName,
         get_store_cost_strategy: GetStoreCostStrategy,
         max_repayments_reached: bool,
+        expired: bool,
     },
     MakePaymentsOk {
         paid_xornames: Vec<XorName>,

--- a/sn_client/src/uploader/tests/setup.rs
+++ b/sn_client/src/uploader/tests/setup.rs
@@ -226,6 +226,7 @@ impl UploaderInterface for TestUploader {
                             xorname,
                             get_store_cost_strategy,
                             max_repayments_reached,
+                            expired: false,
                         })
                         .await
                         .expect("Failed to send task result");


### PR DESCRIPTION
Previously we could error out if all quotes were old, now we require at least double batch size errors from store cost quote fails

## Description

reviewpad:summary 
