### PR TITLE
chore(auditor): set repository field in cargo

### DIFF
--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -5,6 +5,7 @@ name = "sn_auditor"
 version = "0.1.2"
 edition = "2021"
 homepage = "https://maidsafe.net"
+repository = "https://github.com/maidsafe/safe_network"
 license = "GPL-3.0"
 readme = "README.md"
 


### PR DESCRIPTION
Update [repository](https://rust-digger.code-maven.com/about-repository) field in `Cargo.toml` to point to the GitHub repo.

This makes the location of the source code show correctly on Crates.io. 🙂