### PR TITLE
fix(node): add only the external addresses with the configured port

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -491,6 +491,7 @@ impl NetworkBuilder {
             swarm,
             self_peer_id: peer_id,
             local: self.local,
+            listen_port: self.listen_addr.map(|addr| addr.port()),
             is_client,
             connected_peers: 0,
             bootstrap,
@@ -535,6 +536,8 @@ pub struct SwarmDriver {
     pub(crate) self_peer_id: PeerId,
     pub(crate) local: bool,
     pub(crate) is_client: bool,
+    /// The port that was set by the user
+    pub(crate) listen_port: Option<u16>,
     pub(crate) connected_peers: usize,
     pub(crate) bootstrap: ContinuousBootstrap,
     /// The peers that are closer to our PeerId. Includes self.

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -32,6 +32,7 @@ use libp2p::{
 use crate::target_arch::Instant;
 
 use sn_protocol::{
+    get_port_from_multiaddr,
     messages::{CmdResponse, Query, Request, Response},
     storage::RecordType,
     NetworkAddress, PrettyPrintRecordKey,
@@ -538,13 +539,24 @@ impl SwarmDriver {
 
                 if !self.swarm.external_addresses().any(|addr| addr == &address) && !self.is_client
                 {
-                    info!(%address, "external address: new candidate");
+                    debug!(%address, "external address: new candidate");
 
                     // Identify will let us know when we have a candidate. (Peers will tell us what address they see us as.)
                     // We manually confirm this to be our externally reachable address, though in theory it's possible we
-                    // are not actually reachable. (Peers can lie to us.) This is a good enough heuristic for now.
+                    // are not actually reachable. This event returns addresses with ports that were not set by the user,
+                    // so we must not add those ports as they will not be forwarded.
                     // Setting this will also switch kad to server mode if it's not already in it.
-                    self.swarm.add_external_address(address);
+                    if let Some(our_port) = self.listen_port {
+                        if let Some(port) = get_port_from_multiaddr(&address) {
+                            if port == our_port {
+                                info!(%address, "external address: new candidate has the same configured port, adding it.");
+                                self.swarm.add_external_address(address);
+                            } else {
+                                info!(%address, %our_port, "external address: new candidate has a different port, not adding it.");
+                            }
+                        }
+                        trace!("external address: listen port not set. This has to be set if you're running a node");
+                    }
                 }
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {


### PR DESCRIPTION
## Description
Here is a PR to only add the reported external addresses if the ports match. The port should match the one that was passed in by the user.
As reported by Shu in the forum, this emitted event contains addresses with port that was not set by the user and which have not been forwarded by the router. I feel blindly adding these might cause handshake timeouts.
