### PR TITLE
Allow nodes sig verify quotes (Updates libp2p to 0.53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,7 @@ dependencies = [
  "fs2",
  "hex",
  "lazy_static",
+ "libp2p",
  "pprof",
  "rand",
  "rayon",

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -170,6 +170,11 @@ impl Network {
         self.keypair.public().verify(msg, sig)
     }
 
+    /// Returns the protobuf serialised PublicKey to allow messaging out for share.
+    pub fn get_pub_key(&self) -> Vec<u8> {
+        self.keypair.public().encode_protobuf()
+    }
+
     /// Dial the given peer at the given address.
     /// This function will only be called for the bootstrap nodes.
     pub async fn dial(&self, addr: Multiaddr) -> Result<()> {

--- a/sn_node/src/quote.rs
+++ b/sn_node/src/quote.rs
@@ -33,6 +33,7 @@ impl Node {
             cost,
             timestamp,
             quoting_metrics: quoting_metrics.clone(),
+            pub_key: network.get_pub_key(),
             signature,
         };
 
@@ -104,7 +105,14 @@ pub(crate) async fn quotes_verification(network: &Network, quotes: Vec<(PeerId, 
                         quote.timestamp + time_gap > self_quote.timestamp
                     };
 
-                    is_same_target && is_not_self && is_not_zero_quote && is_around_same_time
+                    let is_signed_by_the_claimed_peer =
+                        quote.check_is_signed_by_claimed_peer(*peer_id);
+
+                    is_same_target
+                        && is_not_self
+                        && is_not_zero_quote
+                        && is_around_same_time
+                        && is_signed_by_the_claimed_peer
                 })
                 .cloned()
                 .collect();

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -16,6 +16,7 @@ custom_debug = "~0.5.0"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
+libp2p = { version="0.53", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}


### PR DESCRIPTION
## Description

Sending out the pub_key info within the Quote, so that other nodes can verify the quote was really generated by the claimed peer.

reviewpad:summary 
