### PR TITLE
feat: rename token to amount in Spend

### DIFF
--- a/sn_cli/src/bin/subcommands/wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet.rs
@@ -61,7 +61,7 @@ impl WalletApiHelper {
         let cash_notes = vec![cash_note.clone()];
 
         let spent_unique_pubkeys: BTreeSet<_> = cash_note
-            .src_tx
+            .parent_tx
             .inputs
             .iter()
             .map(|input| input.unique_pubkey())

--- a/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
@@ -293,7 +293,7 @@ fn sign_transaction(tx: &str, root_dir: &Path, force: bool) -> Result<()> {
     for (i, (spend, _)) in unsigned_transfer.spends.iter().enumerate() {
         println!("\nSpending input #{i}:");
         println!("\tKey: {}", spend.unique_pubkey.to_hex());
-        println!("\tAmount: {}", spend.token);
+        println!("\tAmount: {}", spend.amount);
         if let Some(ref tx) = spent_tx {
             if tx != &spend.spent_tx {
                 bail!("Transaction seems corrupted, not all Spends (inputs) refer to the same transaction");

--- a/sn_client/src/audit/spend_check.rs
+++ b/sn_client/src/audit/spend_check.rs
@@ -86,10 +86,10 @@ impl Client {
                 trace!("Spends for {parent_tx_hash:?} - {spends:?}");
 
                 // check if we reached the genesis Tx
-                if parent_tx == sn_transfers::GENESIS_CASHNOTE.src_tx
-                    && spends
-                        .iter()
-                        .all(|s| s.spend.unique_pubkey == sn_transfers::GENESIS_CASHNOTE.id)
+                if parent_tx == sn_transfers::GENESIS_CASHNOTE.parent_tx
+                    && spends.iter().all(|s| {
+                        s.spend.unique_pubkey == sn_transfers::GENESIS_CASHNOTE.unique_pubkey
+                    })
                     && spends.len() == 1
                 {
                     debug!("Depth {depth} - Reached genesis Tx on one branch: {parent_tx_hash:?}");

--- a/sn_client/src/audit/spend_dag_building.rs
+++ b/sn_client/src/audit/spend_dag_building.rs
@@ -194,10 +194,10 @@ impl Client {
                 trace!("Spends for {parent_tx_hash:?} - {spends:?}");
 
                 // check if we reached the genesis Tx
-                if parent_tx == sn_transfers::GENESIS_CASHNOTE.src_tx
-                    && spends
-                        .iter()
-                        .all(|s| s.spend.unique_pubkey == sn_transfers::GENESIS_CASHNOTE.id)
+                if parent_tx == sn_transfers::GENESIS_CASHNOTE.parent_tx
+                    && spends.iter().all(|s| {
+                        s.spend.unique_pubkey == sn_transfers::GENESIS_CASHNOTE.unique_pubkey
+                    })
                     && spends.len() == 1
                 {
                     debug!("Depth {depth} - reached genesis Tx on one branch: {parent_tx_hash:?}");

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -973,7 +973,7 @@ impl Client {
         // and compare them to the spends in the cash_note, to know if the
         // transfer is considered valid in the network.
         let mut tasks = Vec::new();
-        for spend in &cash_note.signed_spends {
+        for spend in &cash_note.parent_spends {
             let address = SpendAddress::from_unique_pubkey(spend.unique_pubkey());
             debug!(
                 "Getting spend for pubkey {:?} from network at {address:?}",
@@ -991,7 +991,7 @@ impl Client {
 
         // If all the spends in the cash_note are the same as the ones in the network,
         // we have successfully verified that the cash_note is globally recognised and therefor valid.
-        if received_spends == cash_note.signed_spends {
+        if received_spends == cash_note.parent_spends {
             return Ok(());
         }
         Err(WalletError::CouldNotVerifyTransfer(

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -166,9 +166,9 @@ impl Network {
                 .cloned()
                 .collect();
             let cash_note = CashNote {
-                id,
-                src_tx,
-                signed_spends,
+                unique_pubkey: id,
+                parent_tx: src_tx,
+                parent_spends: signed_spends,
                 main_pubkey,
                 derivation_index,
             };

--- a/sn_transfers/src/cashnotes.rs
+++ b/sn_transfers/src/cashnotes.rs
@@ -46,9 +46,9 @@ pub(crate) mod tests {
             outputs: vec![Output::new(derived_key.unique_pubkey(), amount)],
         };
         let cashnote = CashNote {
-            id: derived_key.unique_pubkey(),
-            src_tx: tx,
-            signed_spends: Default::default(),
+            unique_pubkey: derived_key.unique_pubkey(),
+            parent_tx: tx,
+            parent_spends: Default::default(),
             main_pubkey: main_key.main_pubkey(),
             derivation_index,
         };
@@ -73,9 +73,9 @@ pub(crate) mod tests {
             outputs: vec![Output::new(derived_key.unique_pubkey(), amount)],
         };
         let cashnote = CashNote {
-            id: derived_key.unique_pubkey(),
-            src_tx: tx,
-            signed_spends: Default::default(),
+            unique_pubkey: derived_key.unique_pubkey(),
+            parent_tx: tx,
+            parent_spends: Default::default(),
             main_pubkey: main_key.main_pubkey(),
             derivation_index,
         };
@@ -104,9 +104,9 @@ pub(crate) mod tests {
         };
 
         let cashnote = CashNote {
-            id: derived_key.unique_pubkey(),
-            src_tx: tx,
-            signed_spends: Default::default(),
+            unique_pubkey: derived_key.unique_pubkey(),
+            parent_tx: tx,
+            parent_spends: Default::default(),
             main_pubkey: main_key.main_pubkey(),
             derivation_index,
         };
@@ -135,9 +135,9 @@ pub(crate) mod tests {
         };
 
         let cashnote = CashNote {
-            id: derived_key.unique_pubkey(),
-            src_tx: tx,
-            signed_spends: Default::default(),
+            unique_pubkey: derived_key.unique_pubkey(),
+            parent_tx: tx,
+            parent_spends: Default::default(),
             main_pubkey: main_key.main_pubkey(),
             derivation_index,
         };

--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -235,9 +235,9 @@ impl CashNoteBuilder {
 
                 Ok((
                     CashNote {
-                        id: main_pubkey.new_unique_pubkey(derivation_index),
-                        src_tx: self.spent_tx.clone(),
-                        signed_spends: self.signed_spends.clone(),
+                        unique_pubkey: main_pubkey.new_unique_pubkey(derivation_index),
+                        parent_tx: self.spent_tx.clone(),
+                        parent_spends: self.signed_spends.clone(),
                         main_pubkey: *main_pubkey,
                         derivation_index: *derivation_index,
                     },

--- a/sn_transfers/src/cashnotes/builder.rs
+++ b/sn_transfers/src/cashnotes/builder.rs
@@ -119,7 +119,7 @@ impl TransactionBuilder {
                     unique_pubkey: *input.unique_pubkey(),
                     spent_tx: spent_tx.clone(),
                     reason,
-                    token: input.amount,
+                    amount: input.amount,
                     parent_tx: input_src_tx.clone(),
                     network_royalties: network_royalties.clone(),
                 };
@@ -158,7 +158,7 @@ impl TransactionBuilder {
                     unique_pubkey: *input.unique_pubkey(),
                     spent_tx: tx.clone(),
                     reason,
-                    token: input.amount,
+                    amount: input.amount,
                     parent_tx: input_src_tx.clone(),
                     network_royalties: network_royalties.clone(),
                 };

--- a/sn_transfers/src/cashnotes/cashnote.rs
+++ b/sn_transfers/src/cashnotes/cashnote.rs
@@ -59,7 +59,7 @@ use tiny_keccak::{Hasher, Sha3};
 #[derive(custom_debug::Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct CashNote {
     /// The unique public key of this CashNote. It is unique, and there can never
-    /// be another CashNote with the same pulbic key. It used in SignedSpends.
+    /// be another CashNote with the same public key. It used in SignedSpends.
     pub unique_pubkey: UniquePubkey,
     /// The transaction where this CashNote was created.
     #[debug(skip)]

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -51,7 +51,7 @@ impl SignedSpend {
 
     /// Get Nano
     pub fn token(&self) -> &NanoTokens {
-        &self.spend.token
+        &self.spend.amount
     }
 
     /// Get reason.
@@ -113,7 +113,7 @@ impl SignedSpend {
         }
 
         // check that the value of the spend wasn't tampered with
-        let claimed_value = self.spend.token;
+        let claimed_value = self.spend.amount;
         let creation_value = self
             .spend
             .parent_tx
@@ -214,7 +214,7 @@ pub struct Spend {
     pub reason: Hash,
     /// The amount of the input CashNote.
     #[debug(skip)]
-    pub token: NanoTokens,
+    pub amount: NanoTokens,
     /// The transaction that the input CashNote was created in (where it is an output)
     #[debug(skip)]
     pub parent_tx: Transaction,
@@ -231,7 +231,7 @@ impl Spend {
         bytes.extend(self.unique_pubkey.to_bytes());
         bytes.extend(self.spent_tx.hash().as_ref());
         bytes.extend(self.reason.as_ref());
-        bytes.extend(self.token.to_bytes());
+        bytes.extend(self.amount.to_bytes());
         bytes.extend(self.parent_tx.hash().as_ref());
         bytes
     }

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -81,7 +81,7 @@ lazy_static! {
 
 /// Return if provided Transaction is genesis parent tx.
 pub fn is_genesis_parent_tx(parent_tx: &Transaction) -> bool {
-    parent_tx == &GENESIS_CASHNOTE.src_tx
+    parent_tx == &GENESIS_CASHNOTE.parent_tx
 }
 
 /// Return if provided Spend is genesis spend.

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -92,7 +92,7 @@ pub fn is_genesis_spend(spend: &SignedSpend) -> bool {
             .unique_pubkey()
             .verify(&spend.derived_key_sig, bytes)
         && is_genesis_parent_tx(&spend.spend.parent_tx)
-        && spend.spend.token == NanoTokens::from(GENESIS_CASHNOTE_AMOUNT)
+        && spend.spend.amount == NanoTokens::from(GENESIS_CASHNOTE_AMOUNT)
 }
 
 pub fn load_genesis_wallet() -> Result<HotWallet, Error> {

--- a/sn_transfers/src/transfers/offline_transfer.rs
+++ b/sn_transfers/src/transfers/offline_transfer.rs
@@ -258,10 +258,10 @@ fn create_transaction_builder_with(
         inputs.push((
             input,
             derived_key,
-            cash_note.src_tx.clone(),
+            cash_note.parent_tx.clone(),
             cash_note.derivation_index,
         ));
-        let _ = src_txs.insert(cash_note.unique_pubkey(), cash_note.src_tx);
+        let _ = src_txs.insert(cash_note.unique_pubkey(), cash_note.parent_tx);
     }
 
     // Build the transaction and create change cash_note if needed

--- a/sn_transfers/src/transfers/transfer.rs
+++ b/sn_transfers/src/transfers/transfer.rs
@@ -151,7 +151,7 @@ impl CashNoteRedemption {
 
     pub fn from_cash_note(cash_note: &CashNote) -> Result<Self> {
         let derivation_index = cash_note.derivation_index();
-        let parent_spend = match cash_note.signed_spends.iter().next() {
+        let parent_spend = match cash_note.parent_spends.iter().next() {
             Some(s) => SpendAddress::from_unique_pubkey(s.unique_pubkey()),
             None => {
                 return Err(TransferError::CashNoteHasNoParentSpends);

--- a/sn_transfers/src/wallet/watch_only.rs
+++ b/sn_transfers/src/wallet/watch_only.rs
@@ -74,7 +74,12 @@ impl WatchOnlyWallet {
         let cash_notes = load_cash_notes_from_disk(&self.wallet_dir)?;
         let spent_unique_pubkeys: BTreeSet<_> = cash_notes
             .iter()
-            .flat_map(|cn| cn.src_tx.inputs.iter().map(|input| input.unique_pubkey()))
+            .flat_map(|cn| {
+                cn.parent_tx
+                    .inputs
+                    .iter()
+                    .map(|input| input.unique_pubkey())
+            })
             .collect();
         self.deposit(&cash_notes)?;
         self.mark_notes_as_spent(spent_unique_pubkeys);


### PR DESCRIPTION
BREAKING CHANGE: 
- field containing amount renamed to "amount" instead of confusing "token" in Spend
- renamed other fields in `CashNote` as well