### PR TITLE
feat(network): update our listen port if it set to zero

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -55,7 +55,7 @@ publish = true
 name = "sn_metrics"
 changelog_update = true
 git_release_enable = false
-publish = false
+publish = true
 
 [[package]]
 name = "sn_networking"

--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -353,6 +353,17 @@ impl SwarmDriver {
             SwarmEvent::NewListenAddr { address, .. } => {
                 event_string = "new listen addr";
 
+                // update our stored port if it is configured to be 0 or None
+                match self.listen_port {
+                    Some(0) | None => {
+                        if let Some(actual_port) = get_port_from_multiaddr(&address) {
+                            info!("Our listen port is configured as 0 or is not set. Setting it to our actual port: {actual_port}");
+                            self.listen_port = Some(actual_port);
+                        }
+                    }
+                    _ => {}
+                };
+
                 let local_peer_id = *self.swarm.local_peer_id();
                 let address = address.with(Protocol::P2p(local_peer_id));
 
@@ -581,6 +592,7 @@ impl SwarmDriver {
                                 info!(%address, %our_port, "external address: new candidate has a different port, not adding it.");
                             }
                         }
+                    } else {
                         trace!("external address: listen port not set. This has to be set if you're running a node");
                     }
                 }

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -78,14 +78,11 @@ fn write_network_version_with_slash() -> String {
 
 // Protocol support shall be downward compatible for patch only version update.
 // i.e. versions of `A.B.X` shall be considered as a same protocol of `A.B`
+// And any pre-release versions `A.B.C-alpha.X` shall be considered as a same protocol of `A.B.C-alpha`
 fn get_truncate_version_str() -> &'static str {
     let version_str = env!("CARGO_PKG_VERSION");
-    if version_str.matches('.').count() == 2 {
-        match version_str.rfind('.') {
-            Some(pos) => &version_str[..pos],
-            None => version_str,
-        }
-    } else {
-        version_str
+    match version_str.rfind('.') {
+        Some(pos) => &version_str[..pos],
+        None => version_str,
     }
 }


### PR DESCRIPTION
## Description

Here is a PR to update our listen port if we're initially set to listen on any available port, i.e. port 0.
This updates the port to the actual one set by libp2p.
