### PR TITLE
ci: ensure cross uses version-mode variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,6 @@ jobs:
       - name: build release artifacts
         shell: bash
         run: |
-          # make sure the version env variable is set
-          export NETWORK_VERSION_MODE=${{ env.NETWORK_VERSION_MODE }}
-          echo "NETWORK_VERSION_MODE=$NETWORK_VERSION_MODE"
           just build-release-artifacts "${{ matrix.target }}"
 
       - uses: actions/upload-artifact@main

--- a/Justfile
+++ b/Justfile
@@ -104,6 +104,12 @@ build-release-artifacts arch:
   rm -rf artifacts
   mkdir artifacts
   cargo clean
+
+  if [[ -n "${NETWORK_VERSION_MODE+x}"]]; then
+    echo "The NETWORK_VERSION_MODE variable is set to $NETWORK_VERSION_MODE"
+    export CROSS_CONTAINER_OPTS="--env NETWORK_VERSION_MODE=$NETWORK_VERSION_MODE"
+  fi
+
   if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
     cargo install cross
     cross build --release --features="network-contacts,distribution" --target $arch --bin safe


### PR DESCRIPTION
The ARM builds are done using a tool called `cross`, which uses Docker containers, and therefore the compile-time variables need to be passed to the containers. This is done using the `CROSS_CONTAINER_OPTS` variable.

I tested this locally to confirm the desired effect.

## Description

reviewpad:summary 
