### PR TITLE
feat(cli): return the files upload summary after a successful files upload

### DIFF
--- a/sn_cli/src/files.rs
+++ b/sn_cli/src/files.rs
@@ -15,7 +15,7 @@ mod upload;
 pub use chunk_manager::ChunkManager;
 pub use download::{download_file, download_files};
 pub use estimate::Estimator;
-pub use files_uploader::FilesUploader;
+pub use files_uploader::{FilesUploadStatusNotifier, FilesUploader};
 pub use upload::{UploadedFile, UPLOADED_FILES};
 
 use color_eyre::Result;

--- a/sn_cli/src/lib.rs
+++ b/sn_cli/src/lib.rs
@@ -11,6 +11,6 @@ mod files;
 
 pub use acc_packet::AccountPacket;
 pub use files::{
-    download_file, download_files, ChunkManager, Estimator, FilesUploader, UploadedFile,
-    UPLOADED_FILES,
+    download_file, download_files, ChunkManager, Estimator, FilesUploadStatusNotifier,
+    FilesUploader, UploadedFile, UPLOADED_FILES,
 };


### PR DESCRIPTION
In regard to https://github.com/maidsafe/safe_network/issues/1576

- Return more info after we upload files.
- Provide a trait to override printing things to stdout. Now that these structs are marked as public, not everyone would want to print to stdout by default.