### PR TITLE
Make files_uploader::FilesUploadSummary public

### DIFF
--- a/sn_cli/src/files.rs
+++ b/sn_cli/src/files.rs
@@ -15,7 +15,7 @@ mod upload;
 pub use chunk_manager::ChunkManager;
 pub use download::{download_file, download_files};
 pub use estimate::Estimator;
-pub use files_uploader::{FilesUploadStatusNotifier, FilesUploader};
+pub use files_uploader::{FilesUploadStatusNotifier, FilesUploadSummary, FilesUploader};
 pub use upload::{UploadedFile, UPLOADED_FILES};
 
 use color_eyre::Result;

--- a/sn_cli/src/lib.rs
+++ b/sn_cli/src/lib.rs
@@ -12,5 +12,5 @@ mod files;
 pub use acc_packet::AccountPacket;
 pub use files::{
     download_file, download_files, ChunkManager, Estimator, FilesUploadStatusNotifier,
-    FilesUploader, UploadedFile, UPLOADED_FILES,
+    FilesUploadSummary, FilesUploader, UploadedFile, UPLOADED_FILES,
 };


### PR DESCRIPTION
## Description
Enable users of module `autonomi` to import `files_uploader::FilesUploadSummary`.

reviewpad:summary 
