### PR TITLE
fix(node): fetcher completes on_going_fetch entry on record_key only

### DIFF
--- a/sn_networking/src/event.rs
+++ b/sn_networking/src/event.rs
@@ -1307,7 +1307,12 @@ impl SwarmDriver {
 
                 // if we have a local value of matching record_type, we don't need to fetch it
                 if let Some((_, local_record_type)) = local {
-                    local_record_type != record_type
+                    let not_same_type = local_record_type != record_type;
+                    if not_same_type {
+                        // Shall only happens for Register
+                        info!("Record {addr:?} has different type: local {local_record_type:?}, incoming {record_type:?}");
+                    }
+                    not_same_type
                 } else {
                     true
                 }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -681,6 +681,12 @@ impl Network {
         response
     }
 
+    /// Notify ReplicationFetch a fetch attempt is completed.
+    /// (but it won't trigger any real writes to disk, say fetched an old version of register)
+    pub fn notify_fetch_completed(&self, key: RecordKey) {
+        self.send_swarm_cmd(SwarmCmd::FetchCompleted(key))
+    }
+
     /// Put `Record` to the local RecordStore
     /// Must be called after the validations are performed on the Record
     pub fn put_local_record(&self, record: Record) {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -582,7 +582,7 @@ impl RecordStore for NodeRecordStore {
         // ignored if we don't have the record locally.
         let key = PrettyPrintRecordKey::from(k);
         if !self.records.contains_key(k) {
-            trace!("Record not found locally: {key}");
+            trace!("Record not found locally: {key:?}");
             return None;
         }
 

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -152,6 +152,18 @@ impl ReplicationFetcher {
         self.next_keys_to_fetch()
     }
 
+    // An early completion of a fetch means the target is an old version record (Register or Spend).
+    pub(crate) fn notify_fetch_early_completed(
+        &mut self,
+        key_in: RecordKey,
+    ) -> Vec<(PeerId, RecordKey)> {
+        self.to_be_fetched.retain(|(key, _t, _), _| key != &key_in);
+
+        self.on_going_fetches.retain(|(key, _t), _| key != &key_in);
+
+        self.next_keys_to_fetch()
+    }
+
     // Returns the set of keys that has to be fetched from the peer/network.
     // Target must not be under-fetching
     // and no more than MAX_PARALLEL_FETCH fetches to be undertaken at the same time.

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -89,6 +89,9 @@ impl Node {
                         record_key,
                         RecordType::NonChunk(content_hash),
                     );
+                } else {
+                    // Notify replication_fetcher to mark the attempt as completed.
+                    self.network.notify_fetch_completed(record.key.clone());
                 }
                 result
             }
@@ -289,6 +292,8 @@ impl Node {
         let updated_register = match self.register_validation(&register, present_locally).await? {
             Some(reg) => reg,
             None => {
+                // Notify replication_fetcher to mark the attempt as completed.
+                self.network.notify_fetch_completed(key.clone());
                 return Ok(CmdOk::DataAlreadyPresent);
             }
         };


### PR DESCRIPTION
## Description

Register of different content using same record_key.
The record_store derive file name from record_key directly, which means different version of a regsiter, will write to the same file.
i.e. the latter one will overwrites the previous one.

Meanwhile, the replication_fetcher using tuple of `(record_key, record_type)` to identify a fetch attempt.
Where the record_type is derived from content hash, i.e. different for different version of a register.

This results in a false alert that: 
when a node ask for register_v_A from holder, but holder already updated to register_v_B,
holder will respond with register_v_B;
which the fetch attempt of register_v_A never got marked as completed, and triggers a FailedFetch alert eventually.

reviewpad:summary 
