### PR TITLE
feat: distinguish failure to start during upgrade

### DIFF
--- a/sn_node_manager/src/add_services/tests.rs
+++ b/sn_node_manager/src/add_services/tests.rs
@@ -31,7 +31,7 @@ use sn_service_management::{
 use std::{
     ffi::OsString,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
 };
 
@@ -54,7 +54,7 @@ mock! {
         fn create_service_user(&self, username: &str) -> ServiceControlResult<()>;
         fn get_available_port(&self) -> ServiceControlResult<u16>;
         fn install(&self, install_ctx: ServiceInstallCtx) -> ServiceControlResult<()>;
-        fn get_process_pid(&self, name: &str) -> ServiceControlResult<u32>;
+        fn get_process_pid(&self, bin_path: &Path) -> ServiceControlResult<u32>;
         fn is_service_process_running(&self, pid: u32) -> bool;
         fn start(&self, service_name: &str) -> ServiceControlResult<()>;
         fn stop(&self, service_name: &str) -> ServiceControlResult<()>;

--- a/sn_node_manager/src/cmd/mod.rs
+++ b/sn_node_manager/src/cmd/mod.rs
@@ -75,6 +75,13 @@ pub fn print_upgrade_summary(upgrade_summary: Vec<(String, UpgradeResult)>) {
                     service_name
                 );
             }
+            UpgradeResult::UpgradedButNotStarted(previous_version, new_version, _) => {
+                println!(
+                    "{} {} was upgraded from {previous_version} to {new_version} but it did not start",
+                    "✕".red(),
+                    service_name
+                );
+            }
             UpgradeResult::Forced(previous_version, target_version) => {
                 println!(
                     "{} Forced {} version change from {previous_version} to {target_version}.",

--- a/sn_service_management/src/daemon.rs
+++ b/sn_service_management/src/daemon.rs
@@ -96,7 +96,7 @@ impl<'a> ServiceStateActions for DaemonService<'a> {
         // get_process_pid causes errors for the daemon. Maybe because it is being run as root?
         if let Ok(pid) = self
             .service_control
-            .get_process_pid(&self.service_data.service_name)
+            .get_process_pid(&self.service_data.daemon_path)
         {
             self.service_data.pid = Some(pid);
         }

--- a/sn_service_management/src/error.rs
+++ b/sn_service_management/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     RpcNodeUpdateError(String),
     #[error("Could not obtain record addresses through RPC: {0}")]
     RpcRecordAddressError(String),
-    #[error("Could not find process '{0}'")]
+    #[error("Could not find process at '{0}'")]
     ServiceProcessNotFound(String),
     #[error("The user may have removed the '{0}' service outwith the node manager")]
     ServiceRemovedManually(String),

--- a/sn_service_management/src/faucet.rs
+++ b/sn_service_management/src/faucet.rs
@@ -102,7 +102,7 @@ impl<'a> ServiceStateActions for FaucetService<'a> {
     async fn on_start(&mut self) -> Result<()> {
         let pid = self
             .service_control
-            .get_process_pid(&self.service_data.service_name)?;
+            .get_process_pid(&self.service_data.faucet_path)?;
         self.service_data.pid = Some(pid);
         self.service_data.status = ServiceStatus::Running;
         Ok(())

--- a/sn_service_management/src/lib.rs
+++ b/sn_service_management/src/lib.rs
@@ -49,6 +49,7 @@ pub enum UpgradeResult {
     Forced(String, String),
     NotRequired,
     Upgraded(String, String),
+    UpgradedButNotStarted(String, String, String),
     Error(String),
 }
 


### PR DESCRIPTION
It's possible for a service to be upgraded but then not subsequently start. In this case, it has still been upgraded to a new version. It's worth making a distinction to the user between an actual error in the upgrade process, or a failure to start, because in the latter case, they do actually have an upgrade. They can then take action to try and start their services again.

As part of this change, the start process attempts to find whether the service process did indeed start, because you don't always seem to get errors back from the service infrastructure. We also make sure that we return an error if there was a failure with the upgrade process for any services. This is necessary for visibility on our own deploy process.

## Description

reviewpad:summary 
