### PR TITLE
Node Manager: Various Small Features

### DIFF
--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -187,6 +187,18 @@ pub enum SubCmd {
         #[clap(long)]
         keep_directories: bool,
     },
+    /// Reset back to a clean base state.
+    ///
+    /// Stop and remove all services and delete the node registry, which will set the service
+    /// counter back to zero.
+    ///
+    /// This command must run as the root/administrative user.
+    #[clap(name = "reset")]
+    Reset {
+        /// Set to suppress the confirmation prompt.
+        #[clap(long, short)]
+        force: bool,
+    },
     /// Start safenode service(s).
     ///
     /// If no peer ID(s) or service name(s) are supplied, all services will be started.
@@ -729,6 +741,7 @@ async fn main() -> Result<()> {
             peer_id: peer_ids,
             service_name: service_names,
         } => cmd::node::remove(keep_directories, peer_ids, service_names, verbosity).await,
+        SubCmd::Reset { force } => cmd::node::reset(force, verbosity).await,
         SubCmd::Start {
             interval,
             peer_id: peer_ids,

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -162,65 +162,8 @@ pub enum SubCmd {
     Daemon(DaemonSubCmd),
     #[clap(subcommand)]
     Faucet(FaucetSubCmd),
-    /// Kill the running local network.
-    #[clap(name = "kill")]
-    Kill {
-        /// Set this flag to keep the node's data and log directories.
-        #[clap(long)]
-        keep_directories: bool,
-    },
-    /// Join an existing local network.
-    ///
-    /// The existing network can be managed outwith the node manager. If this is the case, use the
-    /// `--peer` argument to specify an initial peer to connect to.
-    ///
-    /// If no `--peer` argument is supplied, the nodes will be added to the existing local network
-    /// being managed by the node manager.
-    #[clap(name = "join")]
-    Join {
-        /// Set to build the safenode and faucet binaries.
-        ///
-        /// This option requires the command run from the root of the safe_network repository.
-        #[clap(long)]
-        build: bool,
-        /// The number of nodes to run.
-        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
-        count: u16,
-        /// Path to a faucet binary
-        ///
-        /// The path and version arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "faucet_version")]
-        faucet_path: Option<PathBuf>,
-        /// The version of the faucet to use.
-        ///
-        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
-        ///
-        /// The version and path arguments are mutually exclusive.
-        #[clap(long)]
-        faucet_version: Option<String>,
-        /// An interval applied between launching each node.
-        ///
-        /// Units are milliseconds.
-        #[clap(long, default_value_t = 200)]
-        interval: u64,
-        /// Path to a safenode binary
-        ///
-        /// The path and version arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "node_version")]
-        node_path: Option<PathBuf>,
-        /// The version of safenode to use.
-        ///
-        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
-        ///
-        /// The version and path arguments are mutually exclusive.
-        #[clap(long)]
-        node_version: Option<String>,
-        #[command(flatten)]
-        peers: PeersArgs,
-        /// Set to skip the network validation process
-        #[clap(long)]
-        skip_validation: bool,
-    },
+    #[clap(subcommand)]
+    Local(LocalSubCmd),
     /// Remove safenode service(s).
     ///
     /// Either peer ID(s) or service name(s) must be supplied.
@@ -241,59 +184,6 @@ pub enum SubCmd {
         /// Set this flag to keep the node's data and log directories.
         #[clap(long)]
         keep_directories: bool,
-    },
-    /// Run a local network.
-    ///
-    /// This will run safenode processes on the current machine to form a local network. A faucet
-    /// service will also run for dispensing tokens.
-    ///
-    /// Paths can be supplied for safenode and faucet binaries, but otherwise, the latest versions
-    /// will be downloaded.
-    #[clap(name = "run")]
-    Run {
-        /// Set to build the safenode and faucet binaries.
-        ///
-        /// This option requires the command run from the root of the safe_network repository.
-        #[clap(long)]
-        build: bool,
-        /// Set to remove the client data directory and kill any existing local network.
-        #[clap(long)]
-        clean: bool,
-        /// The number of nodes to run.
-        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
-        count: u16,
-        /// Path to a faucet binary.
-        ///
-        /// The path and version arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "faucet_version", conflicts_with = "build")]
-        faucet_path: Option<PathBuf>,
-        /// The version of the faucet to use.
-        ///
-        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
-        ///
-        /// The version and path arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "build")]
-        faucet_version: Option<String>,
-        /// An interval applied between launching each node.
-        ///
-        /// Units are milliseconds.
-        #[clap(long, default_value_t = 200)]
-        interval: u64,
-        /// Path to a safenode binary
-        ///
-        /// The path and version arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "node_version", conflicts_with = "build")]
-        node_path: Option<PathBuf>,
-        /// The version of safenode to use.
-        ///
-        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
-        ///
-        /// The version and path arguments are mutually exclusive.
-        #[clap(long, conflicts_with = "build")]
-        node_version: Option<String>,
-        /// Set to skip the network validation process
-        #[clap(long)]
-        skip_validation: bool,
     },
     /// Start safenode service(s).
     ///
@@ -401,7 +291,7 @@ pub enum SubCmd {
     },
 }
 
-/// Manage Daemon service.
+/// Manage the RPC service.
 #[derive(Subcommand, Debug)]
 pub enum DaemonSubCmd {
     /// Add a daemon service for issuing commands via RPC.
@@ -463,7 +353,7 @@ pub enum DaemonSubCmd {
     Stop {},
 }
 
-/// Manage faucet services.
+/// Manage the faucet service.
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum FaucetSubCmd {
@@ -566,6 +456,124 @@ pub enum FaucetSubCmd {
     },
 }
 
+/// Manage local networks.
+#[allow(clippy::large_enum_variant)]
+#[derive(Subcommand, Debug)]
+pub enum LocalSubCmd {
+    /// Kill the running local network.
+    #[clap(name = "kill")]
+    Kill {
+        /// Set this flag to keep the node's data and log directories.
+        #[clap(long)]
+        keep_directories: bool,
+    },
+    /// Join an existing local network.
+    ///
+    /// The existing network can be managed outwith the node manager. If this is the case, use the
+    /// `--peer` argument to specify an initial peer to connect to.
+    ///
+    /// If no `--peer` argument is supplied, the nodes will be added to the existing local network
+    /// being managed by the node manager.
+    #[clap(name = "join")]
+    Join {
+        /// Set to build the safenode and faucet binaries.
+        ///
+        /// This option requires the command run from the root of the safe_network repository.
+        #[clap(long)]
+        build: bool,
+        /// The number of nodes to run.
+        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
+        count: u16,
+        /// Path to a faucet binary
+        ///
+        /// The path and version arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "faucet_version")]
+        faucet_path: Option<PathBuf>,
+        /// The version of the faucet to use.
+        ///
+        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
+        ///
+        /// The version and path arguments are mutually exclusive.
+        #[clap(long)]
+        faucet_version: Option<String>,
+        /// An interval applied between launching each node.
+        ///
+        /// Units are milliseconds.
+        #[clap(long, default_value_t = 200)]
+        interval: u64,
+        /// Path to a safenode binary
+        ///
+        /// The path and version arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "node_version")]
+        node_path: Option<PathBuf>,
+        /// The version of safenode to use.
+        ///
+        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
+        ///
+        /// The version and path arguments are mutually exclusive.
+        #[clap(long)]
+        node_version: Option<String>,
+        #[command(flatten)]
+        peers: PeersArgs,
+        /// Set to skip the network validation process
+        #[clap(long)]
+        skip_validation: bool,
+    },
+    /// Run a local network.
+    ///
+    /// This will run safenode processes on the current machine to form a local network. A faucet
+    /// service will also run for dispensing tokens.
+    ///
+    /// Paths can be supplied for safenode and faucet binaries, but otherwise, the latest versions
+    /// will be downloaded.
+    #[clap(name = "run")]
+    Run {
+        /// Set to build the safenode and faucet binaries.
+        ///
+        /// This option requires the command run from the root of the safe_network repository.
+        #[clap(long)]
+        build: bool,
+        /// Set to remove the client data directory and kill any existing local network.
+        #[clap(long)]
+        clean: bool,
+        /// The number of nodes to run.
+        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
+        count: u16,
+        /// Path to a faucet binary.
+        ///
+        /// The path and version arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "faucet_version", conflicts_with = "build")]
+        faucet_path: Option<PathBuf>,
+        /// The version of the faucet to use.
+        ///
+        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
+        ///
+        /// The version and path arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "build")]
+        faucet_version: Option<String>,
+        /// An interval applied between launching each node.
+        ///
+        /// Units are milliseconds.
+        #[clap(long, default_value_t = 200)]
+        interval: u64,
+        /// Path to a safenode binary
+        ///
+        /// The path and version arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "node_version", conflicts_with = "build")]
+        node_path: Option<PathBuf>,
+        /// The version of safenode to use.
+        ///
+        /// The version number should be in the form X.Y.Z, with no 'v' prefix.
+        ///
+        /// The version and path arguments are mutually exclusive.
+        #[clap(long, conflicts_with = "build")]
+        node_version: Option<String>,
+        /// Set to skip the network validation process
+        #[clap(long)]
+        skip_validation: bool,
+    },
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
@@ -662,18 +670,8 @@ async fn main() -> Result<()> {
                 .await
             }
         },
-        SubCmd::Join {
-            build,
-            count,
-            faucet_path,
-            faucet_version,
-            interval,
-            node_path,
-            node_version,
-            peers,
-            skip_validation: _,
-        } => {
-            cmd::local::join(
+        SubCmd::Local(local_command) => match local_command {
+            LocalSubCmd::Join {
                 build,
                 count,
                 faucet_path,
@@ -682,28 +680,23 @@ async fn main() -> Result<()> {
                 node_path,
                 node_version,
                 peers,
-                true,
-            )
-            .await
-        }
-        SubCmd::Kill { keep_directories } => cmd::local::kill(keep_directories, verbosity),
-        SubCmd::Remove {
-            keep_directories,
-            peer_id: peer_ids,
-            service_name: service_names,
-        } => cmd::node::remove(keep_directories, peer_ids, service_names, verbosity).await,
-        SubCmd::Run {
-            build,
-            clean,
-            count,
-            faucet_path,
-            faucet_version,
-            interval,
-            node_path,
-            node_version,
-            skip_validation: _,
-        } => {
-            cmd::local::run(
+                skip_validation: _,
+            } => {
+                cmd::local::join(
+                    build,
+                    count,
+                    faucet_path,
+                    faucet_version,
+                    interval,
+                    node_path,
+                    node_version,
+                    peers,
+                    true,
+                )
+                .await
+            }
+            LocalSubCmd::Kill { keep_directories } => cmd::local::kill(keep_directories, verbosity),
+            LocalSubCmd::Run {
                 build,
                 clean,
                 count,
@@ -712,11 +705,28 @@ async fn main() -> Result<()> {
                 interval,
                 node_path,
                 node_version,
-                true,
-                verbosity,
-            )
-            .await
-        }
+                skip_validation: _,
+            } => {
+                cmd::local::run(
+                    build,
+                    clean,
+                    count,
+                    faucet_path,
+                    faucet_version,
+                    interval,
+                    node_path,
+                    node_version,
+                    true,
+                    verbosity,
+                )
+                .await
+            }
+        },
+        SubCmd::Remove {
+            keep_directories,
+            peer_id: peer_ids,
+            service_name: service_names,
+        } => cmd::node::remove(keep_directories, peer_ids, service_names, verbosity).await,
         SubCmd::Start {
             interval,
             peer_id: peer_ids,

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -144,6 +144,20 @@ pub enum SubCmd {
         #[clap(long)]
         version: Option<String>,
     },
+    /// Get node reward balances.
+    #[clap(name = "balance")]
+    Balance {
+        /// Display the balance for a specific service using its peer ID.
+        ///
+        /// The argument can be used multiple times.
+        #[clap(long)]
+        peer_id: Vec<String>,
+        /// Display the balance for a specific service using its name.
+        ///
+        /// The argument can be used multiple times.
+        #[clap(long, conflicts_with = "peer_id")]
+        service_name: Vec<String>,
+    },
     #[clap(subcommand)]
     Daemon(DaemonSubCmd),
     #[clap(subcommand)]
@@ -594,6 +608,10 @@ async fn main() -> Result<()> {
             )
             .await
         }
+        SubCmd::Balance {
+            peer_id: peer_ids,
+            service_name: service_names,
+        } => cmd::node::balance(peer_ids, service_names, verbosity).await,
         SubCmd::Daemon(DaemonSubCmd::Add {
             address,
             env_variables,

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -166,7 +166,9 @@ pub enum SubCmd {
     Local(LocalSubCmd),
     /// Remove safenode service(s).
     ///
-    /// Either peer ID(s) or service name(s) must be supplied.
+    /// If no peer ID(s) or service name(s) are supplied, all services will be removed.
+    ///
+    /// Services must be stopped before they can be removed.
     ///
     /// This command must run as the root/administrative user.
     #[clap(name = "remove")]

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -168,9 +168,6 @@ pub async fn remove(
     if !is_running_as_root() {
         return Err(eyre!("The remove command must run as the root user"));
     }
-    if peer_ids.is_empty() && service_names.is_empty() {
-        return Err(eyre!("Either a peer ID or a service name must be supplied"));
-    }
 
     println!("=================================================");
     println!("           Remove Safenode Services              ");

--- a/sn_node_manager/src/lib.rs
+++ b/sn_node_manager/src/lib.rs
@@ -44,6 +44,7 @@ use sn_service_management::{
     NodeRegistry, NodeServiceData, ServiceStateActions, ServiceStatus, UpgradeOptions,
     UpgradeResult,
 };
+use sn_transfers::HotWallet;
 use tracing::debug;
 
 pub const DAEMON_DEFAULT_PORT: u16 = 12500;
@@ -326,6 +327,8 @@ pub async fn status_report(
                     .as_ref()
                     .map_or("-".to_string(), |p| p.len().to_string())
             );
+            let wallet = HotWallet::load_from(&node.data_dir_path)?;
+            println!("Reward balance: {}", wallet.balance());
             println!();
         }
 


### PR DESCRIPTION
- efeb5da0 **feat: make `--peer` argument optional**

  Make the `--peer` argument on the node manager `add` command optional by handling the
  `PeersNotObtained` error. See the comment in the diff for more details.

- eea33e2f **feat: provide `balance` command**

  The node manager makes it easy to list the rewards balances for all the nodes it's managing. It was
  also requested that `status --details` show the balance.

  There was also a request to include the store cost for the node, but this information isn't as
  easily available. It may require an RPC extension to obtain it.

- bb0cc629 **refactor: provide `local` subcommand**

  A `local` subcommand is introduced for working with local networks.

  We observed a user make the mistake of using the `run` command to try to connect to a remote
  testnet, so it seems like a `local` subcommand would be useful for clarity.

  There are no functional changes here, it's just some reorganisation.

- 6b7ddfcc **chore: `remove` cmd operates over all services**

  Like the `start` and `stop` commands, the `remove` command is changed so that it can operate over
  all services if no arguments are provided.

- 1e705dd7 **feat: provide `reset` command**

  This command was requested in community feedback. It will remove all services, clearing out all logs
  and data, and also delete the node registry file, which will reset the service counter back to zero.

## Description

reviewpad:summary 
