### PR TITLE
feat: spend dag double spend faults

### DIFF
--- a/sn_client/src/audit/spend_dag.rs
+++ b/sn_client/src/audit/spend_dag.rs
@@ -132,7 +132,7 @@ impl SpendDag {
                 self.spends
                     .insert(spend_addr, DagEntry::Spend(Box::new(spend.clone()), idx));
                 let node_idx = NodeIndex::new(idx);
-                self.reset_edges(node_idx);
+                self.remove_all_edges(node_idx);
                 node_idx
             }
             // or upgrade spend to double spend if it is different from the existing one
@@ -354,7 +354,7 @@ impl SpendDag {
     }
 
     /// Remove all edges from a Node in the DAG
-    fn reset_edges(&mut self, node: NodeIndex) {
+    fn remove_all_edges(&mut self, node: NodeIndex) {
         let incoming: Vec<_> = self
             .dag
             .edges_directed(node, petgraph::Direction::Incoming)

--- a/sn_client/src/audit/tests/mod.rs
+++ b/sn_client/src/audit/tests/mod.rs
@@ -195,7 +195,7 @@ fn test_spend_dag_double_spend_branches() -> Result<()> {
     }]);
     assert_eq!(got, expected, "spend3a should be unspendable");
 
-    // make sur all the descendants further down the branch are marked as bad as well
+    // make sure all the descendants further down the branch are marked as bad as well
     let utxo_of_5a = SpendAddress::from_unique_pubkey(
         &net.wallets
             .get(&owner5a)


### PR DESCRIPTION
## Description

- add double spend fork detection to DAG verification
- test for that scenario
- fix DAG edges issue caused by double spends
- now shows correct amounts in DAG edges