### PR TITLE
Node Manager Extensions for `upgrade` Command

### DIFF
--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -284,6 +284,11 @@ pub enum SubCmd {
         /// Required if we want to downgrade, or for testing purposes.
         #[clap(long)]
         force: bool,
+        /// An interval applied between upgrading each service.
+        ///
+        /// Units are milliseconds.
+        #[clap(long, default_value_t = 200)]
+        interval: u64,
         /// Provide a path for the safenode binary to be used by the service.
         ///
         /// Useful for upgrading the service using a custom built binary.
@@ -764,6 +769,7 @@ async fn main() -> Result<()> {
         SubCmd::Upgrade {
             do_not_start,
             force,
+            interval,
             path,
             peer_id: peer_ids,
             service_name: service_names,
@@ -775,6 +781,7 @@ async fn main() -> Result<()> {
                 do_not_start,
                 path,
                 force,
+                interval,
                 peer_ids,
                 provided_env_variable,
                 service_names,

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -284,6 +284,11 @@ pub enum SubCmd {
         /// Required if we want to downgrade, or for testing purposes.
         #[clap(long)]
         force: bool,
+        /// Provide a path for the safenode binary to be used by the service.
+        ///
+        /// Useful for upgrading the service using a custom built binary.
+        #[clap(long)]
+        path: Option<PathBuf>,
         /// The peer ID of the service to upgrade
         #[clap(long)]
         peer_id: Vec<String>,
@@ -759,6 +764,7 @@ async fn main() -> Result<()> {
         SubCmd::Upgrade {
             do_not_start,
             force,
+            path,
             peer_id: peer_ids,
             service_name: service_names,
             env_variables: provided_env_variable,
@@ -767,6 +773,7 @@ async fn main() -> Result<()> {
         } => {
             cmd::node::upgrade(
                 do_not_start,
+                path,
                 force,
                 peer_ids,
                 provided_env_variable,

--- a/sn_node_manager/src/cmd/faucet.rs
+++ b/sn_node_manager/src/cmd/faucet.rs
@@ -161,7 +161,7 @@ pub async fn upgrade(
     }
 
     let (upgrade_bin_path, target_version) =
-        download_and_get_upgrade_bin_path(ReleaseType::Faucet, url, version).await?;
+        download_and_get_upgrade_bin_path(None, ReleaseType::Faucet, url, version).await?;
     let faucet = node_registry.faucet.as_mut().unwrap();
 
     if !force {

--- a/sn_node_manager/src/cmd/mod.rs
+++ b/sn_node_manager/src/cmd/mod.rs
@@ -11,7 +11,7 @@ pub mod faucet;
 pub mod local;
 pub mod node;
 
-use crate::helpers::download_and_extract_release;
+use crate::helpers::{download_and_extract_release, get_bin_version};
 use color_eyre::{eyre::eyre, Result};
 use colored::Colorize;
 use semver::Version;
@@ -33,10 +33,20 @@ pub fn is_running_as_root() -> bool {
 }
 
 pub async fn download_and_get_upgrade_bin_path(
+    custom_bin_path: Option<PathBuf>,
     release_type: ReleaseType,
     url: Option<String>,
     version: Option<String>,
 ) -> Result<(PathBuf, Version)> {
+    if let Some(path) = custom_bin_path {
+        println!(
+            "Using the supplied custom binary at {}",
+            path.to_string_lossy()
+        );
+        let bin_version = get_bin_version(&path)?;
+        return Ok((path, bin_version.parse()?));
+    }
+
     let release_repo = <dyn SafeReleaseRepoActions>::default_config();
     if let Some(version) = version {
         let (upgrade_bin_path, version) =

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -32,6 +32,7 @@ use sn_service_management::{
 };
 use sn_transfers::HotWallet;
 use std::{io::Write, net::Ipv4Addr, path::PathBuf, str::FromStr};
+use tracing::debug;
 
 pub async fn add(
     count: Option<u16>,
@@ -264,6 +265,7 @@ pub async fn start(
         let service = NodeService::new(node, Box::new(rpc_client));
         let mut service_manager =
             ServiceManager::new(service, Box::new(ServiceController {}), verbosity.clone());
+        debug!("Sleeping for {} milliseconds", interval);
         std::thread::sleep(std::time::Duration::from_millis(interval));
         match service_manager.start().await {
             Ok(()) => {
@@ -363,6 +365,7 @@ pub async fn upgrade(
     do_not_start: bool,
     custom_bin_path: Option<PathBuf>,
     force: bool,
+    interval: u64,
     peer_ids: Vec<String>,
     provided_env_variables: Option<Vec<(String, String)>>,
     service_names: Vec<String>,
@@ -449,6 +452,9 @@ pub async fn upgrade(
                 ));
             }
         }
+
+        debug!("Sleeping for {} milliseconds", interval);
+        std::thread::sleep(std::time::Duration::from_millis(interval));
     }
 
     node_registry.save()?;


### PR DESCRIPTION
- e42cccdc **feat: provide `--path` arg for `upgrade` cmd**

  This feature was requested in community feedback.

  It allows users to build a custom binary and use that for the upgrade. We use the 'force' mechanism
  here to cause the upgrade process to accept this binary, regardless of its version number. The user
  may have built it from an experimental branch which could have a version number that's less than the
  current version.

  If the user is building their own binary from source, they are likely advanced, and aware of the
  risks, so it seems reasonable to apply the force.

- 9b15523e **feat: provide `--interval` arg for `upgrade` cmd**

  This was another community feedback request.

  As with the `start` command, a time-based interval is applied between each node being upgraded.

  We will probably need something more sophisticated, but this simple mechanism should hopefully be
  useful for now.

## Description

reviewpad:summary 
