### PR TITLE
fix: do not delete custom bin on `add` cmd

### DIFF
--- a/sn_node_manager/src/add_services/config.rs
+++ b/sn_node_manager/src/add_services/config.rs
@@ -108,6 +108,7 @@ impl InstallNodeServiceCtxBuilder {
 pub struct AddNodeServiceOptions {
     pub bootstrap_peers: Vec<Multiaddr>,
     pub count: Option<u16>,
+    pub delete_safenode_src: bool,
     pub env_variables: Option<Vec<(String, String)>>,
     pub genesis: bool,
     pub local: bool,

--- a/sn_node_manager/src/add_services/mod.rs
+++ b/sn_node_manager/src/add_services/mod.rs
@@ -198,7 +198,9 @@ pub async fn add_node(
         rpc_port = increment_port_option(rpc_port);
     }
 
-    std::fs::remove_file(options.safenode_src_path)?;
+    if options.delete_safenode_src {
+        std::fs::remove_file(options.safenode_src_path)?;
+    }
 
     if !added_service_data.is_empty() {
         println!("Services Added:");

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -73,7 +73,7 @@ pub async fn add(
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
     let release_repo = <dyn SafeReleaseRepoActions>::default_config();
 
-    let (safenode_src_path, version) = if let Some(path) = src_path {
+    let (safenode_src_path, version) = if let Some(path) = src_path.clone() {
         let version = get_bin_version(&path)?;
         (path, version)
     } else {
@@ -102,6 +102,7 @@ pub async fn add(
 
     let options = AddNodeServiceOptions {
         count,
+        delete_safenode_src: src_path.is_none(),
         env_variables,
         genesis: is_first,
         local,


### PR DESCRIPTION
When the `--path` argument is specified on the node manager's `add` command, a custom binary is supplied, and now, the source of `--path` is not deleted.

By default, the `add` command downloads the latest version of a binary to a temporary location, and that binary is then copied to the service location. Having finished with it, the node manager then cleans up the temporary binary. When the `--path` argument is used, it goes through the same code path, and hence the source of `--path` was being deleted as a side effect. Now, a flag is used to indicate whether the binary should be deleted, and it is set to `false` when the `--path` argument is supplied.

The `--path` argument is being used when users build their own `safenode`, so they are expecting that the built binary will still exist.

## Description

reviewpad:summary 
