### PR TITLE
feat(client): speed up register checks when paying

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -813,6 +813,40 @@ impl Client {
         self.get_signed_register_from_network(address, true).await
     }
 
+    /// Quickly checks if a `Register` is stored by expected nodes on the network.
+    ///
+    /// To be used for initial register put checks eg, if we expect the data _not_
+    /// to exist, we can use it and essentially use the RetryStrategy::Quick under the hood
+    ///
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sn_client::{Client, Error};
+    /// use bls::SecretKey;
+    /// use xor_name::XorName;
+    /// use sn_registers::RegisterAddress;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(),Error>{
+    /// // Set up Client
+    /// let client = Client::new(SecretKey::random(), None, None, None).await?;
+    /// // Set up an address
+    /// let mut rng = rand::thread_rng();
+    /// let owner = SecretKey::random().public_key();
+    /// let xorname = XorName::random(&mut rng);
+    /// let address = RegisterAddress::new(xorname, owner);
+    /// // Verify address is stored
+    /// let is_stored = client.verify_register_stored(address).await.is_ok();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn quickly_check_if_register_stored(
+        &self,
+        address: RegisterAddress,
+    ) -> Result<SignedRegister> {
+        info!("Quickly checking for existing register : {address:?}");
+        self.get_signed_register_from_network(address, false).await
+    }
+
     /// Send a `SpendCashNote` request to the network. Protected method.
     ///
     /// # Arguments

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -500,7 +500,18 @@ impl ClientRegister {
         let mut royalties_fees = NanoTokens::zero();
         let reg_result = if verify_store {
             debug!("VERIFYING REGISTER STORED {:?}", self.address());
-            let res = self.client.verify_register_stored(*self.address()).await;
+
+            let res = if payment_info.is_some() {
+                // we expect this to be a _fresh_ register.
+                // It still could have been PUT previously, but we'll do a quick verification
+                // instead of thorough one.
+                self.client
+                    .quickly_check_if_register_stored(*self.address())
+                    .await
+            } else {
+                self.client.verify_register_stored(*self.address()).await
+            };
+
             // we need to keep the error here if verifying, so we can retry and pay for storage
             // once more below
             match res {


### PR DESCRIPTION
We take the existence of Payment at regsiter.sync as a proxy for intent to create a register. With that we can effectively use RetryStrategy::Quick under the hood to speed up initial register PUTs (15s check vs 60s with retries).

## Description

reviewpad:summary 
