### PR TITLE
ci: add `node-launchpad` binary to release process

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -10,7 +10,7 @@ on:
         default: main
 
 env:
-  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.25.2/just-1.25.2-x86_64-unknown-linux-musl.tar.gz
 
 jobs:
   build:
@@ -95,8 +95,8 @@ jobs:
         run: |
           curl -L -O $JUST_BIN_URL
           mkdir just
-          tar xvf just-1.13.0-x86_64-unknown-linux-musl.tar.gz -C just
-          rm just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+          tar xvf just-1.25.2-x86_64-unknown-linux-musl.tar.gz -C just
+          rm just-1.25.2-x86_64-unknown-linux-musl.tar.gz
           sudo mv just/just /usr/local/bin
           rm -rf just
           sudo apt-get install -y tree
@@ -106,9 +106,9 @@ jobs:
           tree artifacts
           just package-release-assets "safe"
           just package-release-assets "safenode"
-          just package-release-assets "testnet"
           just package-release-assets "faucet"
           just package-release-assets "safenode_rpc_client"
+          just package-release-assets "node-launchpad"
       - uses: actions/upload-artifact@main
         with:
           name: packaged_binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.43/release-plz-x86_64-unknown-linux-gnu.tar.gz
-  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+  JUST_BIN_URL: https://github.com/casey/just/releases/download/1.25.2/just-1.25.2-x86_64-unknown-linux-musl.tar.gz
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -133,8 +133,8 @@ jobs:
 
           curl -L -O $JUST_BIN_URL
           mkdir just
-          tar xvf just-1.13.0-x86_64-unknown-linux-musl.tar.gz -C just
-          rm just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+          tar xvf just-1.25.2-x86_64-unknown-linux-musl.tar.gz -C just
+          rm just-1.25.2-x86_64-unknown-linux-musl.tar.gz
           sudo mv just/just /usr/local/bin
           rm -rf just
 
@@ -158,12 +158,14 @@ jobs:
           just package-release-assets "safenode_rpc_client"
           just package-release-assets "safenode-manager"
           just package-release-assets "safenodemand"
+          just package-release-assets "node-launcher"
           just upload-release-assets-to-s3 "safe"
           just upload-release-assets-to-s3 "safenode"
           just upload-release-assets-to-s3 "safenode-manager"
           just upload-release-assets-to-s3 "safenodemand"
           just upload-release-assets-to-s3 "faucet"
           just upload-release-assets-to-s3 "safenode_rpc_client"
+          just upload-release-assets-to-s3 "node-launcher"
 
           # The `release-plz` command publishes crates which had their versions bumped, and also
           # creates Github releases. The binaries are then attached to the releases in the
@@ -184,12 +186,14 @@ jobs:
           just package-release-assets "safenode_rpc_client" "latest"
           just package-release-assets "safenode-manager" "latest"
           just package-release-assets "safenodemand" "latest"
+          just package-release-assets "node-launcher" "latest"
           just upload-release-assets-to-s3 "safe"
           just upload-release-assets-to-s3 "safenode"
           just upload-release-assets-to-s3 "safenode-manager"
           just upload-release-assets-to-s3 "safenodemand"
           just upload-release-assets-to-s3 "faucet"
           just upload-release-assets-to-s3 "safenode_rpc_client"
+          just upload-release-assets-to-s3 "node-launcher"
 
       - name: post notification to slack on failure
         if: ${{ failure() }}

--- a/Justfile
+++ b/Justfile
@@ -98,8 +98,9 @@ build-release-artifacts arch:
       sudo apt update -y
       sudo apt-get install -y musl-tools
     fi
-    rustup target add x86_64-unknown-linux-musl
   fi
+
+  rustup target add {{arch}}
 
   rm -rf artifacts
   mkdir artifacts
@@ -118,6 +119,7 @@ build-release-artifacts arch:
     cross build --release --target $arch --bin safenodemand
     cross build --release --target $arch --bin faucet --features=distribution
     cross build --release --target $arch --bin safenode_rpc_client
+    cross build --release --target $arch --bin node-launchpad
   else
     cargo build --release --features="network-contacts,distribution" --target $arch --bin safe
     cargo build --release --features=network-contacts --target $arch --bin safenode
@@ -125,6 +127,7 @@ build-release-artifacts arch:
     cargo build --release --target $arch --bin safenodemand
     cargo build --release --target $arch --bin faucet --features=distribution
     cargo build --release --target $arch --bin safenode_rpc_client
+    cargo build --release --target $arch --bin node-launchpad
   fi
 
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
@@ -168,7 +171,8 @@ package-release-assets bin version="":
 
   bin="{{bin}}"
 
-  supported_bins=("safe" "safenode" "safenode-manager" "safenodemand" "faucet" "safenode_rpc_client")
+  supported_bins=(\
+    "safe" "safenode" "safenode-manager" "safenodemand" "faucet" "safenode_rpc_client" "node-launchpad")
   crate_dir_name=""
 
   # In the case of the node manager, the actual name of the crate is `sn-node-manager`, but the
@@ -192,6 +196,9 @@ package-release-assets bin version="":
       ;;
     safenode_rpc_client)
       crate_dir_name="sn_node_rpc_client"
+      ;;
+    node-launchpad)
+      crate_dir_name="sn_node_launchpad"
       ;;
     *)
       echo "The $bin binary is not supported"
@@ -234,6 +241,7 @@ upload-github-release-assets:
     "sn-node-manager"
     "sn_faucet"
     "sn_node_rpc_client"
+    "sn_node_launchpad"
   )
 
   commit_msg=$(git log -1 --pretty=%B)
@@ -269,6 +277,10 @@ upload-github-release-assets:
           sn_node_rpc_client)
             bin_name="safenode_rpc_client"
             bucket="sn-node-rpc-client"
+            ;;
+          sn_node_launchpad)
+            bin_name="node-launchpad"
+            bucket="sn-node-launchpad"
             ;;
           *)
             echo "The $crate crate is not supported"
@@ -315,6 +327,9 @@ upload-release-assets-to-s3 bin_name:
       ;;
     safenode_rpc_client)
       bucket="sn-node-rpc-client"
+      ;;
+    node-launchpad)
+      bucket="sn-node-launchpad"
       ;;
     *)
       echo "The {{bin_name}} binary is not supported"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,12 @@ semver_check = false
 git_release_type = "auto"
 
 [[package]]
+name = "sn_auditor"
+changelog_update = true
+git_release_enable = false
+publish = true
+
+[[package]]
 name = "sn_build_info"
 changelog_update = true
 git_release_enable = false
@@ -74,6 +80,12 @@ changelog_include = [
     "sn_peers_acquisition",
     "sn_protocol",
 ]
+
+[[package]]
+name = "sn_node_launchpad"
+changelog_update = true
+git_release_enable = true
+publish = true
 
 [[package]]
 name = "sn_node_rpc_client"


### PR DESCRIPTION
The new TUI for the node manager is a new, separate binary that is being added in to the release process. It will have a Github release.

For some reason it seems to have became necessary to explicitly call `rustup target` during the artifacts build process. Without doing it, I was getting build errors on macOS.

## Description

reviewpad:summary 
