### PR TITLE
chore(ci): do not publish crates by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,12 @@ jobs:
           sudo mv just/just /usr/local/bin
           rm -rf just
 
+      # only publish if we're on the stable branch
+      - name: Conditionally remove 'publish = false' from workspace in release-plz.toml on stable branch
+        if: github.ref_name == 'stable'
+        run: sed -i '' '/^\[workspace\]/,/^\[/ {/^publish = false$/d;}' release-plz.toml 
+
+
       - name: publish and release
         shell: bash
         run: |

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,5 @@
 [workspace]
+publish=false
 allow_dirty = false
 changelog_update = true
 dependencies_update = false
@@ -11,18 +12,15 @@ git_release_type = "auto"
 name = "sn_auditor"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_build_info"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_cli"
 changelog_update = true
-publish = true
 changelog_include = [
     "sn_client",
     "sn_networking",
@@ -36,7 +34,6 @@ changelog_include = [
 name = "sn_client"
 changelog_update = true
 git_release_enable = false
-publish = true
 changelog_include = [
     "sn_networking",
     "sn_transfers",
@@ -49,30 +46,25 @@ changelog_include = [
 name = "sn_faucet"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_logging"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_metrics"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_networking"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_node"
 changelog_update = true
-publish = true
 changelog_include = [
     "sn_networking",
     "sn_transfers",
@@ -85,43 +77,36 @@ changelog_include = [
 name = "node-launchpad"
 changelog_update = true
 git_release_enable = true
-publish = true
 
 [[package]]
 name = "sn_node_rpc_client"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_peers_acquisition"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_protocol"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_registers"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_service_management"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "sn_transfers"
 changelog_update = true
 git_release_enable = false
-publish = true
 
 [[package]]
 name = "test_utils"
@@ -133,4 +118,3 @@ publish = false
 name = "token_supplies"
 changelog_update = true
 git_release_enable = false
-publish = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-publish=false
+publish = false
 allow_dirty = false
 changelog_update = true
 dependencies_update = false


### PR DESCRIPTION
This should avoid accidental publishing of prereleases to crates.io

We'll follow this up to optionally remove the workspace publish=false on specific branches## Description

reviewpad:summary 
