### PR TITLE
ci: fix packaging for node launchpad

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -108,6 +108,8 @@ jobs:
           just package-release-assets "safenode"
           just package-release-assets "faucet"
           just package-release-assets "safenode_rpc_client"
+          just package-release-assets "safenode-manager"
+          just package-release-assets "safenodemand"
           just package-release-assets "node-launchpad"
       - uses: actions/upload-artifact@main
         with:

--- a/Justfile
+++ b/Justfile
@@ -204,7 +204,7 @@ package-release-assets bin version="":
       crate_dir_name="sn_node_rpc_client"
       ;;
     node-launchpad)
-      crate_dir_name="node_launchpad"
+      crate_dir_name="node-launchpad"
       ;;
    
     *)
@@ -338,6 +338,7 @@ upload-release-assets-to-s3 bin_name:
     node-launchpad)
       bucket="node-launchpad"
       ;;
+    *)
       echo "The {{bin_name}} binary is not supported"
       exit 1
       ;;


### PR DESCRIPTION
The "node_launchpad" crate name was changed to "node-launchpad", and there was a small syntax error in the Bash script which meant the switch statement was not terminated correctly.

## Description

reviewpad:summary 
