### PR TITLE
chore: build auditor in release artifacts workflow

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -104,13 +104,14 @@ jobs:
         shell: bash
         run: |
           tree artifacts
+          just package-release-assets "faucet"
+          just package-release-assets "node-launchpad"
           just package-release-assets "safe"
           just package-release-assets "safenode"
-          just package-release-assets "faucet"
           just package-release-assets "safenode_rpc_client"
           just package-release-assets "safenode-manager"
           just package-release-assets "safenodemand"
-          just package-release-assets "node-launchpad"
+          just package-release-assets "sn_auditor"
       - uses: actions/upload-artifact@main
         with:
           name: packaged_binaries

--- a/Justfile
+++ b/Justfile
@@ -129,7 +129,7 @@ build-release-artifacts arch:
     cargo build --release --target $arch --bin safenode-manager
     cargo build --release --target $arch --bin safenodemand
     cargo build --release --target $arch --bin safenode_rpc_client
-    cross build --release --target $arch --bin sn_auditor
+    cargo build --release --target $arch --bin sn_auditor
   fi
 
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;


### PR DESCRIPTION
This workflow is useful for testing and I can use it to produce auditor artifacts that can manually be uploaded to S3.

## Description

reviewpad:summary 
