### PR TITLE
feat: use default keys, or override

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -7,7 +7,6 @@ env:
   RUST_BACKTRACE: 1
   CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
   NODE_DATA_PATH: /home/runner/.local/share/safe/node
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
 
 jobs:
   benchmark-cli:

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -17,7 +17,6 @@ env:
   RUST_BACKTRACE: 1
   CLIENT_DATA_PATH: /home/runner/.local/share/safe/client
   NODE_DATA_PATH: /home/runner/.local/share/safe/node
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
 
 jobs:
   benchmark-cli:

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check we're on the right commit
+        run: git log -1 --oneline
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -16,8 +16,6 @@ env:
   BOOTSTRAP_NODE_DATA_PATH: /home/runner/.local/share/safe/bootstrap_node
   RESTART_TEST_NODE_DATA_PATH: /home/runner/.local/share/safe/restart_node
   FAUCET_LOG_PATH: /home/runner/.local/share/safe/test_faucet/logs
-  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
-  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
 
 jobs:
   memory-check:

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -92,23 +92,6 @@ jobs:
           platform: ubuntu-latest
           set-safe-peers: false
 
-      - name: Check we're warned about using default genesis
-        run: |
-          git log -1 --oneline
-          ls -la $RESTART_TEST_NODE_DATA_PATH
-          cat $RESTART_TEST_NODE_DATA_PATH/safenode.log
-      - name: Check we're warned about using default genesis
-        run: |
-          git log -1 --oneline
-          ls -la $BOOTSTRAP_NODE_DATA_PATH
-          cat $BOOTSTRAP_NODE_DATA_PATH/safenode.log
-      - name: Check we're warned about using default genesis
-        run: |
-          git log -1 --oneline
-          ls -la $NODE_DATA_PATH
-          cat $NODE_DATA_PATH/safenode.log
-
-        shell: bash
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
       - name: Check SAFE_PEERS was not changed
         shell: bash
@@ -155,6 +138,25 @@ jobs:
         env:
           SN_LOG: "all"
         timeout-minutes: 25
+
+        # this check needs to be after some transfer activity
+      - name: Check we're warned about using default genesis
+        run: |
+          git log -1 --oneline
+          ls -la $RESTART_TEST_NODE_DATA_PATH
+          cat $RESTART_TEST_NODE_DATA_PATH/safenode.log
+      - name: Check we're warned about using default genesis
+        run: |
+          git log -1 --oneline
+          ls -la $BOOTSTRAP_NODE_DATA_PATH
+          cat $BOOTSTRAP_NODE_DATA_PATH/safenode.log
+
+      - name: Check we're warned about using default genesis
+        run: |
+          git log -1 --oneline
+          ls -la $NODE_DATA_PATH
+          rg "USING DEFAULT" "$NODE_DATA_PATH" -u
+        shell: bash
 
       # Uploading same file using different client shall not incur any payment neither uploads
       # Note rg will throw an error directly in case of failed to find a matching pattern.

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -16,7 +16,8 @@ env:
   BOOTSTRAP_NODE_DATA_PATH: /home/runner/.local/share/safe/bootstrap_node
   RESTART_TEST_NODE_DATA_PATH: /home/runner/.local/share/safe/restart_node
   FAUCET_LOG_PATH: /home/runner/.local/share/safe/test_faucet/logs
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
+  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
+  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
 
 jobs:
   memory-check:

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -89,6 +89,9 @@ jobs:
           platform: ubuntu-latest
           set-safe-peers: false
 
+      - name: Check we're warned about using default genesis
+        run: rg "USING DEFAULT" "$NODE_DATA_PATH" -u
+        shell: bash
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
       - name: Check SAFE_PEERS was not changed
         shell: bash

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -96,7 +96,18 @@ jobs:
         run: |
           git log -1 --oneline
           ls -la $RESTART_TEST_NODE_DATA_PATH
-          rg "USING DEFAULT" "$RESTART_TEST_NODE_DATA_PATH" -u
+          cat $RESTART_TEST_NODE_DATA_PATH/safenode.log
+      - name: Check we're warned about using default genesis
+        run: |
+          git log -1 --oneline
+          ls -la $BOOTSTRAP_NODE_DATA_PATH
+          cat $BOOTSTRAP_NODE_DATA_PATH/safenode.log
+      - name: Check we're warned about using default genesis
+        run: |
+          git log -1 --oneline
+          ls -la $NODE_DATA_PATH
+          cat $NODE_DATA_PATH/safenode.log
+
         shell: bash
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
       - name: Check SAFE_PEERS was not changed

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -90,7 +90,10 @@ jobs:
           set-safe-peers: false
 
       - name: Check we're warned about using default genesis
-        run: rg "USING DEFAULT" "$NODE_DATA_PATH" -u
+        run: |
+          git log -1 --oneline
+          ls -la $RESTART_TEST_NODE_DATA_PATH
+          rg "USING DEFAULT" "$RESTART_TEST_NODE_DATA_PATH" -u
         shell: bash
       # In this case we did *not* want SAFE_PEERS to be set to another value by starting the testnet
       - name: Check SAFE_PEERS was not changed

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -97,6 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check we're on the right commit
+        run: git log -1 --oneline
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,8 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
+  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
+  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
 
 jobs:
   cargo-udeps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,8 +12,8 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
-  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
-  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
+  GENESIS_PK: 9377ab39708a59d02d09bfd3c9bc7548faab9e0c2a2700b9ac7d5c14f0842f0b4bb0df411b6abd3f1a92b9aa1ebf5c3d
+  GENESIS_SK: 5ec88891c1098a0fede5b98b07f8abc931d7247b7aa310d21ab430cc957f9f02
 
 jobs:
   cargo-udeps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -976,6 +976,13 @@ jobs:
           platform: ubuntu-latest
           build: true
 
+      - name: Check we're _not_ warned about using default genesis
+        run: |
+          if rg "USING DEFAULT" "${{ matrix.safe_path }}"/*/*/logs; then
+            exit 1
+          fi
+        shell: bash
+
       # The test currently fails because the GH runner runs out of disk space. So we clear out the target dir here.
       # Might be related to additional deps used in the codebase.
       - name: Move built binaries and clear out target dir

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
 
 jobs:
   e2e:

--- a/.github/workflows/nightly_wan.yml
+++ b/.github/workflows/nightly_wan.yml
@@ -8,8 +8,6 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
-  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
-  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
 jobs:
   e2e:
     name: E2E tests

--- a/.github/workflows/nightly_wan.yml
+++ b/.github/workflows/nightly_wan.yml
@@ -8,8 +8,8 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
-
+  GENESIS_PK: aa07e487122eb31021301b95f4fb2b01363653cad582a6eb8ba0cfce937e51604350d7fb8a718596411f35d399cbdf28
+  GENESIS_SK: ${{ secrets.CI_TESTING_GENESIS_SK }}
 jobs:
   e2e:
     name: E2E tests

--- a/.github/workflows/nightly_wan_churn.yml
+++ b/.github/workflows/nightly_wan_churn.yml
@@ -1,15 +1,13 @@
-name: Nightly -- Perform long running network churn 
+name: Nightly -- Perform long running network churn
 
 on:
   schedule:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 
-
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
-  GENESIS_PK: 9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee
 
 jobs:
   e2e:

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -76,7 +76,10 @@ lazy_static! {
         };
 
         match MainPubkey::from_hex(pk_str) {
-            Ok(pk) => pk,
+            Ok(pk) => {
+                info!("Genesis PK: {pk:?}");
+                pk
+            },
             Err(err) => panic!("Failed to parse genesis PK: {err:?}"),
         }
     };

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -30,8 +30,9 @@ const GENESIS_DERIVATION_INDEX: DerivationIndex = DerivationIndex([0u8; 32]);
 
 /// Default genesis SK for testing purpose. Be sure to pass the correct `GENESIS_PK` value via env.
 const TESTING_GENESIS_SK: &str = "23746be7fa5df26c3065eb7aa26860981e435c1853cafafe472417bc94f340e9"; // DevSkim: ignore DS173237
+
 /// Genesis PK for live network. Be sure to pass the correct `GENESIS_SK` value via env when to use.
-const LIVE_GENESIS_PK: &str = "b814bc39a357e6f6000f4946da52dcfc72e19efe91e31d4e94e9cb408d765a4a6cf3bf2df14806f8fa524bd7ebb9bb4e"; // DevSkim: ignore DS173237
+const DEFAULT_LIVE_GENESIS_PK: &str = "9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee"; // DevSkim: ignore DS173237
 
 /// Based on the given store cost, it calculates what's the expected amount to be paid as network royalties.
 /// Network royalties fee is expected to be 15% of the payment amount, i.e. 85% of store cost + 15% royalties fees.
@@ -66,7 +67,13 @@ lazy_static! {
     /// The hard coded value is for production release, allows all nodes to validate it.
     /// The env set value is only used for testing purpose.
     pub static ref GENESIS_PK: MainPubkey = {
-        let pk_str = std::env::var("GENESIS_PK").unwrap_or(LIVE_GENESIS_PK.to_string());
+        let pk_str =  if let Ok(pk_str) = std::env::var("GENESIS_PK") {
+            pk_str
+        }
+        else {
+            warn!("USING DEFAULT GENESIS PK FOR TESTING PURPOSES!");
+            DEFAULT_LIVE_GENESIS_PK.to_string()
+        };
 
         match MainPubkey::from_hex(pk_str) {
             Ok(pk) => pk,
@@ -99,7 +106,13 @@ lazy_static! {
     /// Unlike the `GENESIS_PK`, the hard coded secret_key is for testing purpose.
     /// The one for live network shall be passed in via env set.
     static ref GENESIS_SK_STR: String = {
-        std::env::var("GENESIS_SK").unwrap_or(TESTING_GENESIS_SK.to_string())
+        if let Ok(sk) = std::env::var("GENESIS_SK") {
+            sk
+        }
+        else {
+            warn!("USING DEFAULT GENESIS SK FOR TESTING PURPOSES!");
+            TESTING_GENESIS_SK.to_string()
+        }
     };
 }
 

--- a/sn_transfers/src/genesis.rs
+++ b/sn_transfers/src/genesis.rs
@@ -29,9 +29,10 @@ pub(super) const GENESIS_CASHNOTE_AMOUNT: u64 = (0.3 * TOTAL_SUPPLY as f64) as u
 const GENESIS_DERIVATION_INDEX: DerivationIndex = DerivationIndex([0u8; 32]);
 
 /// Default genesis SK for testing purpose. Be sure to pass the correct `GENESIS_PK` value via env.
-const TESTING_GENESIS_SK: &str = "23746be7fa5df26c3065eb7aa26860981e435c1853cafafe472417bc94f340e9"; // DevSkim: ignore DS173237
+const DEFAULT_LIVE_GENESIS_SK: &str =
+    "23746be7fa5df26c3065eb7aa26860981e435c1853cafafe472417bc94f340e9"; // DevSkim: ignore DS173237
 
-/// Genesis PK for live network. Be sure to pass the correct `GENESIS_SK` value via env when to use.
+/// Default genesis PK for tsting purposes. Be sure to pass the correct `GENESIS_SK` value via env when to use.
 const DEFAULT_LIVE_GENESIS_PK: &str = "9934c21469a68415e6b06a435709e16bff6e92bf302aeb0ea9199d2d06a55f1b1a21e155853d3f94ae31f8f313f886ee"; // DevSkim: ignore DS173237
 
 /// Based on the given store cost, it calculates what's the expected amount to be paid as network royalties.
@@ -64,14 +65,16 @@ pub enum Error {
 
 lazy_static! {
     /// This key is public for auditing purposes.
-    /// The hard coded value is for production release, allows all nodes to validate it.
+    /// The hard coded value is for testing purposes,
+    /// In production a hard-coded PK should be set at build time.
+    /// This allows all nodes to validate it.
     /// The env set value is only used for testing purpose.
     pub static ref GENESIS_PK: MainPubkey = {
         let pk_str =  if let Ok(pk_str) = std::env::var("GENESIS_PK") {
             pk_str
         }
         else {
-            warn!("USING DEFAULT GENESIS PK FOR TESTING PURPOSES!");
+            warn!("USING DEFAULT GENESIS SK (9934c2) FOR TESTING PURPOSES! EXPECTING PAIRED SK (23746b) TO BE USED!");
             DEFAULT_LIVE_GENESIS_PK.to_string()
         };
 
@@ -106,15 +109,15 @@ lazy_static! {
 }
 
 lazy_static! {
-    /// Unlike the `GENESIS_PK`, the hard coded secret_key is for testing purpose.
+    /// Secret_key for testing purposes.
     /// The one for live network shall be passed in via env set.
     static ref GENESIS_SK_STR: String = {
         if let Ok(sk) = std::env::var("GENESIS_SK") {
             sk
         }
         else {
-            warn!("USING DEFAULT GENESIS SK FOR TESTING PURPOSES!");
-            TESTING_GENESIS_SK.to_string()
+             warn!("USING DEFAULT GENESIS SK (23746b) FOR TESTING PURPOSES! EXPECTING PAIRED PK (9934c2) TO BE USED!");
+            DEFAULT_LIVE_GENESIS_SK.to_string()
         }
     };
 }


### PR DESCRIPTION
This pull request primarily involves changes to the handling of the `GENESIS_PK` and `GENESIS_SK` environment variables in various GitHub workflow files and in the `sn_transfers/src/genesis.rs` file. The key changes include the removal of hardcoded `GENESIS_PK` values in several workflow files, a change in the hardcoded `GENESIS_PK` value in `merge.yml`, and changes to the default handling of these environment variables in `genesis.rs`.

Environment Variables:

* `.github/workflows/benchmark-prs.yml`, `.github/workflows/generate-benchmark-charts.yml`, `.github/workflows/memcheck.yml`, `.github/workflows/nightly.yml`, `.github/workflows/nightly_wan.yml`, and `.github/workflows/nightly_wan_churn.yml`: Removed hardcoded `GENESIS_PK` from the `env:` block. [[1]](diffhunk://#diff-c802009d797f0c766fb6721741fed236fa5ea30d678d67b88d6274379b2310e0L10) [[2]](diffhunk://#diff-7082d21102e2388737490a71510fcce74745099a1960eb928bcf80c50e8cc955L20) [[3]](diffhunk://#diff-c73109a65fa890a2e8daf1c61b2003395d8fe8e0e574a9cd11ff500721c72b61L19) [[4]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L11) [[5]](diffhunk://#diff-8dedfaee6fa8b6a88ec43a019f2826ca517279b52f2ded7a0f923d3fb12b1c32L11-L12) [[6]](diffhunk://#diff-c824e20d21304f76db5bd6e79be56509330a5b31e7302df446781eefc64a8ad9L8-L12)
* [`.github/workflows/merge.yml`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1L15-R16): Changed hardcoded `GENESIS_PK` value in the `env:` block and added `GENESIS_SK`.

Codebase Modifications:

* [`sn_transfers/src/genesis.rs`](diffhunk://#diff-85617a48a317bca063b2d2b5977a5eb1a0b6acfdfe9d00dc5947fa05af5e903fR33-R35): Modified the handling of `GENESIS_PK` and `GENESIS_SK` environment variables. If these variables are not set, a warning is issued and default values are used for testing purposes. Also, the `LIVE_GENESIS_PK` constant was renamed to `DEFAULT_LIVE_GENESIS_PK` and its value was changed. [[1]](diffhunk://#diff-85617a48a317bca063b2d2b5977a5eb1a0b6acfdfe9d00dc5947fa05af5e903fR33-R35) [[2]](diffhunk://#diff-85617a48a317bca063b2d2b5977a5eb1a0b6acfdfe9d00dc5947fa05af5e903fL69-R76) [[3]](diffhunk://#diff-85617a48a317bca063b2d2b5977a5eb1a0b6acfdfe9d00dc5947fa05af5e903fL102-R115)
