### PR TITLE
fix(node): notify fetch completion earlier to avoid being skipped

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -440,6 +440,16 @@ jobs:
           fi
         if: always()
 
+      - name: check there is no failed replication fetch
+        shell: bash
+        timeout-minutes: 1
+        run: |
+          if grep -r "failed to fetch" $NODE_DATA_PATH
+          then
+            echo "We find failed replication fetch"
+            exit 1
+          fi
+
       - name: Upload payment wallet initialization log
         uses: actions/upload-artifact@main
         with:

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -526,7 +526,7 @@ impl ClientRegister {
             // any error here will result in a repayment of the register
             // TODO: be smart about this and only pay for storage if we need to
             Err(err) => {
-                debug!("Failed to fetch register: {err:?}");
+                debug!("Failed to get register: {err:?}");
                 debug!("Creating Register as it doesn't exist at {addr:?}!");
                 let cmd = RegisterCmd::Create {
                     register: self.register.clone(),


### PR DESCRIPTION
### Description

This PR is trying to avoid false `failed to fetch` alert, which occasionally happens within the `location verify` CI test.
The root reason is because of interleaved processes, there is chance that a previously un-available record becomes stored during fetch it. Which case the `replication fetcher` not get notified of the completion.
To resolve it, the completion of the fetch will always trigger a notification to be sent to replication_fetcher, on receive a fetch response.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [x] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
