### PR TITLE
feat(audit): simplify reward output

### DIFF
--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -19,6 +19,7 @@ use crate::{
 use color_eyre::eyre::Result;
 use crossterm::event::KeyEvent;
 use ratatui::prelude::Rect;
+use sn_peers_acquisition::PeersArgs;
 use tokio::sync::mpsc;
 
 pub struct App {
@@ -35,11 +36,15 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(tick_rate: f64, frame_rate: f64) -> Result<Self> {
+    pub fn new(tick_rate: f64, frame_rate: f64, peers_args: PeersArgs) -> Result<Self> {
         let app_data = AppData::load()?;
 
         let tab = Tab::default();
-        let home = Home::new(app_data.allocated_disk_space, &app_data.discord_username)?;
+        let home = Home::new(
+            app_data.allocated_disk_space,
+            &app_data.discord_username,
+            peers_args,
+        )?;
         let config = Config::new()?;
         let discord_username_input =
             DiscordUsernameInputBox::new(app_data.discord_username.clone());

--- a/node-launchpad/src/bin/tui/main.rs
+++ b/node-launchpad/src/bin/tui/main.rs
@@ -8,6 +8,7 @@
 
 use clap::Parser;
 use color_eyre::eyre::Result;
+use sn_peers_acquisition::PeersArgs;
 use std::env;
 use tokio::task::LocalSet;
 
@@ -38,6 +39,9 @@ pub struct Cli {
         default_value_t = 60.0
     )]
     pub frame_rate: f64,
+
+    #[command(flatten)]
+    pub(crate) peers: PeersArgs,
 }
 
 async fn tokio_main() -> Result<()> {
@@ -46,7 +50,8 @@ async fn tokio_main() -> Result<()> {
     initialize_panic_handler()?;
 
     let args = Cli::parse();
-    let mut app = App::new(args.tick_rate, args.frame_rate)?;
+
+    let mut app = App::new(args.tick_rate, args.frame_rate, args.peers)?;
     app.run().await?;
 
     Ok(())


### PR DESCRIPTION
### Description
This pull request includes changes to the `node-launchpad` and `sn_auditor` packages. The most significant changes involve the addition of the `PeersArgs` parameter to the `App` and `Home` structs in the `node-launchpad` package and a modification to the `beta_program_json` method in the `sn_auditor` package.

Changes to `node-launchpad`:

* [`node-launchpad/src/app.rs`](diffhunk://#diff-9f8096fe1600486aa665a9f47e883f3c90d9a5a8ff147b026c757d9cbca765cfL38-R47): The `App` struct's `new` method now requires a `PeersArgs` parameter. This parameter is also passed to the `Home` struct's `new` method.
* [`node-launchpad/src/components/home.rs`](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63R39-R50): The `Home` struct now includes a `peers_args` field. This field is used when starting nodes, replacing the previous default `PeersArgs` value. [[1]](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63R39-R50) [[2]](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63R253) [[3]](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63R455-L449) [[4]](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63L462-R469)

Changes to `sn_auditor`:

* [`sn_auditor/src/dag_db.rs`](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L227-R243): The `beta_program_json` method now includes total rewards for each participant in the returned JSON. Previously, it only returned the current state of the beta program.


### Type of Change

Please mark the types of changes made in this pull request.

- [ x ] New feature (non-breaking change which adds functionality)
