### PR TITLE
fix(cli): avoid mis-estimation due to overflow

### DIFF
--- a/sn_cli/src/files/estimate.rs
+++ b/sn_cli/src/files/estimate.rs
@@ -67,7 +67,7 @@ impl Estimator {
             .expect("estimate_cost: Concurrency error.");
         }
 
-        let total = balance - estimate;
+        let total = balance.saturating_sub(estimate);
 
         println!("**************************************");
         println!("Your current balance: {}", NanoTokens::from(balance));


### PR DESCRIPTION
### Description

This pull request includes a change to the `Estimator` implementation in the `sn_cli/src/files/estimate.rs` file. The change modifies the calculation of `total` to use the `saturating_sub` function instead of a simple subtraction. This ensures that `total` will never underflow and become a large positive number if `estimate` is larger than `balance`.

Please provide a brief description of the changes made in this pull request. Highlight the purpose of the changes and the problem they address.

### Related Issue

Fixes #1745

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [x] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
