### PR TITLE
feat(node_manager): pass beta encryption sk to the auditor

### DIFF
--- a/sn_node_manager/src/add_services/config.rs
+++ b/sn_node_manager/src/add_services/config.rs
@@ -150,9 +150,10 @@ pub struct AddNodeServiceOptions {
 
 #[derive(Debug, PartialEq)]
 pub struct InstallAuditorServiceCtxBuilder {
+    pub auditor_path: PathBuf,
+    pub beta_encryption_key: Option<String>,
     pub bootstrap_peers: Vec<Multiaddr>,
     pub env_variables: Option<Vec<(String, String)>>,
-    pub auditor_path: PathBuf,
     pub log_dir_path: PathBuf,
     pub name: String,
     pub service_user: String,
@@ -174,6 +175,10 @@ impl InstallAuditorServiceCtxBuilder {
                 .join(",");
             args.push(OsString::from("--peer"));
             args.push(OsString::from(peers_str));
+        }
+        if let Some(beta_encryption_key) = self.beta_encryption_key {
+            args.push(OsString::from("--beta-encryption-key"));
+            args.push(OsString::from(beta_encryption_key));
         }
 
         Ok(ServiceInstallCtx {
@@ -232,10 +237,11 @@ impl InstallFaucetServiceCtxBuilder {
 }
 
 pub struct AddAuditorServiceOptions {
-    pub bootstrap_peers: Vec<Multiaddr>,
-    pub env_variables: Option<Vec<(String, String)>>,
     pub auditor_install_bin_path: PathBuf,
     pub auditor_src_bin_path: PathBuf,
+    pub beta_encryption_key: Option<String>,
+    pub bootstrap_peers: Vec<Multiaddr>,
+    pub env_variables: Option<Vec<(String, String)>>,
     pub service_log_dir_path: PathBuf,
     pub user: String,
     pub version: String,

--- a/sn_node_manager/src/add_services/mod.rs
+++ b/sn_node_manager/src/add_services/mod.rs
@@ -312,9 +312,10 @@ pub fn add_auditor(
     )?;
 
     let install_ctx = InstallAuditorServiceCtxBuilder {
+        auditor_path: install_options.auditor_install_bin_path.clone(),
+        beta_encryption_key: install_options.beta_encryption_key.clone(),
         bootstrap_peers: install_options.bootstrap_peers.clone(),
         env_variables: install_options.env_variables.clone(),
-        auditor_path: install_options.auditor_install_bin_path.clone(),
         log_dir_path: install_options.service_log_dir_path.clone(),
         name: "auditor".to_string(),
         service_user: install_options.user.clone(),

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -369,6 +369,10 @@ pub enum AuditorSubCmd {
     /// This command must run as the root/administrative user.
     #[clap(name = "add")]
     Add {
+        /// Secret encryption key of the beta rewards to decypher
+        /// discord usernames of the beta participants
+        #[clap(short = 'k', long, value_name = "hex_secret_key")]
+        beta_encryption_key: Option<String>,
         /// Provide environment variables for the auditor service.
         ///
         /// Useful to set log levels. Variables should be comma separated without spaces.
@@ -847,6 +851,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         SubCmd::Auditor(AuditorSubCmd::Add {
+            beta_encryption_key,
             env_variables,
             log_dir_path,
             path,
@@ -855,6 +860,7 @@ async fn main() -> Result<()> {
             version,
         }) => {
             cmd::auditor::add(
+                beta_encryption_key,
                 env_variables,
                 log_dir_path,
                 peers,

--- a/sn_node_manager/src/cmd/auditor.rs
+++ b/sn_node_manager/src/cmd/auditor.rs
@@ -25,7 +25,9 @@ use sn_service_management::{
 };
 use std::path::PathBuf;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn add(
+    beta_encryption_key: Option<String>,
     env_variables: Option<Vec<(String, String)>>,
     log_dir_path: Option<PathBuf>,
     peers: PeersArgs,
@@ -72,10 +74,11 @@ pub async fn add(
 
     add_auditor(
         AddAuditorServiceOptions {
-            bootstrap_peers: get_peers_from_args(peers).await?,
-            env_variables,
             auditor_src_bin_path,
             auditor_install_bin_path: PathBuf::from("/usr/local/bin/auditor"),
+            beta_encryption_key,
+            bootstrap_peers: get_peers_from_args(peers).await?,
+            env_variables,
             service_log_dir_path,
             user: service_user.to_string(),
             version,


### PR DESCRIPTION
This pull request introduces a new feature to the `sn_node_manager` package that allows the use of a beta encryption key when adding an auditor service. The key changes involve the addition of the `beta_encryption_key` field in relevant structs and the handling of this new field in various methods and tests.