### PR TITLE
feat(metrics): expose store cost value

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -353,13 +353,18 @@ impl SwarmDriver {
             }
             SwarmCmd::GetLocalStoreCost { key, sender } => {
                 cmd_string = "GetLocalStoreCost";
-                let _res = sender.send(
-                    self.swarm
-                        .behaviour_mut()
-                        .kademlia
-                        .store_mut()
-                        .store_cost(&key),
-                );
+                let cost = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .store_cost(&key);
+                #[cfg(feature = "open-metrics")]
+                if let Some(metrics) = &self.network_metrics {
+                    let _ = metrics.store_cost.set(cost.0.as_nano() as i64);
+                }
+
+                let _res = sender.send(cost);
             }
             SwarmCmd::PaymentReceived => {
                 cmd_string = "PaymentReceived";

--- a/sn_networking/src/metrics.rs
+++ b/sn_networking/src/metrics.rs
@@ -24,6 +24,7 @@ pub(crate) struct NetworkMetrics {
     // metrics from sn_networking
     pub(crate) records_stored: Gauge,
     pub(crate) estimated_network_size: Gauge,
+    pub(crate) store_cost: Gauge,
 
     // system info
     process_memory_used_mb: Gauge,
@@ -48,6 +49,12 @@ impl NetworkMetrics {
             "The estimated number of nodes in the network calculated by the peers in our RT",
             estimated_network_size.clone(),
         );
+        let store_cost = Gauge::default();
+        sub_registry.register(
+            "store_cost",
+            "The store cost of the node",
+            store_cost.clone(),
+        );
 
         let process_memory_used_mb = Gauge::default();
         sub_registry.register(
@@ -67,6 +74,7 @@ impl NetworkMetrics {
             libp2p_metrics,
             records_stored,
             estimated_network_size,
+            store_cost,
             process_memory_used_mb,
             process_cpu_usage_percentage,
         };


### PR DESCRIPTION
This pull request primarily focuses on enhancing the metrics in the `sn_networking` package by adding a new metric `store_cost`. Additionally, the `SwarmDriver` has been refactored to calculate the `store_cost` and update this new metric. 

Here are the key changes:

Metrics Enhancement:
* [`sn_networking/src/metrics.rs`](diffhunk://#diff-6384ddf304044a9133adf3bddda2ff4cbbdeef10162b3c29da4d79a1c16750cfR27): A new metric named `store_cost` was added to the `NetworkMetrics` struct. This metric is registered in the metrics registry and is initialized in the `NetworkMetrics` implementation. [[1]](diffhunk://#diff-6384ddf304044a9133adf3bddda2ff4cbbdeef10162b3c29da4d79a1c16750cfR27) [[2]](diffhunk://#diff-6384ddf304044a9133adf3bddda2ff4cbbdeef10162b3c29da4d79a1c16750cfR52-R57) [[3]](diffhunk://#diff-6384ddf304044a9133adf3bddda2ff4cbbdeef10162b3c29da4d79a1c16750cfR77)

Code Refactoring:
* [`sn_networking/src/cmd.rs`](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76L356-R367): The `SwarmCmd::GetLocalStoreCost` command in the `SwarmDriver` implementation was refactored to calculate the `store_cost` and update the new `store_cost` metric. This change also includes the removal of the previous method of sending the store cost.