### PR TITLE
fix(uploader): do not error out immediately on max repayment errors

### DIFF
--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -8,6 +8,8 @@
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
+use crate::UploadSummary;
+
 use super::ClientEvent;
 use sn_protocol::NetworkAddress;
 use sn_registers::{Entry, EntryHash};
@@ -140,8 +142,14 @@ pub enum Error {
     #[error("Too many sequential payment errors reported during upload")]
     SequentialUploadPaymentError,
 
-    #[error("The maximum specified repayments has been reached for {0:?}")]
-    MaximumRepaymentsReached(Vec<XorName>),
+    #[error("The maximum specified repayments has been reached for a single item: {0:?}")]
+    MaximumRepaymentsReached(XorName),
+
+    #[error("The upload failed with maximum repayments reached for multiple items: {items:?} Summary: {summary:?}")]
+    UploadFailedWithMaximumRepaymentsReached {
+        items: Vec<XorName>,
+        summary: UploadSummary,
+    },
 
     #[error("Error occurred when access wallet file")]
     FailedToAccessWallet,

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -140,8 +140,8 @@ pub enum Error {
     #[error("Too many sequential payment errors reported during upload")]
     SequentialUploadPaymentError,
 
-    #[error("The maximum specified repayments has been reached")]
-    MaximumRepaymentsReached,
+    #[error("The maximum specified repayments has been reached for {0:?}")]
+    MaximumRepaymentsReached(Vec<XorName>),
 
     #[error("Error occurred when access wallet file")]
     FailedToAccessWallet,

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -140,8 +140,8 @@ pub enum Error {
     #[error("Too many sequential payment errors reported during upload")]
     SequentialUploadPaymentError,
 
-    #[error("The maximum specified repayments were made for the address: {0:?}")]
-    MaximumRepaymentsReached(XorName),
+    #[error("The maximum specified repayments has been reached")]
+    MaximumRepaymentsReached,
 
     #[error("Error occurred when access wallet file")]
     FailedToAccessWallet,

--- a/sn_client/src/uploader/tests/mod.rs
+++ b/sn_client/src/uploader/tests/mod.rs
@@ -448,7 +448,7 @@ async fn maximum_repayment_error_should_be_triggered_during_get_store_cost() -> 
 
     assert_matches!(
         upload_handle.await?,
-        Err(ClientError::MaximumRepaymentsReached)
+        Err(ClientError::MaximumRepaymentsReached(_))
     );
     let events = events_handle.await?;
 

--- a/sn_client/src/uploader/tests/mod.rs
+++ b/sn_client/src/uploader/tests/mod.rs
@@ -448,7 +448,7 @@ async fn maximum_repayment_error_should_be_triggered_during_get_store_cost() -> 
 
     assert_matches!(
         upload_handle.await?,
-        Err(ClientError::MaximumRepaymentsReached(_))
+        Err(ClientError::MaximumRepaymentsReached)
     );
     let events = events_handle.await?;
 

--- a/sn_client/src/uploader/tests/mod.rs
+++ b/sn_client/src/uploader/tests/mod.rs
@@ -448,7 +448,7 @@ async fn maximum_repayment_error_should_be_triggered_during_get_store_cost() -> 
 
     assert_matches!(
         upload_handle.await?,
-        Err(ClientError::MaximumRepaymentsReached(_))
+        Err(ClientError::UploadFailedWithMaximumRepaymentsReached { .. })
     );
     let events = events_handle.await?;
 

--- a/sn_client/src/uploader/upload.rs
+++ b/sn_client/src/uploader/upload.rs
@@ -128,7 +128,9 @@ pub(super) async fn start_upload(
                     "The maximum repayments were reached for these addresses: {:?}",
                     uploader.max_repayments_reached
                 );
-                return Err(ClientError::MaximumRepaymentsReached);
+                return Err(ClientError::MaximumRepaymentsReached(
+                    uploader.max_repayments_reached.into_iter().collect(),
+                ));
             }
 
             let summary = UploadSummary {
@@ -535,7 +537,7 @@ impl UploaderInterface for Uploader {
                     error!("Encountered error {err:?} when getting store_cost for {xorname:?}",);
 
                     let max_repayments_reached =
-                        matches!(&err, ClientError::MaximumRepaymentsReached);
+                        matches!(&err, ClientError::MaximumRepaymentsReached(_));
 
                     TaskResult::GetStoreCostErr {
                         xorname,
@@ -940,7 +942,7 @@ impl InnerUploader {
                     max_repayments_for_failed_data,
                 ) {
                     // error is used by the caller.
-                    return Err(ClientError::MaximumRepaymentsReached);
+                    return Err(ClientError::MaximumRepaymentsReached(vec![xorname]));
                 }
 
                 debug!("Filtering out payments from {filter_list:?} during get_store_cost for {xorname:?}");


### PR DESCRIPTION
This PR allows us to continue the upload process even if a single item fails due to `MaxRepaymentsReached`
The error is then triggered after all the other item are cleared.

Closes Issue https://github.com/maidsafe/safe_network/issues/1730