### PR TITLE
fix: check node registry exists before deleting it

### DIFF
--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -253,8 +253,13 @@ pub async fn reset(force: bool, verbosity: VerbosityLevel) -> Result<()> {
     stop(vec![], vec![], verbosity).await?;
     remove(false, vec![], vec![], verbosity).await?;
 
+    // Due the possibility of repeated runs of the `reset` command, we need to check for the
+    // existence of this file before attempting to delete it, since `remove_file` will return an
+    // error if the file doesn't exist. On Windows this has been observed to happen.
     let node_registry_path = config::get_node_registry_path()?;
-    std::fs::remove_file(node_registry_path)?;
+    if node_registry_path.exists() {
+        std::fs::remove_file(node_registry_path)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Description

The `remove_file` command returns an error if the file we are attempting to delete does not exist. This meant on Windows, subsequent runs of the `reset` command could produce an error. It did not occur on Linux or macOS because the registry file is briefly recreated on those platforms so that it can be assigned special permissions; this does not apply on Windows.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have performed a self-review of my own code.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
