### PR TITLE
version bump for main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "atty",
  "better-panic",
@@ -6895,7 +6895,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sn-node-manager"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -6953,7 +6953,7 @@ dependencies = [
 
 [[package]]
 name = "sn_auditor"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "blsttc",
  "clap",
@@ -6991,7 +6991,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.91.4"
+version = "0.92.0"
 dependencies = [
  "aes 0.7.5",
  "base64 0.22.1",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "sn_client"
-version = "0.106.2"
+version = "0.106.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "sn_faucet"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "sn_logging"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "sn_networking"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.106.4"
+version = "0.106.5"
 dependencies = [
  "assert_fs",
  "assert_matches",
@@ -7279,7 +7279,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node_rpc_client"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "assert_fs",
  "async-trait",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "sn_protocol"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "blsttc",
  "bytes",
@@ -7368,7 +7368,7 @@ dependencies = [
 
 [[package]]
 name = "sn_service_management"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "dirs-next",
@@ -7394,7 +7394,7 @@ dependencies = [
 
 [[package]]
 name = "sn_transfers"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "assert_fs",
  "blsttc",

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -28,7 +28,7 @@ libp2p = { version = "0.53", features = [
     "macros",
     "upnp",
 ] }
-sn_networking = { path = "../sn_networking", version = "0.15.2" }
+sn_networking = { path = "../sn_networking", version = "0.15.3" }
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = { version = "~0.1.26" }
 tracing-log = "0.2.0"

--- a/node-launchpad/CHANGELOG.md
+++ b/node-launchpad/CHANGELOG.md
@@ -6,6 +6,143 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshuef/safe_network/compare/node-launchpad-v0.1.5...node-launchpad-v0.2.0) - 2024-05-24
+
+### Added
+- *(launchpad)* provide safenode path for testing
+- *(manager)* maintain n running nodes
+- *(auditor)* add new beta participants via endpoint
+- *(launchpad)* accept peers args
+- supply discord username on launchpad
+- provide `--owner` arg for `add` cmd
+- *(nodeman)* add LogFormat as a startup arg for nodes
+- *(node-launchpad)* discord name widget styling
+- *(node-launchpad)* tweaks on resource allocation widget
+- *(launchpad)* initial automatic resource allocation logic
+- *(launchpad)* allow users to input disk space to allocate
+- *(launchpad)* store discord username to disk
+- *(launchpad)* use escape to exit input screen and restore old value
+- *(launchpad)* have customizable footer
+- *(launchpad)* add discord username scene
+- *(launchpad)* remove separate ai launcher bin references
+- *(launchpad)* ensure start mac launchapd with sudo only if not set
+- use different key for payment forward
+- hide genesis keypair
+- *(node)* periodically forward reward to specific address
+- spend reason enum and sized cipher
+- *(network)* add --upnp flag to node
+- spend shows the purposes of outputs created for
+- *(node)* make spend and cash_note reason field configurable
+- *(relay)* remove autonat and enable hole punching manually
+- *(relay)* impl RelayManager to perform circuit relay when behind NAT
+- *(node)* notify peer it is now considered as BAD
+- *(networking)* shift to use ilog2 bucket distance for close data calcs
+- unit testing dag, double spend poisoning tweaks
+- report protocol mismatch error
+- *(node_manager)* pass beta encryption sk to the auditor
+- provide `local status` command
+- *(node_manager)* add auditor support
+- provide `--upnp` flag for `add` command
+- *(audit)* collect payment forward statistics
+- run safenode services in user mode
+- provide `autonomi-launcher` binary
+- *(manager)* reuse downloaded binaries
+- *(launchpad)* remove nodes
+- *(tui)* adding services
+- [**breaking**] provide `--home-network` arg for `add` cmd
+- provide `--interval` arg for `upgrade` cmd
+- provide `--path` arg for `upgrade` cmd
+- rpc restart command
+- provide `reset` command
+- provide `balance` command
+- make `--peer` argument optional
+- distinguish failure to start during upgrade
+
+### Fixed
+- retain options on upgrade and prevent dup ports
+- *(launchpad)* check if component is active before handling events
+- *(launchpad)* prevent mac opening with sudo
+- use fixed size popups
+- *(launchpad)* prevent loops from terminal/sudo relaunching
+- *(launchpad)* do not try to run sudo twice
+- *(node)* notify fetch completion earlier to avoid being skipped
+- create faucet via account load or generation
+- more test and cli fixes
+- update calls to HotWallet::load
+- do not add reported external addressese if we are behind home network
+- *(node)* notify replication_fetcher of early completion
+- *(node)* not send out replication when failed read from local
+- avoid adding mixed type addresses into RT
+- *(manager)* download again if cached archive is corrupted
+- check node registry exists before deleting it
+- *(manager)* do not print to stdout on low verbosity level
+- do not create wallet on registry refresh
+- change reward balance to optional
+- apply interval only to non-running nodes
+- do not delete custom bin on `add` cmd
+- incorrect release type reference
+- use correct release type in upgrade process
+
+### Other
+- update sn-releases
+- update based on comment
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- check we are in terminal before creating one
+- *(release)* node-launchpad-v0.1.4
+- use published versions of deps
+- *(release)* node-launchpad-v0.1.3/sn-node-manager-v0.7.6
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- *(launchpad)* removing redudnat for loops
+- move helper text inside popup
+- change trigger resource allocation input box keybind
+- *(launchpad)* highlight the table in green if we're currently running
+- *(launchpad)* add more alternative keybinds
+- change terminal launch behaviour
+- use consistent border styles
+- *(launchpad)* use safe data dir to store configs
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs for nodeman
+- *(versions)* sync versions with latest crates.io vs
+- rename sn_node_launchpad -> node-launchpad
+- rename `node-launchpad` crate to `sn_node_launchpad`
+- rebased and removed custom rustfmt
+- *(tui)* rename crate
+- *(node)* log node owner
+- make open metrics feature default but without starting it by default
+- *(refactor)* stabilise node size to 4k records,
+- resolve errors after reverts
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "feat: spend shows the purposes of outputs created for"
+- Revert "chore: rename output reason to purpose for clarity"
+- *(node)* use proper SpendReason enum
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_registers-v0.3.13
+- *(node)* make owner optional
+- cargo fmt
+- rename output reason to purpose for clarity
+- store owner info inside node instead of network
+- *(CI)* upload faucet log during CI
+- *(node)* lower some log levels to reduce log size
+- *(CI)* confirm there is no failed replication fetch
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+- *(node)* pass entire QuotingMetrics into calculate_cost_for_records
+- enable node man integration tests
+- use owners on memcheck workflow local network
+- reconfigure local network owner args
+- *(nodemanager)* upgrade_should_retain_the_log_format_flag
+- use helper function to print banners
+- use const for default user or owner
+- update cli and readme for user-mode services
+- upgrade service manager crate
+- use node registry for status
+- [**breaking**] output reward balance in `status --json` cmd
+- use better banners
+- properly use node registry and surface peer ids if they're not
+- `remove` cmd operates over all services
+- provide `local` subcommand
+
 ## [0.1.5](https://github.com/maidsafe/safe_network/compare/node-launchpad-v0.1.4...node-launchpad-v0.1.5) - 2024-05-20
 
 ### Added

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Node Launchpad"
 name = "node-launchpad"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -44,10 +44,10 @@ ratatui = { version = "0.26.0", features = ["serde", "macros"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 signal-hook = "0.3.17"
-sn-node-manager = { version = "0.7.7", path = "../sn_node_manager" }
+sn-node-manager = { version = "0.8.0", path = "../sn_node_manager" }
 sn_peers_acquisition = { version = "0.2.12", path = "../sn_peers_acquisition" }
 sn-releases = "~0.2.4"
-sn_service_management = { version = "0.2.8", path = "../sn_service_management" }
+sn_service_management = { version = "0.3.0", path = "../sn_service_management" }
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }
 sysinfo = "0.30.12"

--- a/sn_auditor/CHANGELOG.md
+++ b/sn_auditor/CHANGELOG.md
@@ -6,6 +6,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/joshuef/safe_network/compare/sn_auditor-v0.1.16...sn_auditor-v0.1.17) - 2024-05-24
+
+### Added
+- *(auditor)* cache beta participants to the disk
+- *(auditor)* add new beta participants via endpoint
+- backup rewards json to disk regularly
+- docs for sn_auditor
+- offline mode for beta rewards
+- upgrade cli audit to use DAG
+- *(audit)* simplify reward output
+- *(audit)* make svg processing a non-deafult feat
+- *(audit)* accept line separated list of discord ids
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- pass sk_str via cli opt
+- improve code to use existing utils
+- tracking beta rewards from the DAG
+- dag faults unit tests, sn_auditor offline mode
+
+### Fixed
+- *(auditor)* discord id cannot be empty
+- *(auditor)* extend the beta particpants list
+- auditor key arg to match docs
+- dag and dag-svg feature mismatch
+- beta rewards participants overwriting and renamings
+- allow unknown discord IDs temporarily
+- orphan parent bug, improve fault detection and logging
+
+### Other
+- move dag svg
+- rename improperly named foundation_key
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+
 ## [0.1.16](https://github.com/maidsafe/safe_network/compare/sn_auditor-v0.1.15...sn_auditor-v0.1.16) - 2024-05-20
 
 ### Other

--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Safe Network Auditor"
 name = "sn_auditor"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 homepage = "https://maidsafe.net"
 repository = "https://github.com/maidsafe/safe_network"
@@ -28,8 +28,8 @@ dirs-next = "~2.0.0"
 graphviz-rust = { version = "0.9.0", optional = true }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 serde_json = "1.0.108"
-sn_client = { path = "../sn_client", version = "0.106.2" }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
+sn_client = { path = "../sn_client", version = "0.106.3" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tracing = { version = "~0.1.26" }

--- a/sn_cli/CHANGELOG.md
+++ b/sn_cli/CHANGELOG.md
@@ -6,6 +6,117 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.92.0](https://github.com/joshuef/safe_network/compare/sn_cli-v0.91.4...sn_cli-v0.92.0) - 2024-05-24
+
+### Added
+- improved spend verification with DAG and fault detection
+- upgrade cli audit to use DAG
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- pass sk_str via cli opt
+- *(audit)* collect payment forward statistics
+- *(client)* dump spends creation_reason statistics
+- *(node)* make spend and cash_note reason field configurable
+- *(cli)* readd wallet helper address for dist feat
+- *(cli)* generate a mnemonic as wallet basis if no wallet found
+- *(cli)* eip2333 helpers for accounts
+- [**breaking**] renamings in CashNote
+- [**breaking**] rename token to amount in Spend
+- *(cli)* implement FilesUploadStatusNotifier trait for lib code
+- *(cli)* return the files upload summary after a successful files upload
+- unit testing dag, double spend poisoning tweaks
+- report protocol mismatch error
+- hide genesis keypair
+- *(node)* use separate keys of Foundation and Royalty
+- *(wallet)* ensure genesis wallet attempts to load from local on init first
+- *(faucet)* increase initial balance
+- *(faucet)* make gifting server feat dependent
+- *(faucet)* send small amount to faucet, rest to foundation
+- *(faucet)* add feat for gifting-from-genesis
+- *(audit)* intercept sender of the payment forward
+- spend reason enum and sized cipher
+- *(metrics)* expose store cost value
+- keep track of the estimated network size metric
+- record lip2p relay and dctur metrics
+- *(node)* periodically forward reward to specific address
+- use default keys for genesis, or override
+- use different key for payment forward
+- hide genesis keypair
+- tracking beta rewards from the DAG
+
+### Fixed
+- audit flags activated independently
+- reduce blabber in dot and royalties audit mode
+- *(cli)* avoid mis-estimation due to overflow
+- *(cli)* acct_packet tests updated
+- more test and cli fixes
+- update calls to HotWallet::load
+- *(client)* move acct_packet mnemonic into client layer
+- *(client)* ensure we have a wallet or generate one via mnemonic
+- *(uploader)* do not error out immediately on max repayment errors
+- *(node)* notify fetch completion earlier to avoid being skipped
+- avoid adding mixed type addresses into RT
+- enable libp2p metrics to be captured
+- correct genesis_pk naming
+- genesis_cn public fields generated from hard coded value
+- invalid spend reason in data payments
+
+### Other
+- further improve fast mode gathering speed
+- improve cli DAG collection
+- improve DAG collection perf
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- improve DAG verification redundancy
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- resolve errors after reverts
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "chore: refactor CASH_NOTE_REASON strings to consts"
+- Revert "feat(client): dump spends creation_reason statistics"
+- Revert "chore: address review comments"
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs
+- address review comments
+- refactor CASH_NOTE_REASON strings to consts
+- addres review comments
+- *(cli)* update mnemonic wallet seed phrase wording
+- *(CI)* upload faucet log during CI
+- remove deprecated wallet deposit cmd
+- fix typo for issue 1494
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(cli)* make FilesUploadSummary public
+- *(deps)* bump dependencies
+- *(uploader)* return summary when upload fails due to max repayments
+- *(uploader)* return the list of max repayment reached items
+- remove now unused mostly duplicated code
+- *(faucet)* devskim ignore
+- *(faucet)* log existing faucet balance if non-zero
+- *(faucet)* add foundation PK as const
+- *(faucet)* clarify logs for verification
+- increase initial faucet balance
+- add temp log
+- *(faucet)* refresh cashnotes on fund
+- devSkim ignore foundation pub temp key
+- update got 'gifting-from-genesis' faucet feat
+- make open metrics feature default but without starting it by default
+- Revert "feat(cli): track spend creation reasons during audit"
+- *(node)* tuning the pricing curve
+- *(node)* remove un-necessary is_relayed check inside add_potential_candidates
+- move historic_quoting_metrics out of the record_store dir
+- clippy fixes for open metrics feature
+- *(networking)* update tests for pricing curve tweaks
+- *(refactor)* stabilise node size to 4k records,
+- Revert "chore: rename output reason to purpose for clarity"
+- *(transfers)* comment and naming updates for clarity
+- log genesis PK
+- rename improperly named foundation_key
+- reconfigure local network owner args
+- use const for default user or owner
+- Revert "feat: spend shows the purposes of outputs created for"
+- *(node)* use proper SpendReason enum
+- add consts
+
 ## [0.91.4](https://github.com/maidsafe/safe_network/compare/sn_cli-v0.91.3...sn_cli-v0.91.4) - 2024-05-20
 
 ### Other

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_cli"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.91.4"
+version = "0.92.0"
 
 [[bin]]
 path = "src/bin/main.rs"
@@ -58,10 +58,10 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = ["derive"] }
 sn_build_info = { path = "../sn_build_info", version = "0.1.7" }
-sn_client = { path = "../sn_client", version = "0.106.2" }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
+sn_client = { path = "../sn_client", version = "0.106.3" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
 tempfile = "3.6.0"
 tiny-keccak = "~2.0.2"
 tokio = { version = "1.32.0", features = [
@@ -83,7 +83,7 @@ eyre = "0.6.8"
 criterion = "0.5.1"
 tempfile = "3.6.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
-sn_client = { path = "../sn_client", version = "0.106.2", features = [
+sn_client = { path = "../sn_client", version = "0.106.3", features = [
     "test-utils",
 ] }
 

--- a/sn_client/CHANGELOG.md
+++ b/sn_client/CHANGELOG.md
@@ -6,6 +6,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.106.3](https://github.com/joshuef/safe_network/compare/sn_client-v0.106.2...sn_client-v0.106.3) - 2024-05-24
+
+### Added
+- improved spend verification with DAG and fault detection
+- upgrade cli audit to use DAG
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- hide genesis keypair
+- pass sk_str via cli opt
+- *(node)* use separate keys of Foundation and Royalty
+- *(wallet)* ensure genesis wallet attempts to load from local on init first
+- *(faucet)* increase initial balance
+- *(faucet)* make gifting server feat dependent
+- *(faucet)* send small amount to faucet, rest to foundation
+- *(faucet)* add feat for gifting-from-genesis
+- *(audit)* intercept sender of the payment forward
+- *(audit)* collect payment forward statistics
+- spend reason enum and sized cipher
+- *(metrics)* expose store cost value
+- keep track of the estimated network size metric
+- record lip2p relay and dctur metrics
+- *(node)* periodically forward reward to specific address
+- use default keys for genesis, or override
+- use different key for payment forward
+- hide genesis keypair
+- tracking beta rewards from the DAG
+
+### Fixed
+- *(uploader)* do not error out immediately on max repayment errors
+- *(node)* notify fetch completion earlier to avoid being skipped
+- avoid adding mixed type addresses into RT
+- enable libp2p metrics to be captured
+- correct genesis_pk naming
+- genesis_cn public fields generated from hard coded value
+- invalid spend reason in data payments
+
+### Other
+- *(uploader)* return summary when upload fails due to max repayments
+- *(uploader)* return the list of max repayment reached items
+- improve cli DAG collection
+- remove now unused mostly duplicated code
+- improve DAG verification redundancy
+- *(faucet)* devskim ignore
+- *(faucet)* log existing faucet balance if non-zero
+- *(faucet)* add foundation PK as const
+- *(faucet)* clarify logs for verification
+- increase initial faucet balance
+- add temp log
+- *(faucet)* refresh cashnotes on fund
+- devSkim ignore foundation pub temp key
+- update got 'gifting-from-genesis' faucet feat
+- make open metrics feature default but without starting it by default
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "feat(cli): track spend creation reasons during audit"
+- Revert "chore: refactor CASH_NOTE_REASON strings to consts"
+- Revert "feat(client): dump spends creation_reason statistics"
+- Revert "chore: address review comments"
+- *(node)* tuning the pricing curve
+- *(node)* remove un-necessary is_relayed check inside add_potential_candidates
+- move historic_quoting_metrics out of the record_store dir
+- clippy fixes for open metrics feature
+- *(networking)* update tests for pricing curve tweaks
+- *(refactor)* stabilise node size to 4k records,
+- Revert "chore: rename output reason to purpose for clarity"
+- *(transfers)* comment and naming updates for clarity
+- log genesis PK
+- rename improperly named foundation_key
+- reconfigure local network owner args
+- use const for default user or owner
+- resolve errors after reverts
+- Revert "feat: spend shows the purposes of outputs created for"
+- *(node)* use proper SpendReason enum
+- add consts
+
 ## [0.106.2](https://github.com/maidsafe/safe_network/compare/sn_client-v0.106.1...sn_client-v0.106.2) - 2024-05-09
 
 ### Fixed

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.106.2"
+version = "0.106.3"
 
 [features]
 default = []
@@ -41,11 +41,11 @@ rayon = "1.8.0"
 rmp-serde = "1.1.1"
 self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
-sn_networking = { path = "../sn_networking", version = "0.15.2" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6" }
+sn_networking = { path = "../sn_networking", version = "0.15.3" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
 serde_json = "1.0"
 sn_registers = { path = "../sn_registers", version = "0.3.13" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 tempfile = "3.6.0"
 thiserror = "1.0.23"
 tiny-keccak = "~2.0.2"
@@ -68,7 +68,7 @@ dirs-next = "~2.0.0"
 # add rand to libp2p
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 sn_client = { path = "../sn_client", features = ["test-utils"] }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
 sn_registers = { path = "../sn_registers", version = "0.3.13", features = [
     "test-utils",
 ] }

--- a/sn_faucet/CHANGELOG.md
+++ b/sn_faucet/CHANGELOG.md
@@ -6,6 +6,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.19](https://github.com/joshuef/safe_network/compare/sn_faucet-v0.4.18...sn_faucet-v0.4.19) - 2024-05-24
+
+### Added
+- *(faucet)* allow gifting by default
+- *(faucet)* increase initial balance
+- *(faucet)* make gifting server feat dependent
+- *(faucet)* send small amount to faucet, rest to foundation
+- *(faucet)* add feat for gifting-from-genesis
+- faucet donate endpoint to feed the faucet
+- *(faucet)* fully limit any concurrency
+- *(faucet)* log from sn_client
+- report protocol mismatch error
+
+### Fixed
+- *(faucet)* cleanup unused vars
+- *(faucet)* rate limit before getting wallet
+- *(faucet)* ensure faucet is funded in main fn
+- update calls to HotWallet::load
+- *(faucet)* fix distribution 'from' wallet loading
+- *(client)* move acct_packet mnemonic into client layer
+
+### Other
+- enable default features during faucet release
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs
+- addres review comments
+- *(faucet)* log initilization failure and upload faucet log
+- *(CI)* upload faucet log during CI
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+
 ## [0.4.18](https://github.com/maidsafe/safe_network/compare/sn_faucet-v0.4.17...sn_faucet-v0.4.18) - 2024-05-20
 
 ### Other

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_faucet"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.4.18"
+version = "0.4.19"
 
 [features]
 default = ["gifting"]
@@ -37,10 +37,10 @@ minreq = { version = "2.11.0", features = ["https-rustls"], optional = true }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 sn_build_info = { path = "../sn_build_info", version = "0.1.7" }
-sn_client = { path = "../sn_client", version = "0.106.2" }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
+sn_client = { path = "../sn_client", version = "0.106.3" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 tokio = { version = "1.32.0", features = ["parking_lot", "rt"] }
 tracing = { version = "~0.1.26" }
 url = "2.5.0"

--- a/sn_logging/CHANGELOG.md
+++ b/sn_logging/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.27](https://github.com/joshuef/safe_network/compare/sn_logging-v0.2.26...sn_logging-v0.2.27) - 2024-05-24
+
+### Added
+- *(nodeman)* add LogFormat as a startup arg for nodes
+
 ## [0.2.26-alpha.1](https://github.com/maidsafe/safe_network/compare/sn_logging-v0.2.26-alpha.0...sn_logging-v0.2.26-alpha.1) - 2024-05-07
 
 ### Added

--- a/sn_logging/Cargo.toml
+++ b/sn_logging/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_logging"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.2.26"
+version = "0.2.27"
 
 [dependencies]
 chrono = "~0.4.19"

--- a/sn_networking/CHANGELOG.md
+++ b/sn_networking/CHANGELOG.md
@@ -6,6 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/joshuef/safe_network/compare/sn_networking-v0.15.2...sn_networking-v0.15.3) - 2024-05-24
+
+### Added
+- *(metrics)* expose store cost value
+- keep track of the estimated network size metric
+- record lip2p relay and dctur metrics
+- *(node)* periodically forward reward to specific address
+
+### Fixed
+- avoid adding mixed type addresses into RT
+- enable libp2p metrics to be captured
+
+### Other
+- *(node)* tuning the pricing curve
+- *(node)* remove un-necessary is_relayed check inside add_potential_candidates
+- move historic_quoting_metrics out of the record_store dir
+- clippy fixes for open metrics feature
+- make open metrics feature default but without starting it by default
+- *(networking)* update tests for pricing curve tweaks
+- *(refactor)* stabilise node size to 4k records,
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "chore: rename output reason to purpose for clarity"
+
 ## [0.15.2](https://github.com/maidsafe/safe_network/compare/sn_networking-v0.15.1...sn_networking-v0.15.2) - 2024-05-09
 
 ### Fixed

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_networking"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.15.2"
+version = "0.15.3"
 
 [features]
 default = ["libp2p/quic"]
@@ -53,8 +53,8 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rayon = "1.8.0"
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 sn_registers = { path = "../sn_registers", version = "0.3.13" }
 sysinfo = { version = "0.30.8", default-features = false, optional = true }
 thiserror = "1.0.23"

--- a/sn_node/CHANGELOG.md
+++ b/sn_node/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.106.5](https://github.com/joshuef/safe_network/compare/sn_node-v0.106.4...sn_node-v0.106.5) - 2024-05-24
+
+### Added
+- use different key for payment forward
+- hide genesis keypair
+- *(node)* periodically forward reward to specific address
+- spend reason enum and sized cipher
+- *(network)* add --upnp flag to node
+- spend shows the purposes of outputs created for
+- *(node)* make spend and cash_note reason field configurable
+- *(relay)* remove autonat and enable hole punching manually
+- *(relay)* impl RelayManager to perform circuit relay when behind NAT
+- *(node)* notify peer it is now considered as BAD
+- *(networking)* shift to use ilog2 bucket distance for close data calcs
+- unit testing dag, double spend poisoning tweaks
+- report protocol mismatch error
+- *(metrics)* expose store cost value
+- keep track of the estimated network size metric
+- record lip2p relay and dctur metrics
+- use default keys for genesis, or override
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- hide genesis keypair
+- pass sk_str via cli opt
+- *(node)* use separate keys of Foundation and Royalty
+- *(wallet)* ensure genesis wallet attempts to load from local on init first
+- *(faucet)* make gifting server feat dependent
+- tracking beta rewards from the DAG
+- *(audit)* collect payment forward statistics
+
+### Fixed
+- *(node)* notify fetch completion earlier to avoid being skipped
+- create faucet via account load or generation
+- more test and cli fixes
+- update calls to HotWallet::load
+- do not add reported external addressese if we are behind home network
+- *(node)* notify replication_fetcher of early completion
+- *(node)* not send out replication when failed read from local
+- avoid adding mixed type addresses into RT
+- enable libp2p metrics to be captured
+- correct genesis_pk naming
+- genesis_cn public fields generated from hard coded value
+- invalid spend reason in data payments
+
+### Other
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- *(node)* log node owner
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- make open metrics feature default but without starting it by default
+- *(refactor)* stabilise node size to 4k records,
+- resolve errors after reverts
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "feat: spend shows the purposes of outputs created for"
+- Revert "chore: rename output reason to purpose for clarity"
+- *(node)* use proper SpendReason enum
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_registers-v0.3.13
+- *(node)* make owner optional
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs
+- cargo fmt
+- rename output reason to purpose for clarity
+- store owner info inside node instead of network
+- *(CI)* upload faucet log during CI
+- *(node)* lower some log levels to reduce log size
+- *(CI)* confirm there is no failed replication fetch
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+- *(node)* pass entire QuotingMetrics into calculate_cost_for_records
+- *(node)* tuning the pricing curve
+- *(node)* remove un-necessary is_relayed check inside add_potential_candidates
+- move historic_quoting_metrics out of the record_store dir
+- clippy fixes for open metrics feature
+- *(networking)* update tests for pricing curve tweaks
+- *(transfers)* comment and naming updates for clarity
+- log genesis PK
+- rename improperly named foundation_key
+- reconfigure local network owner args
+- use const for default user or owner
+- Revert "feat(cli): track spend creation reasons during audit"
+- Revert "chore: refactor CASH_NOTE_REASON strings to consts"
+- Revert "chore: address review comments"
+- add consts
+
 ## [0.106.4](https://github.com/maidsafe/safe_network/compare/sn_node-v0.106.3...sn_node-v0.106.4) - 2024-05-20
 
 ### Other

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Safe Node"
 name = "sn_node"
-version = "0.106.4"
+version = "0.106.5"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -53,13 +53,13 @@ self_encryption = "~0.29.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sn_build_info = { path = "../sn_build_info", version = "0.1.7" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
-sn_client = { path = "../sn_client", version = "0.106.2" }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
-sn_networking = { path = "../sn_networking", version = "0.15.2" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6" }
+sn_client = { path = "../sn_client", version = "0.106.3" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
+sn_networking = { path = "../sn_networking", version = "0.15.3" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
 sn_registers = { path = "../sn_registers", version = "0.3.13" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
-sn_service_management = { path = "../sn_service_management", version = "0.2.8" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
+sn_service_management = { path = "../sn_service_management", version = "0.3.0" }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = [
     "io-util",
@@ -86,7 +86,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }
 serde_json = "1.0"
-sn_protocol = { path = "../sn_protocol", version = "0.16.6", features = [
+sn_protocol = { path = "../sn_protocol", version = "0.16.7", features = [
     "rpc",
 ] }
 tempfile = "3.6.0"

--- a/sn_node_manager/CHANGELOG.md
+++ b/sn_node_manager/CHANGELOG.md
@@ -6,6 +6,130 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/joshuef/safe_network/compare/sn-node-manager-v0.7.7...sn-node-manager-v0.8.0) - 2024-05-24
+
+### Added
+- *(node_manager)* pass beta encryption sk to the auditor
+- *(manager)* maintain n running nodes
+- provide `local status` command
+- provide `--owner` arg for `add` cmd
+- *(nodeman)* add LogFormat as a startup arg for nodes
+- *(node_manager)* add auditor support
+- provide `--upnp` flag for `add` command
+- *(launchpad)* initial automatic resource allocation logic
+- *(audit)* collect payment forward statistics
+- run safenode services in user mode
+- provide `autonomi-launcher` binary
+- *(manager)* reuse downloaded binaries
+- *(launchpad)* remove nodes
+- *(tui)* adding services
+- *(node)* make spend and cash_note reason field configurable
+- [**breaking**] provide `--home-network` arg for `add` cmd
+- provide `--interval` arg for `upgrade` cmd
+- provide `--path` arg for `upgrade` cmd
+- rpc restart command
+- provide `reset` command
+- provide `balance` command
+- make `--peer` argument optional
+- distinguish failure to start during upgrade
+- use different key for payment forward
+- hide genesis keypair
+- *(node)* periodically forward reward to specific address
+- spend reason enum and sized cipher
+- *(network)* add --upnp flag to node
+- spend shows the purposes of outputs created for
+- *(relay)* remove autonat and enable hole punching manually
+- *(relay)* impl RelayManager to perform circuit relay when behind NAT
+- *(node)* notify peer it is now considered as BAD
+- *(networking)* shift to use ilog2 bucket distance for close data calcs
+- unit testing dag, double spend poisoning tweaks
+- report protocol mismatch error
+- use default keys for genesis, or override
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- hide genesis keypair
+- pass sk_str via cli opt
+- *(node)* use separate keys of Foundation and Royalty
+- *(wallet)* ensure genesis wallet attempts to load from local on init first
+- *(faucet)* make gifting server feat dependent
+- tracking beta rewards from the DAG
+
+### Fixed
+- avoid adding mixed type addresses into RT
+- *(manager)* download again if cached archive is corrupted
+- check node registry exists before deleting it
+- retain options on upgrade and prevent dup ports
+- *(manager)* do not print to stdout on low verbosity level
+- do not create wallet on registry refresh
+- change reward balance to optional
+- apply interval only to non-running nodes
+- do not delete custom bin on `add` cmd
+- incorrect release type reference
+- use correct release type in upgrade process
+- *(node)* notify fetch completion earlier to avoid being skipped
+- create faucet via account load or generation
+- more test and cli fixes
+- update calls to HotWallet::load
+- do not add reported external addressese if we are behind home network
+- *(node)* notify replication_fetcher of early completion
+- *(node)* not send out replication when failed read from local
+- correct genesis_pk naming
+- genesis_cn public fields generated from hard coded value
+- invalid spend reason in data payments
+
+### Other
+- update based on comment
+- enable node man integration tests
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- use owners on memcheck workflow local network
+- reconfigure local network owner args
+- *(nodemanager)* upgrade_should_retain_the_log_format_flag
+- use helper function to print banners
+- use published versions of deps
+- *(release)* node-launchpad-v0.1.3/sn-node-manager-v0.7.6
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- use const for default user or owner
+- resolve errors after reverts
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- change terminal launch behaviour
+- update cli and readme for user-mode services
+- upgrade service manager crate
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs for nodeman
+- *(versions)* sync versions with latest crates.io vs
+- use node registry for status
+- [**breaking**] output reward balance in `status --json` cmd
+- use better banners
+- properly use node registry and surface peer ids if they're not
+- `remove` cmd operates over all services
+- provide `local` subcommand
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+- *(node)* log node owner
+- make open metrics feature default but without starting it by default
+- *(refactor)* stabilise node size to 4k records,
+- Revert "feat: spend shows the purposes of outputs created for"
+- Revert "chore: rename output reason to purpose for clarity"
+- *(node)* use proper SpendReason enum
+- *(release)* sn_client-v0.106.2/sn_networking-v0.15.2/sn_cli-v0.91.2/sn_node-v0.106.2/sn_auditor-v0.1.14/sn_faucet-v0.4.16/sn_node_rpc_client-v0.6.15
+- *(release)* sn_registers-v0.3.13
+- *(node)* make owner optional
+- cargo fmt
+- rename output reason to purpose for clarity
+- store owner info inside node instead of network
+- *(CI)* upload faucet log during CI
+- *(node)* lower some log levels to reduce log size
+- *(CI)* confirm there is no failed replication fetch
+- *(node)* pass entire QuotingMetrics into calculate_cost_for_records
+- *(transfers)* comment and naming updates for clarity
+- log genesis PK
+- rename improperly named foundation_key
+- Revert "feat(cli): track spend creation reasons during audit"
+- Revert "chore: refactor CASH_NOTE_REASON strings to consts"
+- Revert "chore: address review comments"
+- add consts
+
 ## [0.7.7](https://github.com/maidsafe/safe_network/compare/sn-node-manager-v0.7.6...sn-node-manager-v0.7.7) - 2024-05-20
 
 ### Added

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "sn-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.7.7"
+version = "0.8.0"
 
 [[bin]]
 name = "safenode-manager"
@@ -41,12 +41,12 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.6.1"
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.5" }
-sn_service_management = { path = "../sn_service_management", version = "0.2.8" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
+sn_service_management = { path = "../sn_service_management", version = "0.3.0" }
 sn-releases = "~0.2.2"
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 sysinfo = "0.30.12"
 tokio = { version = "1.26", features = ["full"] }
 tracing = { version = "~0.1.26" }

--- a/sn_node_rpc_client/CHANGELOG.md
+++ b/sn_node_rpc_client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.18](https://github.com/joshuef/safe_network/compare/sn_node_rpc_client-v0.6.17...sn_node_rpc_client-v0.6.18) - 2024-05-24
+
+### Other
+- updated the following local packages: sn_client, sn_transfers, sn_logging, sn_node, sn_service_management
+
 ## [0.6.17](https://github.com/maidsafe/safe_network/compare/sn_node_rpc_client-v0.6.16...sn_node_rpc_client-v0.6.17) - 2024-05-20
 
 ### Other

--- a/sn_node_rpc_client/Cargo.toml
+++ b/sn_node_rpc_client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_node_rpc_client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.6.17"
+version = "0.6.18"
 
 [[bin]]
 name = "safenode_rpc_client"
@@ -23,13 +23,13 @@ color-eyre = "0.6.2"
 hex = "~0.4.3"
 libp2p = { version="0.53", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
-sn_client = { path = "../sn_client", version = "0.106.2" }
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
-sn_node = { path = "../sn_node", version = "0.106.4" }
+sn_client = { path = "../sn_client", version = "0.106.3" }
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
+sn_node = { path = "../sn_node", version = "0.106.5" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.2.12" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6", features=["rpc"] }
-sn_service_management = { path = "../sn_service_management", version = "0.2.8" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7", features=["rpc"] }
+sn_service_management = { path = "../sn_service_management", version = "0.3.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems
 # # arm builds + musl are very problematic

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "~1.4.0"
 libp2p = { version="0.53", features = [] }
 rand = "0.8.5"
 reqwest = { version="0.12.2", default-features=false, features = ["rustls-tls"], optional = true }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7" }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", optional = true, default-features = false}
 tracing = { version = "~0.1.26" }

--- a/sn_protocol/CHANGELOG.md
+++ b/sn_protocol/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.7](https://github.com/joshuef/safe_network/compare/sn_protocol-v0.16.6...sn_protocol-v0.16.7) - 2024-05-24
+
+### Other
+- updated the following local packages: sn_transfers
+
 ## [0.16.6](https://github.com/maidsafe/safe_network/compare/sn_protocol-v0.16.5...sn_protocol-v0.16.6) - 2024-05-08
 
 ### Other

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "sn_protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.16.6"
+version = "0.16.7"
 
 [features]
 default = []
@@ -29,7 +29,7 @@ serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 serde_json = "1.0"
 sha2 = "0.10.7"
 sn_build_info = { path="../sn_build_info", version = "0.1.7" }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 sn_registers = { path = "../sn_registers", version = "0.3.13" }
 thiserror = "1.0.23"
 tiny-keccak = { version = "~2.0.2", features = [ "sha3" ] }

--- a/sn_service_management/CHANGELOG.md
+++ b/sn_service_management/CHANGELOG.md
@@ -6,6 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshuef/safe_network/compare/sn_service_management-v0.2.8...sn_service_management-v0.3.0) - 2024-05-24
+
+### Added
+- provide `--owner` arg for `add` cmd
+- *(nodeman)* add LogFormat as a startup arg for nodes
+- *(node_manager)* add auditor support
+- provide `--upnp` flag for `add` command
+- run safenode services in user mode
+- [**breaking**] provide `--home-network` arg for `add` cmd
+- distinguish failure to start during upgrade
+
+### Fixed
+- retain options on upgrade and prevent dup ports
+- change reward balance to optional
+- apply interval only to non-running nodes
+
+### Other
+- *(release)* sn_auditor-v0.1.16/sn_cli-v0.91.4/sn_faucet-v0.4.18/sn_metrics-v0.1.7/sn_node-v0.106.4/sn_service_management-v0.2.8/node-launchpad-v0.1.5/sn-node-manager-v0.7.7/sn_node_rpc_client-v0.6.17
+- *(release)* sn_auditor-v0.1.15/sn_cli-v0.91.3/sn_faucet-v0.4.17/sn_metrics-v0.1.6/sn_node-v0.106.3/sn_service_management-v0.2.7/node-launchpad-v0.1.2/sn_node_rpc_client-v0.6.16
+- upgrade service manager crate
+- *(release)* sn_auditor-v0.1.13/sn_client-v0.106.1/sn_networking-v0.15.1/sn_protocol-v0.16.6/sn_cli-v0.91.1/sn_faucet-v0.4.15/sn_node-v0.106.1/node-launchpad-v0.1.1/sn_node_rpc_client-v0.6.14/sn_peers_acquisition-v0.2.12/sn_service_management-v0.2.6
+- *(release)* sn_auditor-v0.1.12/sn_client-v0.106.0/sn_networking-v0.15.0/sn_transfers-v0.18.0/sn_peers_acquisition-v0.2.11/sn_logging-v0.2.26/sn_cli-v0.91.0/sn_faucet-v0.4.14/sn_metrics-v0.1.5/sn_node-v0.106.0/sn_service_management-v0.2.5/test_utils-v0.4.1/node-launchpad-v/sn-node-manager-v0.7.5/sn_node_rpc_client-v0.6.13/token_supplies-v0.1.48/sn_protocol-v0.16.5
+- *(versions)* sync versions with latest crates.io vs
+- use node registry for status
+- [**breaking**] output reward balance in `status --json` cmd
+- *(release)* sn_auditor-v0.1.7/sn_client-v0.105.3/sn_networking-v0.14.4/sn_protocol-v0.16.3/sn_build_info-v0.1.7/sn_transfers-v0.17.2/sn_peers_acquisition-v0.2.10/sn_cli-v0.90.4/sn_faucet-v0.4.9/sn_metrics-v0.1.4/sn_node-v0.105.6/sn_service_management-v0.2.4/sn-node-manager-v0.7.4/sn_node_rpc_client-v0.6.8/token_supplies-v0.1.47
+- *(deps)* bump dependencies
+
 ## [0.2.8](https://github.com/maidsafe/safe_network/compare/sn_service_management-v0.2.7...sn_service_management-v0.2.8) - 2024-05-20
 
 ### Added

--- a/sn_service_management/Cargo.toml
+++ b/sn_service_management/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "sn_service_management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.2.8"
+version = "0.3.0"
 
 [dependencies]
 async-trait = "0.1"
@@ -19,11 +19,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0.20"
 service-manager = "0.6.1"
-sn_logging = { path = "../sn_logging", version = "0.2.26" }
-sn_protocol = { path = "../sn_protocol", version = "0.16.6", features = [
+sn_logging = { path = "../sn_logging", version = "0.2.27" }
+sn_protocol = { path = "../sn_protocol", version = "0.16.7", features = [
     "rpc",
 ] }
-sn_transfers = { path = "../sn_transfers", version = "0.18.0" }
+sn_transfers = { path = "../sn_transfers", version = "0.18.1" }
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["time"] }

--- a/sn_transfers/CHANGELOG.md
+++ b/sn_transfers/CHANGELOG.md
@@ -6,6 +6,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1](https://github.com/joshuef/safe_network/compare/sn_transfers-v0.18.0...sn_transfers-v0.18.1) - 2024-05-24
+
+### Added
+- use default keys for genesis, or override
+- use different key for payment forward
+- remove two uneeded env vars
+- pass genesis_cn pub fields separate to hide sk
+- hide genesis keypair
+- hide genesis keypair
+- pass sk_str via cli opt
+- *(node)* use separate keys of Foundation and Royalty
+- *(wallet)* ensure genesis wallet attempts to load from local on init first
+- *(faucet)* make gifting server feat dependent
+- tracking beta rewards from the DAG
+- *(audit)* collect payment forward statistics
+- *(node)* periodically forward reward to specific address
+- spend reason enum and sized cipher
+
+### Fixed
+- correct genesis_pk naming
+- genesis_cn public fields generated from hard coded value
+- invalid spend reason in data payments
+
+### Other
+- *(transfers)* comment and naming updates for clarity
+- log genesis PK
+- rename improperly named foundation_key
+- reconfigure local network owner args
+- *(refactor)* stabilise node size to 4k records,
+- use const for default user or owner
+- resolve errors after reverts
+- Revert "feat(node): make spend and cash_note reason field configurable"
+- Revert "feat: spend shows the purposes of outputs created for"
+- Revert "chore: rename output reason to purpose for clarity"
+- Revert "feat(cli): track spend creation reasons during audit"
+- Revert "chore: refactor CASH_NOTE_REASON strings to consts"
+- Revert "chore: address review comments"
+- *(node)* use proper SpendReason enum
+- add consts
+
 ## [0.18.0-alpha.1](https://github.com/maidsafe/safe_network/compare/sn_transfers-v0.18.0-alpha.0...sn_transfers-v0.18.0-alpha.1) - 2024-05-07
 
 ### Added

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_transfers"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.18.0"
+version = "0.18.1"
 
 [features]
 reward-forward = []


### PR DESCRIPTION
…0.15.3/sn_transfers-v0.18.1/sn_logging-v0.2.27/sn_cli-v0.92.0/sn_faucet-v0.4.19/sn_node-v0.106.5/sn_service_management-v0.3.0/node-launchpad-v0.2.0/sn-node-manager-v0.8.0/sn_protocol-v0.16.7/sn_node_rpc_client-v0.6.18
