### PR TITLE
chore(cli): showing cli final execution result explicitly

### DIFF
--- a/sn_cli/src/bin/main.rs
+++ b/sn_cli/src/bin/main.rs
@@ -140,23 +140,27 @@ async fn main() -> Result<()> {
     // default to verifying storage
     let should_verify_store = !opt.no_verify;
 
-    match opt.cmd {
+    // PowerShell seems having issue to showing the unwrapped error
+    // Hence capture the result and print it out explicity.
+    let cmd_str = format!("{:?}", opt.cmd);
+    let result = match opt.cmd {
         SubCmd::Wallet(cmds) => {
-            wallet_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+            wallet_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await
         }
         SubCmd::WatchOnlyWallet(cmds) => {
-            wo_wallet_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+            wo_wallet_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await
         }
         SubCmd::Files(cmds) => {
-            files_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+            files_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await
         }
         SubCmd::Folders(cmds) => {
-            folders_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+            folders_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await
         }
         SubCmd::Register(cmds) => {
-            register_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await?
+            register_cmds(cmds, &client, &client_data_dir_path, should_verify_store).await
         }
     };
+    println!("Completed with {result:?} of execute {cmd_str:?}");
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Showing the cli final execution result, to address the issue raised at https://forum.autonomi.community/t/thisisnotbetarewardsnet-mini-testnet-26-05-24/39824/140
that when receive a transfer, showing no error in terminal nor log, but no balance credited.

Note: there is printout of `Verifying transfer with the Network...`, but no printout of `Successfully verified transfer.`, 
which indicates a failure during `transfer verification` terminated flow.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Documentation update

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
