### PR TITLE
WIP Reward tracking tryout

### DIFF
--- a/sn_auditor/src/main.rs
+++ b/sn_auditor/src/main.rs
@@ -27,7 +27,7 @@ use tiny_http::{Response, Server};
 const DAG_DUMPING_INTERVAL_SECS: u64 = 5 * 60;
 
 /// Backup the beta rewards in a timestamped json file
-const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 3 * 60 * 60;
+const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 3 * 60;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -235,7 +235,7 @@ async fn initialize_background_spend_dag_collection(
     let d = dag.clone();
     tokio::spawn(async move {
         loop {
-            println!("Duming DAG...");
+            println!("Dumping DAG...");
             let _ = d
                 .dump()
                 .map_err(|e| eprintln!("Could not dump DAG to disk: {e}"));

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -12,7 +12,7 @@ lazy_static! {
     /// The node version used during Identify Behaviour.
     pub static ref IDENTIFY_NODE_VERSION_STR: String =
         format!(
-            "safe{}/node/{}",
+            "safe{}/alpha-reward-test/node/{}",
             write_network_version_with_slash(),
             get_truncate_version_str()
         );
@@ -20,7 +20,7 @@ lazy_static! {
     /// The client version used during Identify Behaviour.
     pub static ref IDENTIFY_CLIENT_VERSION_STR: String =
         format!(
-            "safe{}/client/{}",
+            "safe{}/alpha-reward-test/client/{}",
             write_network_version_with_slash(),
             get_truncate_version_str()
         );
@@ -28,7 +28,7 @@ lazy_static! {
     /// / first version for the req/response protocol
     pub static ref REQ_RESPONSE_VERSION_STR: String =
         format!(
-            "/safe{}/node/{}",
+            "/safe{}/alpha-reward-test/node/{}",
             write_network_version_with_slash(),
             get_truncate_version_str()
         );
@@ -37,7 +37,7 @@ lazy_static! {
     /// The identify protocol version
     pub static ref IDENTIFY_PROTOCOL_STR: String =
         format!(
-            "safe{}/{}",
+            "safe{}/alpha-reward-test/{}",
             write_network_version_with_slash(),
             get_truncate_version_str()
         );


### PR DESCRIPTION
This pull request includes significant changes to the `sn_auditor` and `sn_protocol` packages, particularly in the `dag_db.rs` and `main.rs` files of `sn_auditor`, and the `version.rs` file of `sn_protocol`. The changes primarily involve the refactoring and removal of methods related to the SpendDagDb struct, the addition of new methods for DAG crawling and beta rewards backup, and the modification of version strings in the `sn_protocol` package.

### Changes to SpendDagDb struct methods in `sn_auditor/src/dag_db.rs`:

* Removed the `update` method which updated the DAG from the network.
* Removed the `gather_forwarded_payments` method which gathered forwarded payments from the DAG.
* Added the `backup_rewards` method to back up beta rewards to a timestamped JSON file.
* Added the `dag_crawling_from_genesis` method to crawl the DAG from the genesis.

### Changes to `sn_auditor/src/main.rs`:

* Removed the `DAG_UPDATE_INTERVAL_SECS` constant and added the `DAG_DUMPING_INTERVAL_SECS` constant.
* Reduced the interval for backing up beta rewards from 3 hours to 3 minutes.
* Modified the `initialize_background_spend_dag_collection` function to call the new `dag_crawling_from_genesis` method instead of the removed `update` method. [[1]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L204-R212) [[2]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L244-R243)

### Changes to `sn_protocol/src/version.rs`:

* Modified the version strings for `IDENTIFY_NODE_VERSION_STR`, `IDENTIFY_CLIENT_VERSION_STR`, `REQ_RESPONSE_VERSION_STR`, and `IDENTIFY_PROTOCOL_STR` to include `alpha-reward-test`. [[1]](diffhunk://#diff-2f8c5a9c6dea3e1d90db59d2963a2ea238a3616730b5a471486c003cbd7235cdL15-R31) [[2]](diffhunk://#diff-2f8c5a9c6dea3e1d90db59d2963a2ea238a3616730b5a471486c003cbd7235cdL40-R40)

### Other changes:

* Modified the `use color_eyre::eyre::{bail, eyre, Result};` and `use std::time::{SystemTime, UNIX_EPOCH};` import statements in `sn_auditor/src/dag_db.rs`. [[1]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L17-R19) [[2]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48R28)
* Changed the visibility of `beta_participants` in the `SpendDagDb` struct and added the `REATTEMPT_INTERVAL` constant.
* Removed several lines of code in the `impl SpendDagDb` block in `sn_auditor/src/dag_db.rs`. [[1]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L183-L232) [[2]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L305-R416)
* Removed some lines of code in the `async fn main() -> Result<()> {` block in `sn_auditor/src/main.rs`.