### PR TITLE
chore(auditor): refactor spends fetch to be background progressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6979,6 +6979,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "tracing",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,7 +3390,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3649,6 +3649,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -6960,6 +6969,7 @@ dependencies = [
  "color-eyre",
  "dirs-next",
  "graphviz-rust",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "sn_client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6968,6 +6968,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "dirs-next",
+ "futures",
  "graphviz-rust",
  "itertools 0.13.0",
  "serde",

--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -43,3 +43,4 @@ tokio = { version = "1.32.0", features = [
     "fs",
 ] }
 itertools = "0.13.0"
+futures = "0.3.30"

--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -42,3 +42,4 @@ tokio = { version = "1.32.0", features = [
     "time",
     "fs",
 ] }
+itertools = "0.13.0"

--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -44,3 +44,4 @@ tokio = { version = "1.32.0", features = [
 ] }
 itertools = "0.13.0"
 futures = "0.3.30"
+urlencoding = "2.1.3"

--- a/sn_auditor/src/dag_db.rs
+++ b/sn_auditor/src/dag_db.rs
@@ -218,7 +218,7 @@ impl SpendDagDb {
     }
 
     /// Track new beta participants. This just add the participants to the list of tracked participants.
-    pub(crate) fn track_new_beta_participants(&self, participants: Vec<String>) -> Result<()> {
+    pub(crate) fn track_new_beta_participants(&self, participants: BTreeSet<String>) -> Result<()> {
         // track new participants
         {
             let mut beta_participants = self
@@ -248,13 +248,20 @@ impl SpendDagDb {
             .beta_participants
             .read()
             .map_err(|e| eyre!("Failed to get beta participants read lock: {e}"))?;
+
+        debug!("Existing beta participants: {beta_participants:?}");
+
+        debug!(
+            "Adding new beta participants: {discord_id}, {:?}",
+            Hash::hash(discord_id.as_bytes())
+        );
         Ok(beta_participants.contains_key(&Hash::hash(discord_id.as_bytes())))
     }
 
     /// Initialize reward forward tracking, gathers current rewards from the DAG
     pub(crate) async fn init_reward_forward_tracking(
         &self,
-        participants: Vec<String>,
+        participants: BTreeSet<String>,
     ) -> Result<()> {
         self.track_new_beta_participants(participants)?;
         Ok(())

--- a/sn_auditor/src/main.rs
+++ b/sn_auditor/src/main.rs
@@ -27,7 +27,7 @@ use tiny_http::{Response, Server};
 const DAG_DUMPING_INTERVAL_SECS: u64 = 5 * 60;
 
 /// Backup the beta rewards in a timestamped json file
-const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 3 * 60 * 60;
+const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 3 * 60;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -235,7 +235,7 @@ async fn initialize_background_spend_dag_collection(
     let d = dag.clone();
     tokio::spawn(async move {
         loop {
-            println!("Duming DAG...");
+            println!("Dumping DAG...");
             let _ = d
                 .dump()
                 .map_err(|e| eprintln!("Could not dump DAG to disk: {e}"));

--- a/sn_auditor/src/main.rs
+++ b/sn_auditor/src/main.rs
@@ -29,7 +29,7 @@ use tiny_http::{Response, Server};
 const DAG_DUMPING_INTERVAL_SECS: u64 = 5 * 60;
 
 /// Backup the beta rewards in a timestamped json file
-const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 3 * 60;
+const BETA_REWARDS_BACKOUP_INTERVAL_SECS: u64 = 20 * 60;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/sn_auditor/src/routes.rs
+++ b/sn_auditor/src/routes.rs
@@ -10,6 +10,7 @@ use crate::dag_db::{self, SpendDagDb};
 use color_eyre::eyre::{eyre, Result};
 use sn_client::transfers::SpendAddress;
 use std::{
+    collections::BTreeSet,
     fs::{File, OpenOptions},
     io::{Cursor, Write},
     str::FromStr,
@@ -105,7 +106,9 @@ pub(crate) fn add_participant(
 }
 
 fn track_new_participant(dag: &SpendDagDb, discord_id: String) -> Result<()> {
-    dag.track_new_beta_participants(vec![discord_id.to_owned()])?;
+    let mut participants = BTreeSet::new();
+    participants.insert(discord_id.clone());
+    dag.track_new_beta_participants(participants)?;
 
     // only append new ids
     if dag.is_participant_tracked(&discord_id)? {

--- a/sn_auditor/src/routes.rs
+++ b/sn_auditor/src/routes.rs
@@ -78,7 +78,12 @@ pub(crate) fn add_participant(
     request: &Request,
 ) -> Result<Response<Cursor<Vec<u8>>>> {
     let discord_id = match request.url().split('/').last() {
-        Some(discord_id) => discord_id,
+        Some(discord_id) => {
+            // TODO: When we simply accept POST we can remove this decoding
+            // For now we need it to decode #fragments in urls
+            let discord_id = urlencoding::decode(discord_id)?;
+            discord_id.to_string()
+        }
         None => {
             return Ok(Response::from_string(
                 "No discord_id provided. Should be /add-participant/[your_discord_id_here]",

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -944,17 +944,23 @@ impl Client {
 
     /// This is a similar funcation to `get_spend_from_network` to get a spend from network.
     /// Just using different `RetryStrategy` to improve the performance during crawling.
-    pub async fn crawl_spend_from_network(&self, address: SpendAddress) -> Result<SignedSpend> {
-        self.try_fetch_spend_from_network(
-            address,
-            GetRecordCfg {
-                get_quorum: Quorum::Majority,
-                retry_strategy: None,
-                target_record: None,
-                expected_holders: Default::default(),
-            },
-        )
-        .await
+    pub async fn crawl_spend_from_network(
+        &self,
+        address: SpendAddress,
+    ) -> (SpendAddress, Result<SignedSpend>) {
+        let result = self
+            .try_fetch_spend_from_network(
+                address,
+                GetRecordCfg {
+                    get_quorum: Quorum::Majority,
+                    retry_strategy: None,
+                    target_record: None,
+                    expected_holders: Default::default(),
+                },
+            )
+            .await;
+
+        (address, result)
     }
 
     async fn try_fetch_spend_from_network(

--- a/sn_client/src/audit/spend_dag_building.rs
+++ b/sn_client/src/audit/spend_dag_building.rs
@@ -84,7 +84,7 @@ impl Client {
             );
 
             // insert spends in the dag as they are collected
-            while let Some((res, addr)) = stream.next().await {
+            while let Some(((_addr, res), addr)) = stream.next().await {
                 match res {
                     Ok(spend) => {
                         info!("Fetched spend {addr:?} from network.");
@@ -191,7 +191,7 @@ impl Client {
                 let spends = join_all(tasks).await
                     .into_iter()
                     .zip(addrs_to_verify.clone())
-                    .map(|(maybe_spend, a)|
+                    .map(|((_address, maybe_spend), a)|
                         maybe_spend.map_err(|err| WalletError::CouldNotVerifyTransfer(format!("at depth {depth} - Failed to get spend {a:?} from network for parent Tx {parent_tx_hash:?}: {err}"))))
                     .collect::<WalletResult<BTreeSet<_>>>()?;
                 debug!(

--- a/sn_networking/src/version.rs
+++ b/sn_networking/src/version.rs
@@ -80,7 +80,7 @@ fn get_truncate_version_str() -> String {
     let version_str = env!("CARGO_PKG_VERSION");
     let parts = version_str.split('.').collect::<Vec<_>>();
     if parts.len() >= 2 {
-        format!("{}.{}", parts[0], parts[1])
+        format!("{}.{}", parts[0], "16")
     } else {
         panic!("Cannot obtain truncated version str for {version_str:?}: {parts:?}");
     }


### PR DESCRIPTION
This pull request mainly focuses on improving the `sn_auditor` package, particularly the `dag_db.rs` and `main.rs` files. The changes involve adding new libraries, modifying existing methods, and introducing new methods for better DAG collection and handling. The changes are aimed at enhancing the functionality of the `SpendDagDb` struct and improving the overall performance of the software.

The most important changes include:

* Addition of new libraries and modification of existing imports:
  * `tokio = { version = "1.32.0", features = [` in file `sn_auditor/Cargo.toml`: Added `itertools = "0.13.0"` and `futures = "0.3.30"` libraries.
  * `use bls::SecretKey;` in file `sn_auditor/src/dag_db.rs`: Added `use futures::future::join_all;` and modified the `use sn_client::transfers::` import.
  * `use std::time::{SystemTime, UNIX_EPOCH};` in file `sn_auditor/src/dag_db.rs`: Added `use std::time::{Duration, Instant};`.

* Changes to the `SpendDagDb` struct in `sn_auditor/src/dag_db.rs`:
  * Modified the access modifier of `beta_participants` from `pub(crate)` to private and added the `REATTEMPT_INTERVAL` constant.
  * Removed the `update` method and modified the `track_new_beta_participants` and `init_reward_forward_tracking` methods to use `BTreeSet<String>` instead of `Vec<String>`. [[1]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L183-L232) [[2]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48L266-R222) [[3]](diffhunk://#diff-fc4319f01fee1895543b912d85d9455555b052ecc12a54539497148590b3dc48R252-R438)
  * Introduced new methods `backup_rewards`, `dag_crawling_from_genesis`, and `process_spend`.

* Changes to `sn_auditor/src/main.rs`:
  * Modified the `initialize_background_spend_dag_collection` function to use `BTreeSet<String>` instead of `Vec<String>` for `beta_participants` and adjusted the logic for updating the DAG. [[1]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828R19-R32) [[2]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L190-R190) [[3]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L204-R214) [[4]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L244-R245)
  * Adjusted the `load_and_update_beta_participants` function to use `BTreeSet<String>` instead of `Vec<String>`. [[1]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L314-R317) [[2]](diffhunk://#diff-41fbce10df15210e82c92ee34bc0329d4eacabd75c03a2bd9f2cf59b3a208828L348-R339)

* Changes to `sn_auditor/src/routes.rs` and `sn_client/src/api.rs`:
  * Modified the `add_participant` function in `sn_auditor/src/routes.rs` to use `BTreeSet<String>` instead of `Vec<String>`.
  * Adjusted the `crawl_spend_from_network` function in `sn_client/src/api.rs` to return a tuple containing `SpendAddress` and `Result<SignedSpend>`. [[1]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L947-R952) [[2]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L957-R963)