### PR TITLE
tui tweaks

### DIFF
--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -67,7 +67,6 @@ impl App {
             tick_rate,
             frame_rate,
             components: vec![
-                Box::new(tab),
                 Box::new(footer),
                 Box::new(home),
                 Box::new(discord_username_input),

--- a/node-launchpad/src/components/home.rs
+++ b/node-launchpad/src/components/home.rs
@@ -258,7 +258,6 @@ impl Component for Home {
             Direction::Vertical,
             [
                 Constraint::Max(1),
-                Constraint::Min(5),
                 Constraint::Min(3),
                 // footer
                 Constraint::Max(3),
@@ -266,17 +265,6 @@ impl Component for Home {
         )
         .split(area);
         let popup_area = centered_rect_fixed(25, 3, area);
-
-        // top section
-        //
-        f.render_widget(
-            Paragraph::new("").block(
-                Block::default()
-                    .title("Autonomi Node Status")
-                    .borders(Borders::ALL),
-            ),
-            layer_zero[1],
-        );
 
         // Node List
         let rows: Vec<_> = self
@@ -323,7 +311,7 @@ impl Component for Home {
             )
             .highlight_symbol(">");
 
-        f.render_stateful_widget(table, layer_zero[2], &mut self.node_table_state);
+        f.render_stateful_widget(table, layer_zero[1], &mut self.node_table_state);
 
         // popup
         if self.lock_registry {


### PR DESCRIPTION
This pull request primarily focuses on the modification of the application structure and the `Home` component in the `node-launchpad` project. The changes include the commenting out of a component in the application structure, adjustments to the layout constraints in the `Home` component, removal of a section in the `Home` component, and a change in the rendering order of the `Home` component.

Application Structure Modification:
* [`node-launchpad/src/app.rs`](diffhunk://#diff-9f8096fe1600486aa665a9f47e883f3c90d9a5a8ff147b026c757d9cbca765cfL70-R70): The `tab` component was commented out from the application structure. This change suggests that the `tab` component is temporarily not being used in the application.

Changes to `Home` Component:
* [`node-launchpad/src/components/home.rs`](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63L261): Adjusted the layout constraints by removing a `Constraint::Min(5)` and retaining `Constraint::Min(3)`. This change could affect the minimum size of the `Home` component.
* [`node-launchpad/src/components/home.rs`](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63L270-L280): Removed a section titled "Autonomi Node Status" from the `Home` component. This simplifies the UI by removing unnecessary information.
* [`node-launchpad/src/components/home.rs`](diffhunk://#diff-221bc3aa9c1070fa3856dbfabb6e42b296974a55dbca2f63e2ce5b721ae2fc63L326-R314): Changed the rendering order of the stateful widget `table` in the `Home` component. This could affect the visual order of elements in the UI.