### PR TITLE
Improved DAG collection reliability

### DIFF
--- a/sn_auditor/src/dag_db.rs
+++ b/sn_auditor/src/dag_db.rs
@@ -389,8 +389,7 @@ pub async fn new_dag_with_genesis_only(client: &Client) -> Result<SpendDag> {
     let mut dag = SpendDag::new(genesis_addr);
     let genesis_spend = match client.get_spend_from_network(genesis_addr).await {
         Ok(s) => s,
-        Err(ClientError::Network(NetworkError::DoubleSpendAttempt(spend1, spend2)))
-        | Err(ClientError::DoubleSpend(_, spend1, spend2)) => {
+        Err(ClientError::Network(NetworkError::DoubleSpendAttempt(spend1, spend2))) => {
             let addr = spend1.address();
             println!("Double spend detected at Genesis: {addr:?}");
             dag.insert(genesis_addr, *spend2);

--- a/sn_client/src/error.rs
+++ b/sn_client/src/error.rs
@@ -13,7 +13,6 @@ use crate::UploadSummary;
 use super::ClientEvent;
 use sn_protocol::NetworkAddress;
 use sn_registers::{Entry, EntryHash};
-use sn_transfers::{SignedSpend, SpendAddress};
 use std::collections::BTreeSet;
 use thiserror::Error;
 use tokio::time::Duration;
@@ -68,8 +67,6 @@ pub enum Error {
     /// A general error when verifying a transfer validity in the network.
     #[error("Failed to verify transfer validity in the network {0}")]
     CouldNotVerifyTransfer(String),
-    #[error("Double spend detected at address: {0:?}")]
-    DoubleSpend(SpendAddress, Box<SignedSpend>, Box<SignedSpend>),
     #[error("Invalid DAG")]
     InvalidDag,
     #[error("Serialization error: {0:?}")]


### PR DESCRIPTION
Improved DAG collection reliability:
- better and clearer handling of errors in DAG collection
- DAG collection continues on double spend (used to stop if double spend wasn't the first spend collected)