### PR TITLE
ci: allow for feature branch releases via stable- naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - stable
+      - stable*
       - alpha*
       - beta*
       - rc*
@@ -51,7 +51,7 @@ jobs:
       - name: provide network versioning
         shell: bash
         run: |
-          if [[ "$GITHUB_REF_NAME" != "main" && "$GITHUB_REF_NAME" != "stable" && "$GITHUB_REF_NAME" != "alpha" && "$GITHUB_REF_NAME" != "beta" ]]; then
+          if [[ "$GITHUB_REF_NAME" != "main" && ! "$GITHUB_REF_NAME" =~ ^stable && "$GITHUB_REF_NAME" != "alpha" && "$GITHUB_REF_NAME" != "beta" ]]; then
             echo "NETWORK_VERSION_MODE=restricted" >> $GITHUB_ENV
           fi
 
@@ -140,7 +140,7 @@ jobs:
 
       # only publish if we're on the stable branch
       - name: Conditionally remove 'publish = false' from workspace in release-plz.toml on stable branch
-        if: github.ref_name == 'stable'
+        if: startsWith(github.ref_name, 'stable')
         run: |
           ls -la
           sed -i '/^\[workspace\]/,/^\[/ {/^publish = false$/d;}' ./release-plz.toml


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to adjust the workflow for different versions of the stable branch. The changes include modifying the `on:` section to trigger the workflow on all versions of the stable branch, updating the condition in the `provide network versioning` job to account for all versions of the stable branch, and adjusting the condition in the `Conditionally remove 'publish = false' from workspace in release-plz.toml on stable branch` job to run on all versions of the stable branch.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L10-R10): Modified the `on:` section to trigger the workflow on all versions of the stable branch instead of only the main stable branch.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R54): Updated the condition in the `provide network versioning` job to account for all versions of the stable branch instead of only the main stable branch.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L143-R143): Adjusted the condition in the `Conditionally remove 'publish = false' from workspace in release-plz.toml on stable branch` job to run on all versions of the stable branch instead of only the main stable branch.