### PR TITLE
feat(networking): add UPnP metrics

### DIFF
--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -84,6 +84,7 @@ impl SwarmDriver {
                         .on_successful_reservation_by_client(&relay_peer_id, &mut self.swarm);
                 }
             }
+            #[cfg(feature = "upnp")]
             SwarmEvent::Behaviour(NodeEvent::Upnp(upnp_event)) => {
                 #[cfg(feature = "open-metrics")]
                 if let Some(metrics) = &self.network_metrics {

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -84,6 +84,14 @@ impl SwarmDriver {
                         .on_successful_reservation_by_client(&relay_peer_id, &mut self.swarm);
                 }
             }
+            SwarmEvent::Behaviour(NodeEvent::Upnp(upnp_event)) => {
+                #[cfg(feature = "open-metrics")]
+                if let Some(metrics) = &self.network_metrics {
+                    metrics.record(&upnp_event);
+                }
+                event_string = "upnp_event";
+                info!(?upnp_event, "UPnP event");
+            }
 
             SwarmEvent::Behaviour(NodeEvent::RelayServer(event)) => {
                 #[cfg(feature = "open-metrics")]

--- a/sn_networking/src/metrics/mod.rs
+++ b/sn_networking/src/metrics/mod.rs
@@ -8,14 +8,14 @@
 
 use crate::target_arch::sleep;
 use libp2p::metrics::{Metrics as Libp2pMetrics, Recorder};
-use prometheus_client::{
-    metrics::{counter::Counter, family::Family, gauge::Gauge},
-    registry::Registry,
-};
+#[cfg(feature = "upnp")]
+use prometheus_client::metrics::{counter::Counter, family::Family};
+use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
 use sysinfo::{Pid, ProcessRefreshKind, System};
 use tokio::time::Duration;
 
 // Implementation to record `libp2p::upnp::Event` metrics
+#[cfg(feature = "upnp")]
 mod upnp;
 
 const UPDATE_INTERVAL: Duration = Duration::from_secs(15);

--- a/sn_networking/src/metrics/mod.rs
+++ b/sn_networking/src/metrics/mod.rs
@@ -64,7 +64,6 @@ impl NetworkMetrics {
             store_cost.clone(),
         );
 
-
         #[cfg(feature = "upnp")]
         let upnp_events = Family::default();
         #[cfg(feature = "upnp")]

--- a/sn_networking/src/metrics/mod.rs
+++ b/sn_networking/src/metrics/mod.rs
@@ -31,6 +31,7 @@ pub(crate) struct NetworkMetrics {
     pub(crate) records_stored: Gauge,
     pub(crate) estimated_network_size: Gauge,
     pub(crate) store_cost: Gauge,
+    #[cfg(feature = "upnp")]
     pub(crate) upnp_events: Family<upnp::UpnpEventLabels, Counter>,
 
     // system info
@@ -63,7 +64,10 @@ impl NetworkMetrics {
             store_cost.clone(),
         );
 
+
+        #[cfg(feature = "upnp")]
         let upnp_events = Family::default();
+        #[cfg(feature = "upnp")]
         sub_registry.register(
             "upnp_events",
             "Events emitted by the UPnP behaviour",
@@ -89,6 +93,7 @@ impl NetworkMetrics {
             records_stored,
             estimated_network_size,
             store_cost,
+            #[cfg(feature = "upnp")]
             upnp_events,
             process_memory_used_mb,
             process_cpu_usage_percentage,

--- a/sn_networking/src/metrics/upnp.rs
+++ b/sn_networking/src/metrics/upnp.rs
@@ -1,0 +1,35 @@
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct UpnpEventLabels {
+    event: EventType,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+enum EventType {
+    NewExternalAddr,
+    ExpiredExternalAddr,
+    GatewayNotFound,
+    NonRoutableGateway,
+}
+
+impl From<&libp2p::upnp::Event> for EventType {
+    fn from(event: &libp2p::upnp::Event) -> Self {
+        match event {
+            libp2p::upnp::Event::NewExternalAddr { .. } => EventType::NewExternalAddr,
+            libp2p::upnp::Event::ExpiredExternalAddr { .. } => EventType::ExpiredExternalAddr,
+            libp2p::upnp::Event::GatewayNotFound { .. } => EventType::GatewayNotFound,
+            libp2p::upnp::Event::NonRoutableGateway { .. } => EventType::NonRoutableGateway,
+        }
+    }
+}
+
+impl super::Recorder<libp2p::upnp::Event> for super::NetworkMetrics {
+    fn record(&self, event: &libp2p::upnp::Event) {
+        self.upnp_events
+            .get_or_create(&UpnpEventLabels {
+                event: event.into(),
+            })
+            .inc();
+    }
+}


### PR DESCRIPTION
This counts all the UPnP events that are emitted by libp2p.

This is similar to the `libp2p` implementation of the relay server metrics.