### PR TITLE
ci: allow release kickoff via workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Will automatically generate relases for version bumped code.
+# Can optionally be run as workflow action to generate a soft release (no publish steps, just s3 and github release)
+
 name: release
 
 # prevent concurrent version bumps + releases from running at the same time
@@ -11,6 +14,12 @@ on:
       - alpha*
       - beta*
       - rc*
+  workflow_dispatch:
+    inputs:
+      network_version_mode:
+        description: 'Set NETWORK_VERSION_MODE if desired. (This restricts the network from contacting any other network mode. If left empty, the default protocol is used)'
+        required: false
+        default: ''
 
 env:
   RELEASE_PLZ_BIN_URL: https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.43/release-plz-x86_64-unknown-linux-gnu.tar.gz
@@ -21,7 +30,8 @@ jobs:
   build:
     if: |
       github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
+      startsWith(github.event.head_commit.message, 'chore(release):') ||
+      github.event_name == 'workflow_dispatch'
     name: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -46,14 +56,11 @@ jobs:
       - shell: bash
         run: cargo install just
 
-      # Set the network versioning based on our branch
-      # main/stable branches defaults to open compatibility. Other branches will be versioned by their branch name.
+      # Set the network versioning based on our branch or workflow input
       - name: provide network versioning
         shell: bash
         run: |
-          if [[ "$GITHUB_REF_NAME" != "main" && ! "$GITHUB_REF_NAME" =~ ^stable && "$GITHUB_REF_NAME" != "alpha" && "$GITHUB_REF_NAME" != "beta" ]]; then
-            echo "NETWORK_VERSION_MODE=restricted" >> $GITHUB_ENV
-          fi
+          echo "NETWORK_VERSION_MODE=${{ github.event.inputs.network_version_mode || '' }}" >> $GITHUB_ENV
 
       - name: build release artifacts
         shell: bash
@@ -77,8 +84,9 @@ jobs:
   release:
     if: |
       github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    name: publish and release
+      startsWith(github.event.head_commit.message, 'chore(release):') ||
+      github.event_name == 'workflow_dispatch'
+    name: publish flows and release creation
     runs-on: ubuntu-latest
     needs: [build]
     env:
@@ -140,12 +148,12 @@ jobs:
 
       # only publish if we're on the stable branch
       - name: Conditionally remove 'publish = false' from workspace in release-plz.toml on stable branch
-        if: startsWith(github.ref_name, 'stable')
+        if: startsWith(github.ref_name, 'stable/') && github.event_name != 'workflow_dispatch'
         run: |
           ls -la
           sed -i '/^\[workspace\]/,/^\[/ {/^publish = false$/d;}' ./release-plz.toml
 
-      - name: publish and release
+      - name: upload to s3
         shell: bash
         run: |
           # Package versioned assets as tar.gz and zip archives, and upload them to S3.
@@ -178,6 +186,11 @@ jobs:
           just upload-release-assets-to-s3 "safenode_rpc_client"
           just upload-release-assets-to-s3 "sn_auditor"
 
+
+      - name: publish and release
+        shell: bash
+        if: github.event_name != 'workflow_dispatch'
+        run: |
           # The `release-plz` command publishes crates which had their versions bumped, and also
           # creates Github releases. The binaries are then attached to the releases in the
           # `upload-github-release-assets` target.
@@ -187,8 +200,15 @@ jobs:
           release-plz release --git-token ${{ secrets.VERSION_BUMP_COMMIT_PAT }} | \
             awk '{ if (!/^\s*in release with input/ && !/^\s{4}/) print }'
 
-          just upload-github-release-assets
+      - name: create github release assets
+        shell: bash
+        run:  just upload-github-release-assets
 
+
+      - name: upload as latest release
+        shell: bash
+        if: github.event_name != 'workflow_dispatch'
+        run: |
           # Now upload the 'latest' versions to S3. This can be done later because the node manager
           # does not depend on these existing.
           just package-release-assets "faucet" "latest"


### PR DESCRIPTION
Allows the release workflow to be kicked off manually, avoiding the version bump faff + potential issues.

If kicking off via workflow, it does not publish to cargo and does not update the latest version.

It also removes automatically setting network restriction, and moves that into the workflows dispatch