### PR TITLE
fix(transfer): mismatched key shall result in decryption error

### DIFF
--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -88,6 +88,8 @@ pub enum TransferError {
     Blsttc(#[from] bls::error::Error),
     #[error("User name decryption failed")]
     UserNameDecryptFailed,
+    #[error("Using invalid decryption key")]
+    InvalidDecryptionKey,
     #[error("User name encryption failed")]
     DiscordNameCipherTooBig,
 }


### PR DESCRIPTION
### Description

* add a check_sum pad to ensure mismatched key decryption shall trigger error, instead of a random hash
* add test to check mismatched key shall result in discord_name decryption error

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
