### PR TITLE
chore(transfer): make discord_name decryption backward compatible

### DIFF
--- a/sn_transfers/src/cashnotes/spend_reason.rs
+++ b/sn_transfers/src/cashnotes/spend_reason.rs
@@ -114,9 +114,14 @@ impl DiscordName {
         let nonce = DerivationIndex(nonce_bytes.to_owned());
 
         let mut checksum = [0; CHECK_SUM_SIZE];
-        checksum.copy_from_slice(&bytes[CONTENT_SIZE..LIMIT_SIZE]);
-        if checksum != CHECK_SUM {
-            return Err(TransferError::InvalidDecryptionKey);
+        if bytes.len() < LIMIT_SIZE {
+            // Backward compatible, which will allow invalid key generate a random hash result
+            checksum = CHECK_SUM;
+        } else {
+            checksum.copy_from_slice(&bytes[CONTENT_SIZE..LIMIT_SIZE]);
+            if checksum != CHECK_SUM {
+                return Err(TransferError::InvalidDecryptionKey);
+            }
         }
 
         Ok(Self {


### PR DESCRIPTION
### Description

Make discord_name decryption backward compatible, so that old version nodes can still be used.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
