### PR TITLE
feat: add logging to node manager and service management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6943,6 +6943,7 @@ dependencies = [
  "assert_fs",
  "assert_matches",
  "async-trait",
+ "chrono",
  "clap",
  "color-eyre",
  "colored",

--- a/node-launchpad/src/utils.rs
+++ b/node-launchpad/src/utils.rs
@@ -75,6 +75,7 @@ pub fn initialize_panic_handler() -> Result<()> {
     Ok(())
 }
 
+// todo: use sn_logging
 pub fn initialize_logging() -> Result<()> {
     let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
     let log_path = get_launchpad_data_dir_path()?.join("logs");
@@ -84,7 +85,7 @@ pub fn initialize_logging() -> Result<()> {
     std::env::set_var(
         "RUST_LOG",
         std::env::var("RUST_LOG")
-            .unwrap_or_else(|_| format!("{}=trace,debug", env!("CARGO_CRATE_NAME"))),
+            .unwrap_or_else(|_| format!("{}=trace,sn_node_manager=trace,sn_service_management=trace,sn_peers_acquisition=trace", env!("CARGO_CRATE_NAME"))),
     );
     let file_subscriber = tracing_subscriber::fmt::layer()
         .with_file(true)

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -105,10 +105,13 @@ impl TracingLayers {
         format: LogFormat,
         max_uncompressed_log_files: Option<usize>,
         max_compressed_log_files: Option<usize>,
+        print_updates_to_stdout: bool,
     ) -> Result<ReloadHandle> {
         let layer = match output_dest {
             LogOutputDest::Stdout => {
-                println!("Logging to stdout");
+                if print_updates_to_stdout {
+                    println!("Logging to stdout");
+                }
                 tracing_fmt::layer()
                     .with_ansi(false)
                     .with_target(false)
@@ -117,7 +120,9 @@ impl TracingLayers {
             }
             LogOutputDest::Path(path) => {
                 std::fs::create_dir_all(path)?;
-                println!("Logging to directory: {path:?}");
+                if print_updates_to_stdout {
+                    println!("Logging to directory: {path:?}");
+                }
 
                 // the number of normal files
                 let max_uncompressed_log_files =
@@ -153,7 +158,9 @@ impl TracingLayers {
         };
         let targets = match std::env::var("SN_LOG") {
             Ok(sn_log_val) => {
-                println!("Using SN_LOG={sn_log_val}");
+                if print_updates_to_stdout {
+                    println!("Using SN_LOG={sn_log_val}");
+                }
                 get_logging_targets(&sn_log_val)?
             }
             Err(_) => default_logging_targets,
@@ -265,6 +272,8 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
             ("safenode".to_string(), Level::TRACE),
             ("safenode_rpc_client".to_string(), Level::TRACE),
             ("safe".to_string(), Level::TRACE),
+            ("safenode_manager".to_string(), Level::TRACE),
+            ("safenodemand".to_string(), Level::TRACE),
             // libs
             ("sn_build_info".to_string(), Level::TRACE),
             ("sn_cli".to_string(), Level::TRACE),
@@ -272,10 +281,12 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
             ("sn_faucet".to_string(), Level::TRACE),
             ("sn_logging".to_string(), Level::TRACE),
             ("sn_node".to_string(), Level::TRACE),
+            ("sn_node_manager".to_string(), Level::TRACE),
             ("sn_node_rpc_client".to_string(), Level::TRACE),
             ("sn_peers_acquisition".to_string(), Level::TRACE),
             ("sn_protocol".to_string(), Level::TRACE),
             ("sn_registers".to_string(), Level::INFO),
+            ("sn_service_management".to_string(), Level::TRACE),
             ("sn_transfers".to_string(), Level::TRACE),
         ]);
     }

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -124,6 +124,8 @@ pub struct LogBuilder {
     format: LogFormat,
     max_uncompressed_log_files: Option<usize>,
     max_compressed_log_files: Option<usize>,
+    /// Setting this would print the sn_logging related updates to stdout.
+    print_updates_to_stdout: bool,
 }
 
 impl LogBuilder {
@@ -138,6 +140,7 @@ impl LogBuilder {
             format: LogFormat::Default,
             max_uncompressed_log_files: None,
             max_compressed_log_files: None,
+            print_updates_to_stdout: true,
         }
     }
 
@@ -161,6 +164,11 @@ impl LogBuilder {
         self.max_compressed_log_files = Some(files);
     }
 
+    /// Setting this to false would prevent sn_logging from printing things to stdout.
+    pub fn print_updates_to_stdout(&mut self, print: bool) {
+        self.print_updates_to_stdout = print;
+    }
+
     /// Inits node logging, returning the NonBlocking guard if present.
     /// This guard should be held for the life of the program.
     ///
@@ -174,6 +182,7 @@ impl LogBuilder {
             self.format,
             self.max_uncompressed_log_files,
             self.max_compressed_log_files,
+            self.print_updates_to_stdout,
         )?;
 
         #[cfg(feature = "otlp")]
@@ -192,7 +201,7 @@ impl LogBuilder {
             .try_init()
             .is_err()
         {
-            println!("Tried to initialize and set global default subscriber more than once");
+            eprintln!("Tried to initialize and set global default subscriber more than once");
         }
 
         Ok((reload_handle, layers.log_appender_guard))
@@ -257,7 +266,7 @@ impl LogBuilder {
         let mut layers = TracingLayers::default();
 
         let _reload_handle = layers
-            .fmt_layer(vec![], &output_dest, LogFormat::Default, None, None)
+            .fmt_layer(vec![], &output_dest, LogFormat::Default, None, None, true)
             .expect("Failed to get TracingLayers");
         layers
     }

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -266,7 +266,7 @@ impl LogBuilder {
         let mut layers = TracingLayers::default();
 
         let _reload_handle = layers
-            .fmt_layer(vec![], &output_dest, LogFormat::Default, None, None, true)
+            .fmt_layer(vec![], &output_dest, LogFormat::Default, None, None, false)
             .expect("Failed to get TracingLayers");
         layers
     }

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -30,6 +30,7 @@ tcp = []
 websockets = []
 
 [dependencies]
+chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"
 color-eyre = "~0.6"

--- a/sn_node_manager/src/cmd/daemon.rs
+++ b/sn_node_manager/src/cmd/daemon.rs
@@ -31,6 +31,7 @@ pub async fn add(
     verbosity: VerbosityLevel,
 ) -> Result<()> {
     if !is_running_as_root() {
+        error!("The daemon add command must run as the root user");
         return Err(eyre!("The add command must run as the root user"));
     }
 
@@ -40,6 +41,7 @@ pub async fn add(
 
     let service_user = "safe";
     let service_manager = ServiceController {};
+    debug!("Trying to create service user '{service_user}' for the daemon");
     service_manager.create_service_user(service_user)?;
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
@@ -59,6 +61,8 @@ pub async fn add(
         )
         .await?
     };
+
+    info!("Adding daemon service");
 
     // At the moment we don't have the option to provide a user for running the service. Since
     // `safenodemand` requires manipulation of services, the user running it must either be root or
@@ -82,6 +86,7 @@ pub async fn add(
 
 pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
     if !is_running_as_root() {
+        error!("The daemon start command must run as the root user");
         return Err(eyre!("The start command must run as the root user"));
     }
 
@@ -90,6 +95,7 @@ pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
         if verbosity != VerbosityLevel::Minimal {
             print_banner("Start Daemon Service");
         }
+        info!("Starting daemon service");
 
         let service = DaemonService::new(daemon, Box::new(ServiceController {}));
         let mut service_manager =
@@ -109,11 +115,13 @@ pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
         return Ok(());
     }
 
+    error!("The daemon service has not been added yet");
     Err(eyre!("The daemon service has not been added yet"))
 }
 
 pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
     if !is_running_as_root() {
+        error!("The daemon stop command must run as the root user");
         return Err(eyre!("The stop command must run as the root user"));
     }
 
@@ -122,6 +130,7 @@ pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
         if verbosity != VerbosityLevel::Minimal {
             print_banner("Stop Daemon Service");
         }
+        info!("Stopping daemon service");
 
         let service = DaemonService::new(daemon, Box::new(ServiceController {}));
         let mut service_manager =
@@ -133,5 +142,6 @@ pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
         return Ok(());
     }
 
+    error!("The daemon service has not been added yet");
     Err(eyre!("The daemon service has not been added yet"))
 }

--- a/sn_node_manager/src/cmd/faucet.rs
+++ b/sn_node_manager/src/cmd/faucet.rs
@@ -35,6 +35,7 @@ pub async fn add(
     verbosity: VerbosityLevel,
 ) -> Result<()> {
     if !is_running_as_root() {
+        error!("The faucet add command must run as the root user");
         return Err(eyre!("The add command must run as the root user"));
     }
 
@@ -70,6 +71,7 @@ pub async fn add(
         .await?
     };
 
+    info!("Adding faucet service");
     add_faucet(
         AddFaucetServiceOptions {
             bootstrap_peers: get_peers_from_args(peers).await?,
@@ -92,6 +94,7 @@ pub async fn add(
 
 pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
     if !is_running_as_root() {
+        error!("The faucet start command must run as the root user");
         return Err(eyre!("The start command must run as the root user"));
     }
 
@@ -100,6 +103,7 @@ pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
         if verbosity != VerbosityLevel::Minimal {
             print_banner("Start Faucet Service");
         }
+        info!("Starting faucet service");
 
         let service = FaucetService::new(faucet, Box::new(ServiceController {}));
         let mut service_manager = ServiceManager::new(
@@ -113,11 +117,13 @@ pub async fn start(verbosity: VerbosityLevel) -> Result<()> {
         return Ok(());
     }
 
+    error!("The faucet service has not been added yet");
     Err(eyre!("The faucet service has not been added yet"))
 }
 
 pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
     if !is_running_as_root() {
+        error!("The faucet stop command must run as the root user");
         return Err(eyre!("The stop command must run as the root user"));
     }
 
@@ -126,6 +132,7 @@ pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
         if verbosity != VerbosityLevel::Minimal {
             print_banner("Stop Faucet Service");
         }
+        info!("Stopping faucet service");
 
         let service = FaucetService::new(faucet, Box::new(ServiceController {}));
         let mut service_manager =
@@ -137,6 +144,7 @@ pub async fn stop(verbosity: VerbosityLevel) -> Result<()> {
         return Ok(());
     }
 
+    error!("The faucet service has not been added yet");
     Err(eyre!("The faucet service has not been added yet"))
 }
 
@@ -161,6 +169,7 @@ pub async fn upgrade(
     if verbosity != VerbosityLevel::Minimal {
         print_banner("Upgrade Faucet Service");
     }
+    info!("Upgrading faucet service");
 
     let (upgrade_bin_path, target_version) =
         download_and_get_upgrade_bin_path(None, ReleaseType::Faucet, url, version, verbosity)

--- a/sn_service_management/src/auditor.rs
+++ b/sn_service_management/src/auditor.rs
@@ -72,7 +72,11 @@ impl<'a> ServiceStateActions for AuditorService<'a> {
             autostart: true,
             contents: None,
             environment: options.env_variables,
-            label: self.service_data.service_name.parse()?,
+            label: self
+                .service_data
+                .service_name
+                .parse()
+                .inspect_err(|err| error!("Failed to parse service name: {err:?}"))?,
             program: self.service_data.auditor_path.to_path_buf(),
             username: Some(self.service_data.user.to_string()),
             working_directory: None,

--- a/sn_service_management/src/daemon.rs
+++ b/sn_service_management/src/daemon.rs
@@ -53,7 +53,10 @@ impl<'a> ServiceStateActions for DaemonService<'a> {
         let (address, port) = self
             .service_data
             .endpoint
-            .ok_or_else(|| Error::DaemonEndpointNotSet)
+            .ok_or_else(|| {
+                error!("Daemon endpoint not set in the service_data");
+                Error::DaemonEndpointNotSet
+            })
             .map(|e| (e.ip().to_string(), e.port().to_string()))?;
         let install_ctx = ServiceInstallCtx {
             args: vec![

--- a/sn_service_management/src/node.rs
+++ b/sn_service_management/src/node.rs
@@ -134,8 +134,15 @@ impl<'a> ServiceStateActions for NodeService<'a> {
     }
 
     async fn on_start(&mut self) -> Result<()> {
-        let node_info = self.rpc_actions.node_info().await?;
-        let network_info = self.rpc_actions.network_info().await?;
+        let node_info =
+            self.rpc_actions.node_info().await.inspect_err(|err| {
+                error!("Error while obtaining node_info through RPC: {err:?}")
+            })?;
+        let network_info =
+            self.rpc_actions.network_info().await.inspect_err(|err| {
+                error!("Error while obtaining network_info through RPC: {err:?}")
+            })?;
+
         self.service_data.listen_addr = Some(
             network_info
                 .listeners


### PR DESCRIPTION
- adds logging to sn_service_management and sn_node_manager creates
- updates launchpad's logging to target to just log the important crates. Currently, it logs every single dependency at `debug` level, this clogs up the logs with connection (reqwest, hyper) related logs which we don't really care about.