### PR TITLE
chore(node): add unit test for forwarded reward tracking cache logic

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -118,6 +118,10 @@ jobs:
           cargo test --release --package sn_client --lib
           cargo test --release --package sn_client --doc
 
+      - name: Run node tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_node --lib
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release --package sn_networking

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -148,6 +148,10 @@ jobs:
           cargo test --release --package sn_client --bins
           cargo test --release --package sn_client --examples
 
+      - name: Run node tests
+        timeout-minutes: 25
+        run: cargo test --release --package sn_node --lib
+
       - name: Run network tests
         timeout-minutes: 25
         run: cargo test --release -p sn_networking


### PR DESCRIPTION
- This ensures that the forwarded rewards are cached correctly.