### PR TITLE
feat(manager): don't fetch peers from network-contact file

### DIFF
--- a/sn_auditor/src/main.rs
+++ b/sn_auditor/src/main.rs
@@ -18,7 +18,6 @@ use color_eyre::eyre::{eyre, Result};
 use dag_db::SpendDagDb;
 use sn_client::Client;
 use sn_logging::{Level, LogBuilder, LogFormat, LogOutputDest};
-use sn_peers_acquisition::get_peers_from_args;
 use sn_peers_acquisition::PeersArgs;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -138,8 +137,8 @@ fn logging_init(
     Ok(log_builder)
 }
 
-async fn connect_to_network(peers: PeersArgs) -> Result<Client> {
-    let bootstrap_peers = get_peers_from_args(peers).await?;
+async fn connect_to_network(peers_args: PeersArgs) -> Result<Client> {
+    let bootstrap_peers = peers_args.get_peers().await?;
     println!(
         "Connecting to the network with {} bootstrap peers",
         bootstrap_peers.len(),

--- a/sn_cli/src/bin/main.rs
+++ b/sn_cli/src/bin/main.rs
@@ -30,7 +30,6 @@ use sn_client::transfers::bls_secret_from_hex;
 use sn_client::{Client, ClientEvent, ClientEventsBroadcaster, ClientEventsReceiver};
 #[cfg(feature = "metrics")]
 use sn_logging::{metrics::init_metrics, Level, LogBuilder, LogFormat};
-use sn_peers_acquisition::get_peers_from_args;
 use std::{io, path::PathBuf, time::Duration};
 use tokio::{sync::broadcast::error::RecvError, task::JoinHandle};
 
@@ -101,7 +100,7 @@ async fn main() -> Result<()> {
     println!("Instantiating a SAFE client...");
     let secret_key = get_client_secret_key(&client_data_dir_path)?;
 
-    let bootstrap_peers = get_peers_from_args(opt.peers).await?;
+    let bootstrap_peers = opt.peers.get_peers().await?;
 
     println!(
         "Connecting to the network with {} peers",

--- a/sn_faucet/src/main.rs
+++ b/sn_faucet/src/main.rs
@@ -21,7 +21,7 @@ use sn_client::{
     Client, ClientEvent, ClientEventsBroadcaster, ClientEventsReceiver,
 };
 use sn_logging::{Level, LogBuilder, LogOutputDest};
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_transfers::{get_faucet_data_dir, HotWallet, MainPubkey, NanoTokens, Transfer};
 use std::{path::PathBuf, time::Duration};
 use tokio::{sync::broadcast::error::RecvError, task::JoinHandle};
@@ -31,7 +31,7 @@ use tracing::{debug, error, info};
 async fn main() -> Result<()> {
     let opt = Opt::parse();
 
-    let bootstrap_peers = get_peers_from_args(opt.peers).await?;
+    let bootstrap_peers = opt.peers.get_peers().await?;
     let bootstrap_peers = if bootstrap_peers.is_empty() {
         // empty vec is returned if `local-discovery` flag is provided
         None

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -18,7 +18,7 @@ use libp2p::{identity::Keypair, PeerId};
 use sn_logging::metrics::init_metrics;
 use sn_logging::{Level, LogFormat, LogOutputDest, ReloadHandle};
 use sn_node::{Marker, NodeBuilder, NodeEvent, NodeEventsReceiver};
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_protocol::{node::get_safenode_root_dir, node_rpc::NodeCtrl};
 use std::{
     env,
@@ -190,7 +190,7 @@ fn main() -> Result<()> {
         init_logging(&opt, keypair.public().to_peer_id())?;
 
     let rt = Runtime::new()?;
-    let bootstrap_peers = rt.block_on(get_peers_from_args(opt.peers))?;
+    let bootstrap_peers = rt.block_on(opt.peers.get_peers())?;
     let msg = format!(
         "Running {} v{}",
         env!("CARGO_BIN_NAME"),

--- a/sn_node_manager/src/cmd/auditor.rs
+++ b/sn_node_manager/src/cmd/auditor.rs
@@ -16,7 +16,7 @@ use crate::{
 use color_eyre::{eyre::eyre, Result};
 use colored::Colorize;
 use semver::Version;
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_releases::{ReleaseType, SafeReleaseRepoActions};
 use sn_service_management::{
     auditor::AuditorService,
@@ -30,7 +30,7 @@ pub async fn add(
     beta_encryption_key: Option<String>,
     env_variables: Option<Vec<(String, String)>>,
     log_dir_path: Option<PathBuf>,
-    peers: PeersArgs,
+    peers_args: PeersArgs,
     src_path: Option<PathBuf>,
     url: Option<String>,
     version: Option<String>,
@@ -79,7 +79,7 @@ pub async fn add(
             auditor_src_bin_path,
             auditor_install_bin_path: PathBuf::from("/usr/local/bin/auditor"),
             beta_encryption_key,
-            bootstrap_peers: get_peers_from_args(peers).await?,
+            bootstrap_peers: peers_args.get_peers().await?,
             env_variables,
             service_log_dir_path,
             user: service_user.to_string(),

--- a/sn_node_manager/src/cmd/faucet.rs
+++ b/sn_node_manager/src/cmd/faucet.rs
@@ -16,7 +16,7 @@ use crate::{
 use color_eyre::{eyre::eyre, Result};
 use colored::Colorize;
 use semver::Version;
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_releases::{ReleaseType, SafeReleaseRepoActions};
 use sn_service_management::{
     control::{ServiceControl, ServiceController},
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 pub async fn add(
     env_variables: Option<Vec<(String, String)>>,
     log_dir_path: Option<PathBuf>,
-    peers: PeersArgs,
+    peers_args: PeersArgs,
     src_path: Option<PathBuf>,
     url: Option<String>,
     version: Option<String>,
@@ -74,7 +74,7 @@ pub async fn add(
     info!("Adding faucet service");
     add_faucet(
         AddFaucetServiceOptions {
-            bootstrap_peers: get_peers_from_args(peers).await?,
+            bootstrap_peers: peers_args.get_peers().await?,
             env_variables,
             faucet_src_bin_path,
             faucet_install_bin_path: PathBuf::from("/usr/local/bin/faucet"),

--- a/sn_node_manager/src/cmd/local.rs
+++ b/sn_node_manager/src/cmd/local.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use color_eyre::{eyre::eyre, Help, Report, Result};
 use sn_logging::LogFormat;
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_releases::{ReleaseType, SafeReleaseRepoActions};
 use sn_service_management::{
     control::ServiceController, get_local_node_registry_path, NodeRegistry,
@@ -33,7 +33,7 @@ pub async fn join(
     log_format: Option<LogFormat>,
     owner: Option<String>,
     owner_prefix: Option<String>,
-    peers: PeersArgs,
+    peers_args: PeersArgs,
     skip_validation: bool,
     verbosity: VerbosityLevel,
 ) -> Result<(), Report> {
@@ -67,7 +67,7 @@ pub async fn join(
 
     // If no peers are obtained we will attempt to join the existing local network, if one
     // is running.
-    let peers = match get_peers_from_args(peers).await {
+    let peers = match peers_args.get_peers().await {
         Ok(peers) => Some(peers),
         Err(err) => match err {
             sn_peers_acquisition::error::Error::PeersNotObtained => {

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -23,7 +23,7 @@ use colored::Colorize;
 use libp2p_identity::PeerId;
 use semver::Version;
 use sn_logging::LogFormat;
-use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
+use sn_peers_acquisition::PeersArgs;
 use sn_releases::{ReleaseType, SafeReleaseRepoActions};
 use sn_service_management::{
     control::{ServiceControl, ServiceController},
@@ -49,7 +49,7 @@ pub async fn add(
     metrics_port: Option<PortRange>,
     node_port: Option<PortRange>,
     owner: Option<String>,
-    peers: PeersArgs,
+    peers_args: PeersArgs,
     rpc_address: Option<Ipv4Addr>,
     rpc_port: Option<PortRange>,
     src_path: Option<PathBuf>,
@@ -113,8 +113,8 @@ pub async fn add(
     //
     // It's simpler to not use the `network-contacts` feature in the node manager, because it can
     // return a huge peer list, and that's been problematic for service definition files.
-    let is_first = peers.first;
-    let bootstrap_peers = match get_peers_from_args(peers).await {
+    let is_first = peers_args.first;
+    let bootstrap_peers = match peers_args.get_peers().await {
         Ok(p) => {
             info!("Obtained peers of length {}", p.len());
             p


### PR DESCRIPTION
- Currently, the launchpad uses `PeersArgs` to optionally accept `--peers` or `SAFE_PEERS` env variable, but it had the `network-contacts` feature turned on for `sn_peers_acquistion`. This means that when you launch the TUI normally, the bootstrap peers were obtained from the contacts file and were being hard-coded inside the service definition file.
- This is bad because, if there is a change in the `network-contacts` file (say our original bootstrap peers crashed), then the services started with the hardcoded values will have no way to contact the updated boostrap peers.
  - They'd fail to connect
- Also, it is bad because service definition file might not sometimes support a large list of values. This might have been a reason for some nodes not being started.

Changes:
- Modified the manager to not get the `network-contact` peers

For future PR:
- remove the `network-contacts` feature from `node-launchpad`. This would require making some tweaks to `sn_peers_acquistion` to expose a function there. This https://github.com/maidsafe/safe_network/issues/1800 is related.