### PR TITLE
feat(networking): dont add bootstrap ndoes as relay candidates

### DIFF
--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -167,8 +167,13 @@ impl SwarmDriver {
 
                         let has_relayed = is_a_relayed_peer(&addrs);
 
+                        let is_bootstrap_peer = self
+                            .bootstrap_peers
+                            .iter()
+                            .any(|(_ilog2, peers)| peers.contains(&peer_id));
+
                         // Do not use an `already relayed` peer as `potential relay candidate`.
-                        if !has_relayed {
+                        if !has_relayed && !is_bootstrap_peer {
                             self.relay_manager.add_potential_candidates(
                                 &peer_id,
                                 &addrs,

--- a/sn_networking/src/relay_manager.rs
+++ b/sn_networking/src/relay_manager.rs
@@ -13,8 +13,8 @@ use libp2p::{
 use rand::Rng;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
-const MAX_CONCURRENT_RELAY_CONNECTIONS: usize = 3;
-const MAX_POTENTIAL_CANDIDATES: usize = 15;
+const MAX_CONCURRENT_RELAY_CONNECTIONS: usize = 2;
+const MAX_POTENTIAL_CANDIDATES: usize = 1000;
 
 pub(crate) fn is_a_relayed_peer(addrs: &HashSet<Multiaddr>) -> bool {
     addrs


### PR DESCRIPTION
This should more evenly spread the load of bootstrap peering.

------------

This pull request primarily focuses on updating the logic in the `SwarmDriver` implementation and modifying constants in the `relay_manager.rs` file. The key changes include a new condition to prevent bootstrap peers from being used as relay candidates and an adjustment to the maximum concurrent relay connections and potential candidates.

Key changes:

* [`sn_networking/src/event/swarm.rs`](diffhunk://#diff-cb0730cf4bf5e7445bc11bf88d45c13b6f28a706a5d1a7822db1e2dd76b1b2dfR170-R176): A new condition has been added to the `SwarmDriver` implementation to check if a peer is a bootstrap peer. Bootstrap peers will no longer be used as potential relay candidates. This change aims to improve the relay selection process by excluding peers that are already serving a critical role in the network.

Constants adjustment:

* [`sn_networking/src/relay_manager.rs`](diffhunk://#diff-8c7c91b73d8fb79178787f853e75efc42326ed17004556c033e1a075611a74caL16-R17): The constants `MAX_CONCURRENT_RELAY_CONNECTIONS` and `MAX_POTENTIAL_CANDIDATES` have been modified. The maximum concurrent relay connections have been reduced from 3 to 2, while the maximum potential candidates have been increased from 15 to 1000. This change could potentially enhance the efficiency of the relay selection process by exploring a larger pool of candidates while limiting the number of active connections.