### PR TITLE
style: Use `Arc::clone()` instead of `.clone()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ uninlined_format_args = "warn"
 unicode_not_nfc = "warn"
 unused_async = "warn"
 unwrap_used = "warn"
+clone_on_ref_ptr = "warn"
 
 [profile.release]
 debug = 0

--- a/sn_faucet/src/faucet_server.rs
+++ b/sn_faucet/src/faucet_server.rs
@@ -477,10 +477,10 @@ async fn startup_server(client: Client) -> Result<()> {
     let gift_client = client.clone();
     let donation_client = client.clone();
     let donation_addr_client = client.clone();
-    let donation_semaphore = semaphore.clone();
-    let donation_addr_semaphore = semaphore.clone();
+    let donation_semaphore = Arc::clone(&semaphore);
+    let donation_addr_semaphore = Arc::clone(&semaphore);
     #[cfg(feature = "distribution")]
-    let semaphore_dist = semaphore.clone();
+    let semaphore_dist = Arc::clone(&semaphore);
 
     // GET /distribution/address=address&wallet=wallet&signature=signature
     #[cfg(feature = "distribution")]
@@ -492,7 +492,7 @@ async fn startup_server(client: Client) -> Result<()> {
             query
         })
         .and_then(move |query| {
-            let semaphore = semaphore_dist.clone();
+            let semaphore = Arc::clone(&semaphore_dist);
             let client = client.clone();
             respond_to_distribution_request(client, query, balances.clone(), semaphore)
         });
@@ -506,7 +506,7 @@ async fn startup_server(client: Client) -> Result<()> {
         })
         .and_then(move |key| {
             let client = gift_client.clone();
-            let semaphore = semaphore.clone();
+            let semaphore = Arc::clone(&semaphore);
 
             respond_to_gift_request(client, key, semaphore)
         });
@@ -515,7 +515,7 @@ async fn startup_server(client: Client) -> Result<()> {
     let donation_addr = warp::get().and(warp::path("donate")).and_then(move || {
         debug!("Donation address request");
         let client = donation_addr_client.clone();
-        let semaphore = donation_addr_semaphore.clone();
+        let semaphore = Arc::clone(&donation_addr_semaphore);
 
         respond_to_donate_request(client, String::new(), semaphore)
     });
@@ -529,7 +529,7 @@ async fn startup_server(client: Client) -> Result<()> {
         })
         .and_then(move |transfer| {
             let client = donation_client.clone();
-            let semaphore = donation_semaphore.clone();
+            let semaphore = Arc::clone(&donation_semaphore);
 
             respond_to_donate_request(client, transfer, semaphore)
         });

--- a/sn_networking/src/metrics_service.rs
+++ b/sn_networking/src/metrics_service.rs
@@ -127,7 +127,7 @@ impl<T> Service<T> for MakeMetricService {
     }
 
     fn call(&mut self, _: T) -> Self::Future {
-        let reg = self.reg.clone();
+        let reg = Arc::clone(&self.reg);
         let fut = async move { Ok(MetricService { reg }) };
         Box::pin(fut)
     }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -439,7 +439,7 @@ impl Node {
                 event_header = "NewListenAddr";
                 if !cfg!(feature = "local-discovery") {
                     let network = self.network.clone();
-                    let peers = self.initial_peers.clone();
+                    let peers = Arc::clone(&self.initial_peers);
                     let _handle = spawn(async move {
                         for addr in &*peers {
                             if let Err(err) = network.dial(addr.clone()).await {

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -153,7 +153,7 @@ async fn data_availability_during_churn() -> Result<()> {
 
         create_registers_task(
             client.clone(),
-            content.clone(),
+            Arc::clone(&content),
             churn_period,
             paying_wallet_dir.path().to_path_buf(),
         );
@@ -161,8 +161,8 @@ async fn data_availability_during_churn() -> Result<()> {
         create_cash_note_task(
             client.clone(),
             transfers_wallet,
-            content.clone(),
-            cash_notes.clone(),
+            Arc::clone(&content),
+            Arc::clone(&cash_notes),
             churn_period,
         );
     }
@@ -173,13 +173,13 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to store Chunks at random locations, at a higher frequency than the churning events
     store_chunks_task(
         client.clone(),
-        content.clone(),
+        Arc::clone(&content),
         churn_period,
         paying_wallet_dir.path().to_path_buf(),
     );
 
     // Spawn a task to churn nodes
-    churn_nodes_task(churn_count.clone(), test_duration, churn_period);
+    churn_nodes_task(Arc::clone(&churn_count), test_duration, churn_period);
 
     // Shared bucket where we keep track of the content which erred when creating/storing/fetching.
     // We remove them from this bucket if we are then able to query/fetch them successfully.
@@ -192,9 +192,9 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to randomly query/fetch the content we create/store
     query_content_task(
         client.clone(),
-        content.clone(),
-        content_erred.clone(),
-        cash_notes.clone(),
+        Arc::clone(&content),
+        Arc::clone(&content_erred),
+        Arc::clone(&cash_notes),
         churn_period,
         paying_wallet_dir.path().to_path_buf(),
     );
@@ -203,9 +203,9 @@ async fn data_availability_during_churn() -> Result<()> {
     // and mark them as failures if they effectivelly cannot be retrieved.
     retry_query_content_task(
         client.clone(),
-        content_erred.clone(),
-        failures.clone(),
-        cash_notes.clone(),
+        Arc::clone(&content_erred),
+        Arc::clone(&failures),
+        Arc::clone(&cash_notes),
         churn_period,
         paying_wallet_dir.path().to_path_buf(),
     );
@@ -249,9 +249,9 @@ async fn data_availability_during_churn() -> Result<()> {
     for net_addr in content.iter() {
         let client = client.clone();
         let net_addr = net_addr.clone();
-        let cash_notes = cash_notes.clone();
+        let cash_notes = Arc::clone(&cash_notes);
 
-        let failures = failures.clone();
+        let failures = Arc::clone(&failures);
         let wallet_dir = paying_wallet_dir.to_path_buf().clone();
         let handle = tokio::spawn(async move {
             final_retry_query_content(
@@ -467,7 +467,7 @@ fn query_content_task(
             trace!("Querying content (bucket index: {index}) at {net_addr:?} in {delay:?}");
             sleep(delay).await;
 
-            match query_content(&client, &root_dir, &net_addr, cash_notes.clone()).await {
+            match query_content(&client, &root_dir, &net_addr, Arc::clone(&cash_notes)).await {
                 Ok(_) => {
                     let _ = content_erred.write().await.remove(&net_addr);
                 }
@@ -548,7 +548,7 @@ fn retry_query_content_task(
                 println!("Querying erred content at {net_addr}, attempt: #{attempts} ...");
                 info!("Querying erred content at {net_addr}, attempt: #{attempts} ...");
                 if let Err(last_err) =
-                    query_content(&client, &wallet_dir, &net_addr, cash_notes.clone()).await
+                    query_content(&client, &wallet_dir, &net_addr, Arc::clone(&cash_notes)).await
                 {
                     println!("Erred content is still not retrievable at {net_addr} after {attempts} attempts: {last_err:?}");
                     warn!("Erred content is still not retrievable at {net_addr} after {attempts} attempts: {last_err:?}");
@@ -586,7 +586,7 @@ async fn final_retry_query_content(
         println!("Final querying content at {net_addr}, attempt: #{attempts} ...");
         debug!("Final querying content at {net_addr}, attempt: #{attempts} ...");
         if let Err(last_err) =
-            query_content(client, wallet_dir, &net_addr, cash_notes.clone()).await
+            query_content(client, wallet_dir, &net_addr, Arc::clone(&cash_notes)).await
         {
             if attempts == MAX_NUM_OF_QUERY_ATTEMPTS {
                 println!("Final check: Content is still not retrievable at {net_addr} after {attempts} attempts: {last_err:?}");

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -21,7 +21,7 @@ pub mod node_rpc;
 pub mod storage;
 
 // this includes code generated from .proto files
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 #[cfg(feature = "rpc")]
 pub mod safenode_proto {
     tonic::include_proto!("safenode_proto");

--- a/sn_registers/src/register.rs
+++ b/sn_registers/src/register.rs
@@ -676,7 +676,7 @@ mod tests {
                 replicas.push(replica);
             }
 
-            Ok((replicas, owner_sk.clone()))
+            Ok((replicas, Arc::clone(&owner_sk)))
         })
     }
 


### PR DESCRIPTION
- **style: use fully qualified Arc::clone syntax**
