### PR TITLE
feat(launchpad): refresh node states on startup

### DIFF
--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -39,7 +39,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(
+    pub async fn new(
         tick_rate: f64,
         frame_rate: f64,
         peers_args: PeersArgs,
@@ -52,7 +52,8 @@ impl App {
             &app_data.discord_username,
             peers_args,
             safenode_path,
-        )?;
+        )
+        .await?;
         let config = Config::new()?;
         let discord_username_input = BetaProgramme::new(app_data.discord_username.clone());
         let manage_nodes = ManageNodes::new(app_data.nodes_to_start)?;

--- a/node-launchpad/src/bin/tui/main.rs
+++ b/node-launchpad/src/bin/tui/main.rs
@@ -65,7 +65,8 @@ async fn tokio_main() -> Result<()> {
         args.frame_rate,
         args.peers,
         args.safenode_path,
-    )?;
+    )
+    .await?;
     app.run().await?;
 
     Ok(())

--- a/node-launchpad/src/components/home.rs
+++ b/node-launchpad/src/components/home.rs
@@ -573,6 +573,20 @@ impl Component for Home {
     }
 }
 
+fn refresh_node_registry() -> Result<()> {
+    let node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
+    let node_services = node_registry
+        .nodes
+        .into_iter()
+        .filter(|node| node.status != ServiceStatus::Removed)
+        .collect();
+    info!(
+        "Loaded node registry. Running nodes: {:?}",
+        node_services.len()
+    );
+    Ok(())
+}
+
 fn stop_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
     tokio::task::spawn_local(async move {
         if let Err(err) =

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -225,6 +225,7 @@ fn main() -> Result<()> {
         #[cfg(feature = "open-metrics")]
         let mut node_builder = node_builder;
         // if enable flag is provided or only if the port is specified then enable the server by setting Some()
+        #[cfg(feature = "open-metrics")]
         let metrics_server_port = if opt.enable_metrics_server || opt.metrics_server_port != 0 {
             Some(opt.metrics_server_port)
         } else {

--- a/sn_service_management/src/control.rs
+++ b/sn_service_management/src/control.rs
@@ -168,8 +168,7 @@ impl ServiceControl for ServiceController {
     }
 
     fn is_service_process_running(&self, pid: u32) -> bool {
-        let mut system = System::new_all();
-        system.refresh_all();
+        let system = System::new_all();
         system.process(Pid::from(pid as usize)).is_some()
     }
 
@@ -185,8 +184,7 @@ impl ServiceControl for ServiceController {
     }
 
     fn get_process_pid(&self, bin_path: &Path) -> Result<u32> {
-        let mut system = System::new_all();
-        system.refresh_all();
+        let system = System::new_all();
         for (pid, process) in system.processes() {
             if let Some(path) = process.exe() {
                 if bin_path == path {


### PR DESCRIPTION
This should help sync the launchpad to the actual state of the safenode service.