### PR TITLE
fix(manager): use rpc to check if a node is running or not

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6929,6 +6929,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "dirs-next",
+ "futures",
  "indicatif",
  "libp2p",
  "libp2p-identity",

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -45,6 +45,7 @@ impl App {
         peers_args: PeersArgs,
         safenode_path: Option<PathBuf>,
     ) -> Result<Self> {
+        println!("Refreshing node states. This can take a couple seconds");
         let app_data = AppData::load()?;
 
         let home = Home::new(

--- a/node-launchpad/src/components/home.rs
+++ b/node-launchpad/src/components/home.rs
@@ -22,9 +22,7 @@ use rand::seq::SliceRandom;
 use ratatui::{prelude::*, widgets::*};
 use sn_node_manager::{config::get_node_registry_path, VerbosityLevel};
 use sn_peers_acquisition::{get_bootstrap_peers_from_url, PeersArgs};
-use sn_service_management::{
-    control::ServiceController, NodeRegistry, NodeServiceData, ServiceStatus,
-};
+use sn_service_management::{NodeRegistry, NodeServiceData, ServiceStatus};
 use std::{
     path::PathBuf,
     time::{Duration, Instant},
@@ -92,13 +90,10 @@ impl Home {
             safenode_path,
         };
 
-        let now = Instant::now();
         debug!("Refreshing node registry states on startup");
         let mut node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
-        sn_node_manager::refresh_node_registry(&mut node_registry, &ServiceController {}, false)
-            .await?;
+        sn_node_manager::refresh_node_registry(&mut node_registry, false).await?;
         node_registry.save()?;
-        debug!("Node registry states refreshed in {:?}", now.elapsed());
         home.load_node_registry_and_update_states()?;
 
         Ok(home)

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -35,6 +35,7 @@ clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
+futures = "0.3.28"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = { version = "0.53", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }

--- a/sn_node_manager/src/cmd/local.rs
+++ b/sn_node_manager/src/cmd/local.rs
@@ -200,14 +200,7 @@ pub async fn status(details: bool, fail: bool, json: bool) -> Result<()> {
     if !json {
         print_banner("Local Network");
     }
-    status_report(
-        &mut local_node_registry,
-        &ServiceController {},
-        details,
-        json,
-        fail,
-    )
-    .await?;
+    status_report(&mut local_node_registry, details, json, fail).await?;
     local_node_registry.save()?;
     Ok(())
 }

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -178,12 +178,7 @@ pub async fn balance(
     }
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    refresh_node_registry(
-        &mut node_registry,
-        &ServiceController {},
-        verbosity != VerbosityLevel::Minimal,
-    )
-    .await?;
+    refresh_node_registry(&mut node_registry, verbosity != VerbosityLevel::Minimal).await?;
 
     let service_indices = get_services_for_ops(&node_registry, peer_ids, service_names)?;
     if service_indices.is_empty() {
@@ -221,12 +216,7 @@ pub async fn remove(
     info!("Removing safe node services with keep_dirs=({keep_directories}) for: {peer_ids:?}, {service_names:?}");
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    refresh_node_registry(
-        &mut node_registry,
-        &ServiceController {},
-        verbosity != VerbosityLevel::Minimal,
-    )
-    .await?;
+    refresh_node_registry(&mut node_registry, verbosity != VerbosityLevel::Minimal).await?;
 
     let service_indices = get_services_for_ops(&node_registry, peer_ids, service_names)?;
     if service_indices.is_empty() {
@@ -305,12 +295,7 @@ pub async fn start(
     );
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    refresh_node_registry(
-        &mut node_registry,
-        &ServiceController {},
-        verbosity != VerbosityLevel::Minimal,
-    )
-    .await?;
+    refresh_node_registry(&mut node_registry, verbosity != VerbosityLevel::Minimal).await?;
 
     let service_indices = get_services_for_ops(&node_registry, peer_ids, service_names)?;
     if service_indices.is_empty() {
@@ -358,14 +343,7 @@ pub async fn status(details: bool, fail: bool, json: bool) -> Result<()> {
         if !json && !details {
             print_banner("Safenode Services");
         }
-        status_report(
-            &mut node_registry,
-            &ServiceController {},
-            details,
-            json,
-            fail,
-        )
-        .await?;
+        status_report(&mut node_registry, details, json, fail).await?;
         node_registry.save()?;
     }
     Ok(())
@@ -382,12 +360,7 @@ pub async fn stop(
     info!("Stopping safenode services for: {peer_ids:?}, {service_names:?}");
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    refresh_node_registry(
-        &mut node_registry,
-        &ServiceController {},
-        verbosity != VerbosityLevel::Minimal,
-    )
-    .await?;
+    refresh_node_registry(&mut node_registry, verbosity != VerbosityLevel::Minimal).await?;
 
     let service_indices = get_services_for_ops(&node_registry, peer_ids, service_names)?;
     if service_indices.is_empty() {
@@ -455,12 +428,7 @@ pub async fn upgrade(
     .await?;
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    refresh_node_registry(
-        &mut node_registry,
-        &ServiceController {},
-        verbosity != VerbosityLevel::Minimal,
-    )
-    .await?;
+    refresh_node_registry(&mut node_registry, verbosity != VerbosityLevel::Minimal).await?;
 
     debug!(
         "listen addresses for nodes[0]: {:?}",

--- a/sn_node_manager/src/local.rs
+++ b/sn_node_manager/src/local.rs
@@ -452,6 +452,7 @@ mod tests {
         pub RpcClient {}
         #[async_trait]
         impl RpcActions for RpcClient {
+            async fn is_endpoint_active(&self) -> bool;
             async fn node_info(&self) -> RpcResult<NodeInfo>;
             async fn network_info(&self) -> RpcResult<NetworkInfo>;
             async fn record_addresses(&self) -> RpcResult<Vec<RecordAddress>>;

--- a/sn_service_management/src/rpc.rs
+++ b/sn_service_management/src/rpc.rs
@@ -42,6 +42,7 @@ pub struct RecordAddress {
 
 #[async_trait]
 pub trait RpcActions: Sync {
+    async fn is_endpoint_active(&self) -> bool;
     async fn node_info(&self) -> Result<NodeInfo>;
     async fn network_info(&self) -> Result<NetworkInfo>;
     async fn record_addresses(&self) -> Result<Vec<RecordAddress>>;
@@ -108,6 +109,9 @@ impl RpcClient {
 
 #[async_trait]
 impl RpcActions for RpcClient {
+    async fn is_endpoint_active(&self) -> bool {
+        SafeNodeClient::connect(self.endpoint.clone()).await.is_ok()
+    }
     async fn node_info(&self) -> Result<NodeInfo> {
         let mut client = self.connect_with_retry().await?;
         let response = client


### PR DESCRIPTION
- After a reboot, the PID of the service might be taken by some other process and if we use the PID to check if our node is active, then we'd get positive there, but would fail when we try to access the RPC endpoint.
- So just try to connect to the RPC endpoint to see if the node is currently active or not
- Does this in parallel, as a connection failure will take 3 seconds to return.