### PR TITLE
Uploader optimisation

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -863,8 +863,9 @@ impl Client {
         let cash_note_addr = SpendAddress::from_unique_pubkey(&unique_pubkey);
         let network_address = NetworkAddress::from_spend_address(cash_note_addr);
 
-        trace!("Sending spend {unique_pubkey:?} to the network via put_record, with addr of {cash_note_addr:?}");
         let key = network_address.to_record_key();
+        let pretty_key = PrettyPrintRecordKey::from(&key);
+        trace!("Sending spend {unique_pubkey:?} to the network via put_record, with addr of {cash_note_addr:?} - {pretty_key:?}");
         let record_kind = RecordKind::Spend;
         let record = Record {
             key,
@@ -886,9 +887,10 @@ impl Client {
             (None, Default::default())
         };
 
+        // When there is retry on Put side, no need to have a retry on Get
         let verification_cfg = GetRecordCfg {
             get_quorum: Quorum::Majority,
-            retry_strategy: Some(RetryStrategy::Balanced),
+            retry_strategy: None,
             target_record: record_to_verify,
             expected_holders,
         };

--- a/sn_client/src/uploader/upload.rs
+++ b/sn_client/src/uploader/upload.rs
@@ -860,6 +860,10 @@ impl InnerUploader {
                         got_a_previous_force_payment = false;
                     }
 
+                    let _ = wallet_client
+                        .resend_pending_transaction_blocking_loop()
+                        .await;
+
                     let result = match wallet_client.pay_for_records(&cost_map, verify_store).await
                     {
                         Ok((storage_cost, royalty_fees)) => {


### PR DESCRIPTION
This pull request primarily focuses on improving the `sn_client` module in the Rust codebase. The changes include refactoring and renaming methods in the `Client` implementation, adding new methods to handle and resend unconfirmed transactions, and improving log messages for better debugging and user experience. Additionally, a new unit test has been added in the `sn_transfers` module to test the payment selection functionality.

### Changes in `sn_client` module:

* `sn_client/src/api.rs`: 
  * The `trace!` log message in the `Client` implementation has been updated to include a pretty printed version of the record key for better debugging.
  * The `RetryStrategy` for `GetRecordCfg` in the `Client` implementation has been removed to avoid unnecessary retries.
  * The `crawl_spend_from_network` method has been renamed to `peek_a_spend` and its `get_quorum` value has been changed to `Quorum::One` to fetch a single copy of the spend.
  * The `is_genesis_spend_present` method now uses the `peek_a_spend` method to check for the presence of the Genesis spend.
* `sn_client/src/uploader/upload.rs`: 
  * The `InnerUploader` implementation now includes a call to `resend_pending_transaction_blocking_loop` method to handle any pending transactions.
* `sn_client/src/wallet.rs`: 
  * A new method `resend_pending_transaction_blocking_loop` has been added to the `WalletClient` implementation. This method continuously resends unconfirmed transactions until they are all uploaded or the user manually terminates the process. It also logs and prints helpful messages for the user to understand the state of unconfirmed transactions.

### Changes in `sn_transfers` module:

* `sn_transfers/src/wallet/api.rs`: 
  * A new unit test `payment_selective` has been added to test the functionality of selecting a payment transaction.