### PR TITLE
Issue #1890     Correct a misleading error msg sn_cli/src/bin/subcommands/files.rs

### DIFF
--- a/sn_cli/src/bin/subcommands/files.rs
+++ b/sn_cli/src/bin/subcommands/files.rs
@@ -149,7 +149,7 @@ pub(crate) async fn files_cmds(
                 return Err(
                     eyre!("Both the name and address must be supplied if either are used")
                         .suggestion(
-                        "Please run the command again in the form 'files upload <name> <address>'",
+                        "Please run the command again in the form 'files download <name> <address>'",
                     ),
                 );
             }


### PR DESCRIPTION
Existing error message referred to "files upload"
This changes the error to refer to "files download"

### Description

Please provide a brief description of the changes made in this pull request. Highlight the purpose of the changes and the problem they address.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
