### PR TITLE
fix(networking): use default Relay config from libp2p

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -544,12 +544,7 @@ impl NetworkBuilder {
             .boxed();
 
         let relay_server = {
-            let relay_server_cfg = relay::Config {
-                max_reservations: 1024,      // the number of home nodes that we can support
-                max_circuits: 32_000, // total max number of relayed connections we can support
-                max_circuits_per_peer: 1024, // max number of relayed connections per peer
-                ..Default::default()
-            };
+            let relay_server_cfg = relay::Config::default();
             libp2p::relay::Behaviour::new(peer_id, relay_server_cfg)
         };
 


### PR DESCRIPTION
Reduce the relay config to default limits. 

We were allowing nodes to handle thousands of relays (which they cannot)

```rust
let relay_server_cfg = relay::Config {
                max_reservations: 1024,      // the number of home nodes that we can support
                max_circuits: 32_000, // total max number of relayed connections we can support
                max_circuits_per_peer: 1024, // max number of relayed connections per peer
                ..Default::default()
            };
```
becomes effectively

```rust
let relay_server_cfg = relay::Config {
                max_reservations: 128,      // the number of home nodes that we can support
                max_circuits: 16, // total max number of relayed connections we can support
                max_circuits_per_peer: 4, // max number of relayed connections per peer
                ..Default::default()
            };
```

We could further tweak rate limiting via the config rate limiters if desired.


---------


This pull request includes a change to the `NetworkBuilder` implementation in the `sn_networking/src/driver.rs` file. The change simplifies the creation of the `relay_server_cfg` object by using the default configuration provided by `relay::Config::default()`, instead of manually setting each configuration option. This change may affect the number of home nodes, total relayed connections, and relayed connections per peer that the relay server can support.