### PR TITLE
chore: records

### DIFF
--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -844,6 +844,7 @@ impl ClientRegister {
         let verification_cfg = GetRecordCfg {
             get_quorum: Quorum::One,
             retry_strategy: Some(RetryStrategy::Balanced),
+            accumulate_spend_attempts: false,
             target_record: record_to_verify,
             expected_holders,
         };

--- a/sn_client/src/wallet.rs
+++ b/sn_client/src/wallet.rs
@@ -959,7 +959,7 @@ impl Client {
             let pk = cn.unique_pubkey();
             let addr = SpendAddress::from_unique_pubkey(&pk);
             let self_clone = self.network.clone();
-            let _ = tasks.spawn(async move { self_clone.get_spend(addr).await });
+            let _ = tasks.spawn(async move { self_clone.get_valid_spend(addr).await });
         }
         while let Some(result) = tasks.join_next().await {
             let res = result.map_err(|e| WalletError::FailedToGetSpend(format!("{e}")))?;

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -122,6 +122,10 @@ pub struct GetRecordCfg {
     pub get_quorum: Quorum,
     /// If enabled, the provided `RetryStrategy` is used to retry if a GET attempt fails.
     pub retry_strategy: Option<RetryStrategy>,
+    /// If disabled, we error out if any double spend is found.
+    /// If enabled all double spends found are accumulated and returned.
+    /// This is useful for the client to decide if they want to retry the operation.
+    pub accumulate_spend_attempts: bool,
     /// Only return if we fetch the provided record.
     pub target_record: Option<Record>,
     /// Logs if the record was not fetched from the provided set of peers.

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -507,8 +507,6 @@ impl Network {
                         warn!("No holder of record '{pretty_key:?}' found.");
                     }
                     Err(GetRecordError::SplitRecord { .. }) => {
-                        // if get_record_cfg.acc {
-                        // }
                         error!("Encountered a split record for {pretty_key:?}.");
                     }
                     Err(GetRecordError::QueryTimeout) => {
@@ -518,6 +516,7 @@ impl Network {
 
                 // if we don't want to retry, throw permanent error
                 if cfg.retry_strategy.is_none() {
+                    // TODO this is where to decide if we just return accumulated record eg
                     if let Err(e) = result {
                         return Err(BackoffError::Permanent(NetworkError::from(e)));
                     }

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::{
     error::{GetRecordError, NetworkError},
     event::{MsgResponder, NetworkEvent},
     record_store::{calculate_cost_for_records, NodeRecordStore},
-    transfers::{get_raw_signed_spends_from_record, get_signed_spend_from_record},
+    transfers::{get_raw_signed_spends_from_record, get_solitary_signed_spend_from_record},
 };
 
 use self::{cmd::SwarmCmd, error::Result};
@@ -507,6 +507,8 @@ impl Network {
                         warn!("No holder of record '{pretty_key:?}' found.");
                     }
                     Err(GetRecordError::SplitRecord { .. }) => {
+                        // if get_record_cfg.acc {
+                        // }
                         error!("Encountered a split record for {pretty_key:?}.");
                     }
                     Err(GetRecordError::QueryTimeout) => {

--- a/sn_networking/src/spends.rs
+++ b/sn_networking/src/spends.rs
@@ -36,8 +36,10 @@ impl Network {
             .inputs
             .iter()
             .map(|input| input.unique_pubkey);
+        // This will error with double spend... Is that wanted?
+        // I think so here as _this spend_ is now invalid
         let tasks: Vec<_> = parent_keys
-            .map(|a| self.get_spend(SpendAddress::from_unique_pubkey(&a)))
+            .map(|a| self.get_valid_spend(SpendAddress::from_unique_pubkey(&a)))
             .collect();
         let parent_spends: BTreeSet<SignedSpend> = join_all(tasks)
             .await

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -363,6 +363,9 @@ impl Node {
 
         // validate the signed spends against the network and the local knowledge
         debug!("Validating spends for {pretty_key:?} with unique key: {unique_pubkey:?}");
+
+        // In here we are expecting to have at most 2 spends for the same unique_pubkey
+        // This could push out original valid spends if there is a double spend.
         let (spend1, maybe_spend2) = match self
             .signed_spends_to_keep(spends_for_key.clone(), *unique_pubkey)
             .await

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -65,12 +65,16 @@ impl Node {
                     trace!(
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
                     );
+
+                    // Here we don't care about how many nodes are storing this record...
                     let get_cfg = GetRecordCfg {
                         get_quorum: Quorum::One,
                         retry_strategy: None,
                         target_record: None,
                         expected_holders: Default::default(),
                     };
+                    // But this can error out with SplitRecord and so keep retrying so we do not replicate
+                    // DoubleSpendAttempted Spends here!
                     node.network.get_record_from_network(key, &get_cfg).await?
                 };
 

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -68,6 +68,7 @@ impl Node {
 
                     // Here we don't care about how many nodes are storing this record...
                     let get_cfg = GetRecordCfg {
+                        accumulate_spend_attempts: true,
                         get_quorum: Quorum::One,
                         retry_strategy: None,
                         target_record: None,


### PR DESCRIPTION
This pull request primarily modifies the `sn_client/src/api.rs`, `sn_networking/src/driver.rs`, `sn_networking/src/event/kad.rs`, `sn_networking/src/lib.rs`, `sn_networking/src/spends.rs`, `sn_networking/src/transfers.rs`, `sn_node/src/put_validation.rs`, and `sn_node/src/replication.rs` files, focusing on improving the handling of spend records and double spend attempts in the network. The changes include renaming methods and adding a new configuration option to accumulate spend attempts, which can help the client decide whether to retry an operation.

Method Renaming:

* `get_signed_spend_from_record` is renamed to `get_solitary_signed_spend_from_record` and now returns an error if a double spend attempt is detected. [[1]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L24-R24) [[2]](diffhunk://#diff-8f8a3f47ddf2bc5366e5a9166b1b25f05b985ef63349b9cf22473822a765e776L43-R43) [[3]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L88-R90) [[4]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L234-R237)

New Configuration Option:

* A new configuration option `accumulate_spend_attempts` is added to `GetRecordCfg`. This option determines whether to accumulate all double spend attempts and return them, which can help the client decide whether to retry the operation. [[1]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97R463) [[2]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97R658) [[3]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97R743) [[4]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97R895) [[5]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L936-R945) [[6]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L952-R962) [[7]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L967-R978) [[8]](diffhunk://#diff-1b86a48cb70322a3ac64029081787ac6c92b95fe1878ae05e65327b224bc787cR847) [[9]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bR125-R128) [[10]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84R36) [[11]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L51-R57) [[12]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L133-R135) [[13]](diffhunk://#diff-c302643eb99427e41bc3ae0fe33cdf9b841a8d55593fc5f20e132674ecfeb603R68-R78)

Handling of Spend Records:

* Changes are made to handle spend records and double spend attempts more effectively. This includes changes to the `get_valid_spend` method and the addition of a new method `try_fetch_solitary_spend_from_network`. [[1]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L936-R945) [[2]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L952-R962) [[3]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L967-R978) [[4]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L986-R994) [[5]](diffhunk://#diff-6aa8955102cfa98bc83700a7a1860ae21ace8bc5545df1ef0e4d6388defaab97L1006-R1014) [[6]](diffhunk://#diff-d655bcffabb264727633e45f79aff0b7990bb9045b3742352968837f26adca30L962-R962) [[7]](diffhunk://#diff-fafcd0da35496c1241319a739411cfef0a12ceb8209929478680b404ec571384R39-R42) [[8]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L51-R57) [[9]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L133-R135) [[10]](diffhunk://#diff-49da31090158c7c8f8a2cd40cae494a26699c3c53a583570bd58326f52567e84L191-R193)

Other Changes:

* In `sn_node/src/put_validation.rs`, a comment is added to clarify that at most two spends for the same unique public key are expected.
* In `sn_node/src/replication.rs`, a comment is added to explain that the code does not care about how many nodes are storing a record, and that it can error out with `SplitRecord` and keep retrying so it does not replicate `DoubleSpendAttempted` spends.