### PR TITLE
chore: store Arc<NodeInner> and Arc<NetworkInner> to reduce cloning and reference counting

### DIFF
--- a/sn_client/src/uploader/tests/setup.rs
+++ b/sn_client/src/uploader/tests/setup.rs
@@ -428,7 +428,7 @@ pub fn build_unconnected_client(root_dir: PathBuf) -> Result<Client> {
     let network_builder = NetworkBuilder::new(Keypair::generate_ed25519(), true, root_dir);
     let (network, ..) = network_builder.build_client()?;
     let client = Client {
-        network: network.clone(),
+        network,
         events_broadcaster: Default::default(),
         signer: Arc::new(SecretKey::random()),
     };

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -61,7 +61,6 @@ use std::{
     net::SocketAddr,
     num::NonZeroUsize,
     path::PathBuf,
-    sync::Arc,
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Duration;
@@ -610,16 +609,9 @@ impl NetworkBuilder {
             quotes_history: Default::default(),
         };
 
-        Ok((
-            Network {
-                swarm_cmd_sender,
-                peer_id: Arc::new(peer_id),
-                root_dir_path: Arc::new(self.root_dir),
-                keypair: Arc::new(self.keypair),
-            },
-            network_event_receiver,
-            swarm_driver,
-        ))
+        let network = Network::new(swarm_cmd_sender, peer_id, self.root_dir, self.keypair);
+
+        Ok((network, network_event_receiver, swarm_driver))
     }
 }
 

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -68,7 +68,7 @@ pub struct RunningNode {
 impl RunningNode {
     /// Returns this node's `PeerId`
     pub fn peer_id(&self) -> PeerId {
-        *self.network.peer_id
+        self.network.peer_id()
     }
 
     /// Returns the root directory path for the node.
@@ -80,12 +80,12 @@ impl RunningNode {
     ///  - Windows: C:\Users\<username>\AppData\Roaming\safe\node\<peer-id>
     #[allow(rustdoc::invalid_html_tags)]
     pub fn root_dir_path(&self) -> PathBuf {
-        (*self.network.root_dir_path).clone()
+        self.network.root_dir_path().clone()
     }
 
     /// Returns the wallet balance of the node
     pub fn get_node_wallet_balance(&self) -> Result<NanoTokens> {
-        let wallet = HotWallet::load_from(&self.network.root_dir_path)?;
+        let wallet = HotWallet::load_from(self.network.root_dir_path())?;
         Ok(wallet.balance())
     }
 

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -486,7 +486,7 @@ impl Node {
         trace!("Validating record payment for {pretty_key}");
 
         // load wallet
-        let mut wallet = HotWallet::load_from(&self.network.root_dir_path)?;
+        let mut wallet = HotWallet::load_from(self.network.root_dir_path())?;
         let old_balance = wallet.balance().as_nano();
 
         // unpack transfer

--- a/sn_node/src/quote.rs
+++ b/sn_node/src/quote.rs
@@ -86,7 +86,7 @@ pub(crate) async fn quotes_verification(network: &Network, quotes: Vec<(PeerId, 
     // Do nothing if self is not one of the quoters.
     if let Some((_, self_quote)) = quotes
         .iter()
-        .find(|(peer_id, _quote)| *peer_id == *network.peer_id)
+        .find(|(peer_id, _quote)| *peer_id == network.peer_id())
     {
         let target_address =
             NetworkAddress::from_chunk_address(ChunkAddress::new(self_quote.content));
@@ -95,7 +95,7 @@ pub(crate) async fn quotes_verification(network: &Network, quotes: Vec<(PeerId, 
                 .iter()
                 .filter(|(peer_id, quote)| {
                     let is_same_target = quote.content == self_quote.content;
-                    let is_not_self = *peer_id != *network.peer_id;
+                    let is_not_self = *peer_id != network.peer_id();
                     let is_not_zero_quote = quote.cost != NanoTokens::zero();
 
                     let time_gap = Duration::from_secs(10);

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -32,7 +32,7 @@ impl Node {
     ) -> Result<()> {
         for (holder, key) in keys_to_fetch {
             let node = self.clone();
-            let requester = NetworkAddress::from_peer(self.network.peer_id());
+            let requester = NetworkAddress::from_peer(self.network().peer_id());
             let _handle: JoinHandle<Result<()>> = spawn(async move {
                 let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
                 trace!("Fetching record {pretty_key:?} from node {holder:?}");
@@ -40,7 +40,7 @@ impl Node {
                     requester,
                     key: NetworkAddress::from_record_key(&key),
                 });
-                let record_opt = if let Ok(resp) = node.network.send_request(req, holder).await {
+                let record_opt = if let Ok(resp) = node.network().send_request(req, holder).await {
                     match resp {
                         Response::Query(QueryResponse::GetReplicatedRecord(result)) => match result
                         {
@@ -71,7 +71,9 @@ impl Node {
                         target_record: None,
                         expected_holders: Default::default(),
                     };
-                    node.network.get_record_from_network(key, &get_cfg).await?
+                    node.network()
+                        .get_record_from_network(key, &get_cfg)
+                        .await?
                 };
 
                 trace!(
@@ -95,7 +97,7 @@ impl Node {
         paid_key: RecordKey,
         record_type: RecordType,
     ) {
-        let network = self.network.clone();
+        let network = self.network().clone();
 
         let _handle = spawn(async move {
             let start = std::time::Instant::now();

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -32,7 +32,7 @@ impl Node {
     ) -> Result<()> {
         for (holder, key) in keys_to_fetch {
             let node = self.clone();
-            let requester = NetworkAddress::from_peer(*self.network.peer_id);
+            let requester = NetworkAddress::from_peer(self.network.peer_id());
             let _handle: JoinHandle<Result<()>> = spawn(async move {
                 let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
                 trace!("Fetching record {pretty_key:?} from node {holder:?}");
@@ -143,7 +143,7 @@ impl Node {
             };
 
             // remove ourself from these calculations
-            closest_k_peers.retain(|peer_id| peer_id != &*network.peer_id);
+            closest_k_peers.retain(|peer_id| peer_id != &network.peer_id());
 
             let data_addr = NetworkAddress::from_record_key(&paid_key);
 
@@ -161,7 +161,7 @@ impl Node {
                 }
             };
 
-            let our_peer_id = *network.peer_id;
+            let our_peer_id = network.peer_id();
             let our_address = NetworkAddress::from_peer(our_peer_id);
             #[allow(clippy::mutable_key_type)] // for Bytes in NetworkAddress
             let keys = vec![(data_addr.clone(), record_type.clone())];


### PR DESCRIPTION
- Currently, we manually put `Arc<>` on fields inside node and network. And sometimes if we forget to do that, we end up cloning that field way too many times. Also, Arc'ing the entire struct is better than Arc'ing individual fields as it will reduce the number of reference counting vars.
- Thus, we arc the entire struct and wrap it so that we don't leak the Arc to the caller.