### PR TITLE
refactor(network): remove unusued CmdOk type

### DIFF
--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -542,7 +542,7 @@ impl Node {
                 let _handle = spawn(async move {
                     let key = PrettyPrintRecordKey::from(&record.key).into_owned();
                     match self_clone.validate_and_store_record(record).await {
-                        Ok(cmdok) => trace!("UnverifiedRecord {key} stored with {cmdok:?}."),
+                        Ok(()) => trace!("UnverifiedRecord {key} has been stored"),
                         Err(err) => {
                             self_clone.record_metrics(Marker::RecordRejected(&key, &err));
                         }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -79,10 +79,8 @@ impl Node {
                 trace!(
                     "Got Replication Record {pretty_key:?} from network, validating and storing it"
                 );
-                let result = node.store_replicated_in_record(record).await?;
-                trace!(
-                    "Completed storing Replication Record {pretty_key:?} from network, result: {result:?}"
-                );
+                node.store_replicated_in_record(record).await?;
+                trace!("Completed storing Replication Record {pretty_key:?} from network.");
 
                 Ok(())
             });

--- a/sn_protocol/src/messages.rs
+++ b/sn_protocol/src/messages.rs
@@ -20,7 +20,7 @@ pub use self::{
     node_id::NodeId,
     query::Query,
     register::RegisterCmd,
-    response::{CmdOk, CmdResponse, QueryResponse},
+    response::{CmdResponse, QueryResponse},
 };
 
 use super::NetworkAddress;

--- a/sn_protocol/src/messages/response.rs
+++ b/sn_protocol/src/messages/response.rs
@@ -117,10 +117,3 @@ pub enum CmdResponse {
     /// Response to the considered as bad notification
     PeerConsideredAsBad(Result<()>),
 }
-
-/// The Ok variant of a CmdResponse
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CmdOk {
-    StoredSuccessfully,
-    DataAlreadyPresent,
-}


### PR DESCRIPTION
- The CmdOk was used when we were performing PUTs via `ReqResp` protocol instead of `kad` and thus can be removed.