### PR TITLE
feat: node registry refresh searches for pids

### DIFF
--- a/node-launchpad/src/components/home.rs
+++ b/node-launchpad/src/components/home.rs
@@ -95,8 +95,13 @@ impl Home {
         let now = Instant::now();
         debug!("Refreshing node registry states on startup");
         let mut node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
-        sn_node_manager::refresh_node_registry(&mut node_registry, &ServiceController {}, false)
-            .await?;
+        sn_node_manager::refresh_node_registry(
+            &mut node_registry,
+            &ServiceController {},
+            false,
+            true,
+        )
+        .await?;
         node_registry.save()?;
         debug!("Node registry states refreshed in {:?}", now.elapsed());
         home.load_node_registry_and_update_states()?;

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -118,6 +118,12 @@ impl TracingLayers {
                     .event_format(LogFormatter)
                     .boxed()
             }
+            LogOutputDest::Stderr => tracing_fmt::layer()
+                .with_ansi(false)
+                .with_target(false)
+                .event_format(LogFormatter)
+                .with_writer(std::io::stderr)
+                .boxed(),
             LogOutputDest::Path(path) => {
                 std::fs::create_dir_all(path)?;
                 if print_updates_to_stdout {

--- a/sn_logging/src/lib.rs
+++ b/sn_logging/src/lib.rs
@@ -29,6 +29,7 @@ pub use tracing_core::Level;
 
 #[derive(Debug, Clone)]
 pub enum LogOutputDest {
+    Stderr,
     Stdout,
     Path(PathBuf),
 }
@@ -87,6 +88,7 @@ impl LogOutputDest {
 impl std::fmt::Display for LogOutputDest {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            LogOutputDest::Stderr => write!(f, "stderr"),
             LogOutputDest::Stdout => write!(f, "stdout"),
             LogOutputDest::Path(p) => write!(f, "{}", p.to_string_lossy()),
         }
@@ -136,7 +138,7 @@ impl LogBuilder {
     pub fn new(default_logging_targets: Vec<(String, Level)>) -> Self {
         Self {
             default_logging_targets,
-            output_dest: LogOutputDest::Stdout,
+            output_dest: LogOutputDest::Stderr,
             format: LogFormat::Default,
             max_uncompressed_log_files: None,
             max_compressed_log_files: None,

--- a/sn_node_manager/Vagrantfile
+++ b/sn_node_manager/Vagrantfile
@@ -3,13 +3,9 @@ Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = 4096
   end
+  config.vm.network :public_network, :name => "default"
   config.vm.synced_folder "..",
     "/vagrant",
-    type: "9p",
-    accessmode: "mapped",
-    mount_options: ['rw', 'trans=virtio', 'version=9p2000.L']
-  config.vm.synced_folder "../target",
-    "/target",
     type: "9p",
     accessmode: "mapped",
     mount_options: ['rw', 'trans=virtio', 'version=9p2000.L']

--- a/sn_node_manager/src/add_services/mod.rs
+++ b/sn_node_manager/src/add_services/mod.rs
@@ -307,7 +307,7 @@ pub async fn add_node(
     }
 
     if !added_service_data.is_empty() {
-        info!("{} services has been added", added_service_data.len());
+        info!("Added {} services", added_service_data.len());
     } else if !failed_service_data.is_empty() {
         error!("Failed to add {} service(s)", failed_service_data.len());
     }
@@ -316,7 +316,6 @@ pub async fn add_node(
         println!("Services Added:");
         for install in added_service_data.iter() {
             println!(" {} {}", "✓".green(), install.0);
-
             println!("    - Safenode path: {}", install.1);
             println!("    - Data path: {}", install.2);
             println!("    - Log path: {}", install.3);

--- a/sn_node_manager/src/add_services/tests.rs
+++ b/sn_node_manager/src/add_services/tests.rs
@@ -60,7 +60,6 @@ mock! {
         fn get_available_port(&self) -> ServiceControlResult<u16>;
         fn install(&self, install_ctx: ServiceInstallCtx, user_mode: bool) -> ServiceControlResult<()>;
         fn get_process_pid(&self, bin_path: &Path) -> ServiceControlResult<u32>;
-        fn is_service_process_running(&self, pid: u32) -> bool;
         fn start(&self, service_name: &str, user_mode: bool) -> ServiceControlResult<()>;
         fn stop(&self, service_name: &str, user_mode: bool) -> ServiceControlResult<()>;
         fn uninstall(&self, service_name: &str, user_mode: bool) -> ServiceControlResult<()>;

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -1158,6 +1158,7 @@ async fn main() -> Result<()> {
 
 fn get_log_builder(level: Level) -> Result<LogBuilder> {
     let logging_targets = vec![
+        ("sn_peers_acquisition".to_string(), level),
         ("sn_node_manager".to_string(), level),
         ("safenode_manager".to_string(), level),
         ("safenodemand".to_string(), level),

--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -182,6 +182,7 @@ pub async fn balance(
         &mut node_registry,
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
+        false,
     )
     .await?;
 
@@ -225,6 +226,7 @@ pub async fn remove(
         &mut node_registry,
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
+        false,
     )
     .await?;
 
@@ -309,12 +311,13 @@ pub async fn start(
         &mut node_registry,
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
+        false,
     )
     .await?;
 
     let service_indices = get_services_for_ops(&node_registry, peer_ids, service_names)?;
     if service_indices.is_empty() {
-        info!("Service indices is empty, no services were eligible to be started");
+        info!("No services are eligible to be started");
         // This could be the case if all services are at `Removed` status.
         if verbosity != VerbosityLevel::Minimal {
             println!("No services were eligible to be started");
@@ -386,6 +389,7 @@ pub async fn stop(
         &mut node_registry,
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
+        false,
     )
     .await?;
 
@@ -459,6 +463,7 @@ pub async fn upgrade(
         &mut node_registry,
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
+        false,
     )
     .await?;
 

--- a/sn_service_management/src/auditor.rs
+++ b/sn_service_management/src/auditor.rs
@@ -108,11 +108,8 @@ impl<'a> ServiceStateActions for AuditorService<'a> {
         self.service_data.status = ServiceStatus::Removed;
     }
 
-    async fn on_start(&mut self) -> Result<()> {
-        let pid = self
-            .service_control
-            .get_process_pid(&self.service_data.auditor_path)?;
-        self.service_data.pid = Some(pid);
+    async fn on_start(&mut self, pid: Option<u32>, _full_refresh: bool) -> Result<()> {
+        self.service_data.pid = pid;
         self.service_data.status = ServiceStatus::Running;
         Ok(())
     }

--- a/sn_service_management/src/daemon.rs
+++ b/sn_service_management/src/daemon.rs
@@ -101,15 +101,8 @@ impl<'a> ServiceStateActions for DaemonService<'a> {
         self.service_data.status = ServiceStatus::Removed;
     }
 
-    async fn on_start(&mut self) -> Result<()> {
-        // get_process_pid causes errors for the daemon. Maybe because it is being run as root?
-        if let Ok(pid) = self
-            .service_control
-            .get_process_pid(&self.service_data.daemon_path)
-        {
-            self.service_data.pid = Some(pid);
-        }
-
+    async fn on_start(&mut self, pid: Option<u32>, _full_refresh: bool) -> Result<()> {
+        self.service_data.pid = pid;
         self.service_data.status = ServiceStatus::Running;
         Ok(())
     }

--- a/sn_service_management/src/faucet.rs
+++ b/sn_service_management/src/faucet.rs
@@ -105,11 +105,8 @@ impl<'a> ServiceStateActions for FaucetService<'a> {
         self.service_data.status = ServiceStatus::Removed;
     }
 
-    async fn on_start(&mut self) -> Result<()> {
-        let pid = self
-            .service_control
-            .get_process_pid(&self.service_data.faucet_path)?;
-        self.service_data.pid = Some(pid);
+    async fn on_start(&mut self, pid: Option<u32>, _full_refresh: bool) -> Result<()> {
+        self.service_data.pid = pid;
         self.service_data.status = ServiceStatus::Running;
         Ok(())
     }

--- a/sn_service_management/src/rpc.rs
+++ b/sn_service_management/src/rpc.rs
@@ -88,8 +88,15 @@ impl RpcClient {
     async fn connect_with_retry(&self) -> Result<SafeNodeClient<tonic::transport::Channel>> {
         let mut attempts = 0;
         loop {
+            debug!(
+                "Attempting connection to node RPC endpoint at {}...",
+                self.endpoint
+            );
             match SafeNodeClient::connect(self.endpoint.clone()).await {
-                Ok(rpc_client) => break Ok(rpc_client),
+                Ok(rpc_client) => {
+                    debug!("Connection successful");
+                    break Ok(rpc_client);
+                }
                 Err(_) => {
                     attempts += 1;
                     tokio::time::sleep(self.retry_delay).await;


### PR DESCRIPTION
### Description

- 72caf9743 **chore: define network for node manager vm**

  After applying updates on Arch, my Vagrant and libvirt setup doesn't work like it did before. The
  network that Vagrant creates doesn't have internet access. So, the VM needs to be explicitly added
  to the `default` network, rather than the `vagrant-libvirt` network. Shared folders are also a more
  difficult situation now. So one of these were removed.

- 26baf6a4a **feat: node manager logs to stderr**

  A short-lived program like the node manager doesn't need to log to file. The logs can go straight to
  stderr, like most other programs do.

  Two global arguments are added to support this: `--debug` and `--trace`. Setting either of those
  flags will set the logging level to debug or trace, respectively. Normally you can also set an
  environment variable, but I'm leaving this out because there are all sorts of different crate scopes
  you can set with respect to our program.

  BREAKING CHANGE: the previous logging mechanism for logging to file was removed.

  We should also consider actually removing the `Stdout` variant from the `LogOutputDest` enum,
  because it's very non-standard to put logs there.

- 52a587edc **feat: node registry refresh searches for pids**

  The node registry refresh is changed to determine if each service process is running by searching
  for processes that have a binary running at a particular path. Since each node service has its own
  copy of the binary, it is uniquely identified by the location of that binary.

  The refresh is split into partial or full. In the partial case, we will only attempt to find the PID
  by searching for a process by its binary path. If it is found, we set the new PID for the service
  and set its status to `RUNNING`; if it's not found, we set the status to `STOPPED`. This mechanism
  should be robust against user interference, e.g., if they manually start/stop processes by whatever
  means. For a full refresh, we also connect to the node's RPC service to get information about
  connected peers and listeners.

  We will use partial refresh for commands like `start` and `stop`, to help us determine whether we
  should attempt to start/stop services that were already running or not. These commands will
  potentially operate over lots of services so we will avoid the RPC connections here.

  Full refresh will be used when the `status` command runs.

  Finally, I have also reassigned the connected peers data, and added/updated some of the log
  information which I found useful to have during my testing.

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):