### PR TITLE
Handling stalled wallet

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -995,12 +995,13 @@ jobs:
           df
           du -sh /home/runner/
 
-      - name: Confirm the cash_notes files
+      - name: Confirm the wallet files (cash_notes, confirmed_spends)
         run: |
           pwd
           ls $CLIENT_DATA_PATH/ -l
           ls $CLIENT_DATA_PATH/wallet -l
           ls $CLIENT_DATA_PATH/wallet/cash_notes -l
+          ls $CLIENT_DATA_PATH/wallet/confirmed_spends -l
           ls $CLIENT_DATA_PATH/logs -l
         env:
           CLIENT_DATA_PATH: /home/runner/.local/share/safe/client

--- a/sn_cli/src/bin/main.rs
+++ b/sn_cli/src/bin/main.rs
@@ -78,7 +78,8 @@ async fn main() -> Result<()> {
         if let WalletCmds::Address { .. }
         | WalletCmds::Balance { .. }
         | WalletCmds::Create { .. }
-        | WalletCmds::Sign { .. } = cmds
+        | WalletCmds::Sign { .. }
+        | WalletCmds::Status = cmds
         {
             wallet_cmds_without_client(cmds, &client_data_dir_path).await?;
             return Ok(());

--- a/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
@@ -128,6 +128,7 @@ pub enum WalletCmds {
         #[clap(long, name = "sk_str")]
         sk_str: Option<String>,
     },
+    Status,
 }
 
 pub(crate) async fn wallet_cmds_without_client(cmds: &WalletCmds, root_dir: &Path) -> Result<()> {
@@ -194,6 +195,12 @@ pub(crate) async fn wallet_cmds_without_client(cmds: &WalletCmds, root_dir: &Pat
             Ok(())
         }
         WalletCmds::Sign { tx, force } => sign_transaction(tx, root_dir, *force),
+        WalletCmds::Status => {
+            let mut wallet = WalletApiHelper::load_from(root_dir)?;
+            println!("{}", wallet.balance());
+            wallet.status();
+            Ok(())
+        }
         cmd => Err(eyre!("{cmd:?} requires us to be connected to the Network")),
     }
 }

--- a/sn_transfers/src/wallet/hot_wallet.rs
+++ b/sn_transfers/src/wallet/hot_wallet.rs
@@ -11,8 +11,8 @@ use super::{
     data_payments::{PaymentDetails, PaymentQuote},
     keys::{get_main_key_from_disk, store_new_keypair},
     wallet_file::{
-        get_unconfirmed_spend_requests, load_created_cash_note, remove_cash_notes,
-        remove_unconfirmed_spend_requests, store_created_cash_notes,
+        get_confirmed_spend, get_unconfirmed_spend_requests, load_created_cash_note,
+        remove_cash_notes, remove_unconfirmed_spend_requests, store_created_cash_notes,
         store_unconfirmed_spend_requests,
     },
     watch_only::WatchOnlyWallet,
@@ -23,8 +23,8 @@ use crate::{
     cashnotes::UnsignedTransfer,
     transfers::{CashNotesAndSecretKey, OfflineTransfer},
     CashNote, CashNoteRedemption, DerivationIndex, DerivedSecretKey, MainPubkey, MainSecretKey,
-    NanoTokens, SignedSpend, Spend, SpendReason, Transaction, Transfer, UniquePubkey, WalletError,
-    NETWORK_ROYALTIES_PK,
+    NanoTokens, SignedSpend, Spend, SpendAddress, SpendReason, Transaction, Transfer, UniquePubkey,
+    WalletError, NETWORK_ROYALTIES_PK,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -107,6 +107,11 @@ impl HotWallet {
             self.watchonly_wallet.wallet_dir(),
             self.unconfirmed_spend_requests(),
         )
+    }
+
+    /// Get confirmed spend from disk.
+    pub fn get_confirmed_spend(&mut self, spend_addr: SpendAddress) -> Result<Option<SignedSpend>> {
+        get_confirmed_spend(self.watchonly_wallet.wallet_dir(), spend_addr)
     }
 
     /// Remove unconfirmed_spend_requests from disk.

--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -79,6 +79,24 @@ pub(super) fn remove_unconfirmed_spend_requests(
     Ok(())
 }
 
+/// Returns `Some(SignedSpend)` or None if spend doesn't exist.
+pub(super) fn get_confirmed_spend(
+    wallet_dir: &Path,
+    spend_addr: SpendAddress,
+) -> Result<Option<SignedSpend>> {
+    let spends_dir = wallet_dir.join(CONFIRMED_SPENDS_DIR_NAME);
+    let spend_hex_name = spend_addr.to_hex();
+    let spend_file_path = spends_dir.join(spend_hex_name);
+    if !spend_file_path.is_file() {
+        return Ok(None);
+    }
+
+    let file = fs::File::open(&spend_file_path)?;
+    let confirmed_spend = rmp_serde::from_read(&file)?;
+
+    Ok(Some(confirmed_spend))
+}
+
 /// Returns `Some(Vec<SpendRequest>)` or None if file doesn't exist.
 pub(super) fn get_unconfirmed_spend_requests(
     wallet_dir: &Path,


### PR DESCRIPTION
### Description

This PR contains following part to help with resolving stalled wallet:
1, a client `status` wallet cmd to print out current wallet status explicitly. useful to understand what caused wallet stalling.
2, backup all confirmed_spends for future use
3, resend confirmed_spends if necessary

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change



<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
