### PR TITLE
test(node): poisoning old spend should not affect descendants

### DIFF
--- a/sn_cli/src/files/chunk_manager.rs
+++ b/sn_cli/src/files/chunk_manager.rs
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn chunked_files_should_be_written_to_artifacts_dir() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, _, random_files_dir) = init_manager()?;
         let artifacts_dir = manager.artifacts_dir.clone();
         let _ = create_random_files(&random_files_dir, 1, 1)?;
@@ -665,7 +665,7 @@ mod tests {
 
     #[test]
     fn no_datamap_chunked_files_should_be_written_to_artifacts_dir_when_not_public() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, _, random_files_dir) = init_manager()?;
         let artifacts_dir = manager.artifacts_dir.clone();
         let _ = create_random_files(&random_files_dir, 1, 1)?;
@@ -742,7 +742,7 @@ mod tests {
 
     #[test]
     fn chunks_should_be_removed_from_artifacts_dir_if_marked_as_completed() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, _, random_files_dir) = init_manager()?;
 
         let _ = create_random_files(&random_files_dir, 1, 1)?;
@@ -792,7 +792,7 @@ mod tests {
 
     #[test]
     fn marking_all_chunks_as_completed_should_not_remove_the_dir() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, _, random_files_dir) = init_manager()?;
 
         let _ = create_random_files(&random_files_dir, 5, 5)?;
@@ -835,7 +835,7 @@ mod tests {
 
     #[test]
     fn mark_none_and_resume() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, root_dir, random_files_dir) = init_manager()?;
 
         let _ = create_random_files(&random_files_dir, 5, 5)?;
@@ -862,7 +862,7 @@ mod tests {
 
     #[test]
     fn mark_one_chunk_and_resume() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, root_dir, random_files_dir) = init_manager()?;
 
         let _ = create_random_files(&random_files_dir, 5, 5)?;
@@ -910,7 +910,7 @@ mod tests {
 
     #[test]
     fn mark_all_and_resume() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, root_dir, random_files_dir) = init_manager()?;
 
         let _ = create_random_files(&random_files_dir, 5, 5)?;
@@ -941,7 +941,7 @@ mod tests {
 
     #[test]
     fn absence_of_metadata_file_should_re_chunk_the_entire_file() -> Result<()> {
-        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager");
+        let _log_guards = LogBuilder::init_single_threaded_tokio_test("chunk_manager", true);
         let (_tmp_dir, mut manager, _root_dir, random_files_dir) = init_manager()?;
 
         let mut random_files = create_random_files(&random_files_dir, 1, 1)?;

--- a/sn_client/src/uploader/tests/mod.rs
+++ b/sn_client/src/uploader/tests/mod.rs
@@ -26,7 +26,7 @@ use tempfile::tempdir;
 /// 1. Chunk: if cost =0, then chunk is present in the network.
 #[tokio::test]
 async fn chunk_that_already_exists_in_the_network_should_return_zero_store_cost() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -54,7 +54,7 @@ async fn chunk_that_already_exists_in_the_network_should_return_zero_store_cost(
 /// 2. Chunk: if cost !=0, then make payment upload to the network.
 #[tokio::test]
 async fn chunk_should_be_paid_for_and_uploaded_if_cost_is_not_zero() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -87,7 +87,7 @@ async fn chunk_should_be_paid_for_and_uploaded_if_cost_is_not_zero() -> Result<(
 /// 3. Register: if GET register = ok, then merge and push the register.
 #[tokio::test]
 async fn register_should_be_merged_and_pushed_if_it_already_exists_in_the_network() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -112,7 +112,7 @@ async fn register_should_be_merged_and_pushed_if_it_already_exists_in_the_networ
 /// 4. Register: if Get register = err, then get store cost and upload.
 #[tokio::test]
 async fn register_should_be_paid_and_uploaded_if_it_does_not_exists() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -150,7 +150,7 @@ async fn register_should_be_paid_and_uploaded_if_it_does_not_exists() -> Result<
 /// and then uploaded.
 #[tokio::test]
 async fn chunks_should_perform_repayment_if_the_upload_fails_multiple_times() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -192,7 +192,7 @@ async fn chunks_should_perform_repayment_if_the_upload_fails_multiple_times() ->
 /// and then uploaded.
 #[tokio::test]
 async fn registers_should_perform_repayment_if_the_upload_fails_multiple_times() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -235,7 +235,7 @@ async fn registers_should_perform_repayment_if_the_upload_fails_multiple_times()
 /// 1. Registers: Multiple PushRegisterErr should result in Error::SequentialNetworkErrors
 #[tokio::test]
 async fn register_upload_should_error_out_if_there_are_multiple_push_failures() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -267,7 +267,7 @@ async fn register_upload_should_error_out_if_there_are_multiple_push_failures() 
 /// 2. Chunk: Multiple errors during get store cost should result in Error::SequentialNetworkErrors
 #[tokio::test]
 async fn chunk_should_error_out_if_there_are_multiple_errors_during_get_store_cost() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -303,7 +303,7 @@ async fn chunk_should_error_out_if_there_are_multiple_errors_during_get_store_co
 #[tokio::test]
 async fn register_should_error_out_if_there_are_multiple_errors_during_get_store_cost() -> Result<()>
 {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -339,7 +339,7 @@ async fn register_should_error_out_if_there_are_multiple_errors_during_get_store
 /// 4. Chunk: Multiple errors during make payment should result in Error::SequentialUploadPaymentError
 #[tokio::test]
 async fn chunk_should_error_out_if_there_are_multiple_errors_during_make_payment() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -375,7 +375,7 @@ async fn chunk_should_error_out_if_there_are_multiple_errors_during_make_payment
 #[tokio::test]
 async fn register_should_error_out_if_there_are_multiple_errors_during_make_payment() -> Result<()>
 {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 
@@ -411,7 +411,7 @@ async fn register_should_error_out_if_there_are_multiple_errors_during_make_paym
 // 6: Chunks + Registers: if the number of repayments exceed a threshold, it should return MaximumRepaymentsReached error.
 #[tokio::test]
 async fn maximum_repayment_error_should_be_triggered_during_get_store_cost() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("uploader", true);
     let temp_dir = tempdir()?;
     let (mut inner_uploader, task_result_rx) = get_inner_uploader(temp_dir.path().to_path_buf())?;
 

--- a/sn_faucet/src/token_distribution.rs
+++ b/sn_faucet/src/token_distribution.rs
@@ -518,7 +518,7 @@ mod tests {
     #[tokio::test]
     async fn token_distribute_to_user() -> Result<()> {
         let _log_guards =
-            LogBuilder::init_single_threaded_tokio_test("token_distribute_to_user test");
+            LogBuilder::init_single_threaded_tokio_test("token_distribute_to_user test", true);
 
         let amount = NanoTokens::from(10);
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -77,7 +77,7 @@ type ContentErredList = Arc<RwLock<BTreeMap<NetworkAddress, ContentError>>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn data_availability_during_churn() -> Result<()> {
-    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("data_with_churn");
+    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("data_with_churn", false);
 
     let test_duration = if let Ok(str) = std::env::var("TEST_DURATION_MINS") {
         Duration::from_secs(60 * str.parse::<u64>()?)

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -21,9 +21,7 @@ use tracing::info;
 
 #[tokio::test]
 async fn cash_note_transfer_double_spend_fail() -> Result<()> {
-    let _log_guards =
-        LogBuilder::init_single_threaded_tokio_test("cash_note_transfer_double_spend");
-
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("double_spend", true);
     // create 1 wallet add money from faucet
     let first_wallet_dir = TempDir::new()?;
 
@@ -86,7 +84,7 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
 
 #[tokio::test]
 async fn genesis_double_spend_fail() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("genesis_double_spend");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("double_spend", true);
 
     // create a client and an unused wallet to make sure some money already exists in the system
     let first_wallet_dir = TempDir::new()?;

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -17,7 +17,8 @@ use sn_transfers::{
     get_genesis_sk, rng, DerivationIndex, HotWallet, NanoTokens, OfflineTransfer, SpendReason,
     WalletError, GENESIS_CASHNOTE,
 };
-use tracing::info;
+use std::time::Duration;
+use tracing::*;
 
 #[tokio::test]
 async fn cash_note_transfer_double_spend_fail() -> Result<()> {
@@ -69,15 +70,16 @@ async fn cash_note_transfer_double_spend_fail() -> Result<()> {
     assert!(res.is_ok());
 
     // check the CashNotes, it should fail
-    info!("Verifying the transfers from first wallet...");
+    info!("Verifying the transfers from first wallet... Sleeping for 3 seconds.");
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     let cash_notes_for_2: Vec<_> = transfer_to_2.cash_notes_for_recipient.clone();
     let cash_notes_for_3: Vec<_> = transfer_to_3.cash_notes_for_recipient.clone();
 
     let could_err1 = client.verify_cashnote(&cash_notes_for_2[0]).await;
     let could_err2 = client.verify_cashnote(&cash_notes_for_3[0]).await;
-    info!("Verifying at least one fails : {could_err1:?} {could_err2:?}");
-    assert!(could_err1.is_err() || could_err2.is_err());
+    info!("Both should fail during GET record accumulation : {could_err1:?} {could_err2:?}");
+    assert!(could_err1.is_err() && could_err2.is_err());
 
     Ok(())
 }
@@ -149,6 +151,119 @@ async fn genesis_double_spend_fail() -> Result<()> {
         .await;
     std::mem::drop(exclusive_access);
     assert_matches!(res, Err(WalletError::CouldNotSendMoney(_)));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn poisoning_old_spend_should_not_affect_descendant() -> Result<()> {
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("double_spend", true);
+    let mut rng = rng::thread_rng();
+    let reason = SpendReason::default();
+    // create 1 wallet add money from faucet
+    let wallet_dir_1 = TempDir::new()?;
+
+    let (client, mut wallet_1) = get_client_and_funded_wallet(wallet_dir_1.path()).await?;
+    let balance_1 = wallet_1.balance().as_nano();
+    let amount = NanoTokens::from(balance_1 / 2);
+    let to1 = wallet_1.address();
+
+    // Send from 1 -> 2
+    let wallet_dir_2 = TempDir::new()?;
+    let mut wallet_2 = get_wallet(wallet_dir_2.path());
+    assert_eq!(wallet_2.balance(), NanoTokens::zero());
+
+    let to2 = wallet_2.address();
+    let (cash_notes_1, _exclusive_access) = wallet_1.available_cash_notes()?;
+    let to_2_unique_key = (amount, to2, DerivationIndex::random(&mut rng));
+    let transfer_to_2 = OfflineTransfer::new(
+        cash_notes_1.clone(),
+        vec![to_2_unique_key],
+        to1,
+        reason.clone(),
+    )
+    .unwrap();
+
+    info!("Sending 1->2 to the network...");
+    client
+        .send_spends(transfer_to_2.all_spend_requests.iter(), false)
+        .await?;
+    // std::mem::drop(exclusive_access);
+
+    info!("Verifying the transfers from 1 -> 2 wallet...");
+    let cash_notes_for_2: Vec<_> = transfer_to_2.cash_notes_for_recipient.clone();
+    client.verify_cashnote(&cash_notes_for_2[0]).await?;
+    wallet_2.deposit_and_store_to_disk(&cash_notes_for_2)?; // store inside 2
+
+    // Send from 2 -> 22
+    let wallet_dir_22 = TempDir::new()?;
+    let mut wallet_22 = get_wallet(wallet_dir_22.path());
+    assert_eq!(wallet_22.balance(), NanoTokens::zero());
+
+    let (cash_notes_2, _exclusive_access) = wallet_2.available_cash_notes()?;
+    assert!(!cash_notes_2.is_empty());
+    let to_22_unique_key = (
+        wallet_2.balance(),
+        wallet_22.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_22 =
+        OfflineTransfer::new(cash_notes_2, vec![to_22_unique_key], to2, reason.clone()).unwrap();
+
+    client
+        .send_spends(transfer_to_22.all_spend_requests.iter(), false)
+        .await?;
+    // std::mem::drop(exclusive_access);
+
+    info!("Verifying the transfers from 2 -> 22 wallet...");
+    let cash_notes_for_22: Vec<_> = transfer_to_22.cash_notes_for_recipient.clone();
+    client.verify_cashnote(&cash_notes_for_22[0]).await?;
+    wallet_22.deposit_and_store_to_disk(&cash_notes_for_22)?; // store inside 22
+
+    // Try to double spend from 1 -> 3
+    let wallet_dir_3 = TempDir::new()?;
+    let wallet_3 = get_wallet(wallet_dir_3.path());
+    assert_eq!(wallet_3.balance(), NanoTokens::zero());
+
+    let to_3_unique_key = (
+        amount,
+        wallet_3.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_3 =
+        OfflineTransfer::new(cash_notes_1, vec![to_3_unique_key], to1, reason.clone()).unwrap(); // reuse the old cash notes
+    client
+        .send_spends(transfer_to_3.all_spend_requests.iter(), false)
+        .await?;
+    info!("Verifying the transfers from 1 -> 3 wallet... It should error out.");
+    let cash_notes_for_3: Vec<_> = transfer_to_3.cash_notes_for_recipient.clone();
+    assert!(client.verify_cashnote(&cash_notes_for_3[0]).await.is_err()); // the old spend has been poisoned
+
+    // The old spend has been poisoned, but spends from 22 -> 222 should still work
+    let wallet_dir_222 = TempDir::new()?;
+    let wallet_222 = get_wallet(wallet_dir_222.path());
+    assert_eq!(wallet_222.balance(), NanoTokens::zero());
+
+    let (cash_notes_22, _exclusive_access) = wallet_22.available_cash_notes()?;
+    assert!(!cash_notes_22.is_empty());
+    let to_222_unique_key = (
+        wallet_22.balance(),
+        wallet_222.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_222 = OfflineTransfer::new(
+        cash_notes_22,
+        vec![to_222_unique_key],
+        wallet_22.address(),
+        reason,
+    )
+    .unwrap();
+    client
+        .send_spends(transfer_to_222.all_spend_requests.iter(), false)
+        .await?;
+    info!("Verifying the transfers from 22 -> 222 wallet...");
+    let cash_notes_for_222: Vec<_> = transfer_to_222.cash_notes_for_recipient.clone();
+    client.verify_cashnote(&cash_notes_for_222[0]).await?;
 
     Ok(())
 }

--- a/sn_node/tests/sequential_transfers.rs
+++ b/sn_node/tests/sequential_transfers.rs
@@ -18,7 +18,7 @@ use tracing::info;
 
 #[tokio::test]
 async fn cash_note_transfer_multiple_sequential_succeed() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("sequential_transfer");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("sequential_transfer", true);
 
     let first_wallet_dir = TempDir::new()?;
 

--- a/sn_node/tests/storage_payments.rs
+++ b/sn_node/tests/storage_payments.rs
@@ -30,7 +30,7 @@ use xor_name::XorName;
 
 #[tokio::test]
 async fn storage_payment_succeeds() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir = TempDir::new()?;
 
@@ -68,7 +68,7 @@ async fn storage_payment_succeeds() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir: TempDir = TempDir::new()?;
     let chunks_dir = TempDir::new()?;
@@ -106,7 +106,7 @@ async fn storage_payment_fails_with_insufficient_money() -> Result<()> {
 #[ignore = "Currently we do not cache the proofs in the wallet"]
 #[tokio::test]
 async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir: TempDir = TempDir::new()?;
 
@@ -177,7 +177,7 @@ async fn storage_payment_proofs_cached_in_wallet() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir = TempDir::new()?;
     let chunks_dir = TempDir::new()?;
@@ -211,7 +211,7 @@ async fn storage_payment_chunk_upload_succeeds() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir = TempDir::new()?;
     let chunks_dir = TempDir::new()?;
@@ -261,7 +261,7 @@ async fn storage_payment_chunk_upload_fails_if_no_tokens_sent() -> Result<()> {
 
 #[tokio::test]
 async fn storage_payment_register_creation_succeeds() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir = TempDir::new()?;
 
@@ -301,7 +301,7 @@ async fn storage_payment_register_creation_succeeds() -> Result<()> {
 #[tokio::test]
 #[ignore = "Test currently invalid as we always try to pay and upload registers if none found... need to check if this test is valid"]
 async fn storage_payment_register_creation_and_mutation_fails() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments");
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("storage_payments", true);
 
     let paying_wallet_dir = TempDir::new()?;
 

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -74,7 +74,8 @@ type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
-    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("verify_data_location");
+    let _log_appender_guard =
+        LogBuilder::init_multi_threaded_tokio_test("verify_data_location", false);
 
     let churn_count = if let Ok(str) = std::env::var("CHURN_COUNT") {
         str.parse::<u8>()?

--- a/sn_node/tests/verify_routing_table.rs
+++ b/sn_node/tests/verify_routing_table.rs
@@ -30,7 +30,8 @@ const SLEEP_BEFORE_VERIFICATION: Duration = Duration::from_secs(5);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_routing_table() -> Result<()> {
-    let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("verify_routing_table");
+    let _log_appender_guard =
+        LogBuilder::init_multi_threaded_tokio_test("verify_routing_table", false);
 
     let sleep_duration = std::env::var("SLEEP_BEFORE_VERIFICATION")
         .map(|value| {


### PR DESCRIPTION
- Update the logging to prioritize passed in targets (i.e., `sn_networking=warn`) over the defaults set by keywords (i.e., `all`). Thus setting `SN_LOG=all,sn_networking=warn` would mean that we don't use the`sn_networking=trace` set by `all`, instead use the overridden `warn` value.
- Add a test to make sure that spends are valid even if the ancestor is poisoned. 