### PR TITLE
fix(launchpad): make sure the correct primary path is used 

### DIFF
--- a/node-launchpad/src/components/manage_nodes.rs
+++ b/node-launchpad/src/components/manage_nodes.rs
@@ -53,11 +53,20 @@ impl ManageNodes {
 
     fn get_available_space_b() -> Result<usize> {
         let disks = Disks::new_with_refreshed_list();
+        if tracing::level_enabled!(tracing::Level::DEBUG) {
+            for disk in disks.list() {
+                let res = disk.mount_point().ends_with(Self::get_mount_point());
+                debug!(
+                    "Disk: {disk:?} ends with '{:?}': {res:?}",
+                    Self::get_mount_point()
+                );
+            }
+        }
 
         let available_space_b = disks
             .list()
             .iter()
-            .find(|disk| disk.mount_point().starts_with(Self::get_mount_point()))
+            .find(|disk| disk.mount_point().ends_with(Self::get_mount_point()))
             .context("Cannot find the primary disk")?
             .available_space() as usize;
 


### PR DESCRIPTION
Fixes https://github.com/maidsafe/safe_network/issues/1888
- When dealing with unix, every mount point would start with '/'. This would lead to incorrect result when selecting the primary partition. So instead, find the mount point that ends with '/'. This would be our primary partition.
- Tested on windows and mac, and it works as intended.