### PR TITLE
test(node): consecutive double spends should be tracked

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -359,7 +359,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --no-run
         env:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
@@ -397,6 +397,12 @@ jobs:
         run: cargo test --release -p sn_node --features="local-discovery" --test storage_payments -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 25
+
+      - name: execute the double spend tests
+        run: cargo test --release -p sn_node --features="local-discovery" --test double_spend -- --nocapture --test-threads=1
+        env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -203,7 +203,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --no-run
         env:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
@@ -233,6 +233,12 @@ jobs:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           SN_LOG: "all"
         timeout-minutes: 10
+
+      - name: execute the storage payment tests
+        run: cargo test --release -p sn_node --features="local-discovery" --test double_spend -- --nocapture --test-threads=1
+        env:
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 25
 
       - name: Small wait to allow reward receipt
         run: sleep 30

--- a/.github/workflows/nightly_wan.yml
+++ b/.github/workflows/nightly_wan.yml
@@ -169,7 +169,7 @@ jobs:
         continue-on-error: true
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --test sequential_transfers --test storage_payments --no-run
+        run: cargo test --release -p sn_node --test sequential_transfers --test storage_payments --test double_spend --no-run
         timeout-minutes: 30
 
       - name: Start a WAN network
@@ -209,6 +209,10 @@ jobs:
         run: cargo test --release -p sn_node --test storage_payments -- --nocapture --test-threads=1
         env:
           SN_LOG: "all"
+        timeout-minutes: 45
+
+      - name: execute the storage payment tests
+        run: cargo test --release -p sn_node --test double_spend -- --nocapture --test-threads=1
         timeout-minutes: 45
 
       - name: Small wait to allow reward receipt

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -42,6 +42,7 @@ pub use self::{
     error::{GetRecordError, NetworkError},
     event::{MsgResponder, NetworkEvent},
     record_store::{calculate_cost_for_records, NodeRecordStore},
+    spends::SpendVerificationOk,
     transfers::{get_raw_signed_spends_from_record, get_signed_spend_from_record},
 };
 

--- a/sn_networking/src/spends.rs
+++ b/sn_networking/src/spends.rs
@@ -11,14 +11,22 @@ use futures::future::join_all;
 use sn_transfers::{is_genesis_spend, SignedSpend, SpendAddress, TransferError};
 use std::{collections::BTreeSet, iter::Iterator};
 
+#[derive(Debug)]
+pub enum SpendVerificationOk {
+    Valid,
+    ParentDoubleSpend,
+}
+
 impl Network {
     /// This function verifies a single spend.
     /// This is used by nodes for spends validation, before storing them.
-    /// - It checks if the spend has valid ancestry, that its parents exist on the Network
+    /// - It checks if the spend has valid ancestry, that its parents exist on the Network.
+    /// - If the parent is a double spend, we still carry out the valdiation, but return SpendVerificationOk::ParentDoubleSpend
     /// - It checks that the spend has a valid signature and content
     /// - It does NOT check if the spend exists online
     /// - It does NOT check if the spend is already spent on the Network
-    pub async fn verify_spend(&self, spend: &SignedSpend) -> Result<()> {
+    pub async fn verify_spend(&self, spend: &SignedSpend) -> Result<SpendVerificationOk> {
+        let mut result = SpendVerificationOk::Valid;
         let unique_key = spend.unique_pubkey();
         debug!("Verifying spend {unique_key}");
         spend.verify(spend.spent_tx_hash())?;
@@ -26,7 +34,7 @@ impl Network {
         // genesis does not have parents so we end here
         if is_genesis_spend(spend) {
             debug!("Verified {unique_key} was Genesis spend!");
-            return Ok(());
+            return Ok(result);
         }
 
         // get its parents
@@ -39,19 +47,28 @@ impl Network {
         let tasks: Vec<_> = parent_keys
             .map(|a| self.get_spend(SpendAddress::from_unique_pubkey(&a)))
             .collect();
-        let parent_spends: BTreeSet<SignedSpend> = join_all(tasks)
-            .await
-            .into_iter()
-            .collect::<Result<BTreeSet<_>>>()
-            .map_err(|e| {
-                let s = format!("Failed to get parent spend of {unique_key:?}: {e}");
-                warn!("{}", s);
-                NetworkError::Transfer(TransferError::InvalidParentSpend(s))
-            })?;
+        let mut parent_spends = BTreeSet::new();
+        for parent_spend in join_all(tasks).await {
+            match parent_spend {
+                Ok(parent_spend) => {
+                    parent_spends.insert(BTreeSet::from_iter([parent_spend]));
+                }
+                Err(NetworkError::DoubleSpendAttempt(attempts)) => {
+                    warn!("While verifying {unique_key:?}, a double spend attempt detected for the parent {attempts:?}. Continuing verification.");
+                    parent_spends.insert(BTreeSet::from_iter(attempts));
+                    result = SpendVerificationOk::ParentDoubleSpend;
+                }
+                Err(e) => {
+                    let s = format!("Failed to get parent spend of {unique_key}: {e}");
+                    warn!("{}", s);
+                    return Err(NetworkError::Transfer(TransferError::InvalidParentSpend(s)));
+                }
+            }
+        }
 
         // verify the parents
         spend.verify_parent_spends(parent_spends.iter())?;
 
-        Ok(())
+        Ok(result)
     }
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -22,7 +22,7 @@ use sn_protocol::{
 use sn_registers::SignedRegister;
 use sn_transfers::{
     calculate_royalties_fee, CashNote, CashNoteRedemption, HotWallet, NanoTokens, Payment,
-    SignedSpend, Transfer, UniquePubkey, WalletError, NETWORK_ROYALTIES_PK,
+    SignedSpend, Transfer, TransferError, UniquePubkey, WalletError, NETWORK_ROYALTIES_PK,
 };
 use std::collections::BTreeSet;
 use tokio::task::JoinSet;
@@ -743,8 +743,8 @@ impl Node {
 
         if parent_is_a_double_spend && all_verified_spends.len() == 1 {
             warn!("Parent is a double spend for {unique_pubkey:?}, ignoring this spend");
-            return Err(Error::InvalidRequest(format!(
-                "Parent is a double spend for {unique_pubkey:?}, ignoring this spend."
+            return Err(Error::Transfers(TransferError::InvalidParentSpend(
+                format!("Parent is a double spend for {unique_pubkey:?}"),
             )));
         } else if parent_is_a_double_spend && all_verified_spends.len() > 1 {
             warn!("Parent is a double spend for {unique_pubkey:?}, but we're also a double spend. So storing our double spend attempt.");

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -181,7 +181,6 @@ impl SignedSpend {
             }
 
             // if parent is a double spend, get the actual parent among the parent double spends
-            // We cannot have more than 1 parent double spend with same tx hash.
             let actual_parent = parents
                 .iter()
                 .find(|p| p.spent_tx_hash() == tx_our_cash_note_was_created_in)


### PR DESCRIPTION
Consider valid spends, A -> B -> C
Now if A is double spent and then B is double spent, then C should not be valid because B is a double spend.
But this does not happen because we reject double spend of B as its parent was invalid.