### PR TITLE
ci: use `cargo binstall` in release workflow

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -45,7 +45,8 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
       - uses: dtolnay/rust-toolchain@stable
-      # cargo-binstall will try and use pre-built binaries if they are available (also speeds up installing `cross`)
+      # cargo-binstall will try and use pre-built binaries if they are available and also speeds up
+      # installing `cross`
       - uses: cargo-bins/cargo-binstall@main
       - shell: bash
         run: cargo binstall --no-confirm just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      # It's quite slow to install just by building it, but here we need a cross-platform solution.
+      # cargo-binstall will try and use pre-built binaries if they are available and also speeds up
+      # installing `cross`
+      - uses: cargo-bins/cargo-binstall@main
       - shell: bash
-        run: cargo install just
+        run: cargo binstall --no-confirm just
 
       # Set the network versioning based on our branch or workflow input
       - name: provide network versioning


### PR DESCRIPTION
This change was applied to the testing workflow but not the main release workflow. Aligning the two now.