### PR TITLE
fix(network): validate spends even if we get did not get the majority

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -359,7 +359,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --test spend_simulation --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --no-run
         env:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
@@ -406,6 +406,67 @@ jobs:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25
 
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_spend
+          platform: ${{ matrix.os }}
+
+  # runs with increased node count
+  spend_simulation:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    name: spend simulation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build binaries
+        run: cargo build --release --features=local-discovery --bin safenode
+        timeout-minutes: 30
+
+      - name: Build faucet binary
+        run: cargo build --release --bin faucet --features="local-discovery,gifting"
+        timeout-minutes: 30
+
+      - name: Build testing executable
+        run: cargo test --release -p sn_node --features=local-discovery --test spend_simulation --no-run
+        env:
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-count: 50
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ${{ matrix.os }}
+          build: true
+
+      - name: Check SAFE_PEERS was set
+        shell: bash
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+          fi
+
       - name: execute the spend simulation
         run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture --test-threads=1
         env:
@@ -417,7 +478,7 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_spend
+          log_file_prefix: safe_test_logs_spend_simulation
           platform: ${{ matrix.os }}
 
   token_distribution_test:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -468,7 +468,7 @@ jobs:
           fi
 
       - name: execute the spend simulation
-        run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture --test-threads=1
+        run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -300,7 +300,7 @@ jobs:
           build: true
 
       - name: execute the spend simulation test
-        run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture --test-threads=1
+        run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -203,7 +203,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Build testing executable
-        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --test spend_simulation --no-run
+        run: cargo test --release -p sn_node --features=local-discovery --test sequential_transfers --test storage_payments --test double_spend --no-run
         env:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
@@ -221,7 +221,7 @@ jobs:
           build: true
 
       - name: execute the sequential transfers test
-        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture
+        run: cargo test --release -p sn_node --features="local-discovery" --test sequential_transfers -- --nocapture --test-threads=1
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
           SN_LOG: "all"
@@ -240,6 +240,65 @@ jobs:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25
 
+      - name: Small wait to allow reward receipt
+        run: sleep 30
+        timeout-minutes: 1
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_spend
+          platform: ${{ matrix.os }}
+
+      - name: post notification to slack on failure
+        if: ${{ failure() }}
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Nightly Spend Test Run Failed"
+
+  # runs with increased node count
+  spend_simulation:
+    name: spend simulation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+
+      - name: Build binaries
+        run: cargo build --release --features=local-discovery --bin safenode --bin faucet
+        timeout-minutes: 30
+
+      - name: Build testing executable
+        run: cargo test --release -p sn_node --features=local-discovery --test spend_simulation --no-run
+        env:
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@main
+        with:
+          action: start
+          interval: 2000
+          node-count: 50
+          node-path: target/release/safenode
+          faucet-path: target/release/faucet
+          platform: ${{ matrix.os }}
+          build: true
+
       - name: execute the spend simulation test
         run: cargo test --release -p sn_node --features="local-discovery" --test spend_simulation -- --nocapture --test-threads=1
         env:
@@ -255,7 +314,7 @@ jobs:
         uses: maidsafe/sn-local-testnet-action@main
         with:
           action: stop
-          log_file_prefix: safe_test_logs_spend
+          log_file_prefix: safe_test_logs_spend_simulation
           platform: ${{ matrix.os }}
 
       - name: post notification to slack on failure

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -33,6 +33,7 @@ impl Network {
         let get_cfg = GetRecordCfg {
             get_quorum: Quorum::Majority,
             retry_strategy: None,
+            // This should not be set.
             target_record: None,
             expected_holders: Default::default(),
         };

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -33,7 +33,9 @@ impl Network {
         let get_cfg = GetRecordCfg {
             get_quorum: Quorum::Majority,
             retry_strategy: None,
-            // This should not be set.
+            // This should not be set here. This function is used as a quick check to find the spends around the key during
+            // validation. The returned records might possibly be double spend attempt and the record will not match
+            // what we will have in hand.
             target_record: None,
             expected_holders: Default::default(),
         };

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -700,6 +700,23 @@ impl Node {
                 }
                 spends
             }
+            Err(NetworkError::GetRecordError(GetRecordError::NotEnoughCopies {
+                record,
+                got,
+                ..
+            })) => {
+                info!(
+                    "Retrieved {got} copies of the record for {unique_pubkey:?} from the network"
+                );
+                match get_raw_signed_spends_from_record(&record) {
+                    Ok(spends) => spends,
+                    Err(err) => {
+                        warn!("Ignoring invalid record received from the network for spend: {unique_pubkey:?}: {err}");
+                        vec![]
+                    }
+                }
+            }
+
             Err(e) => {
                 warn!("Continuing without network spends as failed to get spends from the network for {unique_pubkey:?}: {e}");
                 vec![]

--- a/sn_node/tests/spend_simulation.rs
+++ b/sn_node/tests/spend_simulation.rs
@@ -226,6 +226,11 @@ async fn spend_simulation() -> Result<()> {
             handle_wallet_task_result(&mut state, result, &mut pending_task_results).await?;
         }
 
+        // Since it is a tiny network, it will be overwhelemed during the verification of things and will lead to a lot
+        // of Query Timeouts & huge number of pending Get requests. So let them settle.
+        println!("Cycle {cycle} completed. Sleeping for 5s before next cycle.");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
         cycle += 1;
     }
 

--- a/sn_node/tests/spend_simulation.rs
+++ b/sn_node/tests/spend_simulation.rs
@@ -29,8 +29,8 @@ use std::{
 use tokio::sync::mpsc;
 use tracing::*;
 
-const MAX_WALLETS: usize = 30;
-const MAX_CYCLES: usize = 10;
+const MAX_WALLETS: usize = 15;
+const MAX_CYCLES: usize = 5;
 const AMOUNT_PER_RECIPIENT: NanoTokens = NanoTokens::from(1000);
 /// The chance for an attack to happen. 1 in X chance.
 const ONE_IN_X_CHANCE_FOR_AN_ATTACK: u32 = 2;
@@ -125,7 +125,7 @@ struct PendingTasksTracker {
 /// cycle is repeated until the max cycles are reached.
 #[tokio::test]
 async fn spend_simulation() -> Result<()> {
-    let _log_guards = LogBuilder::init_single_threaded_tokio_test("spend_simulation", true);
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("spend_simulation", false);
 
     let (client, mut state) = init_state(MAX_WALLETS).await?;
 
@@ -157,6 +157,7 @@ async fn spend_simulation() -> Result<()> {
             .map(|(id, s)| (*id, s.clone()))
             .collect_vec();
         for (id, action_sender) in iter {
+            tokio::time::sleep(Duration::from_secs(3)).await;
             let illicit_spend = rng.gen::<u32>() % ONE_IN_X_CHANCE_FOR_AN_ATTACK == 0;
 
             if illicit_spend {

--- a/sn_node/tests/spend_simulation.rs
+++ b/sn_node/tests/spend_simulation.rs
@@ -29,7 +29,7 @@ use std::{
 use tokio::sync::mpsc;
 use tracing::*;
 
-const MAX_WALLETS: usize = 50;
+const MAX_WALLETS: usize = 30;
 const MAX_CYCLES: usize = 10;
 const AMOUNT_PER_RECIPIENT: NanoTokens = NanoTokens::from(1000);
 /// The chance for an attack to happen. 1 in X chance.


### PR DESCRIPTION
- We were not considering the records that were returned from the network if the quorum was not fulfilled. But these should be considered during validation.

What the PR buys us is that:
Quickly consolidate double spends attempts and store them in nodes. Clients were already safe, but nodes can possibly be out of sync for a while and would wait for replication to get them to sync. So it just reduces 1 step for the nodes

- Also run spend simulation as its own CI run. The local network was getting overwhelemed. 