### PR TITLE
feat: double spend spam protection

### DIFF
--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -42,7 +42,6 @@ pub use self::{
     error::{GetRecordError, NetworkError},
     event::{MsgResponder, NetworkEvent},
     record_store::{calculate_cost_for_records, NodeRecordStore},
-    spends::SpendVerificationOk,
     transfers::{get_raw_signed_spends_from_record, get_signed_spend_from_record},
 };
 

--- a/sn_networking/src/spends.rs
+++ b/sn_networking/src/spends.rs
@@ -11,22 +11,15 @@ use futures::future::join_all;
 use sn_transfers::{is_genesis_spend, SignedSpend, SpendAddress, TransferError};
 use std::{collections::BTreeSet, iter::Iterator};
 
-#[derive(Debug)]
-pub enum SpendVerificationOk {
-    Valid,
-    ParentDoubleSpend,
-}
-
 impl Network {
     /// This function verifies a single spend.
     /// This is used by nodes for spends validation, before storing them.
     /// - It checks if the spend has valid ancestry, that its parents exist on the Network.
-    /// - If the parent is a double spend, we still carry out the valdiation, but return SpendVerificationOk::ParentDoubleSpend
+    /// - If the parent is a double spend, we still carry out the valdiation, but at the end return the error
     /// - It checks that the spend has a valid signature and content
     /// - It does NOT check if the spend exists online
     /// - It does NOT check if the spend is already spent on the Network
-    pub async fn verify_spend(&self, spend: &SignedSpend) -> Result<SpendVerificationOk> {
-        let mut result = SpendVerificationOk::Valid;
+    pub async fn verify_spend(&self, spend: &SignedSpend) -> Result<()> {
         let unique_key = spend.unique_pubkey();
         debug!("Verifying spend {unique_key}");
         spend.verify(spend.spent_tx_hash())?;
@@ -34,10 +27,11 @@ impl Network {
         // genesis does not have parents so we end here
         if is_genesis_spend(spend) {
             debug!("Verified {unique_key} was Genesis spend!");
-            return Ok(result);
+            return Ok(());
         }
 
         // get its parents
+        let mut result = Ok(());
         let parent_keys = spend
             .spend
             .parent_tx
@@ -61,7 +55,7 @@ impl Network {
                 Err(NetworkError::DoubleSpendAttempt(attempts)) => {
                     warn!("While verifying {unique_key:?}, a double spend attempt ({attempts:?}) detected for the parent with pub key {parent_key:?} . Continuing verification.");
                     parent_spends.insert(BTreeSet::from_iter(attempts));
-                    result = SpendVerificationOk::ParentDoubleSpend;
+                    result = Err(NetworkError::Transfer(TransferError::DoubleSpentParent));
                 }
                 Err(e) => {
                     let s = format!("Failed to get parent spend of {unique_key} parent pubkey: {parent_key:?} error: {e}");
@@ -74,6 +68,6 @@ impl Network {
         // verify the parents
         spend.verify_parent_spends(parent_spends.iter())?;
 
-        Ok(result)
+        result
     }
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -8,9 +8,7 @@
 
 use crate::{node::Node, quote::verify_quote_for_storecost, Error, Marker, Result};
 use libp2p::kad::{Record, RecordKey};
-use sn_networking::{
-    get_raw_signed_spends_from_record, GetRecordError, NetworkError, MAX_PACKET_SIZE,
-};
+use sn_networking::{get_raw_signed_spends_from_record, GetRecordError, NetworkError};
 use sn_protocol::{
     storage::{
         try_deserialize_record, try_serialize_record, Chunk, RecordHeader, RecordKind, RecordType,
@@ -26,12 +24,6 @@ use sn_transfers::{
 use std::collections::BTreeSet;
 use tokio::task::JoinSet;
 use xor_name::XorName;
-
-/// The maximum number of double spend attempts to store that we got from PUTs
-const MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_FROM_PUTS: usize = 15;
-
-/// The maximum number of double spend attempts to store inside a record
-const MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_PER_RECORD: usize = 30;
 
 impl Node {
     /// Validate a record and it's payment, and store the record to the RecordStore
@@ -98,7 +90,7 @@ impl Node {
                 let value_to_hash = record.value.clone();
                 let spends = try_deserialize_record::<Vec<SignedSpend>>(&record)?;
                 let result = self
-                    .validate_merge_and_store_spends(spends, &record_key, true)
+                    .validate_merge_and_store_spends(spends, &record_key)
                     .await;
                 if result.is_ok() {
                     Marker::ValidSpendPutFromClient(&PrettyPrintRecordKey::from(&record_key)).log();
@@ -206,7 +198,7 @@ impl Node {
             RecordKind::Spend => {
                 let record_key = record.key.clone();
                 let spends = try_deserialize_record::<Vec<SignedSpend>>(&record)?;
-                self.validate_merge_and_store_spends(spends, &record_key, false)
+                self.validate_merge_and_store_spends(spends, &record_key)
                     .await
             }
             RecordKind::Register => {
@@ -341,7 +333,6 @@ impl Node {
         &self,
         signed_spends: Vec<SignedSpend>,
         record_key: &RecordKey,
-        from_put: bool,
     ) -> Result<()> {
         let pretty_key = PrettyPrintRecordKey::from(record_key);
         debug!("Validating spends before storage at {pretty_key:?}");
@@ -380,10 +371,11 @@ impl Node {
         // validate the signed spends against the network and the local knowledge
         debug!("Validating spends for {pretty_key:?} with unique key: {unique_pubkey:?}");
         let validated_spends = match self
-            .signed_spends_to_keep(spends_for_key.clone(), *unique_pubkey, from_put)
+            .signed_spends_to_keep(spends_for_key.clone(), *unique_pubkey)
             .await
         {
-            Ok(s) => s,
+            Ok((one, None)) => vec![one],
+            Ok((one, Some(two))) => vec![one, two],
             Err(e) => {
                 warn!("Failed to validate spends at {pretty_key:?} with unique key {unique_pubkey:?}: {e}");
                 return Err(e);
@@ -647,47 +639,32 @@ impl Node {
     }
 
     /// Determine which spends our node should keep and store
-    /// - if our local copy has reached the len/size limits, we don't store anymore from kad::PUT and return the local copy
-    /// - else if the request is from replication OR if limit not reached during kad::PUT, then:
-    /// - trust local spends
-    /// - downloads spends from the network
-    /// - verifies incoming spend + network spends and ignores the invalid ones.
-    /// - orders all the verified spends from local + incoming + network
-    /// - returns a maximum of MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_PER_RECORD spends
+    /// - get local spends and trust them
+    /// - get spends from the network
+    /// - verify incoming spend + network spends and ignore the invalid ones
+    /// - orders all the verified spends by:
+    ///     - if they have spent descendants (meaning live branch)
+    ///     - deterministicaly by their order in the BTreeSet
+    /// - returns the spend to keep along with another spend if it was a double spend
+    /// - when we get more than two spends, only keeps 2 that are chosen deterministically so
+    ///     all nodes running this code are eventually consistent
     async fn signed_spends_to_keep(
         &self,
         signed_spends: Vec<SignedSpend>,
         unique_pubkey: UniquePubkey,
-        from_put: bool,
-    ) -> Result<Vec<SignedSpend>> {
+    ) -> Result<(SignedSpend, Option<SignedSpend>)> {
         let spend_addr = SpendAddress::from_unique_pubkey(&unique_pubkey);
         debug!(
             "Validating before storing spend at {spend_addr:?} with unique key: {unique_pubkey}"
         );
 
+        // trust local spends as we've verified them before
         let local_spends = self.get_local_spends(spend_addr).await?;
-        let size_of_local_spends = try_serialize_record(&local_spends, RecordKind::Spend)?
-            .to_vec()
-            .len();
-        let max_spend_len_reached =
-            local_spends.len() >= MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_FROM_PUTS;
-        let max_spend_size_reached = {
-            // todo: limit size of a single signed spend to < max_packet_size/2
-            let size_limit = size_of_local_spends >= MAX_PACKET_SIZE / 2;
-            // just so that we can store the double spend
-            size_limit && local_spends.len() > 1
-        };
-
-        if (max_spend_len_reached || max_spend_size_reached) && from_put {
-            info!("We already have {MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_FROM_PUTS} spends locally or have maximum size of spends, skipping spends received via PUT for {unique_pubkey:?}");
-            return Ok(local_spends);
-        }
         let mut all_verified_spends = BTreeSet::from_iter(local_spends.into_iter());
 
         // get spends from the network at the address for that unique pubkey
         let network_spends = match self.network().get_raw_spends(spend_addr).await {
             Ok(spends) => spends,
-            Err(NetworkError::GetRecordError(GetRecordError::RecordNotFound)) => vec![],
             Err(NetworkError::GetRecordError(GetRecordError::SplitRecord { result_map })) => {
                 warn!("Got a split record (double spend) for {unique_pubkey:?} from the network");
                 let mut spends = vec![];
@@ -722,28 +699,34 @@ impl Node {
             }
         };
 
-        let mut parent_is_a_double_spend = false;
-        // check the received spends and the spends got from the network
+        // only verify spends we don't know of
+        let unverified_spends =
+            BTreeSet::from_iter(network_spends.into_iter().chain(signed_spends.into_iter()));
+        let known_spends = all_verified_spends.clone();
+        let new_unverified_spends: BTreeSet<_> =
+            unverified_spends.difference(&known_spends).collect();
+
         let mut tasks = JoinSet::new();
-        for s in signed_spends.into_iter().chain(network_spends.into_iter()) {
+        for s in new_unverified_spends.into_iter() {
             let self_clone = self.clone();
+            let spend_clone = s.clone();
             let _ = tasks.spawn(async move {
-                let res = self_clone.network().verify_spend(&s).await;
-                (s, res)
+                let res = self_clone.network().verify_spend(&spend_clone).await;
+                (spend_clone, res)
             });
         }
 
-        // collect spends until we have a double spend or until we have all the results
+        // gather verified spends
+        let mut double_spent_parent = vec![];
         while let Some(res) = tasks.join_next().await {
             match res {
                 Ok((spend, Ok(()))) => {
                     info!("Successfully verified {spend:?}");
-                    let _inserted = all_verified_spends.insert(spend);
+                    let _inserted = all_verified_spends.insert(spend.to_owned().clone());
                 }
                 Ok((spend, Err(NetworkError::Transfer(TransferError::DoubleSpentParent)))) => {
-                    // The parent of the spend is a double spend, but we will store it incase our spend is also a double spend
-                    parent_is_a_double_spend = true;
-                    let _inserted = all_verified_spends.insert(spend);
+                    warn!("Parent of {spend:?} was double spent, keeping aside in case we're a double spend as well");
+                    double_spent_parent.push(spend.clone());
                 }
                 Ok((spend, Err(e))) => {
                     // an error here most probably means the received spend is invalid
@@ -758,31 +741,109 @@ impl Node {
             }
         }
 
-        if parent_is_a_double_spend && all_verified_spends.len() == 1 {
-            warn!("Parent is a double spend for {unique_pubkey:?}, ignoring this spend");
-            return Err(Error::Transfers(TransferError::DoubleSpentParent));
-        } else if parent_is_a_double_spend && all_verified_spends.len() > 1 {
-            warn!("Parent is a double spend for {unique_pubkey:?}, but we're also a double spend. So storing our double spend attempt.");
+        // keep track of double spend with double spent parent
+        let some_parents_double_spent = !double_spent_parent.is_empty();
+        let we_re_double_spent = all_verified_spends.len() > 1;
+        if some_parents_double_spent && we_re_double_spent {
+            warn!("Parent of {unique_pubkey:?} was double spent, but it's also a double spend. So keeping track of this double spend attempt.");
+            all_verified_spends.extend(double_spent_parent.into_iter())
         }
 
-        // todo: should we also check the size of spends here? Maybe just limit the size of a single
-        // SignedSpend to < max_packet_size/2 so that we can store atleast 2 of them.
-        let verified_spends = all_verified_spends
-            .into_iter()
-            .take(MAX_DOUBLE_SPEND_ATTEMPTS_TO_KEEP_PER_RECORD)
-            .collect::<Vec<SignedSpend>>();
+        // return 2 spends max
+        let all_verified_spends: Vec<_> = all_verified_spends.into_iter().collect();
+        match all_verified_spends.as_slice() {
+            [one_spend] => Ok((one_spend.clone(), None)),
+            [one, two] => Ok((one.clone(), Some(two.clone()))),
+            [] => {
+                warn!("Invalid request: none of the spends were valid for {unique_pubkey:?}");
+                Err(Error::InvalidRequest(format!(
+                    "Found no valid spends while validating Spends for {unique_pubkey:?}"
+                )))
+            }
+            more => {
+                warn!("Got more than 2 verified spends, this might be a double spend spam attack, making sure to favour live branches (branches with spent descendants)");
+                let (one, two) = self.verified_spends_select_2_live(more).await?;
+                Ok((one, Some(two)))
+            }
+        }
+    }
 
-        if verified_spends.is_empty() {
-            debug!("No valid spends found while validating Spend PUT. Who is sending us garbage?");
-            Err(Error::InvalidRequest(format!(
-                "Found no valid spends while validating Spend PUT for {unique_pubkey:?}"
-            )))
-        } else if verified_spends.len() > 1 {
-            warn!("Got a double spend for {unique_pubkey:?}");
-            Ok(verified_spends)
-        } else {
-            debug!("Got a single valid spend for {unique_pubkey:?}");
-            Ok(verified_spends)
+    async fn verified_spends_select_2_live(
+        &self,
+        many_spends: &[SignedSpend],
+    ) -> Result<(SignedSpend, SignedSpend)> {
+        // get all spends descendants
+        let mut tasks = JoinSet::new();
+        for spend in many_spends {
+            let descendants: BTreeSet<_> = spend
+                .spend
+                .spent_tx
+                .outputs
+                .iter()
+                .map(|o| o.unique_pubkey())
+                .map(SpendAddress::from_unique_pubkey)
+                .collect();
+            for d in descendants {
+                let self_clone = self.clone();
+                let spend_clone = spend.to_owned();
+                let _ = tasks.spawn(async move {
+                    let res = self_clone.network().get_raw_spends(d).await;
+                    (spend_clone, res)
+                });
+            }
+        }
+
+        // identify up to two live spends (aka spends with spent descendants)
+        let mut live_spends = BTreeSet::new();
+        while let Some(res) = tasks.join_next().await {
+            match res {
+                Ok((spend, Ok(_descendant))) => {
+                    let _inserted = live_spends.insert(spend);
+                    if live_spends.len() > 1 {
+                        let array: Vec<_> = live_spends.clone().into_iter().collect();
+                        if let [one, two] = array.as_slice() {
+                            warn!("Got two live spends {one:?} and {two:?}, things are messed up!");
+                            return Ok((one.to_owned().clone(), two.to_owned().clone()));
+                        }
+                    }
+                }
+                Ok((spend, Err(NetworkError::GetRecordError(GetRecordError::RecordNotFound)))) => {
+                    trace!("Spend {spend:?} descendant was not found, continuing...");
+                }
+                Ok((spend, Err(e))) => {
+                    warn!(
+                        "Error fetching spend descendant while checking if {spend:?} is live: {e}"
+                    );
+                }
+                Err(e) => {
+                    let s = format!("Async thread error while selecting live spends: {e}");
+                    error!("{}", s);
+                    return Err(Error::JoinErrorInAsyncThread(s))?;
+                }
+            }
+        }
+
+        // less than 2 live spends were found, order by is live,
+        // then position in BTreeSet and take first two
+        let not_live_spends: BTreeSet<_> = many_spends
+            .iter()
+            .filter(|s| !live_spends.contains(s))
+            .collect();
+        debug!(
+            "Got {} live spends and {} not live ones, keeping only the favoured 2",
+            live_spends.len(),
+            not_live_spends.len()
+        );
+        let ordered_spends: Vec<_> = live_spends
+            .iter()
+            .chain(not_live_spends.into_iter())
+            .collect();
+        match ordered_spends.as_slice() {
+            [one, two, ..] => Ok((one.to_owned().clone(), two.to_owned().clone())),
+            _ => Err(Error::InvalidRequest(format!(
+                "Expected many spends but got {}",
+                many_spends.len()
+            ))),
         }
     }
 }

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -749,9 +749,7 @@ impl Node {
         }
 
         // keep track of double spend with double spent parent
-        let some_parents_double_spent = !double_spent_parent.is_empty();
-        let we_re_double_spent = all_verified_spends.len() > 1;
-        if some_parents_double_spent && we_re_double_spent {
+        if !all_verified_spends.is_empty() && !double_spent_parent.is_empty() {
             warn!("Parent of {unique_pubkey:?} was double spent, but it's also a double spend. So keeping track of this double spend attempt.");
             all_verified_spends.extend(double_spent_parent.into_iter())
         }

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -404,7 +404,7 @@ async fn parent_and_child_double_spends_should_lead_to_cashnote_being_invalid() 
         assert!(str.starts_with("Network Error Double spend(s) was detected"));
     });
 
-    info!("Verifying the original cashnote of B -> C");
+    println!("Verifying the original cashnote of B -> C");
     let result = client.verify_cashnote(&cash_notes_for_c[0]).await;
     info!("Got result while verifying the original spend from B -> C: {result:?}");
     assert_matches!(result, Err(WalletError::CouldNotVerifyTransfer(str)) => {

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -334,6 +334,7 @@ async fn parent_and_child_double_spends_should_lead_to_cashnote_being_invalid() 
         reason.clone(),
     )?;
 
+    info!("spend B to C: {:?}", transfer_to_c.all_spend_requests);
     client
         .send_spends(transfer_to_c.all_spend_requests.iter(), false)
         .await?;
@@ -386,9 +387,18 @@ async fn parent_and_child_double_spends_should_lead_to_cashnote_being_invalid() 
         wallet_b.address(),
         reason.clone(),
     )?; // reuse the old cash notes
+
+    info!("spend B to Y: {:?}", transfer_to_y.all_spend_requests);
     client
         .send_spends(transfer_to_y.all_spend_requests.iter(), false)
         .await?;
+    let spend_b_to_y = transfer_to_y
+        .all_spend_requests
+        .first()
+        .expect("should have one");
+    let b_spends = client.get_spend_from_network(spend_b_to_y.address()).await;
+    info!("B spends: {b_spends:?}");
+
     info!("Verifying the transfers from B -> Y wallet... It should error out.");
     let cash_notes_for_y: Vec<_> = transfer_to_y.cash_notes_for_recipient.clone();
     let result = client.verify_cashnote(&cash_notes_for_y[0]).await;

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -16,7 +16,8 @@ use itertools::Itertools;
 use sn_logging::LogBuilder;
 use sn_networking::NetworkError;
 use sn_transfers::{
-    get_genesis_sk, rng, DerivationIndex, HotWallet, NanoTokens, OfflineTransfer, SpendReason, WalletError, GENESIS_CASHNOTE
+    get_genesis_sk, rng, DerivationIndex, HotWallet, NanoTokens, OfflineTransfer, SpendReason,
+    WalletError, GENESIS_CASHNOTE,
 };
 use std::time::Duration;
 use tracing::*;
@@ -518,13 +519,20 @@ async fn spamming_double_spends_should_not_shadow_live_branch() -> Result<()> {
     });
 
     // the original A should still be present as one of the double spends
-    let res = client.get_spend_from_network(original_a_spend.address()).await;
-    assert_matches!(res, Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(_))));
+    let res = client
+        .get_spend_from_network(original_a_spend.address())
+        .await;
+    assert_matches!(
+        res,
+        Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(
+            _
+        )))
+    );
     if let Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(spends))) = res {
         assert!(spends.iter().contains(original_a_spend))
     }
 
-    // Try to double spend A -> 10 different random keys
+    // Try to double spend A -> n different random keys
     for _ in 0..20 {
         println!("Spamming double spends on A");
         let wallet_dir_y = TempDir::new()?;
@@ -554,8 +562,15 @@ async fn spamming_double_spends_should_not_shadow_live_branch() -> Result<()> {
         });
 
         // the original A should still be present as one of the double spends
-        let res = client.get_spend_from_network(original_a_spend.address()).await;
-        assert_matches!(res, Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(_))));
+        let res = client
+            .get_spend_from_network(original_a_spend.address())
+            .await;
+        assert_matches!(
+            res,
+            Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(
+                _
+            )))
+        );
         if let Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(spends))) = res {
             assert!(spends.iter().contains(original_a_spend))
         }

--- a/sn_node/tests/double_spend.rs
+++ b/sn_node/tests/double_spend.rs
@@ -12,10 +12,11 @@ use assert_fs::TempDir;
 use assert_matches::assert_matches;
 use common::client::{get_client_and_funded_wallet, get_wallet};
 use eyre::Result;
+use itertools::Itertools;
 use sn_logging::LogBuilder;
+use sn_networking::NetworkError;
 use sn_transfers::{
-    get_genesis_sk, rng, DerivationIndex, HotWallet, NanoTokens, OfflineTransfer, SpendReason,
-    WalletError, GENESIS_CASHNOTE,
+    get_genesis_sk, rng, DerivationIndex, HotWallet, NanoTokens, OfflineTransfer, SpendReason, WalletError, GENESIS_CASHNOTE
 };
 use std::time::Duration;
 use tracing::*;
@@ -408,6 +409,157 @@ async fn parent_and_child_double_spends_should_lead_to_cashnote_being_invalid() 
     assert_matches!(result, Err(WalletError::CouldNotVerifyTransfer(str)) => {
         assert!(str.starts_with("Network Error Double spend(s) was detected"));
     });
+
+    Ok(())
+}
+
+#[tokio::test]
+/// When A -> B -> C where C is the UTXO cashnote, double spending A many times over and over
+/// should not lead to the original A disappearing and B becoming orphan
+async fn spamming_double_spends_should_not_shadow_live_branch() -> Result<()> {
+    let _log_guards = LogBuilder::init_single_threaded_tokio_test("double_spend", true);
+    let mut rng = rng::thread_rng();
+    let reason = SpendReason::default();
+    // create 1 wallet add money from faucet
+    let wallet_dir_a = TempDir::new()?;
+
+    let (client, mut wallet_a) = get_client_and_funded_wallet(wallet_dir_a.path()).await?;
+    let balance_a = wallet_a.balance().as_nano();
+    let amount = NanoTokens::from(balance_a / 2);
+
+    // Send from A -> B
+    let wallet_dir_b = TempDir::new()?;
+    let mut wallet_b = get_wallet(wallet_dir_b.path());
+    assert_eq!(wallet_b.balance(), NanoTokens::zero());
+
+    let (cash_notes_a, _exclusive_access) = wallet_a.available_cash_notes()?;
+    let to_b_unique_key = (
+        amount,
+        wallet_b.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_b = OfflineTransfer::new(
+        cash_notes_a.clone(),
+        vec![to_b_unique_key],
+        wallet_a.address(),
+        reason.clone(),
+    )?;
+
+    info!("Sending A->B to the network...");
+    client
+        .send_spends(transfer_to_b.all_spend_requests.iter(), false)
+        .await?;
+
+    // save original A spend
+    let original_a_spend = if let [spend] = transfer_to_b.all_spend_requests.as_slice() {
+        spend
+    } else {
+        panic!("Expected to have one spend here!");
+    };
+
+    info!("Verifying the transfers from A -> B wallet...");
+    let cash_notes_for_b: Vec<_> = transfer_to_b.cash_notes_for_recipient.clone();
+    client.verify_cashnote(&cash_notes_for_b[0]).await?;
+    wallet_b.deposit_and_store_to_disk(&cash_notes_for_b)?; // store inside B
+
+    // Send from B -> C
+    let wallet_dir_c = TempDir::new()?;
+    let mut wallet_c = get_wallet(wallet_dir_c.path());
+    assert_eq!(wallet_c.balance(), NanoTokens::zero());
+
+    let (cash_notes_b, _exclusive_access) = wallet_b.available_cash_notes()?;
+    assert!(!cash_notes_b.is_empty());
+    let to_c_unique_key = (
+        wallet_b.balance(),
+        wallet_c.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_c = OfflineTransfer::new(
+        cash_notes_b.clone(),
+        vec![to_c_unique_key],
+        wallet_b.address(),
+        reason.clone(),
+    )?;
+
+    client
+        .send_spends(transfer_to_c.all_spend_requests.iter(), false)
+        .await?;
+
+    info!("Verifying the transfers from B -> C wallet...");
+    let cash_notes_for_c: Vec<_> = transfer_to_c.cash_notes_for_recipient.clone();
+    client.verify_cashnote(&cash_notes_for_c[0]).await?;
+    wallet_c.deposit_and_store_to_disk(&cash_notes_for_c.clone())?; // store inside c
+
+    // Try to double spend from A -> X
+    let wallet_dir_x = TempDir::new()?;
+    let wallet_x = get_wallet(wallet_dir_x.path());
+    assert_eq!(wallet_x.balance(), NanoTokens::zero());
+
+    let to_x_unique_key = (
+        amount,
+        wallet_x.address(),
+        DerivationIndex::random(&mut rng),
+    );
+    let transfer_to_x = OfflineTransfer::new(
+        cash_notes_a.clone(),
+        vec![to_x_unique_key],
+        wallet_a.address(),
+        reason.clone(),
+    )?; // reuse the old cash notes
+    client
+        .send_spends(transfer_to_x.all_spend_requests.iter(), false)
+        .await?;
+    info!("Verifying the transfers from A -> X wallet... It should error out.");
+    let cash_notes_for_x: Vec<_> = transfer_to_x.cash_notes_for_recipient.clone();
+    let result = client.verify_cashnote(&cash_notes_for_x[0]).await;
+    info!("Got result while verifying double spend from A -> X: {result:?}");
+    assert_matches!(result, Err(WalletError::CouldNotVerifyTransfer(str)) => {
+        assert!(str.starts_with("Network Error Double spend(s) was detected"));
+    });
+
+    // the original A should still be present as one of the double spends
+    let res = client.get_spend_from_network(original_a_spend.address()).await;
+    assert_matches!(res, Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(_))));
+    if let Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(spends))) = res {
+        assert!(spends.iter().contains(original_a_spend))
+    }
+
+    // Try to double spend A -> 10 different random keys
+    for _ in 0..20 {
+        println!("Spamming double spends on A");
+        let wallet_dir_y = TempDir::new()?;
+        let wallet_y = get_wallet(wallet_dir_y.path());
+        assert_eq!(wallet_y.balance(), NanoTokens::zero());
+
+        let to_y_unique_key = (
+            amount,
+            wallet_y.address(),
+            DerivationIndex::random(&mut rng),
+        );
+        let transfer_to_y = OfflineTransfer::new(
+            cash_notes_a.clone(),
+            vec![to_y_unique_key],
+            wallet_a.address(),
+            reason.clone(),
+        )?; // reuse the old cash notes
+        client
+            .send_spends(transfer_to_y.all_spend_requests.iter(), false)
+            .await?;
+        info!("Verifying the transfers from A -> Y wallet... It should error out.");
+        let cash_notes_for_y: Vec<_> = transfer_to_y.cash_notes_for_recipient.clone();
+        let result = client.verify_cashnote(&cash_notes_for_y[0]).await;
+        info!("Got result while verifying double spend from A -> Y: {result:?}");
+        assert_matches!(result, Err(WalletError::CouldNotVerifyTransfer(str)) => {
+            assert!(str.starts_with("Network Error Double spend(s) was detected"));
+        });
+
+        // the original A should still be present as one of the double spends
+        let res = client.get_spend_from_network(original_a_spend.address()).await;
+        assert_matches!(res, Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(_))));
+        if let Err(sn_client::Error::Network(NetworkError::DoubleSpendAttempt(spends))) = res {
+            assert!(spends.iter().contains(original_a_spend))
+        }
+    }
 
     Ok(())
 }

--- a/sn_transfers/src/cashnotes/signed_spend.rs
+++ b/sn_transfers/src/cashnotes/signed_spend.rs
@@ -235,25 +235,26 @@ impl std::hash::Hash for SignedSpend {
 }
 
 /// Represents the data to be signed by the DerivedSecretKey of the CashNote being spent.
-#[derive(custom_debug::Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Spend {
     /// UniquePubkey of input CashNote that this SignedSpend is proving to be spent.
     pub unique_pubkey: UniquePubkey,
     /// The transaction that the input CashNote is being spent in (where it is an input)
-    #[debug(skip)]
     pub spent_tx: Transaction,
     /// Reason why this CashNote was spent.
-    #[debug(skip)]
     pub reason: SpendReason,
     /// The amount of the input CashNote.
-    #[debug(skip)]
     pub amount: NanoTokens,
     /// The transaction that the input CashNote was created in (where it is an output)
-    #[debug(skip)]
     pub parent_tx: Transaction,
     /// Data to claim the Network Royalties (if any) from the Spend's descendants (outputs in spent_tx)
-    #[debug(skip)]
     pub network_royalties: Vec<DerivationIndex>,
+}
+
+impl core::fmt::Debug for Spend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Spend({:?}({:?}))", self.unique_pubkey, self.hash())
+    }
 }
 
 impl Spend {

--- a/sn_transfers/src/error.rs
+++ b/sn_transfers/src/error.rs
@@ -31,6 +31,8 @@ pub enum TransferError {
     InvalidSpentTx(String),
     #[error("Invalid parent spend: {0}")]
     InvalidParentSpend(String),
+    #[error("Parent spend was double spent")]
+    DoubleSpentParent,
     #[error("Invalid Spend Signature for {0:?}")]
     InvalidSpendSignature(UniquePubkey),
     #[error("Transaction hash is different from the hash in the the Spend: {0:?} != {1:?}")]


### PR DESCRIPTION
### Description

- protects from spend shadowing through spamming attack
- now Network Spend entries can only ever contain 2 entries max, chosen deterministically so all nodes are eventually consistent and there are NO FORKS in the knowledge, and less space is used!
- small cleanup of spend verification API

### The attack

An attack to hide a good spend. Say we have:
A->B->C->D
The attacker wants to get rid of B to poison C and D. They can spam the network with lots of double spends for B until none of the nodes have the original one. The attack is quite intricate and we discussed different alternatives with 2 spends as max for a spend record or unlimited (record size) as max. In both cases the attack was successful.
The solution was to add a descendency check in the case where we have more than 2 spends to choose which to keep:

  -  spend arrives from put
  -  check local kad (assume those are correct)
  -  ask peers for what they have at this addr (verify those)
   - then verify the incoming put ones
   - If we have more than 2 spends in total after all these checks, order by
       - Do they have valid descendants?
       - determistic Hash (order in BTreeSet)
   - And keep 2 of them only
       - If only one has a valid descendency, we successfully saved the good branch
       - If two or more do, we keep two, both become invalid, and the others orphans (invalid too as a result)
       - If none do, the line stops here and that’s what we want

