### PR TITLE
fix(networking): keep live peer if not last conn

### DIFF
--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -407,7 +407,12 @@ impl SwarmDriver {
             } => {
                 event_string = "ConnectionClosed";
                 trace!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
-                let _ = self.live_connected_peers.remove(&connection_id);
+
+                // If no other connections remaining (to this peer), stop monitoring
+                if num_established == 0 {
+                    let _ = self.live_connected_peers.remove(&connection_id);
+                }
+
                 #[cfg(feature = "open-metrics")]
                 if let Some(metrics) = &self.network_metrics {
                     metrics

--- a/sn_networking/src/relay_manager.rs
+++ b/sn_networking/src/relay_manager.rs
@@ -9,7 +9,7 @@
 use crate::driver::{BadNodes, NodeBehaviour};
 use itertools::Itertools;
 use libp2p::{
-    core::transport::ListenerId, multiaddr::Protocol, Multiaddr, PeerId, StreamProtocol, Swarm,
+    core::transport::ListenerId, multiaddr::Protocol, relay::STOP_PROTOCOL_NAME, Multiaddr, PeerId, StreamProtocol, Swarm
 };
 use rand::Rng;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -23,7 +23,7 @@ pub(crate) fn is_a_relayed_peer(addrs: &HashSet<Multiaddr>) -> bool {
         .any(|multiaddr| multiaddr.iter().any(|p| matches!(p, Protocol::P2pCircuit)))
 }
 
-/// To manager relayed connections.
+/// To manage relayed connections.
 #[derive(Debug)]
 pub(crate) struct RelayManager {
     self_peer_id: PeerId,
@@ -260,7 +260,7 @@ impl RelayManager {
 
     fn does_it_support_relay_server_protocol(protocols: &Vec<StreamProtocol>) -> bool {
         for stream_protocol in protocols {
-            if *stream_protocol == "/libp2p/circuit/relay/0.2.0/stop" {
+            if stream_protocol == &STOP_PROTOCOL_NAME {
                 return true;
             }
         }


### PR DESCRIPTION
We are keeping a list of live connections to a peer, but removed the
peer from this list when we'd close a connection.

However, it's possible that we have multiple connections to a single
peer, so we only should remove it from the list if no connections are
remaining.
