### PR TITLE
refactor(cli)!: `wallet address` and `wallet create` changes

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -5,9 +5,9 @@ on:
   # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [ main, alpha*, beta*, rc* ]
   pull_request:
-    branches: ["*"]
+    branches: [ "*" ]
 
 env:
   SAFE_DATA_PATH: /home/runner/.local/share/safe
@@ -100,6 +100,7 @@ jobs:
       - name: Create and fund a wallet to pay for files storage
         run: |
           echo "Obtaining address for use with the faucet..."
+          ./target/release/safe --log-output-dest=data-dir wallet create
           address=$(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1)
           echo "Sending tokens to the faucet at $address"
           ./target/release/faucet --log-output-dest=data-dir send 5000000 $address > initial_balance_from_faucet.txt
@@ -171,6 +172,7 @@ jobs:
           mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
           ls -l $CLIENT_DATA_PATH
           cp ./the-test-data.zip ./the-test-data_1.zip
+          ./target/release/safe --log-output-dest=data-dir wallet create --no-replace
           ./target/release/faucet --log-output-dest=data-dir send 5000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) > initial_balance_from_faucet_1.txt
           cat initial_balance_from_faucet_1.txt
           cat initial_balance_from_faucet_1.txt | tail -n 1 > transfer_hex

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,9 +5,9 @@ on:
   # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [ main, alpha*, beta*, rc* ]
   pull_request:
-    branches: ["*"]
+    branches: [ "*" ]
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
@@ -95,7 +95,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -207,6 +207,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
+          ./target/release/safe --log-output-dest=data-dir wallet create
           ./target/release/faucet --log-output-dest=data-dir send 1000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
           ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
         env:
@@ -341,7 +342,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -421,7 +422,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -487,7 +488,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -855,6 +856,7 @@ jobs:
 
       - name: Create and fund a wallet first time
         run: |
+          ~/safe --log-output-dest=data-dir wallet create
           ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 1>first.txt
           echo "----------"
           cat first.txt
@@ -869,6 +871,7 @@ jobs:
           rm -rf /home/runner/.local/share/safe/test_faucet
           rm -rf /home/runner/.local/share/safe/test_genesis
           rm -rf /home/runner/.local/share/safe/client
+          ~/safe --log-output-dest=data-dir wallet create
           ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 1>second.txt
           echo "----------"
           cat second.txt
@@ -889,6 +892,7 @@ jobs:
           rm -rf /home/runner/.local/share/safe/test_faucet
           rm -rf /home/runner/.local/share/safe/test_genesis
           rm -rf /home/runner/.local/share/safe/client
+          ~/safe --log-output-dest=data-dir wallet create
           if GENESIS_PK=a9925296499299fdbf4412509d342a92e015f5b996e9acd1d2ab7f2326e3ad05934326efdc345345a95e973ac1bb6637 GENESIS_SK=40f6bbc870355c68138ac70b450b6425af02b49874df3f141b7018378ceaac66 nohup ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1); then
             echo "Faucet with different genesis key not rejected!"
             exit 1
@@ -1027,6 +1031,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
+          ~/safe --log-output-dest=data-dir wallet create
           ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
           ~/safe --log-output-dest=data-dir wallet receive --file transfer_hex
         env:
@@ -1159,6 +1164,7 @@ jobs:
 
       - name: Create and fund a wallet to pay for files storage
         run: |
+          ./target/release/safe --log-output-dest=data-dir wallet create
           ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
           ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
         env:
@@ -1243,6 +1249,7 @@ jobs:
           ls -l $SAFE_DATA_PATH
           mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
           ls -l $CLIENT_DATA_PATH
+          ./target/release/safe --log-output-dest=data-dir wallet create
           ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
           ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
         env:

--- a/README.md
+++ b/README.md
@@ -24,18 +24,23 @@ Libp2p.<br>
 
 ### For Developers
 
-At build time the following env vars can be set to override default keys (** and must be set during the release process to override the default keys**. Github Secrets can be used to set these values for the release process):
+At build time the following env vars can be set to override default keys (** and must be set during the release process
+to override the default keys**. Github Secrets can be used to set these values for the release process):
 
 - `GENESIS_PK` - The genesis spend public key to use for genesis verification.
-- `GENESIS_SK` - If building the faucet for the genesis spend, this is the secret key to use for genesis verification. This should be kept secret.
+- `GENESIS_SK` - If building the faucet for the genesis spend, this is the secret key to use for genesis verification.
+  This should be kept secret.
 - `FOUNDATION_PK` - The foundation public key to use for the initial disbursement to the foundation.
 - `NETWORK_ROYALTIES_PK` - The foundation public key to use for receiving network royalties.
 - `PAYMENT_FORWARD_PK` - The public key to use for payment forwarding for the beta network collection.
 
 When you start a network there are a few scripts to aid with basic processes:
 
-- `resources/scripts/claim-genesis.sh` which will claim the genesis tokens for a wallet on a launched network (if you have set up the foundation wallet locally by adding a `client/account_secret` and regenerating the wallet or directly adding the `client/wallet/main_secret_key` itself).
-- `resources/scripts/make-wallets.sh` which if you have a wallet with a balance will create a number of wallets with another balance. eg `resources/scripts/make-wallets.sh 5 1` will make 5 wallets with 1 token.
+- `resources/scripts/claim-genesis.sh` which will claim the genesis tokens for a wallet on a launched network (if you
+  have set up the foundation wallet locally by adding a `client/account_secret` and regenerating the wallet or directly
+  adding the `client/wallet/main_secret_key` itself).
+- `resources/scripts/make-wallets.sh` which if you have a wallet with a balance will create a number of wallets with
+  another balance. eg `resources/scripts/make-wallets.sh 5 1` will make 5 wallets with 1 token.
 - `resources/scripts/upload-random-data` will use the existing `client` to upload random data to the network.
 
 - [Client](https://github.com/maidsafe/safe_network/blob/main/sn_client/README.md) The client APIs
@@ -254,7 +259,7 @@ Steps on the offline device/computer with the corresponding hot-wallet:
 
 5. If you still don't have a hot-wallet created, which owns the cash-notes used to build the
    unsigned transaction, create it with the corresponding secret key:
-   `cargo run --release --bin safe -- wallet create <hex-encoded secret key>`
+   `cargo run --release --bin safe -- wallet create --key <hex-encoded secret key>`
 
 6. Use the hot-wallet to sign the built transaction:
    `cargo run --release --bin safe -- wallet sign <unsigned transaction>`
@@ -527,7 +532,8 @@ metrics.
 
 ## Contributing
 
-Feel free to clone and modify this project. Pull requests are welcome.<br>You can also visit \* \*[The MaidSafe Forum](https://safenetforum.org/)\*\* for discussion or if you would like to join our
+Feel free to clone and modify this project. Pull requests are welcome.<br>You can also
+visit \* \*[The MaidSafe Forum](https://safenetforum.org/)\*\* for discussion or if you would like to join our
 online community.
 
 ### Pull Request Process

--- a/sn_cli/src/bin/main.rs
+++ b/sn_cli/src/bin/main.rs
@@ -244,3 +244,97 @@ fn get_stdin_response(prompt: &str) -> String {
     };
     buffer
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::subcommands::wallet::hot_wallet::{wallet_cmds_without_client, WalletCmds};
+    use crate::subcommands::wallet::WalletApiHelper;
+    use bls::SecretKey;
+    use color_eyre::Result;
+    use sn_client::acc_packet::{load_or_create_mnemonic, secret_key_from_mnemonic};
+    use sn_client::transfers::HotWallet;
+    use std::path::Path;
+
+    fn create_wallet(root_dir: &Path, derivation_passphrase: Option<String>) -> Result<HotWallet> {
+        let mnemonic = load_or_create_mnemonic(root_dir)?;
+        let secret_key = secret_key_from_mnemonic(mnemonic, derivation_passphrase)?;
+        let wallet = HotWallet::create_from_key(root_dir, secret_key)?;
+        Ok(wallet)
+    }
+
+    #[tokio::test]
+    async fn test_wallet_address_command() {
+        let tmp_dir = tempfile::tempdir().expect("Could not create temp dir");
+        let root_dir = tmp_dir.path().to_path_buf();
+
+        // Create wallet
+        let _wallet = create_wallet(&root_dir, None).expect("Could not create wallet");
+
+        let cmds = WalletCmds::Address;
+
+        let result = wallet_cmds_without_client(&cmds, &root_dir).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_wallet_address_command_should_fail_with_no_existing_wallet() {
+        let tmp_dir = tempfile::tempdir().expect("Could not create temp dir");
+        let client_data_dir = tmp_dir.path().to_path_buf();
+
+        let cmds = WalletCmds::Address;
+
+        // Runs command without a wallet being present, thus should fail
+        let result = wallet_cmds_without_client(&cmds, &client_data_dir).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_wallet_create_command() {
+        let tmp_dir = tempfile::tempdir().expect("Could not create temp dir");
+        let root_dir = tmp_dir.path().to_path_buf();
+
+        let cmds = WalletCmds::Create {
+            no_replace: false,
+            key: None,
+            derivation_passphrase: None,
+        };
+
+        // Run command and hopefully create a wallet
+        let result = wallet_cmds_without_client(&cmds, &root_dir).await;
+        assert!(result.is_ok());
+
+        // Check if valid wallet exists
+        let result = WalletApiHelper::load_from(&root_dir);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_wallet_create_command_with_hex_key() {
+        let tmp_dir = tempfile::tempdir().expect("Could not create temp dir");
+        let root_dir = tmp_dir.path().to_path_buf();
+
+        let secret_key = SecretKey::random();
+        let secret_key_hex = secret_key.to_hex();
+
+        let cmds = WalletCmds::Create {
+            no_replace: false,
+            key: Some(secret_key_hex),
+            derivation_passphrase: None,
+        };
+
+        // Run command and hopefully create a wallet
+        let result = wallet_cmds_without_client(&cmds, &root_dir).await;
+        assert!(result.is_ok());
+
+        // Check if valid wallet exists
+        let result = WalletApiHelper::load_from(&root_dir);
+        assert!(result.is_ok());
+
+        if let WalletApiHelper::HotWallet(wallet) = result.expect("No valid wallet found") {
+            // Compare public addresses (secret keys are the same if the public addresses are)
+            assert_eq!(wallet.address().to_hex(), secret_key.public_key().to_hex());
+        } else {
+            panic!("Did not expect a watch only wallet");
+        }
+    }
+}

--- a/sn_cli/src/bin/subcommands/wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet.rs
@@ -18,7 +18,7 @@ use color_eyre::Result;
 use std::{collections::BTreeSet, io::Read, path::Path};
 
 // TODO: convert this into a Trait part of the wallet APIs.
-enum WalletApiHelper {
+pub(crate) enum WalletApiHelper {
     WatchOnlyWallet(WatchOnlyWallet),
     HotWallet(HotWallet),
 }

--- a/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::get_stdin_response;
 
+use autonomi::utils::is_valid_key_hex;
 use bls::SecretKey;
 use clap::Parser;
 use color_eyre::{
@@ -175,6 +176,13 @@ pub(crate) async fn wallet_cmds_without_client(cmds: &WalletCmds, root_dir: &Pat
                 return Err(eyre!(
                     "Only one of `--key` or `--derivation` may be specified"
                 ));
+            }
+            if let Some(key) = key {
+                // Check if key is valid
+                // Doing this early to avoid stashing an existing wallet while the provided key is invalid
+                if !is_valid_key_hex(key) {
+                    return Err(eyre!("Please provide a valid secret key in hex format. It must be 64 characters long."));
+                }
             }
             // Check for existing wallet
             if let Ok(existing_wallet) = WalletApiHelper::load_from(root_dir) {

--- a/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
@@ -50,13 +50,13 @@ pub enum WalletCmds {
         #[clap(long, short, action)]
         no_replace: bool,
         /// Optional hex-encoded main secret key.
-        #[clap(name = "key")]
+        #[clap(long, short, name = "key")]
         key: Option<String>,
         /// Optional derivation passphrase to protect the mnemonic,
         /// it's not the source of the entropy for the mnemonic generation.
         /// The mnemonic+passphrase will be the seed. See detail at
         /// `<https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed>`
-        #[clap(name = "derivation")]
+        #[clap(long, short, name = "derivation")]
         derivation_passphrase: Option<String>,
         // Optional password to encrypt the wallet with.
         // #[clap(name = "password")]

--- a/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
+++ b/sn_cli/src/bin/subcommands/wallet/hot_wallet.rs
@@ -173,7 +173,7 @@ pub(crate) async fn wallet_cmds_without_client(cmds: &WalletCmds, root_dir: &Pat
         } => {
             if key.is_some() && derivation_passphrase.is_some() {
                 return Err(eyre!(
-                    "Only one of `--hex` or `--derivation` may be specified"
+                    "Only one of `--key` or `--derivation` may be specified"
                 ));
             }
             // Check for existing wallet

--- a/sn_cli/src/lib.rs
+++ b/sn_cli/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod acc_packet;
 mod files;
+pub mod utils;
 
 pub use acc_packet::AccountPacket;
 pub use files::{

--- a/sn_cli/src/utils.rs
+++ b/sn_cli/src/utils.rs
@@ -1,0 +1,4 @@
+/// Returns whether a hex string is a valid secret key in hex format.
+pub fn is_valid_key_hex(hex: &str) -> bool {
+    hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}

--- a/sn_client/src/acc_packet.rs
+++ b/sn_client/src/acc_packet.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::path::Path;
-
 use super::error::Result;
-use sn_transfers::{get_faucet_data_dir, HotWallet};
+use bip39::Mnemonic;
+use sn_transfers::{get_faucet_data_dir, HotWallet, MainSecretKey};
+use std::path::Path;
 
 pub mod user_secret;
 
@@ -21,34 +21,48 @@ pub fn load_account_wallet_or_create_with_mnemonic(
     derivation_passphrase: Option<&str>,
 ) -> Result<HotWallet> {
     let wallet = HotWallet::load_from(root_dir);
+
     match wallet {
         Ok(wallet) => Ok(wallet),
         Err(error) => {
             warn!("Issue loading wallet, creating a new one: {error}");
             println!("Issue loading wallet from {root_dir:?}");
 
-            let mnemonic = match user_secret::read_mnemonic_from_disk(root_dir) {
-                Ok(mnemonic) => {
-                    println!("Found existing mnemonic in {root_dir:?}, this will be used for key derivation.");
-                    info!("Using existing mnemonic from {root_dir:?}");
-                    mnemonic
-                }
-                Err(error) => {
-                    println!("No existing mnemonic found, creating a new one in {root_dir:?}.");
-                    warn!("No existing mnemonic found in {root_dir:?}, creating new one. Error was: {error:?}");
-                    let mnemonic = user_secret::random_eip2333_mnemonic()?;
-                    user_secret::write_mnemonic_to_disk(root_dir, &mnemonic)?;
+            let mnemonic = load_or_create_mnemonic(root_dir)?;
+            let wallet =
+                secret_key_from_mnemonic(mnemonic, derivation_passphrase.map(|v| v.to_owned()))?;
 
-                    mnemonic
-                }
-            };
-
-            let passphrase = derivation_passphrase.unwrap_or(DEFAULT_WALLET_DERIVIATION_PASSPHRASE);
-
-            let wallet = user_secret::account_wallet_secret_key(mnemonic, passphrase)?;
             Ok(HotWallet::create_from_key(root_dir, wallet)?)
         }
     }
+}
+
+pub fn load_or_create_mnemonic(root_dir: &Path) -> Result<Mnemonic> {
+    match user_secret::read_mnemonic_from_disk(root_dir) {
+        Ok(mnemonic) => {
+            println!(
+                "Found existing mnemonic in {root_dir:?}, this will be used for key derivation."
+            );
+            info!("Using existing mnemonic from {root_dir:?}");
+            Ok(mnemonic)
+        }
+        Err(error) => {
+            println!("No existing mnemonic found, creating a new one in {root_dir:?}.");
+            warn!("No existing mnemonic found in {root_dir:?}, creating new one. Error was: {error:?}");
+            let mnemonic = user_secret::random_eip2333_mnemonic()?;
+            user_secret::write_mnemonic_to_disk(root_dir, &mnemonic)?;
+            Ok(mnemonic)
+        }
+    }
+}
+
+pub fn secret_key_from_mnemonic(
+    mnemonic: Mnemonic,
+    derivation_passphrase: Option<String>,
+) -> Result<MainSecretKey> {
+    let passphrase =
+        derivation_passphrase.unwrap_or(DEFAULT_WALLET_DERIVIATION_PASSPHRASE.to_owned());
+    user_secret::account_wallet_secret_key(mnemonic, &passphrase)
 }
 
 pub fn create_faucet_account_and_wallet() -> HotWallet {


### PR DESCRIPTION
### Description

CLI changes.

`wallet address` command no longer creates a new wallet when there is no active wallet.

`wallet create` command now accepts the optional flags `--no-replace`, `--key` and `--derivation`, and eventually also `--password` to optionally encrypt the wallet.

| Flag  | Description |
| - | - |
| --no-replace | Auto answers with no, when asked if user wants to replace an existing wallet. |
| --key | Allows a user to create a wallet from an existing hex encoded private key. |
| --derivation | Allows users to set a derivation passphrase that will be used together with the mnemonic to create a new private key. If not set, a default derivation passphrase will be used. |

The mnemonic will automatically be generated if it doesn't exist already.

`--key` and `--derivation` can't be used together.

### Related Issue

Fixes #1963 

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
