### PR TITLE
fix(network): do not add bootstrap peer as relay candidate

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -577,7 +577,7 @@ impl NetworkBuilder {
 
         let bootstrap = ContinuousBootstrap::new();
         let replication_fetcher = ReplicationFetcher::new(peer_id, network_event_sender.clone());
-        let mut relay_manager = RelayManager::new(self.initial_peers, peer_id);
+        let mut relay_manager = RelayManager::new(peer_id);
         if !is_client {
             relay_manager.enable_hole_punching(self.is_behind_home_network);
         }

--- a/sn_networking/src/relay_manager.rs
+++ b/sn_networking/src/relay_manager.rs
@@ -40,27 +40,14 @@ pub(crate) struct RelayManager {
 }
 
 impl RelayManager {
-    pub(crate) fn new(initial_peers: Vec<Multiaddr>, self_peer_id: PeerId) -> Self {
-        let candidates = initial_peers
-            .into_iter()
-            .filter_map(|addr| {
-                for protocol in addr.iter() {
-                    if let Protocol::P2p(peer_id) = protocol {
-                        let relay_addr = Self::craft_relay_address(&addr, Some(peer_id))?;
-
-                        return Some((peer_id, relay_addr));
-                    }
-                }
-                None
-            })
-            .collect();
+    pub(crate) fn new(self_peer_id: PeerId) -> Self {
         Self {
             self_peer_id,
             reserved_by: Default::default(),
             enable_client: false,
             connected_relays: Default::default(),
             waiting_for_reservation: Default::default(),
-            candidates,
+            candidates: Default::default(),
             relayed_listener_id_map: Default::default(),
         }
     }


### PR DESCRIPTION
- We were adding the bootstrap peers as relay candidate during init of RelayManager. We should not be doing that.