### PR TITLE
[wip]: Testing For Replication Decrease

### DIFF
--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -286,6 +286,9 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
                 ("sn_registers".to_string(), Level::INFO),
                 ("sn_service_management".to_string(), Level::TRACE),
                 ("sn_transfers".to_string(), Level::TRACE),
+                // ("libp2p".to_string(), Level::TRACE),
+                ("libp2p_swarm".to_string(), Level::TRACE),
+                ("libp2p_kad".to_string(), Level::TRACE),
             ]);
 
             // Override sn_networking if it was not specified.

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -55,7 +55,15 @@ use sn_protocol::storage::{try_serialize_record, RecordKind, SpendAddress};
 
 /// Interval to trigger replication of all records to all peers.
 /// This is the max time it should take. Minimum interval at any node will be half this
-pub const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 45;
+pub const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 450;
+
+/// Interval to trigger bad node detection.
+/// This is the max time it should take. Minimum interval at any node will be half this
+const PERIODIC_BAD_NODE_DETECTION_INTERVAL_MAX_S: u64 = 45;
+
+/// Interval to trigger reward forwarding.
+/// This is the max time it should take. Minimum interval at any node will be half this
+const PERIODIC_REWARD_FORWARD_INTERVAL_MAX_S: u64 = 45;
 
 /// Max number of attempts that chunk proof verification will be carried out against certain target,
 /// before classifying peer as a bad peer.
@@ -300,7 +308,8 @@ impl Node {
 
             // use a random timeout to ensure not sync when transmit messages.
             let bad_nodes_check_interval: u64 = 5 * rng.gen_range(
-                PERIODIC_REPLICATION_INTERVAL_MAX_S / 2..PERIODIC_REPLICATION_INTERVAL_MAX_S,
+                PERIODIC_BAD_NODE_DETECTION_INTERVAL_MAX_S / 2
+                    ..PERIODIC_BAD_NODE_DETECTION_INTERVAL_MAX_S,
             );
             let bad_nodes_check_time = Duration::from_secs(bad_nodes_check_interval);
             debug!("BadNodesCheck interval set to {bad_nodes_check_time:?}");
@@ -313,7 +322,8 @@ impl Node {
             // use a random timeout to ensure not sync when transmit messages.
             let balance_forward_interval: u64 = 10
                 * rng.gen_range(
-                    PERIODIC_REPLICATION_INTERVAL_MAX_S / 2..PERIODIC_REPLICATION_INTERVAL_MAX_S,
+                    PERIODIC_REWARD_FORWARD_INTERVAL_MAX_S / 2
+                        ..PERIODIC_REWARD_FORWARD_INTERVAL_MAX_S,
                 );
             let balance_forward_time = Duration::from_secs(balance_forward_interval);
             debug!(


### PR DESCRIPTION
This pull request includes changes to the `sn_logging/src/layers.rs` and `sn_node/src/node.rs` files. The changes mainly focus on adjusting logging targets and updating a constant value for the periodic replication interval.

Changes in detail:

* [`sn_logging/src/layers.rs`](diffhunk://#diff-fc0871899e69639566e972f9565abb8e87a6081a320a171b5c2d02615fcf8311R289-R291): Commented out the `"libp2p"` logging target and added `"libp2p_swarm"` and `"libp2p_kad"` as new logging targets. This change helps to focus logging on specific areas of the libp2p library.
  
* [`sn_node/src/node.rs`](diffhunk://#diff-d2cb48f19fc64bccfdccf4187b2fe789d77a080308a0fd2d69369e095cc0bcd4L58-R58): Increased the `PERIODIC_REPLICATION_INTERVAL_MAX_S` constant from 45 to 450. This change extends the maximum interval for triggering replication of all records to all peers, potentially reducing network load.