### PR TITLE
feat(networking): remove self.close_group and checks there as unused

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -832,7 +832,6 @@ impl SwarmDriver {
             warn!("Cleaning out bad_peer {peer_id:?}");
             if let Some(dead_peer) = self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id) {
                 self.update_on_peer_removal(*dead_peer.node.key.preimage());
-                let _ = self.check_for_change_in_our_close_group();
             }
 
             if is_new_bad {

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -592,7 +592,6 @@ impl NetworkBuilder {
             peers_in_rt: 0,
             bootstrap,
             relay_manager,
-            close_group: Default::default(),
             replication_fetcher,
             #[cfg(feature = "open-metrics")]
             network_metrics,
@@ -635,7 +634,6 @@ pub struct SwarmDriver {
     pub(crate) bootstrap: ContinuousBootstrap,
     pub(crate) relay_manager: RelayManager,
     /// The peers that are closer to our PeerId. Includes self.
-    pub(crate) close_group: Vec<PeerId>,
     pub(crate) replication_fetcher: ReplicationFetcher,
     #[cfg(feature = "open-metrics")]
     pub(crate) network_metrics: Option<NetworkMetrics>,

--- a/sn_networking/src/event/kad.rs
+++ b/sn_networking/src/event/kad.rs
@@ -263,7 +263,6 @@ impl SwarmDriver {
                     info!("Evicted old peer on new peer join: {old_peer:?}");
                     self.update_on_peer_removal(old_peer);
                 }
-                let _ = self.check_for_change_in_our_close_group();
             }
             kad::Event::InboundRequest {
                 request: InboundRequest::PutRecord { .. },

--- a/sn_networking/src/event/mod.rs
+++ b/sn_networking/src/event/mod.rs
@@ -10,7 +10,7 @@ mod kad;
 mod request_response;
 mod swarm;
 
-use crate::{driver::SwarmDriver, error::Result, CLOSE_GROUP_SIZE};
+use crate::{driver::SwarmDriver, error::Result};
 use core::fmt;
 use custom_debug::Debug as CustomDebug;
 #[cfg(feature = "local-discovery")]
@@ -27,7 +27,7 @@ use sn_protocol::{
 };
 use sn_transfers::PaymentQuote;
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::BTreeSet,
     fmt::{Debug, Formatter},
 };
 use tokio::sync::oneshot;
@@ -236,29 +236,6 @@ impl Debug for NetworkEvent {
 }
 
 impl SwarmDriver {
-    /// Check for changes in our close group
-    pub(crate) fn check_for_change_in_our_close_group(&mut self) -> bool {
-        // this includes self
-        let closest_k_peers = self.get_closest_k_value_local_peers();
-
-        let new_closest_peers: Vec<_> =
-            closest_k_peers.into_iter().take(CLOSE_GROUP_SIZE).collect();
-
-        let old = self.close_group.iter().cloned().collect::<HashSet<_>>();
-        let new_members: Vec<_> = new_closest_peers
-            .iter()
-            .filter(|p| !old.contains(p))
-            .collect();
-        if !new_members.is_empty() {
-            debug!("The close group has been updated. The new members are {new_members:?}");
-            debug!("New close group: {new_closest_peers:?}");
-            self.close_group = new_closest_peers;
-            true
-        } else {
-            false
-        }
-    }
-
     /// Update state on addition of a peer to the routing table.
     pub(crate) fn update_on_peer_addition(&mut self, added_peer: PeerId) {
         self.peers_in_rt = self.peers_in_rt.saturating_add(1);

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -143,7 +143,6 @@ impl SwarmDriver {
                             {
                                 error!("Clearing out a protocol mistmatch peer from RT. Something went wrong, we should not have added this peer to RT: {peer_id:?}");
                                 self.update_on_peer_removal(*dead_peer.node.key.preimage());
-                                let _ = self.check_for_change_in_our_close_group();
                             }
 
                             return Ok(());
@@ -549,8 +548,6 @@ impl SwarmDriver {
                             peer_id: failed_peer_id,
                             issue: crate::NodeIssue::ConnectionIssue,
                         })?;
-
-                        let _ = self.check_for_change_in_our_close_group();
                     }
                 }
             }
@@ -661,7 +658,6 @@ impl SwarmDriver {
                 .remove_peer(&to_be_removed_bootstrap);
             if let Some(removed_peer) = entry {
                 self.update_on_peer_removal(*removed_peer.node.key.preimage());
-                let _ = self.check_for_change_in_our_close_group();
             }
         }
     }


### PR DESCRIPTION
check_close_group bool was never used, and only effect was updating self for use in the call of that fn.


This pull request primarily focuses on removing the concept of a 'close group' from the `SwarmDriver` in the `sn_networking` module. The 'close group' was previously used to keep track of the closest peers to our PeerId, but it has now been removed from the `NetworkBuilder` and `SwarmDriver` structures. This change also leads to the removal of the `check_for_change_in_our_close_group` method, which was used to update the 'close group'. The method was called in several places throughout the code, and these calls have been removed as part of this pull request.

Here are the key changes:

Removal of 'close group':

* [`sn_networking/src/driver.rs`](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL595): Removed `close_group` from the `NetworkBuilder` and `SwarmDriver` structures. [[1]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL595) [[2]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL638)

Removal of 'close group' update method:

* [`sn_networking/src/event/mod.rs`](diffhunk://#diff-0dddae34c35d4f0fa1be30db4113a61fd477612a10488adae531039d360c51f5L239-L261): Removed the `check_for_change_in_our_close_group` method from `SwarmDriver`.

Removal of 'close group' update calls:

* [`sn_networking/src/cmd.rs`](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76L835): Removed the call to `check_for_change_in_our_close_group` in `SwarmDriver`.
* [`sn_networking/src/event/kad.rs`](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022L266): Removed the call to `check_for_change_in_our_close_group` in `SwarmDriver`.
* [`sn_networking/src/event/swarm.rs`](diffhunk://#diff-cb0730cf4bf5e7445bc11bf88d45c13b6f28a706a5d1a7822db1e2dd76b1b2dfL552-L553): Removed the calls to `check_for_change_in_our_close_group` in `SwarmDriver`. [[1]](diffhunk://#diff-cb0730cf4bf5e7445bc11bf88d45c13b6f28a706a5d1a7822db1e2dd76b1b2dfL552-L553) [[2]](diffhunk://#diff-cb0730cf4bf5e7445bc11bf88d45c13b6f28a706a5d1a7822db1e2dd76b1b2dfL664)

Cleanup of unused imports:

* [`sn_networking/src/event/mod.rs`](diffhunk://#diff-0dddae34c35d4f0fa1be30db4113a61fd477612a10488adae531039d360c51f5L13-R13): Removed unused imports related to the 'close group' concept. [[1]](diffhunk://#diff-0dddae34c35d4f0fa1be30db4113a61fd477612a10488adae531039d360c51f5L13-R13) [[2]](diffhunk://#diff-0dddae34c35d4f0fa1be30db4113a61fd477612a10488adae531039d360c51f5L30-R30)