### PR TITLE
refactor(network): reserver trace log level for tracking event stats

### DIFF
--- a/sn_cli/src/bin/main.rs
+++ b/sn_cli/src/bin/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     let opt = Opt::parse();
     let logging_targets = vec![
         // TODO: Reset to nice and clean defaults once we have a better idea of what we want
-        ("sn_networking".to_string(), Level::DEBUG),
+        ("sn_networking".to_string(), Level::INFO),
         ("safe".to_string(), Level::TRACE),
         ("sn_build_info".to_string(), Level::TRACE),
         ("autonomi".to_string(), Level::TRACE),

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -278,7 +278,6 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
                 ("sn_client".to_string(), Level::TRACE),
                 ("sn_faucet".to_string(), Level::TRACE),
                 ("sn_logging".to_string(), Level::TRACE),
-                ("sn_node".to_string(), Level::TRACE),
                 ("sn_node_manager".to_string(), Level::TRACE),
                 ("sn_node_rpc_client".to_string(), Level::TRACE),
                 ("sn_peers_acquisition".to_string(), Level::TRACE),
@@ -292,8 +291,21 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
             if !t.contains_key("sn_networking") {
                 if contains_keyword_all_sn_logs {
                     t.insert("sn_networking".to_string(), Level::TRACE)
-                } else {
+                } else if contains_keyword_verbose_sn_logs {
                     t.insert("sn_networking".to_string(), Level::DEBUG)
+                } else {
+                    t.insert("sn_networking".to_string(), Level::INFO)
+                };
+            }
+
+            // Override sn_node if it was not specified.
+            if !t.contains_key("sn_node") {
+                if contains_keyword_all_sn_logs {
+                    t.insert("sn_node".to_string(), Level::TRACE)
+                } else if contains_keyword_verbose_sn_logs {
+                    t.insert("sn_node".to_string(), Level::DEBUG)
+                } else {
+                    t.insert("sn_node".to_string(), Level::INFO)
                 };
             }
             t

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -396,7 +396,7 @@ impl SwarmDriver {
             } => {
                 cmd_string = "PutRecord";
                 let record_key = PrettyPrintRecordKey::from(&record.key).into_owned();
-                trace!(
+                debug!(
                     "Putting record sized: {:?} to network {:?}",
                     record.value.len(),
                     record_key
@@ -408,7 +408,7 @@ impl SwarmDriver {
                     .put_record(record, quorum)
                 {
                     Ok(request_id) => {
-                        trace!("Sent record {record_key:?} to network. Request id: {request_id:?} to network");
+                        debug!("Sent record {record_key:?} to network. Request id: {request_id:?} to network");
                         Ok(())
                     }
                     Err(error) => {
@@ -429,7 +429,7 @@ impl SwarmDriver {
             } => {
                 cmd_string = "PutRecordTo";
                 let record_key = PrettyPrintRecordKey::from(&record.key).into_owned();
-                trace!(
+                debug!(
                     "Putting record {record_key:?} sized: {:?} to {peers:?}",
                     record.value.len(),
                 );
@@ -439,7 +439,7 @@ impl SwarmDriver {
                     peers.into_iter(),
                     quorum,
                 );
-                trace!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
+                debug!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
 
                 if let Err(err) = sender.send(Ok(())) {
                     error!("Could not send response to PutRecordTo cmd: {:?}", err);
@@ -669,7 +669,7 @@ impl SwarmDriver {
                 // be handled.
                 // `self` then handles the request and sends a response back again to itself.
                 if peer == *self.swarm.local_peer_id() {
-                    trace!("Sending query request to self");
+                    debug!("Sending query request to self");
                     if let Request::Query(query) = req {
                         self.send_event(NetworkEvent::QueryRequestReceived {
                             query,
@@ -678,7 +678,7 @@ impl SwarmDriver {
                     } else {
                         // We should never receive a Replicate request from ourselves.
                         // we already hold this data if we do... so we can ignore
-                        trace!("Replicate cmd to self received, ignoring");
+                        debug!("Replicate cmd to self received, ignoring");
                     }
                 } else {
                     let request_id = self
@@ -686,10 +686,10 @@ impl SwarmDriver {
                         .behaviour_mut()
                         .request_response
                         .send_request(&peer, req);
-                    trace!("Sending request {request_id:?} to peer {peer:?}");
+                    debug!("Sending request {request_id:?} to peer {peer:?}");
                     let _ = self.pending_requests.insert(request_id, sender);
 
-                    trace!("Pending Requests now: {:?}", self.pending_requests.len());
+                    debug!("Pending Requests now: {:?}", self.pending_requests.len());
                 }
             }
             SwarmCmd::SendResponse { resp, channel } => {
@@ -697,7 +697,7 @@ impl SwarmDriver {
                 match channel {
                     // If the response is for `self`, send it directly through the oneshot channel.
                     MsgResponder::FromSelf(channel) => {
-                        trace!("Sending response to self");
+                        debug!("Sending response to self");
                         match channel {
                             Some(channel) => {
                                 channel
@@ -898,7 +898,7 @@ impl SwarmDriver {
             .collect();
 
         if !all_records.is_empty() {
-            trace!(
+            debug!(
                 "Sending a replication list of {} keys to {replicate_targets:?} ",
                 all_records.len()
             );
@@ -912,13 +912,13 @@ impl SwarmDriver {
                     .behaviour_mut()
                     .request_response
                     .send_request(&peer_id, request.clone());
-                trace!("Sending request {request_id:?} to peer {peer_id:?}");
+                debug!("Sending request {request_id:?} to peer {peer_id:?}");
                 let _ = self.pending_requests.insert(request_id, None);
                 let _ = self
                     .replication_targets
                     .insert(peer_id, now + REPLICATION_TIMEOUT);
             }
-            trace!("Pending Requests now: {:?}", self.pending_requests.len());
+            debug!("Pending Requests now: {:?}", self.pending_requests.len());
         }
 
         Ok(())

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -827,7 +827,7 @@ impl SwarmDriver {
     /// Dials the given multiaddress. If address contains a peer ID, simultaneous
     /// dials to that peer are prevented.
     pub(crate) fn dial(&mut self, mut addr: Multiaddr) -> Result<(), DialError> {
-        trace!(%addr, "Dialing manually");
+        debug!(%addr, "Dialing manually");
 
         let peer_id = multiaddr_pop_p2p(&mut addr);
         let opts = match peer_id {
@@ -844,7 +844,7 @@ impl SwarmDriver {
 
     /// Dials with the `DialOpts` given.
     pub(crate) fn dial_with_opts(&mut self, opts: DialOpts) -> Result<(), DialError> {
-        trace!(?opts, "Dialing manually");
+        debug!(?opts, "Dialing manually");
 
         self.swarm.dial(opts)
     }

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -790,18 +790,6 @@ impl SwarmDriver {
         });
     }
 
-    // get all the peers from our local RoutingTable. Contains self
-    pub(crate) fn get_all_local_peers(&mut self) -> Vec<PeerId> {
-        let mut all_peers: Vec<PeerId> = vec![];
-        for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
-            for entry in kbucket.iter() {
-                all_peers.push(entry.node.key.clone().into_preimage());
-            }
-        }
-        all_peers.push(self.self_peer_id);
-        all_peers
-    }
-
     /// get closest k_value the peers from our local RoutingTable. Contains self.
     /// Is sorted for closeness to self.
     pub(crate) fn get_closest_k_value_local_peers(&mut self) -> Vec<PeerId> {
@@ -838,13 +826,6 @@ impl SwarmDriver {
                 .build(),
             None => DialOpts::unknown_peer_id().address(addr).build(),
         };
-
-        self.swarm.dial(opts)
-    }
-
-    /// Dials with the `DialOpts` given.
-    pub(crate) fn dial_with_opts(&mut self, opts: DialOpts) -> Result<(), DialError> {
-        debug!(?opts, "Dialing manually");
 
         self.swarm.dial(opts)
     }

--- a/sn_networking/src/event/kad.rs
+++ b/sn_networking/src/event/kad.rs
@@ -40,7 +40,7 @@ impl SwarmDriver {
                 ref step,
             } => {
                 event_string = "kad_event::get_closest_peers";
-                trace!(
+                debug!(
                     "Query task {id:?} of key {:?} returned with peers {:?}, {stats:?} - {step:?}",
                     hex::encode(closest_peers.key.clone()),
                     closest_peers.peers,
@@ -68,7 +68,7 @@ impl SwarmDriver {
                         }
                     }
                 } else {
-                    trace!("Can't locate query task {id:?}, it has likely been completed already.");
+                    debug!("Can't locate query task {id:?}, it has likely been completed already.");
                     return Err(NetworkError::ReceivedKademliaEventDropped {
                         query_id: id,
                         event: "GetClosestPeers Ok".to_string(),
@@ -87,7 +87,7 @@ impl SwarmDriver {
 
                 let (get_closest_type, mut current_closest) =
                     self.pending_get_closest_peers.remove(&id).ok_or_else(|| {
-                        trace!(
+                        debug!(
                             "Can't locate query task {id:?}, it has likely been completed already."
                         );
                         NetworkError::ReceivedKademliaEventDropped {
@@ -124,7 +124,7 @@ impl SwarmDriver {
                 step,
             } => {
                 event_string = "kad_event::get_record::found";
-                trace!(
+                debug!(
                     "Query task {id:?} returned with record {:?} from peer {:?}, {stats:?} - {step:?}",
                     PrettyPrintRecordKey::from(&peer_record.record.key),
                     peer_record.peer
@@ -141,7 +141,7 @@ impl SwarmDriver {
                 step,
             } => {
                 event_string = "kad_event::get_record::finished_no_additional";
-                trace!("Query task {id:?} of get_record completed with {stats:?} - {step:?} - {cache_candidates:?}");
+                debug!("Query task {id:?} of get_record completed with {stats:?} - {step:?} - {cache_candidates:?}");
                 self.handle_get_record_finished(id, step)?;
             }
             kad::Event::OutboundQueryProgressed {
@@ -224,7 +224,7 @@ impl SwarmDriver {
                 step,
             } => {
                 event_string = "kad_event::PutRecordOk";
-                trace!(
+                debug!(
                     "Query task {id:?} put record {:?} ok, {stats:?} - {step:?}",
                     PrettyPrintRecordKey::from(&put_record_ok.key)
                 );
@@ -239,7 +239,7 @@ impl SwarmDriver {
                 event_string = "kad_event::OutboundQueryProgressed::Bootstrap";
                 // here BootstrapOk::num_remaining refers to the remaining random peer IDs to query, one per
                 // bucket that still needs refreshing.
-                trace!("Kademlia Bootstrap with {id:?} progressed with {bootstrap_result:?} and step {step:?}");
+                debug!("Kademlia Bootstrap with {id:?} progressed with {bootstrap_result:?} and step {step:?}");
             }
             kad::Event::RoutingUpdated {
                 peer,
@@ -286,22 +286,22 @@ impl SwarmDriver {
             } => {
                 event_string = "kad_event::InboundRequest::GetRecord";
                 if !present_locally && num_closer_peers < CLOSE_GROUP_SIZE {
-                    trace!("InboundRequest::GetRecord doesn't have local record, with {num_closer_peers:?} closer_peers");
+                    debug!("InboundRequest::GetRecord doesn't have local record, with {num_closer_peers:?} closer_peers");
                 }
             }
             kad::Event::UnroutablePeer { peer } => {
                 event_string = "kad_event::UnroutablePeer";
-                trace!(peer_id = %peer, "kad::Event: UnroutablePeer");
+                debug!(peer_id = %peer, "kad::Event: UnroutablePeer");
             }
             kad::Event::RoutablePeer { peer, .. } => {
                 // We get this when we don't add a peer via the identify step.
                 // And we don't want to add these as they were rejected by identify for some reason.
                 event_string = "kad_event::RoutablePeer";
-                trace!(peer_id = %peer, "kad::Event: RoutablePeer");
+                debug!(peer_id = %peer, "kad::Event: RoutablePeer");
             }
             other => {
                 event_string = "kad_event::Other";
-                trace!("kad::Event ignored: {other:?}");
+                debug!("kad::Event ignored: {other:?}");
             }
         }
 
@@ -383,7 +383,7 @@ impl SwarmDriver {
 
             let expected_answers = get_quorum_value(&cfg.get_quorum);
 
-            trace!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
+            debug!("Expecting {expected_answers:?} answers for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
 
             if responded_peers >= expected_answers {
                 if !cfg.expected_holders.is_empty() {
@@ -503,7 +503,7 @@ impl SwarmDriver {
         } else {
             // We manually perform `query.finish()` if we return early from accumulate fn.
             // Thus we will still get FinishedWithNoAdditionalRecord.
-            trace!("Can't locate query task {query_id:?} during GetRecord finished. We might have already returned the result to the sender.");
+            debug!("Can't locate query task {query_id:?} during GetRecord finished. We might have already returned the result to the sender.");
         }
         Ok(())
     }
@@ -527,7 +527,7 @@ impl SwarmDriver {
                 // return error if the entry cannot be found
                 let (sender, _, cfg) =
                 self.pending_get_record.remove(&query_id).ok_or_else(|| {
-                    trace!("Can't locate query task {query_id:?}, it has likely been completed already.");
+                    debug!("Can't locate query task {query_id:?}, it has likely been completed already.");
                     NetworkError::ReceivedKademliaEventDropped {
                             query_id,
                             event: "GetRecordError NotFound or QuorumFailed".to_string(),
@@ -548,7 +548,7 @@ impl SwarmDriver {
                 let pretty_key = PrettyPrintRecordKey::from(key);
                 let (sender, result_map, cfg) =
                     self.pending_get_record.remove(&query_id).ok_or_else(|| {
-                        trace!(
+                        debug!(
                             "Can't locate query task {query_id:?} for {pretty_key:?}, it has likely been completed already."
                         );
                         NetworkError::ReceivedKademliaEventDropped {

--- a/sn_networking/src/event/mod.rs
+++ b/sn_networking/src/event/mod.rs
@@ -150,8 +150,6 @@ pub enum NetworkEvent {
     TerminateNode { reason: TerminateNodeReason },
     /// List of peer nodes that failed to fetch replication copy from.
     FailedToFetchHolders(BTreeSet<PeerId>),
-    /// A peer in RT that supposed to be verified.
-    BadNodeVerification { peer_id: PeerId },
     /// Quotes to be verified
     QuoteVerification { quotes: Vec<(PeerId, PaymentQuote)> },
     /// Carry out chunk proof check against the specified record and peer
@@ -218,9 +216,6 @@ impl Debug for NetworkEvent {
             }
             NetworkEvent::FailedToFetchHolders(bad_nodes) => {
                 write!(f, "NetworkEvent::FailedToFetchHolders({bad_nodes:?})")
-            }
-            NetworkEvent::BadNodeVerification { peer_id } => {
-                write!(f, "NetworkEvent::BadNodeVerification({peer_id:?})")
             }
             NetworkEvent::QuoteVerification { quotes } => {
                 write!(

--- a/sn_networking/src/event/request_response.rs
+++ b/sn_networking/src/event/request_response.rs
@@ -32,7 +32,7 @@ impl SwarmDriver {
                     request_id,
                     ..
                 } => {
-                    trace!("Received request {request_id:?} from peer {peer:?}, req: {request:?}");
+                    debug!("Received request {request_id:?} from peer {peer:?}, req: {request:?}");
                     // If the request is replication or quote verification,
                     // we can handle it and send the OK response here.
                     // As the handle result is unimportant to the sender.
@@ -108,7 +108,7 @@ impl SwarmDriver {
                     request_id,
                     response,
                 } => {
-                    trace!("Got response {request_id:?} from peer {peer:?}, res: {response}.");
+                    debug!("Got response {request_id:?} from peer {peer:?}, res: {response}.");
                     if let Some(sender) = self.pending_requests.remove(&request_id) {
                         // The sender will be provided if the caller (Requester) is awaiting for a response
                         // at the call site.
@@ -168,7 +168,7 @@ impl SwarmDriver {
                 warn!("RequestResponse: InboundFailure for request_id: {request_id:?} and peer: {peer:?}, with error: {error:?}");
             }
             request_response::Event::ResponseSent { peer, request_id } => {
-                trace!("ResponseSent for request_id: {request_id:?} and peer: {peer:?}");
+                debug!("ResponseSent for request_id: {request_id:?} and peer: {peer:?}");
             }
         }
         Ok(())
@@ -186,7 +186,7 @@ impl SwarmDriver {
             return;
         };
 
-        trace!(
+        debug!(
             "Received replication list from {holder:?} of {} keys",
             incoming_keys.len()
         );
@@ -195,7 +195,7 @@ impl SwarmDriver {
         // giving us some margin for replication
         let closest_k_peers = self.get_closest_k_value_local_peers();
         if !closest_k_peers.contains(&holder) || holder == self.self_peer_id {
-            trace!("Holder {holder:?} is self or not in replication range.");
+            debug!("Holder {holder:?} is self or not in replication range.");
             return;
         }
 
@@ -219,7 +219,7 @@ impl SwarmDriver {
             .replication_fetcher
             .add_keys(holder, incoming_keys, all_keys);
         if keys_to_fetch.is_empty() {
-            trace!("no waiting keys to fetch from the network");
+            debug!("no waiting keys to fetch from the network");
         } else {
             self.send_event(NetworkEvent::KeysToFetchForReplication(keys_to_fetch));
         }

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -128,7 +128,7 @@ impl SwarmDriver {
 
                 match *iden {
                     libp2p::identify::Event::Received { peer_id, info } => {
-                        trace!(%peer_id, ?info, "identify: received info");
+                        debug!(%peer_id, ?info, "identify: received info");
 
                         if info.protocol_version != IDENTIFY_PROTOCOL_STR.to_string() {
                             warn!(?info.protocol_version, "identify: {peer_id:?} does not have the same protocol. Our IDENTIFY_PROTOCOL_STR: {:?}", IDENTIFY_PROTOCOL_STR.as_str());
@@ -227,10 +227,10 @@ impl SwarmDriver {
                                 };
 
                             if kbucket_full {
-                                trace!("received identify for a full bucket {ilog2:?}, not dialing {peer_id:?} on {addrs:?}");
+                                debug!("received identify for a full bucket {ilog2:?}, not dialing {peer_id:?} on {addrs:?}");
                                 return Ok(());
                             } else if already_present_in_rt {
-                                trace!("received identify for {peer_id:?} that is already part of the RT. Not dialing {peer_id:?} on {addrs:?}");
+                                debug!("received identify for {peer_id:?} that is already part of the RT. Not dialing {peer_id:?} on {addrs:?}");
                                 return Ok(());
                             }
 
@@ -263,7 +263,7 @@ impl SwarmDriver {
                                 });
                             }
 
-                            trace!(%peer_id, ?addrs, "identify: attempting to add addresses to routing table");
+                            debug!(%peer_id, ?addrs, "identify: attempting to add addresses to routing table");
 
                             // Attempt to add the addresses to the routing table.
                             for multiaddr in addrs {
@@ -280,9 +280,9 @@ impl SwarmDriver {
                         );
                     }
                     // Log the other Identify events.
-                    libp2p::identify::Event::Sent { .. } => trace!("identify: {iden:?}"),
-                    libp2p::identify::Event::Pushed { .. } => trace!("identify: {iden:?}"),
-                    libp2p::identify::Event::Error { .. } => trace!("identify: {iden:?}"),
+                    libp2p::identify::Event::Sent { .. } => debug!("identify: {iden:?}"),
+                    libp2p::identify::Event::Pushed { .. } => debug!("identify: {iden:?}"),
+                    libp2p::identify::Event::Error { .. } => debug!("identify: {iden:?}"),
                 }
             }
             #[cfg(feature = "local-discovery")]
@@ -304,7 +304,7 @@ impl SwarmDriver {
                         }
                     }
                     mdns::Event::Expired(peer) => {
-                        trace!("mdns peer {peer:?} expired");
+                        debug!("mdns peer {peer:?} expired");
                     }
                 }
             }
@@ -367,7 +367,7 @@ impl SwarmDriver {
                 send_back_addr,
             } => {
                 event_string = "incoming";
-                trace!("IncomingConnection ({connection_id:?}) with local_addr: {local_addr:?} send_back_addr: {send_back_addr:?}");
+                debug!("IncomingConnection ({connection_id:?}) with local_addr: {local_addr:?} send_back_addr: {send_back_addr:?}");
             }
             SwarmEvent::ConnectionEstablished {
                 peer_id,
@@ -378,7 +378,7 @@ impl SwarmDriver {
                 established_in,
             } => {
                 event_string = "ConnectionEstablished";
-                trace!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
+                debug!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
 
                 let _ = self.live_connected_peers.insert(
                     connection_id,
@@ -398,7 +398,7 @@ impl SwarmDriver {
                 connection_id,
             } => {
                 event_string = "ConnectionClosed";
-                trace!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
+                debug!(%peer_id, ?connection_id, ?cause, num_established, "ConnectionClosed: {}", endpoint_str(&endpoint));
                 let _ = self.live_connected_peers.remove(&connection_id);
                 self.record_connection_metrics();
             }
@@ -538,7 +538,7 @@ impl SwarmDriver {
                 connection_id,
             } => {
                 event_string = "Dialing";
-                trace!("Dialing {peer_id:?} on {connection_id:?}");
+                debug!("Dialing {peer_id:?} on {connection_id:?}");
             }
             SwarmEvent::NewExternalAddrCandidate { address } => {
                 event_string = "NewExternalAddrCandidate";
@@ -563,12 +563,12 @@ impl SwarmDriver {
                                 info!(%address, "external address: new candidate has the same configured port, adding it.");
                                 self.swarm.add_external_address(address);
 
-                                if tracing::level_enabled!(tracing::Level::TRACE) {
+                                if tracing::level_enabled!(tracing::Level::DEBUG) {
                                     let all_external_addresses =
                                         self.swarm.external_addresses().collect_vec();
                                     let all_listeners = self.swarm.listeners().collect_vec();
-                                    trace!("All our listeners: {all_listeners:?}");
-                                    trace!(
+                                    debug!("All our listeners: {all_listeners:?}");
+                                    debug!(
                                         "All our external addresses: {all_external_addresses:?}"
                                     );
                                 }
@@ -577,7 +577,7 @@ impl SwarmDriver {
                             }
                         }
                     } else {
-                        trace!("external address: listen port not set. This has to be set if you're running a node");
+                        debug!("external address: listen port not set. This has to be set if you're running a node");
                     }
                 }
             }
@@ -592,7 +592,7 @@ impl SwarmDriver {
             other => {
                 event_string = "Other";
 
-                trace!("SwarmEvent has been ignored: {other:?}")
+                debug!("SwarmEvent has been ignored: {other:?}")
             }
         }
         self.remove_outdated_connections();
@@ -677,11 +677,11 @@ impl SwarmDriver {
 
         self.record_connection_metrics();
 
-        trace!(
+        debug!(
             "Current libp2p peers pool stats is {:?}",
             self.swarm.network_info()
         );
-        trace!(
+        debug!(
             "Removed {removed_conns} outdated live connections, still have {} left.",
             self.live_connected_peers.len()
         );

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -71,9 +71,7 @@ use tokio::sync::{
     mpsc::{self, Sender},
     oneshot,
 };
-
 use tokio::time::Duration;
-use tracing::trace;
 
 /// The type of quote for a selected payee.
 pub type PayeeQuote = (PeerId, MainPubkey, PaymentQuote);
@@ -565,7 +563,7 @@ impl Network {
                     }
                 }
                 if result.is_err() {
-                    trace!("Getting record from network of {pretty_key:?} via backoff...");
+                    debug!("Getting record from network of {pretty_key:?} via backoff...");
                 }
                 result.map_err(|err| BackoffError::Transient {
                     err: NetworkError::from(err),
@@ -735,7 +733,7 @@ impl Network {
     /// Put `Record` to the local RecordStore
     /// Must be called after the validations are performed on the Record
     pub fn put_local_record(&self, record: Record) {
-        trace!(
+        debug!(
             "Writing Record locally, for {:?} - length {:?}",
             PrettyPrintRecordKey::from(&record.key),
             record.value.len()
@@ -830,7 +828,7 @@ impl Network {
         key: &NetworkAddress,
         client: bool,
     ) -> Result<Vec<PeerId>> {
-        trace!("Getting the closest peers to {key:?}");
+        debug!("Getting the closest peers to {key:?}");
         let (sender, receiver) = oneshot::channel();
         self.send_swarm_cmd(SwarmCmd::GetClosestPeersToAddressFromNetwork {
             key: key.clone(),
@@ -845,7 +843,7 @@ impl Network {
             // remove our peer id from the calculations here:
             closest_peers.retain(|&x| x != self.peer_id());
         }
-        if tracing::level_enabled!(tracing::Level::TRACE) {
+        if tracing::level_enabled!(tracing::Level::DEBUG) {
             let close_peers_pretty_print: Vec<_> = closest_peers
                 .iter()
                 .map(|peer_id| {
@@ -856,7 +854,7 @@ impl Network {
                 })
                 .collect();
 
-            trace!("Network knowledge of close peers to {key:?} are: {close_peers_pretty_print:?}");
+            debug!("Network knowledge of close peers to {key:?} are: {close_peers_pretty_print:?}");
         }
 
         let closest_peers = sort_peers_by_address(&closest_peers, key, CLOSE_GROUP_SIZE)?;
@@ -922,7 +920,7 @@ fn get_fees_from_store_cost_responses(
     );
 
     // get the lowest cost
-    trace!("Got all costs: {all_costs:?}");
+    debug!("Got all costs: {all_costs:?}");
     let payee = all_costs
         .into_iter()
         .next()

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -149,7 +149,7 @@ impl NodeRecordStore {
         let process_entry = |entry: &DirEntry| -> _ {
             let path = entry.path();
             if path.is_file() {
-                trace!("Existing record found: {path:?}");
+                debug!("Existing record found: {path:?}");
                 // if we've got a file, lets try and read it
                 let filename = match path.file_name().and_then(|n| n.to_str()) {
                     Some(file_name) => file_name,
@@ -517,7 +517,7 @@ impl NodeRecordStore {
     /// this avoids us returning half-written data or registering it as stored before it is.
     pub(crate) fn put_verified(&mut self, r: Record, record_type: RecordType) -> Result<()> {
         let record_key = PrettyPrintRecordKey::from(&r.key).into_owned();
-        trace!("PUT a verified Record: {record_key:?}");
+        debug!("PUT a verified Record: {record_key:?}");
 
         // if the cache already has this record in it (eg, a conflicting spend)
         // remove it from the cache
@@ -666,7 +666,7 @@ impl RecordStore for NodeRecordStore {
         }
 
         if !self.records.contains_key(k) {
-            trace!("Record not found locally: {key:?}");
+            debug!("Record not found locally: {key:?}");
             return None;
         }
 
@@ -692,7 +692,7 @@ impl RecordStore for NodeRecordStore {
             Ok(record_header) => {
                 match record_header.kind {
                     RecordKind::ChunkWithPayment | RecordKind::RegisterWithPayment => {
-                        trace!("Record {record_key:?} with payment shall always be processed.");
+                        debug!("Record {record_key:?} with payment shall always be processed.");
                     }
                     _ => {
                         // Chunk with existing key do not to be stored again.
@@ -701,13 +701,13 @@ impl RecordStore for NodeRecordStore {
                         // double spend to be detected or register op update.
                         match self.records.get(&record.key) {
                             Some((_addr, RecordType::Chunk)) => {
-                                trace!("Chunk {record_key:?} already exists.");
+                                debug!("Chunk {record_key:?} already exists.");
                                 return Ok(());
                             }
                             Some((_addr, RecordType::NonChunk(existing_content_hash))) => {
                                 let content_hash = XorName::from_content(&record.value);
                                 if content_hash == *existing_content_hash {
-                                    trace!("A non-chunk record {record_key:?} with same content_hash {content_hash:?} already exists.");
+                                    debug!("A non-chunk record {record_key:?} with same content_hash {content_hash:?} already exists.");
                                     return Ok(());
                                 }
                             }
@@ -722,7 +722,7 @@ impl RecordStore for NodeRecordStore {
             }
         }
 
-        trace!("Unverified Record {record_key:?} try to validate and store");
+        debug!("Unverified Record {record_key:?} try to validate and store");
         let event_sender = self.network_event_sender.clone();
         // push the event off thread so as to be non-blocking
         let _handle = spawn(async move {

--- a/sn_networking/src/relay_manager.rs
+++ b/sn_networking/src/relay_manager.rs
@@ -74,7 +74,6 @@ impl RelayManager {
         stream_protocols: &Vec<StreamProtocol>,
     ) {
         if self.candidates.len() >= MAX_POTENTIAL_CANDIDATES {
-            trace!("Got max relay candidates");
             return;
         }
 
@@ -89,7 +88,7 @@ impl RelayManager {
                 }
             }
         } else {
-            trace!("Peer {peer_id:?} does not support relay server protocol");
+            debug!("Peer {peer_id:?} does not support relay server protocol");
         }
     }
 
@@ -120,7 +119,7 @@ impl RelayManager {
 
             // Pick a random candidate from the vector. Check if empty, or `gen_range` panics for empty range.
             let index = if self.candidates.is_empty() {
-                trace!("No more relay candidates.");
+                debug!("No more relay candidates.");
                 break;
             } else {
                 rand::thread_rng().gen_range(0..self.candidates.len())
@@ -130,7 +129,7 @@ impl RelayManager {
                 // skip if detected as a bad node
                 if let Some((_, is_bad)) = bad_nodes.get(&peer_id) {
                     if *is_bad {
-                        trace!("Peer {peer_id:?} is considered as a bad node. Skipping it.");
+                        debug!("Peer {peer_id:?} is considered as a bad node. Skipping it.");
                         continue;
                     }
                 }
@@ -138,7 +137,7 @@ impl RelayManager {
                 if self.connected_relays.contains_key(&peer_id)
                     || self.waiting_for_reservation.contains_key(&peer_id)
                 {
-                    trace!("We are already using {peer_id:?} as a relay server. Skipping.");
+                    debug!("We are already using {peer_id:?} as a relay server. Skipping.");
                     continue;
                 }
 
@@ -154,7 +153,7 @@ impl RelayManager {
                     }
                 }
             } else {
-                trace!("No more relay candidates.");
+                debug!("No more relay candidates.");
                 break;
             }
         }
@@ -176,11 +175,11 @@ impl RelayManager {
         peer_id: &PeerId,
         swarm: &mut Swarm<NodeBehaviour>,
     ) {
-        if tracing::level_enabled!(tracing::Level::TRACE) {
+        if tracing::level_enabled!(tracing::Level::DEBUG) {
             let all_external_addresses = swarm.external_addresses().collect_vec();
             let all_listeners = swarm.listeners().collect_vec();
-            trace!("All our listeners: {all_listeners:?}");
-            trace!("All our external addresses: {all_external_addresses:?}");
+            debug!("All our listeners: {all_listeners:?}");
+            debug!("All our external addresses: {all_external_addresses:?}");
         }
 
         match self.waiting_for_reservation.remove(peer_id) {
@@ -221,7 +220,7 @@ impl RelayManager {
         }
         if let Some(addr) = self.waiting_for_reservation.remove(&peer_id) {
             info!("Removed peer form waiting_for_reservation as the listener has been closed {peer_id:?}: {addr:?}");
-            trace!(
+            debug!(
                 "waiting_for_reservation len: {:?}",
                 self.waiting_for_reservation.len()
             )

--- a/sn_networking/src/replication_fetcher.rs
+++ b/sn_networking/src/replication_fetcher.rs
@@ -107,7 +107,7 @@ impl ReplicationFetcher {
 
             info!("Node is full, among {total_incoming_keys} incoming replications from {holder:?}, found {} beyond current farthest", out_of_range_keys.len());
             for addr in out_of_range_keys.iter() {
-                trace!("Node is full, the incoming record_key {addr:?} is beyond current farthest record");
+                debug!("Node is full, the incoming record_key {addr:?} is beyond current farthest record");
             }
         }
 
@@ -149,7 +149,7 @@ impl ReplicationFetcher {
             info!("Among {total_incoming_keys} incoming replications from {holder:?}, found {} out of range", out_of_range_keys.len());
             for addr in out_of_range_keys.iter() {
                 let ilog2_distance = self_address.distance(addr).ilog2();
-                trace!("The incoming record_key {addr:?} is out of range with ilog2_distance being {ilog2_distance:?}, do not fetch it from {holder:?}");
+                debug!("The incoming record_key {addr:?} is out of range with ilog2_distance being {ilog2_distance:?}, do not fetch it from {holder:?}");
             }
         }
 
@@ -237,7 +237,7 @@ impl ReplicationFetcher {
     pub(crate) fn next_keys_to_fetch(&mut self) -> Vec<(PeerId, RecordKey)> {
         self.prune_expired_keys_and_slow_nodes();
 
-        trace!("Next to fetch....");
+        debug!("Next to fetch....");
 
         if self.on_going_fetches.len() >= MAX_PARALLEL_FETCH {
             warn!("Replication Fetcher doesn't have free fetch capacity. Currently has {} entries in queue.",

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -104,7 +104,7 @@ impl Network {
         wallet: &HotWallet,
     ) -> Result<Vec<CashNote>> {
         // get CashNoteRedemptions from encrypted Transfer
-        trace!("Decyphering Transfer");
+        debug!("Decyphering Transfer");
         let cashnote_redemptions = wallet.unwrap_transfer(transfer)?;
 
         self.verify_cash_notes_redemptions(wallet.address(), &cashnote_redemptions)
@@ -122,7 +122,7 @@ impl Network {
         cashnote_redemptions: &[CashNoteRedemption],
     ) -> Result<Vec<CashNote>> {
         // get the parent transactions
-        trace!(
+        debug!(
             "Getting parent Tx for validation from {:?}",
             cashnote_redemptions.len()
         );
@@ -179,7 +179,7 @@ impl Network {
         }
 
         // check Txs and parent spends are valid
-        trace!("Validating parent spends");
+        debug!("Validating parent spends");
         for tx in parent_txs {
             let tx_inputs_keys: Vec<_> = tx.inputs.iter().map(|i| i.unique_pubkey()).collect();
 
@@ -246,7 +246,7 @@ pub fn get_signed_spend_from_record(
             Err(NetworkError::NoSpendFoundInsideRecord(*address))
         }
         [one] => {
-            trace!("Spend get for address: {address:?} successful");
+            debug!("Spend get for address: {address:?} successful");
             Ok(one.clone())
         }
         _double_spends => {

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -395,7 +395,7 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                 }
                 Ok(event) => {
                     /* we ignore other events */
-                    trace!("Currently ignored node event {event:?}");
+                    debug!("Currently ignored node event {event:?}");
                 }
                 Err(RecvError::Lagged(n)) => {
                     warn!("Skipped {n} node events!");

--- a/sn_node/src/event.rs
+++ b/sn_node/src/event.rs
@@ -39,7 +39,7 @@ impl NodeEventsChannel {
     pub(crate) fn broadcast(&self, event: NodeEvent) {
         let event_string = format!("{event:?}");
         if let Err(err) = self.0.send(event) {
-            trace!(
+            debug!(
                 "Error occurred when trying to broadcast a node event ({event_string:?}): {err}"
             );
         }

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -40,7 +40,7 @@ mod replication;
 pub use self::{
     event::{NodeEvent, NodeEventsChannel, NodeEventsReceiver},
     log_markers::Marker,
-    node::{NodeBuilder, NodeCmd, PERIODIC_REPLICATION_INTERVAL_MAX_S},
+    node::{NodeBuilder, PERIODIC_REPLICATION_INTERVAL_MAX_S},
 };
 
 use crate::error::{Error, Result};
@@ -53,7 +53,6 @@ use std::{
     collections::{BTreeMap, HashSet},
     path::PathBuf,
 };
-use tokio::sync::broadcast;
 
 /// Once a node is started and running, the user obtains
 /// a `NodeRunning` object which can be used to interact with it.
@@ -61,8 +60,6 @@ use tokio::sync::broadcast;
 pub struct RunningNode {
     network: Network,
     node_events_channel: NodeEventsChannel,
-    #[allow(dead_code)]
-    node_cmds: broadcast::Sender<NodeCmd>,
 }
 
 impl RunningNode {

--- a/sn_node/src/log_markers.rs
+++ b/sn_node/src/log_markers.rs
@@ -6,11 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use libp2p::{kad::RecordKey, PeerId};
-use sn_protocol::{messages::Cmd, PrettyPrintRecordKey};
-use std::time::Duration;
-// this gets us to_string easily enough
 use crate::Error;
+use libp2p::{kad::RecordKey, PeerId};
+use sn_protocol::PrettyPrintRecordKey;
 use strum::Display;
 
 /// Public Markers for generating log output,
@@ -21,15 +19,6 @@ pub enum Marker<'a> {
     /// The node has started
     NodeConnectedToNetwork,
 
-    /// No network activity in some time
-    NoNetworkActivity(Duration),
-
-    /// Forced Replication by simulating a churned out node within close range.
-    ForcedReplication,
-
-    /// Network Cmd message received
-    NodeCmdReceived(&'a Cmd),
-
     /// Peer was added to the routing table
     PeerAddedToRoutingTable(PeerId),
 
@@ -39,8 +28,6 @@ pub enum Marker<'a> {
     /// The number of peers in the routing table
     PeersInRoutingTable(usize),
 
-    /// Replication trigger was fired
-    ReplicationTriggered,
     /// Interval based replication
     IntervalReplicationTriggered,
 

--- a/sn_node/src/metrics.rs
+++ b/sn_node/src/metrics.rs
@@ -169,7 +169,7 @@ impl NodeMetrics {
                 let _ = self.put_record_err.inc();
             }
 
-            Marker::ReplicationTriggered => {
+            Marker::IntervalReplicationTriggered => {
                 let _ = self.replication_triggered.inc();
             }
 

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -570,17 +570,6 @@ impl Node {
                     }
                 });
             }
-            NetworkEvent::BadNodeVerification { peer_id } => {
-                event_header = "BadNodeVerification";
-                let network = self.network().clone();
-
-                trace!("Need to verify whether peer {peer_id:?} is a bad node");
-                let _handle = spawn(async move {
-                    if Self::close_nodes_shunning_peer(&network, peer_id).await {
-                        network.record_node_issues(peer_id, NodeIssue::CloseNodesShunning);
-                    }
-                });
-            }
             NetworkEvent::QuoteVerification { quotes } => {
                 event_header = "QuoteVerification";
                 let network = self.network().clone();

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -35,7 +35,7 @@ impl Node {
             let requester = NetworkAddress::from_peer(self.network().peer_id());
             let _handle: JoinHandle<Result<()>> = spawn(async move {
                 let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
-                trace!("Fetching record {pretty_key:?} from node {holder:?}");
+                debug!("Fetching record {pretty_key:?} from node {holder:?}");
                 let req = Request::Query(Query::GetReplicatedRecord {
                     requester,
                     key: NetworkAddress::from_record_key(&key),
@@ -46,12 +46,12 @@ impl Node {
                         {
                             Ok((_holder, record_content)) => Some(record_content),
                             Err(err) => {
-                                trace!("Failed fetch record {pretty_key:?} from node {holder:?}, with error {err:?}");
+                                debug!("Failed fetch record {pretty_key:?} from node {holder:?}, with error {err:?}");
                                 None
                             }
                         },
                         other => {
-                            trace!("Cannot fetch record {pretty_key:?} from node {holder:?}, with response {other:?}");
+                            debug!("Cannot fetch record {pretty_key:?} from node {holder:?}, with response {other:?}");
                             None
                         }
                     }
@@ -62,7 +62,7 @@ impl Node {
                 let record = if let Some(record_content) = record_opt {
                     Record::new(key, record_content.to_vec())
                 } else {
-                    trace!(
+                    debug!(
                         "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
                     );
                     let get_cfg = GetRecordCfg {
@@ -76,11 +76,11 @@ impl Node {
                         .await?
                 };
 
-                trace!(
+                debug!(
                     "Got Replication Record {pretty_key:?} from network, validating and storing it"
                 );
                 node.store_replicated_in_record(record).await?;
-                trace!("Completed storing Replication Record {pretty_key:?} from network.");
+                debug!("Completed storing Replication Record {pretty_key:?} from network.");
 
                 Ok(())
             });
@@ -104,7 +104,7 @@ impl Node {
             // first we wait until our own network store can return the record
             // otherwise it may not be fully written yet
             let mut retry_count = 0;
-            trace!("Checking we have successfully stored the fresh record {pretty_key:?} in the store before replicating");
+            debug!("Checking we have successfully stored the fresh record {pretty_key:?} in the store before replicating");
             loop {
                 let record = match network.get_local_record(&paid_key).await {
                     Ok(record) => record,
@@ -131,7 +131,7 @@ impl Node {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
 
-            trace!("Start replication of fresh record {pretty_key:?} from store");
+            debug!("Start replication of fresh record {pretty_key:?} from store");
 
             // Already contains self_peer_id
             let mut closest_k_peers = match network.get_closest_k_value_local_peers().await {
@@ -167,7 +167,7 @@ impl Node {
             let keys = vec![(data_addr.clone(), record_type.clone())];
 
             for peer_id in sorted_based_on_addr {
-                trace!("Replicating fresh record {pretty_key:?} to {peer_id:?}");
+                debug!("Replicating fresh record {pretty_key:?} to {peer_id:?}");
                 let request = Request::Cmd(Cmd::Replicate {
                     holder: our_address.clone(),
                     keys: keys.clone(),
@@ -175,7 +175,7 @@ impl Node {
 
                 network.send_req_ignore_reply(request, *peer_id);
             }
-            trace!(
+            debug!(
                 "Completed replicate fresh record {pretty_key:?} on store, in {:?}",
                 start.elapsed()
             );


### PR DESCRIPTION
- Currently, when using `SN_LOG=all`, the logs of `sn_networking` contains a lot of trace logs related to the event handling statistics. It is not really useful during debugging.
- So this PR aims to move all the useful logs to `debug` level, and now you can use `SN_LOG=v` instead of `SN_LOG=all` to just get the debug level logs.
- Also removes some unused code