### PR TITLE
chore: remove push triggers for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,6 @@ concurrency:
   group: "version-bump-release-${{ github.ref }}"
 
 on:
-  push:
-    branches:
-      - stable*
-      - alpha*
-      - beta*
-      - rc*
   workflow_dispatch:
     inputs:
       network_version_mode:


### PR DESCRIPTION
For now we just want to trigger releases manually.

The whole release workflow was refactored in another PR, but I'm also going to disable push-based triggers in the short term too.
