### PR TITLE
chore(node): [#1999] panic on upnp event `GatewayNotFound`

### DIFF
--- a/sn_networking/src/event/mod.rs
+++ b/sn_networking/src/event/mod.rs
@@ -157,6 +157,7 @@ pub enum NetworkEvent {
 #[derive(Debug, Clone)]
 pub enum TerminateNodeReason {
     HardDiskWriteError,
+    UpnpGatewayNotFound,
 }
 
 // Manually implement Debug as `#[debug(with = "unverified_record_fmt")]` not working as expected.

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::event::TerminateNodeReason;
 use crate::{
     cmd::LocalSwarmCmd,
     event::NodeEvent,
@@ -80,6 +81,12 @@ impl SwarmDriver {
                 }
                 event_string = "upnp_event";
                 info!(?upnp_event, "UPnP event");
+                if let libp2p::upnp::Event::GatewayNotFound = upnp_event {
+                    warn!("UPnP is not enabled/supported on the gateway. Please rerun without the `--upnp` flag");
+                    self.send_event(NetworkEvent::TerminateNode {
+                        reason: TerminateNodeReason::UpnpGatewayNotFound,
+                    });
+                }
             }
 
             SwarmEvent::Behaviour(NodeEvent::RelayServer(event)) => {


### PR DESCRIPTION
### Description

Makes a node panic on the upnp event `GatewayNotFound`. This event only fires when the node runs with the `--upnp` flag and libp2p couldn't find the upnp gateway to open ports on.

### Related Issue

Fixes #1999 

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Makes it easier to detect a problem with UPnP.

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
