### PR TITLE
networking: Performance tweaks 

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -623,6 +623,7 @@ impl SwarmDriver {
                 let new_keys_to_fetch = self
                     .replication_fetcher
                     .notify_about_new_put(key.clone(), record_type);
+
                 if !new_keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysToFetchForReplication(new_keys_to_fetch));
                 }

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -924,18 +924,16 @@ impl SwarmDriver {
                 keys: all_records,
             });
             for peer_id in replicate_targets {
-                let request_id = self
-                    .swarm
-                    .behaviour_mut()
-                    .request_response
-                    .send_request(&peer_id, request.clone());
-                debug!("Sending request {request_id:?} to peer {peer_id:?}");
-                let _ = self.pending_requests.insert(request_id, None);
+                self.queue_network_swarm_cmd(NetworkSwarmCmd::SendRequest {
+                    req: request.clone(),
+                    peer: peer_id,
+                    sender: None,
+                });
+
                 let _ = self
                     .replication_targets
                     .insert(peer_id, now + REPLICATION_TIMEOUT);
             }
-            debug!("Pending Requests now: {:?}", self.pending_requests.len());
         }
 
         Ok(())

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -38,7 +38,7 @@ use libp2p::Transport as _;
 use libp2p::{core::muxing::StreamMuxerBox, relay};
 use libp2p::{
     identity::Keypair,
-    kad::{self, QueryId, Quorum, Record, K_VALUE},
+    kad::{self, QueryId, Quorum, Record, RecordKey, K_VALUE},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, OutboundRequestId, ProtocolSupport},
     swarm::{
@@ -89,7 +89,8 @@ type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
 pub(crate) type PendingGetRecord = HashMap<
     QueryId,
     (
-        oneshot::Sender<std::result::Result<Record, GetRecordError>>,
+        RecordKey, // record we're fetching, to dedupe repeat requests
+        Vec<oneshot::Sender<std::result::Result<Record, GetRecordError>>>, // vec of senders waiting for this record
         GetRecordResultMap,
         GetRecordCfg,
     ),

--- a/sn_networking/src/error.rs
+++ b/sn_networking/src/error.rs
@@ -29,6 +29,7 @@ pub(super) type Result<T, E = NetworkError> = std::result::Result<T, E>;
 /// GetRecord Query errors
 #[derive(Error)]
 #[allow(missing_docs)]
+#[derive(Clone)]
 pub enum GetRecordError {
     #[error("Get Record completed with non enough copies")]
     NotEnoughCopies {

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -74,6 +74,9 @@ pub struct NodeRecordStore {
     records: HashMap<Key, (NetworkAddress, RecordType)>,
     /// FIFO simple cache of records to reduce read times
     records_cache: VecDeque<Record>,
+    /// A map from record keys to their indices in the cache
+    /// allowing for more efficient cache management
+    records_cache_map: HashMap<Key, usize>,
     /// Send network events to the node layer.
     network_event_sender: mpsc::Sender<NetworkEvent>,
     /// Send cmds to the network layer. Used to interact with self in an async fashion.
@@ -280,6 +283,7 @@ impl NodeRecordStore {
             config,
             records,
             records_cache: VecDeque::with_capacity(cache_size),
+            records_cache_map: HashMap::with_capacity(cache_size),
             network_event_sender,
             local_swarm_cmd_sender: swarm_cmd_sender,
             responsible_distance_range: None,
@@ -517,23 +521,34 @@ impl NodeRecordStore {
     /// The record is marked as written to disk once `mark_as_stored` is called,
     /// this avoids us returning half-written data or registering it as stored before it is.
     pub(crate) fn put_verified(&mut self, r: Record, record_type: RecordType) -> Result<()> {
+        let key = &r.key;
         let record_key = PrettyPrintRecordKey::from(&r.key).into_owned();
-        debug!("PUT a verified Record: {record_key:?}");
+        debug!("PUTting a verified Record: {record_key:?}");
 
         // if the cache already has this record in it (eg, a conflicting spend)
         // remove it from the cache
-        self.records_cache.retain(|record| record.key != r.key);
-
-        // store in the FIFO records cache, removing the oldest if needed
-        if self.records_cache.len() > self.config.records_cache_size {
-            self.records_cache.pop_front();
+        // self.records_cache.retain(|record| record.key != r.key);
+        // Remove from cache if it already exists
+        if let Some(&index) = self.records_cache_map.get(key) {
+            self.records_cache.remove(index);
+            self.update_cache_indices(index);
         }
 
+        // Store in the FIFO records cache, removing the oldest if needed
+        if self.records_cache.len() >= self.config.records_cache_size {
+            if let Some(old_record) = self.records_cache.pop_front() {
+                self.records_cache_map.remove(&old_record.key);
+            }
+        }
+
+        // Push the new record to the back of the cache
         self.records_cache.push_back(r.clone());
+        self.records_cache_map
+            .insert(r.key.clone(), self.records_cache.len() - 1);
 
-        self.prune_records_if_needed(&r.key)?;
+        self.prune_records_if_needed(key)?;
 
-        let filename = Self::generate_filename(&r.key);
+        let filename = Self::generate_filename(key);
         let file_path = self.config.storage_dir.join(&filename);
 
         #[cfg(feature = "open-metrics")]
@@ -543,19 +558,21 @@ impl NodeRecordStore {
 
         let encryption_details = self.encryption_details.clone();
         let cloned_cmd_sender = self.local_swarm_cmd_sender.clone();
+
+        let record_key2 = record_key.clone();
         spawn(async move {
             let key = r.key.clone();
             if let Some(bytes) = Self::prepare_record_bytes(r, encryption_details) {
                 let cmd = match fs::write(&file_path, bytes) {
                     Ok(_) => {
                         // vdash metric (if modified please notify at https://github.com/happybeing/vdash/issues):
-                        info!("Wrote record {record_key:?} to disk! filename: {filename}");
+                        info!("Wrote record {record_key2:?} to disk! filename: {filename}");
 
                         LocalSwarmCmd::AddLocalRecordAsStored { key, record_type }
                     }
                     Err(err) => {
                         error!(
-                        "Error writing record {record_key:?} filename: {filename}, error: {err:?}"
+                        "Error writing record {record_key2:?} filename: {filename}, error: {err:?}"
                     );
                         LocalSwarmCmd::RemoveFailedLocalRecord { key }
                     }
@@ -566,6 +583,15 @@ impl NodeRecordStore {
         });
 
         Ok(())
+    }
+
+    /// Update the cache indices after removing an element
+    fn update_cache_indices(&mut self, start_index: usize) {
+        for index in start_index..self.records_cache.len() {
+            if let Some(record) = self.records_cache.get(index) {
+                self.records_cache_map.insert(record.key.clone(), index);
+            }
+        }
     }
 
     /// Calculate the cost to store data for our current store state


### PR DESCRIPTION
This pull request to `sn_networking` includes significant improvements to the handling of pending record queries, the introduction of a non-blocking command queue for network swarm commands, and various other enhancements to the codebase. The most important changes include adding support for handling multiple senders for pending record queries, introducing a non-blocking command queue for network swarm commands, and improving error handling and logging.

### Enhancements to pending record queries:

* [`sn_networking/src/cmd.rs`](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76R341-R356): Added logic to handle multiple senders for pending record queries in `GetNetworkRecord` command. [[1]](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76R341-R356) [[2]](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76L351-R367) [[3]](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76L361-R377)
* [`sn_networking/src/driver.rs`](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL92-R93): Modified `PendingGetRecord` type to include multiple senders. [[1]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL92-R93) [[2]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022L360-R360) [[3]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022L395-R398) [[4]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022R425-R440) [[5]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022L462-R469) [[6]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022R507-R511) [[7]](diffhunk://#diff-4c7753b4198da926db9ea80d1e10daac655d3472dbc84edc034f41a54ffd0022L528-R537)

### Introduction of non-blocking command queue:

* [`sn_networking/src/driver.rs`](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bR611-R613): Added `network_cmd_sender` to `SwarmDriver` and implemented `queue_network_swarm_cmd` method to send commands off-thread. [[1]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bR611-R613) [[2]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bR663) [[3]](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bR798-R817)
* [`sn_networking/src/event/request_response.rs`](diffhunk://#diff-f9a909155bd3d3e5ad85ae2f220de1d7d30cea5330fc236c480dbed832f27d7cL44-R49): Updated to use `queue_network_swarm_cmd` for sending responses. [[1]](diffhunk://#diff-f9a909155bd3d3e5ad85ae2f220de1d7d30cea5330fc236c480dbed832f27d7cL44-R49) [[2]](diffhunk://#diff-f9a909155bd3d3e5ad85ae2f220de1d7d30cea5330fc236c480dbed832f27d7cL59-R63) [[3]](diffhunk://#diff-f9a909155bd3d3e5ad85ae2f220de1d7d30cea5330fc236c480dbed832f27d7cL85-R89)

### Other improvements:

* [`sn_networking/src/cmd.rs`](diffhunk://#diff-40f3d649e190d6bffdaca7272dccedbb9675ab0769776269f58b3556041fdd76R579): Added a timestamp to `PutLocalRecord` for better tracking.
* [`sn_networking/src/driver.rs`](diffhunk://#diff-985b0f4f68bd09d2bcb4c2da67ab65c5c68d38d8aac388691e361a295bc8ae4bL41-R41): Included `RecordKey` in imports and updated usage.
* [`sn_networking/src/error.rs`](diffhunk://#diff-f734d4dd70d18552f648874ab214698816a51fda11d6506971ac6f464ef1867aR32): Made `GetRecordError` cloneable.

These changes collectively enhance the efficiency, robustness, and maintainability of the networking component.