### PR TITLE
chore(cli): [#2012] show download time per file

### DIFF
--- a/sn_cli/src/files/files_uploader.rs
+++ b/sn_cli/src/files/files_uploader.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::get_progress_bar;
+use crate::utils::duration_to_minute_seconds_string;
 use crate::ChunkManager;
 use bytes::Bytes;
 use color_eyre::{eyre::eyre, Report, Result};
@@ -424,13 +425,7 @@ impl FilesUploadStatusNotifier for StdOutPrinter {
         elapsed_time: Duration,
         chunks_to_upload_len: usize,
     ) {
-        let elapsed_minutes = elapsed_time.as_secs() / 60;
-        let elapsed_seconds = elapsed_time.as_secs() % 60;
-        let elapsed = if elapsed_minutes > 0 {
-            format!("{elapsed_minutes} minutes {elapsed_seconds} seconds")
-        } else {
-            format!("{elapsed_seconds} seconds")
-        };
+        let elapsed = duration_to_minute_seconds_string(elapsed_time);
 
         println!(
             "Among {chunks_to_upload_len} chunks, found {} already existed in network, uploaded \

--- a/sn_cli/src/utils.rs
+++ b/sn_cli/src/utils.rs
@@ -6,7 +6,32 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use std::time::Duration;
+
 /// Returns whether a hex string is a valid secret key in hex format.
 pub fn is_valid_key_hex(hex: &str) -> bool {
     hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+pub fn duration_to_minute_seconds_string(duration: Duration) -> String {
+    let elapsed_minutes = duration.as_secs() / 60;
+    let elapsed_seconds = duration.as_secs() % 60;
+    if elapsed_minutes > 0 {
+        format!("{elapsed_minutes} minutes {elapsed_seconds} seconds")
+    } else {
+        format!("{elapsed_seconds} seconds")
+    }
+}
+
+pub fn duration_to_minute_seconds_miliseconds_string(duration: Duration) -> String {
+    let elapsed_minutes = duration.as_secs() / 60;
+    let elapsed_seconds = duration.as_secs() % 60;
+    let elapsed_millis = duration.subsec_millis();
+    if elapsed_minutes > 0 {
+        format!("{elapsed_minutes} minutes {elapsed_seconds} seconds {elapsed_millis} milliseconds")
+    } else if elapsed_seconds > 0 {
+        format!("{elapsed_seconds} seconds {elapsed_millis} milliseconds")
+    } else {
+        format!("{elapsed_millis} milliseconds")
+    }
 }


### PR DESCRIPTION
### Description

Adds the time it took to download each file to the console output of the `safe files download` command.

e.g.:
```
Downloading "1KB.bin" from 12c1eb9c985dbd6682c4ec2fe0734419d5b48c025706aafb38a322d657aced1a with batch-size 16
Saved "1KB.bin" at /Users/mick/Downloads/safe_files/1KB.bin
File downloaded in 228 milliseconds
```

### Related Issue

Fixes #2012

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
