### PR TITLE
chore(node): check confirmed_spend existence

### DIFF
--- a/sn_transfers/src/wallet/wallet_file.rs
+++ b/sn_transfers/src/wallet/wallet_file.rs
@@ -88,7 +88,7 @@ pub(super) fn get_confirmed_spend(
     let spend_hex_name = spend_addr.to_hex();
     let spend_file_path = spends_dir.join(spend_hex_name);
     debug!("Try to getting a confirmed_spend instance from: {spend_file_path:?}");
-    if !spend_file_path.is_file() {
+    if !spend_file_path.exists() {
         return Ok(None);
     }
 


### PR DESCRIPTION
This pull request includes changes to improve error handling and code clarity in the `sn_node` and `sn_transfers` modules. The most important changes involve refining the logic for detecting spent transactions and updating the method for checking file existence.

Improvements to error handling and code clarity:

* [`sn_node/src/put_validation.rs`](diffhunk://#diff-4068135f5e3a9602f500afc6882d26acae4e2e664594d47644b766fd70566352L554-L562): Updated the logic to handle different outcomes of `wallet.get_confirmed_spend(spend_addr)`, including logging an error when an error is encountered and providing more specific warnings for different cases.
* [`sn_transfers/src/wallet/wallet_file.rs`](diffhunk://#diff-21545ebb857dc06320744ad3e062eac58376c0d33d07d73cb0be4426c966d2baL91-R91): Changed the method for checking if a file exists from `is_file()` to `exists()` to improve clarity and correctness.