### PR TITLE
fix(network): add peer to blocklist only after informing it

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -612,6 +612,7 @@ impl NetworkBuilder {
             // and not block the processing thread unintentionally
             network_cmd_sender: network_swarm_cmd_sender.clone(),
             network_cmd_receiver: network_swarm_cmd_receiver,
+            local_cmd_sender: local_swarm_cmd_sender.clone(),
             local_cmd_receiver: local_swarm_cmd_receiver,
             event_sender: network_event_sender,
             pending_get_closest_peers: Default::default(),
@@ -661,6 +662,7 @@ pub struct SwarmDriver {
     pub(crate) network_metrics: Option<NetworkMetrics>,
 
     network_cmd_sender: mpsc::Sender<NetworkSwarmCmd>,
+    pub(crate) local_cmd_sender: mpsc::Sender<LocalSwarmCmd>,
     local_cmd_receiver: mpsc::Receiver<LocalSwarmCmd>,
     network_cmd_receiver: mpsc::Receiver<NetworkSwarmCmd>,
     event_sender: mpsc::Sender<NetworkEvent>, // Use `self.send_event()` to send a NetworkEvent.

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -28,7 +28,7 @@ use sn_networking::{
 };
 use sn_protocol::{
     error::Error as ProtocolError,
-    messages::{ChunkProof, Cmd, CmdResponse, Query, QueryResponse, Request, Response},
+    messages::{ChunkProof, CmdResponse, Query, QueryResponse, Request, Response},
     NetworkAddress, PrettyPrintRecordKey, CLOSE_GROUP_SIZE,
 };
 use sn_transfers::{HotWallet, MainPubkey, MainSecretKey, NanoTokens, PAYMENT_FORWARD_PK};
@@ -463,24 +463,9 @@ impl Node {
             NetworkEvent::PeerWithUnsupportedProtocol { .. } => {
                 event_header = "PeerWithUnsupportedProtocol";
             }
-            NetworkEvent::PeerConsideredAsBad {
-                detected_by,
-                bad_peer,
-                bad_behaviour,
-            } => {
+            NetworkEvent::PeerConsideredAsBad { bad_peer, .. } => {
                 event_header = "PeerConsideredAsBad";
                 self.record_metrics(Marker::PeerConsideredAsBad(&bad_peer));
-
-                let request = Request::Cmd(Cmd::PeerConsideredAsBad {
-                    detected_by: NetworkAddress::from_peer(detected_by),
-                    bad_peer: NetworkAddress::from_peer(bad_peer),
-                    bad_behaviour,
-                });
-
-                let network = self.network().clone();
-                let _handle = spawn(async move {
-                    network.send_req_ignore_reply(request, bad_peer);
-                });
             }
             NetworkEvent::FlaggedAsBadNode { flagged_by } => {
                 event_header = "FlaggedAsBadNode";


### PR DESCRIPTION
- Add peer to the blocklist after sending `Cmd::PeerConsideredAsBad`. Earlier we were blocking it before sending the cmd. Thus, it would not know about being shunned.