### PR TITLE
feat(metrics): export metadata via the metrics port

### DIFF
--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -17,8 +17,6 @@ use libp2p::{
     kad::{Quorum, Record},
     Multiaddr, PeerId,
 };
-#[cfg(feature = "open-metrics")]
-use prometheus_client::registry::Registry;
 use rand::{thread_rng, Rng};
 use sn_networking::{
     get_signed_spend_from_record, multiaddr_is_global,
@@ -106,13 +104,7 @@ impl Client {
         let root_dir = std::env::temp_dir();
         trace!("Starting Kad swarm in client mode..{root_dir:?}.");
 
-        #[cfg(not(feature = "open-metrics"))]
         let network_builder = NetworkBuilder::new(Keypair::generate_ed25519(), local, root_dir);
-
-        #[cfg(feature = "open-metrics")]
-        let mut network_builder = NetworkBuilder::new(Keypair::generate_ed25519(), local, root_dir);
-        #[cfg(feature = "open-metrics")]
-        network_builder.metrics_registry(Some(Registry::default()));
 
         let (network, mut network_event_receiver, swarm_driver) = network_builder.build_client()?;
         info!("Client constructed network and swarm_driver");

--- a/sn_networking/src/metrics/mod.rs
+++ b/sn_networking/src/metrics/mod.rs
@@ -24,7 +24,8 @@ mod upnp;
 const UPDATE_INTERVAL: Duration = Duration::from_secs(15);
 const TO_MB: u64 = 1_000_000;
 
-pub(crate) struct NetworkMetrics {
+/// The shared recorders that are used to record metrics.
+pub(crate) struct NetworkMetricsRecorder {
     // Records libp2p related metrics
     // Must directly call self.libp2p_metrics.record(libp2p_event) with Recorder trait in scope. But since we have
     // re-implemented the trait for the wrapper struct, we can instead call self.record(libp2p_event)
@@ -47,7 +48,7 @@ pub(crate) struct NetworkMetrics {
     process_cpu_usage_percentage: Gauge,
 }
 
-impl NetworkMetrics {
+impl NetworkMetricsRecorder {
     pub fn new(registry: &mut Registry) -> Self {
         let libp2p_metrics = Libp2pMetrics::new(registry);
         let sub_registry = registry.sub_registry_with_prefix("sn_networking");
@@ -195,25 +196,25 @@ impl NetworkMetrics {
 }
 
 /// Impl the Recorder traits again for our struct.
-impl Recorder<libp2p::kad::Event> for NetworkMetrics {
+impl Recorder<libp2p::kad::Event> for NetworkMetricsRecorder {
     fn record(&self, event: &libp2p::kad::Event) {
         self.libp2p_metrics.record(event)
     }
 }
 
-impl Recorder<libp2p::relay::Event> for NetworkMetrics {
+impl Recorder<libp2p::relay::Event> for NetworkMetricsRecorder {
     fn record(&self, event: &libp2p::relay::Event) {
         self.libp2p_metrics.record(event)
     }
 }
 
-impl Recorder<libp2p::identify::Event> for NetworkMetrics {
+impl Recorder<libp2p::identify::Event> for NetworkMetricsRecorder {
     fn record(&self, event: &libp2p::identify::Event) {
         self.libp2p_metrics.record(event)
     }
 }
 
-impl<T> Recorder<libp2p::swarm::SwarmEvent<T>> for NetworkMetrics {
+impl<T> Recorder<libp2p::swarm::SwarmEvent<T>> for NetworkMetricsRecorder {
     fn record(&self, event: &libp2p::swarm::SwarmEvent<T>) {
         self.libp2p_metrics.record(event);
     }

--- a/sn_networking/src/metrics/upnp.rs
+++ b/sn_networking/src/metrics/upnp.rs
@@ -24,7 +24,7 @@ impl From<&libp2p::upnp::Event> for EventType {
     }
 }
 
-impl super::Recorder<libp2p::upnp::Event> for super::NetworkMetrics {
+impl super::Recorder<libp2p::upnp::Event> for super::NetworkMetricsRecorder {
     fn record(&self, event: &libp2p::upnp::Event) {
         self.upnp_events
             .get_or_create(&UpnpEventLabels {

--- a/sn_node/src/metrics.rs
+++ b/sn_node/src/metrics.rs
@@ -20,7 +20,8 @@ use prometheus_client::{
 use sn_networking::Instant;
 
 #[derive(Clone)]
-pub(crate) struct NodeMetrics {
+/// The shared recorders that are used to record metrics.
+pub(crate) struct NodeMetricsRecorder {
     /// put record
     put_record_ok: Family<PutRecordOk, Counter>,
     put_record_err: Counter,
@@ -54,7 +55,7 @@ enum RecordType {
     Spend,
 }
 
-impl NodeMetrics {
+impl NodeMetricsRecorder {
     pub(crate) fn new(registry: &mut Registry) -> Self {
         let sub_registry = registry.sub_registry_with_prefix("sn_node");
 

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -13,12 +13,12 @@ use super::{
     Marker, NodeEvent,
 };
 #[cfg(feature = "open-metrics")]
-use crate::metrics::NodeMetrics;
+use crate::metrics::NodeMetricsRecorder;
 use crate::RunningNode;
 use bytes::Bytes;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 #[cfg(feature = "open-metrics")]
-use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::{gauge::Gauge, info::Info};
 #[cfg(feature = "open-metrics")]
 use prometheus_client::registry::Registry;
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
@@ -155,20 +155,34 @@ impl NodeBuilder {
         // store in case it's a fresh wallet created if none was found
         wallet.deposit_and_store_to_disk(&vec![])?;
 
-        #[cfg(feature = "open-metrics")]
-        let (metrics_registry, node_metrics) = if self.metrics_server_port.is_some() {
-            let mut metrics_registry = Registry::default();
-            let node_metrics = NodeMetrics::new(&mut metrics_registry);
-            (Some(metrics_registry), Some(node_metrics))
-        } else {
-            (None, None)
-        };
-
         let mut network_builder = NetworkBuilder::new(self.keypair, self.local, self.root_dir);
 
-        network_builder.listen_addr(self.addr);
         #[cfg(feature = "open-metrics")]
-        network_builder.metrics_registry(metrics_registry);
+        let node_metrics = if self.metrics_server_port.is_some() {
+            // metadata registry
+            let mut metadata_registry = Registry::default();
+            let node_metadata_sub_registry = metadata_registry.sub_registry_with_prefix("sn_node");
+            node_metadata_sub_registry.register(
+                "safenode_version",
+                "The version of the safe node",
+                Info::new(vec![(
+                    "safenode_version".to_string(),
+                    env!("CARGO_PKG_VERSION").to_string(),
+                )]),
+            );
+            network_builder.metrics_metadata_registry(metadata_registry);
+
+            // metrics registry
+            let mut metrics_registry = Registry::default();
+            let node_metrics = NodeMetricsRecorder::new(&mut metrics_registry);
+            network_builder.metrics_registry(metrics_registry);
+
+            Some(node_metrics)
+        } else {
+            None
+        };
+
+        network_builder.listen_addr(self.addr);
         #[cfg(feature = "open-metrics")]
         network_builder.metrics_server_port(self.metrics_server_port);
         network_builder.initial_peers(self.initial_peers.clone());
@@ -220,7 +234,7 @@ struct NodeInner {
     initial_peers: Vec<Multiaddr>,
     network: Network,
     #[cfg(feature = "open-metrics")]
-    node_metrics: Option<NodeMetrics>,
+    node_metrics: Option<NodeMetricsRecorder>,
     /// Node owner's discord username, in readable format
     /// If not set, there will be no payment forward to be undertaken
     owner: Option<String>,
@@ -245,7 +259,7 @@ impl Node {
 
     #[cfg(feature = "open-metrics")]
     /// Returns a reference to the NodeMetrics if the `open-metrics` feature flag is enabled
-    pub(crate) fn node_metrics(&self) -> Option<&NodeMetrics> {
+    pub(crate) fn node_metrics(&self) -> Option<&NodeMetricsRecorder> {
         self.inner.node_metrics.as_ref()
     }
 


### PR DESCRIPTION
- Exposes `/metadata` endpoint at the metrics port, to provide static metadata aout about a node.
```
# HELP sn_node_safenode_version The version of the safe node.
# TYPE sn_node_safenode_version info
sn_node_safenode_version_info{safenode_version="0.110.0"} 1
# HELP sn_networking_peer_id Identifier of a peer of the network.
# TYPE sn_networking_peer_id info
sn_networking_peer_id_info{peer_id="12D3KooWLDzPJigeXtZA6n7UK4HzqyfgKpZY3DtrBu9C6S6bYK9w"} 1
# HELP sn_networking_identify_protocol_str The protocol version string that is used to connect to the correct network.
# TYPE sn_networking_identify_protocol_str info
sn_networking_identify_protocol_str_info{identify_protocol_str="safe/0.17/8f73b9_9934c2_b4243e_a58583"} 1
# EOF

```