### PR TITLE
feat(node): prune unrelevant records if accumulated too many

### DIFF
--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -133,6 +133,8 @@ pub enum LocalSwarmCmd {
     /// Triggers interval repliation
     /// NOTE: This does result in outgoing messages, but is produced locally
     TriggerIntervalReplication,
+    /// Triggers unrelevant record cleanup
+    TriggerUnrelevantRecordCleanup,
 }
 
 /// Commands to send to the Swarm
@@ -280,6 +282,9 @@ impl Debug for LocalSwarmCmd {
             }
             LocalSwarmCmd::TriggerIntervalReplication => {
                 write!(f, "LocalSwarmCmd::TriggerIntervalReplication")
+            }
+            LocalSwarmCmd::TriggerUnrelevantRecordCleanup => {
+                write!(f, "LocalSwarmCmd::TriggerUnrelevantRecordCleanup")
             }
         }
     }
@@ -816,6 +821,14 @@ impl SwarmDriver {
                 if !new_keys_to_fetch.is_empty() {
                     self.send_event(NetworkEvent::KeysToFetchForReplication(new_keys_to_fetch));
                 }
+            }
+            LocalSwarmCmd::TriggerUnrelevantRecordCleanup => {
+                cmd_string = "TriggerUnrelevantRecordCleanup";
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .cleanup_unrelevant_records();
             }
         }
 

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -801,6 +801,10 @@ impl Network {
         self.send_local_swarm_cmd(LocalSwarmCmd::QuoteVerification { quotes });
     }
 
+    pub fn trigger_unrelevant_record_cleanup(&self) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::TriggerUnrelevantRecordCleanup)
+    }
+
     /// Helper to send NetworkSwarmCmd
     fn send_network_swarm_cmd(&self, cmd: NetworkSwarmCmd) {
         send_network_swarm_cmd(self.network_swarm_cmd_sender().clone(), cmd);

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -169,4 +169,13 @@ impl UnifiedRecordStore {
             Self::Node(store) => store.mark_as_stored(k, record_type),
         };
     }
+
+    pub(crate) fn cleanup_unrelevant_records(&mut self) {
+        match self {
+            Self::Client(_store) => {
+                warn!("Calling cleanup_unrelevant_records at Client. This should not happen");
+            }
+            Self::Node(store) => store.cleanup_unrelevant_records(),
+        }
+    }
 }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -25,6 +25,11 @@ impl Node {
         network.trigger_interval_replication()
     }
 
+    /// Cleanup unrelevant records if accumulated too many.
+    pub(crate) fn trigger_unrelevant_record_cleanup(network: Network) {
+        network.trigger_unrelevant_record_cleanup()
+    }
+
     /// Get the Record from a peer or from the network without waiting.
     pub(crate) fn fetch_replication_keys_without_wait(
         &self,


### PR DESCRIPTION
### Description

There is observed super-high quote due to incorrectly calculated store_cost quote, as an result of not-fully populated RT, but with records accumulated from historical runs.

In one observed scenario, a node accumulated 3k records, normally quoting 10/20 nanos (with 1.1k close_range_records calculated), quoted 4million nanos (with all 3k records calculated as close_range_records) as during the restart when its RT only got 56 peers (network size estimated to be just 76 nodes; where normally shall be 230 peers in RT and network size to be over 30k).

This PR is an attempt to:
* have a background thread checks how many records accumulated so far, with an interval say 1 hour
* once reached 60% of the max_record, trigger clean up
* remove ALL records that not within the close_range that got set

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
