### PR TITLE
fix: save node registry on every upgrade

### DIFF
--- a/sn_node_manager/src/cmd/node.rs
+++ b/sn_node_manager/src/cmd/node.rs
@@ -553,6 +553,7 @@ pub async fn upgrade(
                     service_manager.service.service_data.service_name.clone(),
                     upgrade_result,
                 ));
+                node_registry.save()?;
             }
             Err(err) => {
                 error!("Error upgrading service {service_name}: {err}");
@@ -560,11 +561,11 @@ pub async fn upgrade(
                     node.service_name.clone(),
                     UpgradeResult::Error(format!("Error: {err}")),
                 ));
+                node_registry.save()?;
             }
         }
     }
 
-    node_registry.save()?;
     print_upgrade_summary(upgrade_summary.clone());
 
     if upgrade_summary.iter().any(|(_, r)| {


### PR DESCRIPTION
Save the registry when each node is upgraded, whether there was an error or not. Previously, the registry was only being saved after the entire suite was processed.

Waiting to the end was problematic during the deployment process when Ansible's SSH connection was lost. It resulted in the registry not being updated and hence no nodes were being reported as being upgraded. This led me on a bit of a wild goose chase when debugging the connection issues.

It will be very useful to have this fix in for the upgrade process, because nodes should then be correctly reported as upgraded even if a connection is lost.