### PR TITLE
fix(networking): build with --no-default-features

### DIFF
--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.17.2"
 
 [features]
-default = ["libp2p/quic"]
+default = []
 local-discovery = ["libp2p/mdns"]
 upnp = ["libp2p/upnp"]
 # tcp is automatically enabled when compiling for wasm32
@@ -30,7 +30,7 @@ libp2p = { version = "0.53", features = [
     "request-response",
     "cbor",
     "identify",
-    "tcp",
+    "quic",
     "relay",
     "noise",
     "tcp",

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::event::TerminateNodeReason;
 use crate::{
     cmd::LocalSwarmCmd,
     event::NodeEvent,
@@ -82,7 +81,7 @@ impl SwarmDriver {
                 if let libp2p::upnp::Event::GatewayNotFound = upnp_event {
                     warn!("UPnP is not enabled/supported on the gateway. Please rerun without the `--upnp` flag");
                     self.send_event(NetworkEvent::TerminateNode {
-                        reason: TerminateNodeReason::UpnpGatewayNotFound,
+                        reason: crate::event::TerminateNodeReason::UpnpGatewayNotFound,
                     });
                 }
             }


### PR DESCRIPTION
When building without UPnP, there was a warning about an unused import. And, building without the default "libp2p/quic" feature doesn't work. Hence it's added to the dependency itself instead  of a default feature.
