### PR TITLE
fix(launchpad): storage mountpoint for node data is not set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4699,6 +4699,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum",
  "sysinfo",
+ "tempfile",
  "tokio",
  "tokio-util 0.7.11",
  "tracing",
@@ -5119,7 +5120,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7758,14 +7759,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8912,7 +8914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8930,7 +8932,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8948,7 +8950,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8968,18 +8979,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -8990,9 +9001,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9002,9 +9013,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9014,15 +9025,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9032,9 +9043,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9044,9 +9055,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9056,9 +9067,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9068,9 +9079,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -67,3 +67,6 @@ faccess = "0.2.4"
 
 [build-dependencies]
 vergen = { version = "8.2.6", features = ["build", "git", "gitoxide", "cargo"] }
+
+[dev-dependencies]
+tempfile = "3.12.0"

--- a/node-launchpad/src/bin/tui/main.rs
+++ b/node-launchpad/src/bin/tui/main.rs
@@ -65,6 +65,7 @@ async fn tokio_main() -> Result<()> {
         args.frame_rate,
         args.peers,
         args.safenode_path,
+        None,
     )
     .await?;
     app.run().await?;

--- a/node-launchpad/src/config.rs
+++ b/node-launchpad/src/config.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::system;
 use crate::system::get_primary_mount_point;
 use crate::{action::Action, mode::Scene};
 use color_eyre::eyre::{eyre, Result};
@@ -98,7 +97,7 @@ pub async fn configure_winsw() -> Result<()> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Deserialize, Default, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AppData {
     pub discord_username: String,
     pub nodes_to_start: usize,
@@ -106,37 +105,49 @@ pub struct AppData {
     pub storage_drive: Option<String>,
 }
 
+impl Default for AppData {
+    fn default() -> Self {
+        Self {
+            discord_username: "".to_string(),
+            nodes_to_start: 1,
+            storage_mountpoint: None,
+            storage_drive: None,
+        }
+    }
+}
+
 impl AppData {
-    pub fn load() -> Result<Self> {
-        let config_dir =
-            get_config_dir().map_err(|_| color_eyre::eyre::eyre!("Could not obtain config dir"))?;
-        let config_path = config_dir.join("app_data.json");
+    pub fn load(custom_path: Option<PathBuf>) -> Result<Self> {
+        let config_path = if let Some(path) = custom_path {
+            path
+        } else {
+            get_config_dir()
+                .map_err(|_| color_eyre::eyre::eyre!("Could not obtain config dir"))?
+                .join("app_data.json")
+        };
 
         if !config_path.exists() {
             return Ok(Self::default());
         }
 
-        let data = std::fs::read_to_string(config_path)
+        let data = std::fs::read_to_string(&config_path)
             .map_err(|_| color_eyre::eyre::eyre!("Failed to read app data file"))?;
 
-        let mut app_data: AppData = serde_json::from_str(&data)
+        let app_data: AppData = serde_json::from_str(&data)
             .map_err(|_| color_eyre::eyre::eyre!("Failed to parse app data"))?;
 
-        if app_data.storage_mountpoint.is_none() || app_data.storage_drive.is_none() {
-            // If the storage drive is not set, set it to the default mount point
-            let drive_info = system::get_default_mount_point()?;
-            app_data.storage_drive = Some(drive_info.0);
-            app_data.storage_mountpoint = Some(drive_info.1);
-            debug!("Setting storage drive to {:?}", app_data.storage_mountpoint);
-        }
         Ok(app_data)
     }
 
-    pub fn save(&self) -> Result<()> {
-        let config_dir = get_config_dir()
-            .map_err(|_| config::ConfigError::Message("Could not obtain data dir".to_string()))?;
+    pub fn save(&self, custom_path: Option<PathBuf>) -> Result<()> {
+        let config_path = if let Some(path) = custom_path {
+            path
+        } else {
+            get_config_dir()
+                .map_err(|_| config::ConfigError::Message("Could not obtain data dir".to_string()))?
+                .join("app_data.json")
+        };
 
-        let config_path = config_dir.join("app_data.json");
         let serialized_config = serde_json::to_string_pretty(&self)?;
         std::fs::write(config_path, serialized_config)?;
 
@@ -536,6 +547,7 @@ fn parse_color(s: &str) -> Option<Color> {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -680,5 +692,127 @@ mod tests {
             parse_key_event("AlT-eNtEr").unwrap(),
             KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)
         );
+    }
+
+    #[test]
+    fn test_app_data_file_does_not_exist() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let non_existent_path = temp_dir.path().join("non_existent_app_data.json");
+
+        let app_data = AppData::load(Some(non_existent_path))?;
+
+        assert_eq!(app_data.discord_username, "");
+        assert_eq!(app_data.nodes_to_start, 1);
+        assert_eq!(app_data.storage_mountpoint, None);
+        assert_eq!(app_data.storage_drive, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_app_data_partial_info() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let partial_data_path = temp_dir.path().join("partial_app_data.json");
+
+        let partial_data = r#"
+        {
+            "discord_username": "test_user",
+            "nodes_to_start": 3
+        }
+        "#;
+
+        std::fs::write(&partial_data_path, partial_data)?;
+
+        let app_data = AppData::load(Some(partial_data_path))?;
+
+        assert_eq!(app_data.discord_username, "test_user");
+        assert_eq!(app_data.nodes_to_start, 3);
+        assert_eq!(app_data.storage_mountpoint, None);
+        assert_eq!(app_data.storage_drive, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_app_data_missing_mountpoint() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let missing_mountpoint_path = temp_dir.path().join("missing_mountpoint_app_data.json");
+
+        let missing_mountpoint_data = r#"
+        {
+            "discord_username": "test_user",
+            "nodes_to_start": 3,
+            "storage_drive": "C:"
+        }
+        "#;
+
+        std::fs::write(&missing_mountpoint_path, missing_mountpoint_data)?;
+
+        let app_data = AppData::load(Some(missing_mountpoint_path))?;
+
+        assert_eq!(app_data.discord_username, "test_user");
+        assert_eq!(app_data.nodes_to_start, 3);
+        assert_eq!(app_data.storage_mountpoint, None);
+        assert_eq!(app_data.storage_drive, Some("C:".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_app_data_complete_info() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let complete_data_path = temp_dir.path().join("complete_app_data.json");
+
+        let complete_data = r#"
+        {
+            "discord_username": "complete_user",
+            "nodes_to_start": 5,
+            "storage_mountpoint": "/mnt/data",
+            "storage_drive": "D:"
+        }
+        "#;
+
+        std::fs::write(&complete_data_path, complete_data)?;
+
+        let app_data = AppData::load(Some(complete_data_path))?;
+
+        assert_eq!(app_data.discord_username, "complete_user");
+        assert_eq!(app_data.nodes_to_start, 5);
+        assert_eq!(
+            app_data.storage_mountpoint,
+            Some(PathBuf::from("/mnt/data"))
+        );
+        assert_eq!(app_data.storage_drive, Some("D:".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_app_data_save_and_load() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let test_path = temp_dir.path().join("test_app_data.json");
+
+        let mut app_data = AppData::default();
+        let var_name = &"save_load_user";
+        app_data.discord_username = var_name.to_string();
+        app_data.nodes_to_start = 4;
+        app_data.storage_mountpoint = Some(PathBuf::from("/mnt/test"));
+        app_data.storage_drive = Some("E:".to_string());
+
+        // Save to custom path
+        app_data.save(Some(test_path.clone()))?;
+
+        // Load from custom path
+        let loaded_data = AppData::load(Some(test_path))?;
+
+        assert_eq!(loaded_data.discord_username, "save_load_user");
+        assert_eq!(loaded_data.nodes_to_start, 4);
+        assert_eq!(
+            loaded_data.storage_mountpoint,
+            Some(PathBuf::from("/mnt/test"))
+        );
+        assert_eq!(loaded_data.storage_drive, Some("E:".to_string()));
+
+        Ok(())
     }
 }

--- a/node-launchpad/src/system.rs
+++ b/node-launchpad/src/system.rs
@@ -124,6 +124,18 @@ pub fn get_primary_mount_point() -> PathBuf {
     PathBuf::from("C:\\")
 }
 
+/// Gets the name of the primary mount point.
+pub fn get_primary_mount_point_name() -> Result<String> {
+    let primary_mount_point = get_primary_mount_point();
+    let available_drives = get_list_of_available_drives_and_available_space()?;
+
+    available_drives
+        .iter()
+        .find(|(_, mount_point, _)| mount_point == &primary_mount_point)
+        .map(|(name, _, _)| name.clone())
+        .ok_or_else(|| eyre!("Unable to find the name of the primary mount point"))
+}
+
 // Gets available disk space in bytes for the given mountpoint
 pub fn get_available_space_b(storage_mountpoint: &PathBuf) -> Result<usize> {
     let disks = Disks::new_with_refreshed_list();
@@ -141,7 +153,7 @@ pub fn get_available_space_b(storage_mountpoint: &PathBuf) -> Result<usize> {
         .list()
         .iter()
         .find(|disk| disk.mount_point() == storage_mountpoint)
-        .context("Cannot find the primary disk")?
+        .context("Cannot find the primary disk. Configuration file might be wrong.")?
         .available_space() as usize;
 
     Ok(available_space_b)


### PR DESCRIPTION
### Description

Branch from `stable` (it's a hotfix then)

A fix for the error `Storage Mountpoint for node data is not set` was implemented. We modified the code to be able to execute tests injecting the configuration path on the main app.

Tests were written for the following cases:
* Happy case
* Configuration file not found (new installation)
* Configuration exists but with wrong mountpoint defined
* Configuration exists but mountpoint is not set or doesn't exists (case were we upgrade LP version)

Internal tests for configuration parsing