### PR TITLE
feat(networking): increase circuit bytes limit

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -600,6 +600,8 @@ impl NetworkBuilder {
                 max_circuits: 1024, // The total amount of relayed connections at any given moment.
                 max_circuits_per_peer: 256, // Amount of relayed connections per peer (both dst and src)
                 circuit_src_rate_limiters: vec![], // No extra rate limiting for now
+                // We should at least be able to relay packets with chunks etc.
+                max_circuit_bytes: MAX_PACKET_SIZE as u64,
                 ..Default::default()
             };
             libp2p::relay::Behaviour::new(peer_id, relay_server_cfg)


### PR DESCRIPTION
### Description

This PR is to bring back a fix, related to make home nodes starts earning, that got reverted by accident.
The reverted by accident PR was https://github.com/maidsafe/safe_network/pull/2053

CLOSE https://github.com/maidsafe/safe_network/pull/2096


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
