### PR TITLE
fix(network): register record shall not be verified by entire content

### DIFF
--- a/autonomi/src/client/data.rs
+++ b/autonomi/src/client/data.rs
@@ -88,6 +88,7 @@ impl Client {
             retry_strategy: None,
             target_record: None,
             expected_holders: HashSet::new(),
+            is_register: false,
         };
         let record = self.network.get_record_from_network(key, &get_cfg).await?;
         let header = RecordHeader::from_record(&record)?;

--- a/autonomi/src/client/registers.rs
+++ b/autonomi/src/client/registers.rs
@@ -138,6 +138,7 @@ impl Client {
             retry_strategy: None,
             target_record: None,
             expected_holders: Default::default(),
+            is_register: true,
         };
 
         let record = self.network.get_record_from_network(key, &get_cfg).await?;

--- a/autonomi/src/client/transfers.rs
+++ b/autonomi/src/client/transfers.rs
@@ -318,6 +318,7 @@ async fn store_spend(network: Network, spend: SignedSpend) -> Result<(), Network
         retry_strategy: None,
         target_record: record_to_verify,
         expected_holders,
+        is_register: false,
     };
     let put_cfg = PutRecordCfg {
         put_quorum: Quorum::Majority,

--- a/sn_client/src/api.rs
+++ b/sn_client/src/api.rs
@@ -617,6 +617,7 @@ impl Client {
                 retry_strategy,
                 target_record: None, // Not used since we use ChunkProof
                 expected_holders: Default::default(),
+                is_register: false,
             };
             // The `ChunkWithPayment` is only used to send out via PutRecord.
             // The holders shall only hold the `Chunk` copies.
@@ -702,6 +703,7 @@ impl Client {
             retry_strategy: Some(retry_strategy.unwrap_or(RetryStrategy::Quick)),
             target_record: None,
             expected_holders,
+            is_register: false,
         };
         let record = self.network.get_record_from_network(key, &get_cfg).await?;
         let header = RecordHeader::from_record(&record)?;
@@ -856,6 +858,7 @@ impl Client {
             retry_strategy: None,
             target_record: record_to_verify,
             expected_holders,
+            is_register: false,
         };
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::Majority,
@@ -903,6 +906,7 @@ impl Client {
                 retry_strategy: Some(RetryStrategy::Balanced),
                 target_record: None,
                 expected_holders: Default::default(),
+                is_register: false,
             },
         )
         .await
@@ -919,6 +923,7 @@ impl Client {
                 retry_strategy: None,
                 target_record: None,
                 expected_holders: Default::default(),
+                is_register: false,
             },
         )
         .await
@@ -934,6 +939,7 @@ impl Client {
                 retry_strategy: None,
                 target_record: None,
                 expected_holders: Default::default(),
+                is_register: false,
             },
         )
         .await

--- a/sn_client/src/register.rs
+++ b/sn_client/src/register.rs
@@ -844,6 +844,7 @@ impl ClientRegister {
             retry_strategy: Some(RetryStrategy::Quick),
             target_record: record_to_verify,
             expected_holders,
+            is_register: true,
         };
         let put_cfg = PutRecordCfg {
             put_quorum: Quorum::All,

--- a/sn_networking/src/event/kad.rs
+++ b/sn_networking/src/event/kad.rs
@@ -612,7 +612,7 @@ impl SwarmDriver {
         record: Record,
         cfg: &GetRecordCfg,
     ) -> Result<()> {
-        let res = if cfg.target_record.is_none() || cfg.does_target_match(&record) {
+        let res = if cfg.does_target_match(&record) {
             Ok(record)
         } else {
             Err(GetRecordError::RecordDoesNotMatch(record))

--- a/sn_networking/src/transfers.rs
+++ b/sn_networking/src/transfers.rs
@@ -35,6 +35,7 @@ impl Network {
             // what we will have in hand.
             target_record: None,
             expected_holders: Default::default(),
+            is_register: false,
         };
         let record = self.get_record_from_network(key.clone(), &get_cfg).await?;
         debug!(
@@ -55,6 +56,7 @@ impl Network {
             retry_strategy: Some(RetryStrategy::Quick),
             target_record: None,
             expected_holders: Default::default(),
+            is_register: false,
         };
         let record = match self.get_record_from_network(key.clone(), &get_cfg).await {
             Ok(record) => record,

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -75,6 +75,9 @@ impl Node {
                         retry_strategy: None,
                         target_record: None,
                         expected_holders: Default::default(),
+                        // This is for replication, which doesn't have target_recrod to verify with.
+                        // Hence value of the flag actually doesn't matter.
+                        is_register: false,
                     };
                     match node.network().get_record_from_network(key, &get_cfg).await {
                         Ok(record) => record,


### PR DESCRIPTION
### Description

For register record, the get_verification against the entire record value will have a high chance of failure, given the nature of the update_history MerkleReg held by the register.
For register, we can only carry out verification against root value, i.e. the final updated value

### Related Issue

https://github.com/maidsafe/safe_network/issues/2077

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
