### PR TITLE
feat(launchpad): Not enough space

### DIFF
--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -115,7 +115,8 @@ impl App {
         // Popups
         let reset_nodes = ResetNodesPopup::default();
         let manage_nodes = ManageNodes::new(app_data.nodes_to_start, storage_mountpoint.clone())?;
-        let change_drive = ChangeDrivePopup::new(storage_mountpoint.clone())?;
+        let change_drive =
+            ChangeDrivePopup::new(storage_mountpoint.clone(), app_data.nodes_to_start)?;
         let change_connection_mode = ChangeConnectionModePopUp::new(connection_mode)?;
         let port_range = PortRangePopUp::new(connection_mode, port_from, port_to);
         let beta_programme = BetaProgramme::new(app_data.discord_username.clone());


### PR DESCRIPTION
### Description

![Screenshot 2024-09-11 at 18 06 24](https://github.com/user-attachments/assets/fbfcfa7a-824b-434f-a492-44eecf901dad)

When a disk doesn't have available space to run nodes, cannot be selected (appears in gray). In the screenshot, "Photodrive 3A" doesn't have enough space; "Seagate SSD" is not readable/writable; the other two can be selected.