### PR TITLE
fix(launchpad): tweaks and fixes

### DIFF
--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -71,10 +71,11 @@ impl Component for Options {
             .constraints(
                 [
                     Constraint::Length(1),
-                    Constraint::Length(9),
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                    Constraint::Length(5),
+                    Constraint::Length(7),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
                 ]
                 .as_ref(),
             )
@@ -85,6 +86,8 @@ impl Component for Options {
         f.render_stateful_widget(header, layout[0], &mut SelectedMenuItem::Options);
 
         // Storage Drive
+        let port_legend = " Edit Port Range ";
+        let port_key = " [Ctrl+P] ";
         let block1 = Block::default()
             .title(" Device Options ")
             .title_style(Style::default().bold().fg(GHOST_WHITE))
@@ -93,11 +96,7 @@ impl Component for Options {
             .border_style(Style::default().fg(VERY_LIGHT_AZURE));
         let storage_drivename = Table::new(
             vec![
-                Row::new(vec![
-                    Cell::from(Span::raw(" ")), // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
-                ]),
+                Row::new(vec![Line::from(vec![])]),
                 Row::new(vec![
                     Cell::from(
                         Line::from(vec![Span::styled(
@@ -122,11 +121,6 @@ impl Component for Options {
                     ),
                 ]),
                 Row::new(vec![
-                    Cell::from(Span::raw(" ")), // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
-                ]),
-                Row::new(vec![
                     Cell::from(
                         Line::from(vec![Span::styled(
                             " Connection Mode: ",
@@ -148,11 +142,6 @@ impl Component for Options {
                         ])
                         .alignment(Alignment::Right),
                     ),
-                ]),
-                Row::new(vec![
-                    Cell::from(Span::raw(" ")), // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
                 ]),
                 Row::new(vec![
                     Cell::from(
@@ -182,7 +171,7 @@ impl Component for Options {
                     Cell::from(
                         Line::from(vec![
                             Span::styled(
-                                " Edit Port Range ",
+                                port_legend,
                                 if self.connection_mode == ConnectionMode::CustomPorts {
                                     Style::default().fg(VERY_LIGHT_AZURE)
                                 } else {
@@ -190,7 +179,7 @@ impl Component for Options {
                                 },
                             ),
                             Span::styled(
-                                " [Ctrl+P] ",
+                                port_key,
                                 if self.connection_mode == ConnectionMode::CustomPorts {
                                     Style::default().fg(GHOST_WHITE)
                                 } else {
@@ -201,17 +190,20 @@ impl Component for Options {
                         .alignment(Alignment::Right),
                     ),
                 ]),
+                Row::new(vec![Line::from(vec![])]),
             ],
             &[
                 Constraint::Length(18),
-                Constraint::Percentage(25),
                 Constraint::Fill(1),
+                Constraint::Length((port_legend.len() + port_key.len()) as u16),
             ],
         )
         .block(block1)
         .style(Style::default().fg(GHOST_WHITE));
 
         // Beta Rewards Program
+        let beta_legend = " Edit Discord Username ";
+        let beta_key = " [Ctrl+B] ";
         let block2 = Block::default()
             .title(" Beta Rewards Program ")
             .title_style(Style::default().bold().fg(GHOST_WHITE))
@@ -219,50 +211,41 @@ impl Component for Options {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(VERY_LIGHT_AZURE));
         let beta_rewards = Table::new(
-            vec![
-                Row::new(vec![
-                    // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
-                ]),
-                Row::new(vec![
-                    Cell::from(
-                        Line::from(vec![Span::styled(
-                            " Discord Username: ",
-                            Style::default().fg(LIGHT_PERIWINKLE),
-                        )])
-                        .alignment(Alignment::Left),
-                    ),
-                    Cell::from(
-                        Line::from(vec![Span::styled(
-                            format!(" {} ", self.discord_username),
-                            Style::default().fg(VIVID_SKY_BLUE),
-                        )])
-                        .alignment(Alignment::Left),
-                    ),
-                    Cell::from(
-                        Line::from(vec![
-                            Span::styled(
-                                " Edit Discord Username ",
-                                Style::default().fg(VERY_LIGHT_AZURE),
-                            ),
-                            Span::styled(" [Ctrl+B] ", Style::default().fg(GHOST_WHITE)),
-                        ])
-                        .alignment(Alignment::Right),
-                    ),
-                ]),
-            ],
+            vec![Row::new(vec![
+                Cell::from(
+                    Line::from(vec![Span::styled(
+                        " Discord Username: ",
+                        Style::default().fg(LIGHT_PERIWINKLE),
+                    )])
+                    .alignment(Alignment::Left),
+                ),
+                Cell::from(
+                    Line::from(vec![Span::styled(
+                        format!(" {} ", self.discord_username),
+                        Style::default().fg(VIVID_SKY_BLUE),
+                    )])
+                    .alignment(Alignment::Left),
+                ),
+                Cell::from(
+                    Line::from(vec![
+                        Span::styled(beta_legend, Style::default().fg(VERY_LIGHT_AZURE)),
+                        Span::styled(beta_key, Style::default().fg(GHOST_WHITE)),
+                    ])
+                    .alignment(Alignment::Right),
+                ),
+            ])],
             &[
                 Constraint::Length(18),
-                Constraint::Percentage(25),
                 Constraint::Fill(1),
+                Constraint::Length((beta_legend.len() + beta_key.len()) as u16),
             ],
         )
         .block(block2)
         .style(Style::default().fg(GHOST_WHITE));
 
         // Access Logs
+        let logs_legend = " Access Logs ";
+        let logs_key = " [Ctrl+L] ";
         let block3 = Block::default()
             .title(" Access Logs ")
             .title_style(Style::default().bold().fg(GHOST_WHITE))
@@ -270,35 +253,33 @@ impl Component for Options {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(VERY_LIGHT_AZURE));
         let logs_folder = Table::new(
-            vec![
-                Row::new(vec![
-                    // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                    Cell::from(Span::raw(" ")),
-                ]),
-                Row::new(vec![
-                    Cell::from(
-                        Line::from(vec![Span::styled(
-                            " Open the Logs folder on this device ",
-                            Style::default().fg(LIGHT_PERIWINKLE),
-                        )])
-                        .alignment(Alignment::Left),
-                    ),
-                    Cell::from(
-                        Line::from(vec![
-                            Span::styled(" Access Logs ", Style::default().fg(VERY_LIGHT_AZURE)),
-                            Span::styled(" [Ctrl+L] ", Style::default().fg(GHOST_WHITE)),
-                        ])
-                        .alignment(Alignment::Right),
-                    ),
-                ]),
+            vec![Row::new(vec![
+                Cell::from(
+                    Line::from(vec![Span::styled(
+                        " Open the Logs folder on this device ",
+                        Style::default().fg(LIGHT_PERIWINKLE),
+                    )])
+                    .alignment(Alignment::Left),
+                ),
+                Cell::from(
+                    Line::from(vec![
+                        Span::styled(logs_legend, Style::default().fg(VERY_LIGHT_AZURE)),
+                        Span::styled(logs_key, Style::default().fg(GHOST_WHITE)),
+                    ])
+                    .alignment(Alignment::Right),
+                ),
+            ])],
+            &[
+                Constraint::Fill(1),
+                Constraint::Length((logs_legend.len() + logs_key.len()) as u16),
             ],
-            &[Constraint::Percentage(50), Constraint::Percentage(50)],
         )
         .block(block3)
         .style(Style::default().fg(GHOST_WHITE));
 
         // Reset All Nodes
+        let reset_legend = " Begin Reset ";
+        let reset_key = " [Ctrl+ R] ";
         let block4 = Block::default()
             .title(" Reset All Nodes ")
             .title_style(Style::default().bold().fg(GHOST_WHITE))
@@ -306,31 +287,60 @@ impl Component for Options {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(EUCALYPTUS));
         let reset_nodes = Table::new(
-            vec![
-                Row::new(vec![
-                    Cell::from(Span::raw(" ")), // Empty row for padding
-                    Cell::from(Span::raw(" ")),
-                ]),
-                Row::new(vec![
-                    Cell::from(
-                        Line::from(vec![Span::styled(
-                            " Remove and Reset all Nodes on this device ",
-                            Style::default().fg(LIGHT_PERIWINKLE),
-                        )])
-                        .alignment(Alignment::Left),
-                    ),
-                    Cell::from(
-                        Line::from(vec![
-                            Span::styled(" Begin Reset ", Style::default().fg(EUCALYPTUS)),
-                            Span::styled(" [Ctrl+R] ", Style::default().fg(GHOST_WHITE)),
-                        ])
-                        .alignment(Alignment::Right),
-                    ),
-                ]),
+            vec![Row::new(vec![
+                Cell::from(
+                    Line::from(vec![Span::styled(
+                        " Remove and Reset all Nodes on this device ",
+                        Style::default().fg(LIGHT_PERIWINKLE),
+                    )])
+                    .alignment(Alignment::Left),
+                ),
+                Cell::from(
+                    Line::from(vec![
+                        Span::styled(reset_legend, Style::default().fg(EUCALYPTUS)),
+                        Span::styled(reset_key, Style::default().fg(GHOST_WHITE)),
+                    ])
+                    .alignment(Alignment::Right),
+                ),
+            ])],
+            &[
+                Constraint::Fill(1),
+                Constraint::Length((reset_legend.len() + reset_key.len()) as u16),
             ],
-            &[Constraint::Percentage(50), Constraint::Percentage(50)],
         )
         .block(block4)
+        .style(Style::default().fg(GHOST_WHITE));
+
+        // Quit
+        let quit_legend = " Quit ";
+        let quit_key = " [Q] ";
+        let block5 = Block::default()
+            .style(Style::default().fg(GHOST_WHITE))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(VIVID_SKY_BLUE));
+        let quit = Table::new(
+            vec![Row::new(vec![
+                Cell::from(
+                    Line::from(vec![Span::styled(
+                        " Close Launchpad (your nodes will keep running in the background) ",
+                        Style::default().fg(LIGHT_PERIWINKLE),
+                    )])
+                    .alignment(Alignment::Left),
+                ),
+                Cell::from(
+                    Line::from(vec![
+                        Span::styled(quit_legend, Style::default().fg(VIVID_SKY_BLUE)),
+                        Span::styled(quit_key, Style::default().fg(GHOST_WHITE)),
+                    ])
+                    .alignment(Alignment::Right),
+                ),
+            ])],
+            &[
+                Constraint::Fill(1),
+                Constraint::Length((quit_legend.len() + quit_key.len()) as u16),
+            ],
+        )
+        .block(block5)
         .style(Style::default().fg(GHOST_WHITE));
 
         // Render the tables in their respective sections
@@ -338,6 +348,7 @@ impl Component for Options {
         f.render_widget(beta_rewards, layout[2]);
         f.render_widget(logs_folder, layout[3]);
         f.render_widget(reset_nodes, layout[4]);
+        f.render_widget(quit, layout[5]);
 
         Ok(())
     }

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -169,24 +169,14 @@ impl Component for Options {
                         .alignment(Alignment::Left),
                     ),
                     Cell::from(
-                        Line::from(vec![
-                            Span::styled(
-                                port_legend,
-                                if self.connection_mode == ConnectionMode::CustomPorts {
-                                    Style::default().fg(VERY_LIGHT_AZURE)
-                                } else {
-                                    Style::default().fg(COOL_GREY)
-                                },
-                            ),
-                            Span::styled(
-                                port_key,
-                                if self.connection_mode == ConnectionMode::CustomPorts {
-                                    Style::default().fg(GHOST_WHITE)
-                                } else {
-                                    Style::default().fg(COOL_GREY)
-                                },
-                            ),
-                        ])
+                        Line::from(if self.connection_mode == ConnectionMode::CustomPorts {
+                            vec![
+                                Span::styled(port_legend, Style::default().fg(VERY_LIGHT_AZURE)),
+                                Span::styled(port_key, Style::default().fg(GHOST_WHITE)),
+                            ]
+                        } else {
+                            vec![]
+                        })
                         .alignment(Alignment::Right),
                     ),
                 ]),

--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -69,7 +69,7 @@ impl BetaProgramme {
                 vec![
                     Action::StoreDiscordUserName(self.discord_input_filed.value().to_string()),
                     Action::OptionsActions(OptionsActions::UpdateBetaProgrammeUsername(username)),
-                    Action::SwitchScene(Scene::Options),
+                    Action::SwitchScene(Scene::Status),
                 ]
             }
             KeyCode::Esc => {

--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -226,11 +226,7 @@ impl Component for BetaProgramme {
                 );
                 let input = Paragraph::new(Span::styled(
                     format!("{}{} ", spaces, self.discord_input_filed.value()),
-                    Style::default()
-                        .fg(VIVID_SKY_BLUE)
-                        .bg(INDIGO)
-                        .underlined()
-                        .underline_color(VIVID_SKY_BLUE),
+                    Style::default().fg(VIVID_SKY_BLUE).bg(INDIGO).underlined(),
                 ))
                 .alignment(Alignment::Center);
                 f.render_widget(input, layer_two[1]);

--- a/node-launchpad/src/components/popup/change_drive.rs
+++ b/node-launchpad/src/components/popup/change_drive.rs
@@ -451,7 +451,7 @@ impl Component for ChangeDrivePopup {
                                     self.drive_selection.mountpoint.clone(),
                                     self.drive_selection.name.clone(),
                                 )),
-                                Action::SwitchScene(Scene::Options),
+                                Action::SwitchScene(Scene::Status),
                             ]
                         }
                         Err(e) => {

--- a/node-launchpad/src/components/popup/change_drive.rs
+++ b/node-launchpad/src/components/popup/change_drive.rs
@@ -508,6 +508,13 @@ impl Component for ChangeDrivePopup {
                 let _ = self.update_drive_items();
                 None
             }
+            Action::StoreStorageDrive(mountpoint, _drive_name) => {
+                self.storage_mountpoint = mountpoint;
+                let _ = self.update_drive_items();
+                self.select_drive();
+                None
+            }
+
             _ => None,
         };
         Ok(send_back)

--- a/node-launchpad/src/components/popup/connection_mode.rs
+++ b/node-launchpad/src/components/popup/connection_mode.rs
@@ -138,7 +138,7 @@ impl Component for ChangeConnectionModePopUp {
                                 ),
                             })
                         } else {
-                            Action::SwitchScene(Scene::Options)
+                            Action::SwitchScene(Scene::Status)
                         },
                     ]
                 } else {

--- a/node-launchpad/src/components/popup/port_range.rs
+++ b/node-launchpad/src/components/popup/port_range.rs
@@ -393,9 +393,9 @@ impl Component for PortRangePopUp {
             }
             PortRangeState::ConfirmChange => match key.code {
                 KeyCode::Enter => {
-                    debug!("Got Enter, saving the ports and switching to Options Screen",);
+                    debug!("Got Enter, saving the ports and switching to Status Screen",);
                     self.state = PortRangeState::Selection;
-                    vec![Action::SwitchScene(Scene::Options)]
+                    vec![Action::SwitchScene(Scene::Status)]
                 }
                 _ => vec![],
             },

--- a/node-launchpad/src/system.rs
+++ b/node-launchpad/src/system.rs
@@ -67,6 +67,11 @@ pub fn get_list_of_available_drives_and_available_space(
     let disks = Disks::new_with_refreshed_list();
     let mut drives: Vec<(String, PathBuf, u64, bool)> = Vec::new();
 
+    let default_mountpoint = match get_default_mount_point() {
+        Ok((_name, mountpoint)) => mountpoint,
+        Err(_) => PathBuf::new(),
+    };
+
     for disk in disks.list() {
         let disk_info = (
             disk.name()
@@ -76,7 +81,8 @@ pub fn get_list_of_available_drives_and_available_space(
                 .to_string(),
             disk.mount_point().to_path_buf(),
             disk.available_space(),
-            has_read_write_access(disk.mount_point().to_path_buf()),
+            has_read_write_access(disk.mount_point().to_path_buf())
+                || default_mountpoint == disk.mount_point().to_path_buf(),
         );
 
         // We avoid adding the same disk multiple times if it's mounted in multiple places


### PR DESCRIPTION
### Description

Some more bunch of fixes.

* Removed underline style on beta programme screen. Made the screen flicker in macos native terminal.
* Adding Quit to options screen. Changed spacing to fit more items.
* We hide change port legend and hotkey (look right) when the option is not available.
* When changing options, we now forward to status screen.
* FIX after #2104, the default mountpoint drive was not being shown.