### PR TITLE
fix(launchpad): discord popup from Status screen and fixes

### DIFF
--- a/node-launchpad/.config/config.json5
+++ b/node-launchpad/.config/config.json5
@@ -14,6 +14,9 @@
       "<Ctrl-x>": {"StatusActions":"StopNodes"},
       "<Ctrl-X>": {"StatusActions":"StopNodes"},
       "<Ctrl-Shift-x>": {"StatusActions":"StopNodes"},
+      "<Ctrl-b>": {"StatusActions":"TriggerBetaProgramme"},
+      "<Ctrl-B>": {"StatusActions":"TriggerBetaProgramme"},
+      "<Ctrl-Shift-b>": {"StatusActions":"TriggerBetaProgramme"},
 
       "up" : {"StatusActions":"PreviousTableItem"},
       "down": {"StatusActions":"NextTableItem"},

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -58,6 +58,7 @@ pub enum StatusActions {
     NodesStatsObtained(NodeStats),
 
     TriggerManageNodes,
+    TriggerBetaProgramme,
 
     PreviousTableItem,
     NextTableItem,

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -350,7 +350,7 @@ impl Component for Options {
                 | Scene::ChangeDrivePopUp
                 | Scene::ChangeConnectionModePopUp
                 | Scene::ChangePortsPopUp { .. }
-                | Scene::BetaProgrammePopUp
+                | Scene::OptionsBetaProgrammePopUp
                 | Scene::ResetNodesPopUp => {
                     self.active = true;
                     // make sure we're in navigation mode
@@ -382,7 +382,7 @@ impl Component for Options {
                     self.port_to = Some(to);
                 }
                 OptionsActions::TriggerBetaProgramme => {
-                    return Ok(Some(Action::SwitchScene(Scene::BetaProgrammePopUp)));
+                    return Ok(Some(Action::SwitchScene(Scene::OptionsBetaProgrammePopUp)));
                 }
                 OptionsActions::UpdateBetaProgrammeUsername(username) => {
                     self.discord_username = username;

--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -407,11 +407,7 @@ impl Component for BetaProgramme {
                 );
                 let input = Paragraph::new(Span::styled(
                     format!("{}{} ", spaces, self.discord_input_filed.value()),
-                    Style::default()
-                        .fg(VIVID_SKY_BLUE)
-                        .bg(INDIGO)
-                        .underlined()
-                        .underline_color(VIVID_SKY_BLUE),
+                    Style::default().fg(VIVID_SKY_BLUE).bg(INDIGO).underlined(),
                 ))
                 .alignment(Alignment::Center);
                 f.render_widget(input, layer_two[1]);

--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -71,7 +71,7 @@ impl BetaProgramme {
                 vec![
                     Action::StoreDiscordUserName(self.discord_input_filed.value().to_string()),
                     Action::OptionsActions(OptionsActions::UpdateBetaProgrammeUsername(username)),
-                    Action::SwitchScene(self.back_to),
+                    Action::SwitchScene(Scene::Status),
                 ]
             }
             KeyCode::Esc => {

--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -60,10 +60,6 @@ impl BetaProgramme {
             KeyCode::Enter => {
                 let username = self.discord_input_filed.value().to_string();
 
-                if username.is_empty() {
-                    debug!("Got Enter, but username is empty, ignoring.");
-                    return vec![];
-                }
                 debug!(
                     "Got Enter, saving the discord username {username:?}  and switching to DiscordIdAlreadySet, and Home Scene",
                 );
@@ -268,14 +264,10 @@ impl Component for BetaProgramme {
                 )]);
 
                 f.render_widget(button_no, buttons_layer[0]);
-                let button_yes_style = if self.discord_input_filed.value().is_empty() {
-                    Style::default().fg(LIGHT_PERIWINKLE)
-                } else {
-                    Style::default().fg(EUCALYPTUS)
-                };
+
                 let button_yes = Line::from(vec![Span::styled(
                     "Save Username [Enter]",
-                    button_yes_style,
+                    Style::default().fg(EUCALYPTUS),
                 )]);
                 f.render_widget(button_yes, buttons_layer[1]);
             }
@@ -443,15 +435,10 @@ impl Component for BetaProgramme {
                     "  No, Cancel [Esc]",
                     Style::default().fg(LIGHT_PERIWINKLE),
                 )]);
-                let button_yes_style = if self.discord_input_filed.value().is_empty() {
-                    Style::default().fg(LIGHT_PERIWINKLE)
-                } else {
-                    Style::default().fg(EUCALYPTUS)
-                };
                 f.render_widget(button_no, buttons_layer[0]);
                 let button_yes = Line::from(vec![Span::styled(
                     "Submit Username [Enter]",
-                    button_yes_style,
+                    Style::default().fg(EUCALYPTUS),
                 )]);
                 f.render_widget(button_yes, buttons_layer[1]);
             }

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -274,7 +274,7 @@ impl Component for Status {
                 self.try_update_node_stats(false)?;
             }
             Action::SwitchScene(scene) => match scene {
-                Scene::Status => {
+                Scene::Status | Scene::StatusBetaProgrammePopUp => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));
@@ -477,6 +477,9 @@ impl Component for Status {
                     info!("Stopping node service: {running_nodes:?}");
 
                     stop_nodes(running_nodes, action_sender);
+                }
+                StatusActions::TriggerBetaProgramme => {
+                    return Ok(Some(Action::SwitchScene(Scene::StatusBetaProgrammePopUp)));
                 }
             },
             Action::OptionsActions(OptionsActions::ResetNodes) => {

--- a/node-launchpad/src/mode.rs
+++ b/node-launchpad/src/mode.rs
@@ -21,7 +21,8 @@ pub enum Scene {
     ChangePortsPopUp {
         connection_mode_old_value: Option<ConnectionMode>,
     },
-    BetaProgrammePopUp,
+    StatusBetaProgrammePopUp,
+    OptionsBetaProgrammePopUp,
     ManageNodesPopUp,
     ResetNodesPopUp,
 }


### PR DESCRIPTION
### Description

Now we can open `Beta Programme` from the `Status` screen. After setting up the nickname, we return to status screen, otherwise, we remain on the current screen (options or status).

Flickering screen on macos terminal (removed underline colour) fixed.

Username now can be empty.
