### PR TITLE
feat(launchpad): flexible status layout

### DIFF
--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -12,6 +12,7 @@ use ratatui::{prelude::*, widgets::*};
 pub enum NodesToStart {
     Configured,
     NotConfigured,
+    Running,
 }
 
 #[derive(Default)]
@@ -33,23 +34,26 @@ impl StatefulWidget for Footer {
             )
         };
 
-        let command1 = vec![
+        let commands = vec![
             Span::styled("[Ctrl+G] ", Style::default().fg(GHOST_WHITE)),
             Span::styled("Manage Nodes", Style::default().fg(EUCALYPTUS)),
-        ];
-        let command2 = vec![
+            Span::styled("  ", Style::default()),
             Span::styled("[Ctrl+S] ", command_style),
             Span::styled("Start Nodes", text_style),
-        ];
-        let command3 = vec![
+            Span::styled("  ", Style::default()),
             Span::styled("[Ctrl+X] ", command_style),
-            Span::styled("Stop Nodes", text_style),
+            Span::styled(
+                "Stop Nodes",
+                if matches!(state, NodesToStart::Running) {
+                    Style::default().fg(EUCALYPTUS)
+                } else {
+                    Style::default().fg(COOL_GREY)
+                },
+            ),
         ];
 
-        let cell1 = Cell::from(Line::from(command1));
-        let cell2 = Cell::from(Line::from(command2));
-        let cell3 = Cell::from(Line::from(command3));
-        let row = Row::new(vec![cell1, cell2, cell3]);
+        let cell1 = Cell::from(Line::from(commands));
+        let row = Row::new(vec![cell1]);
 
         let table = Table::new(vec![row], vec![Constraint::Max(1)])
             .block(
@@ -58,12 +62,7 @@ impl StatefulWidget for Footer {
                     .border_style(Style::default().fg(EUCALYPTUS))
                     .padding(Padding::horizontal(1)),
             )
-            .widths(vec![
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-            ]);
+            .widths(vec![Constraint::Fill(1)]);
 
         StatefulWidget::render(table, area, buf, &mut TableState::default());
     }

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -524,139 +524,117 @@ impl Component for Status {
 
         // ==== Device Status =====
 
-        if self.discord_username.is_empty() {
-            let line1 = Line::from(vec![Span::styled(
-                "Add this device to the Beta Rewards Program",
-                Style::default().fg(VERY_LIGHT_AZURE),
-            )]);
-            let line2 = Line::from(vec![
-                Span::styled("Press ", Style::default().fg(VERY_LIGHT_AZURE)),
-                Span::styled("[Ctrl+B]", Style::default().fg(GHOST_WHITE).bold()),
-                Span::styled(" to add your ", Style::default().fg(VERY_LIGHT_AZURE)),
-                Span::styled(
-                    "Discord Username",
-                    Style::default().fg(VERY_LIGHT_AZURE).bold(),
-                ),
-            ]);
-            f.render_widget(
-                Paragraph::new(vec![Line::raw(""), Line::raw(""), line1, line2]).block(
-                    Block::default()
-                        .title(" Device Status ")
-                        .bold()
-                        .title_style(Style::new().fg(GHOST_WHITE))
-                        .borders(Borders::ALL)
-                        .padding(Padding::horizontal(1))
-                        .border_style(Style::new().fg(VERY_LIGHT_AZURE)),
-                ),
-                layout[1],
-            );
-        } else {
-            // Device Status as a block with two tables so we can shrink the screen
-            // and preserve as much as we can information
+        // Device Status as a block with two tables so we can shrink the screen
+        // and preserve as much as we can information
 
-            let combined_block = Block::default()
-                .title(" Device Status ")
-                .bold()
-                .title_style(Style::default().fg(GHOST_WHITE))
-                .borders(Borders::ALL)
-                .padding(Padding::horizontal(1))
-                .style(Style::default().fg(VERY_LIGHT_AZURE));
+        let combined_block = Block::default()
+            .title(" Device Status ")
+            .bold()
+            .title_style(Style::default().fg(GHOST_WHITE))
+            .borders(Borders::ALL)
+            .padding(Padding::horizontal(1))
+            .style(Style::default().fg(VERY_LIGHT_AZURE));
 
-            f.render_widget(combined_block.clone(), layout[1]);
+        f.render_widget(combined_block.clone(), layout[1]);
 
-            let storage_allocated_row = Row::new(vec![
-                Cell::new("Storage Allocated".to_string()).fg(GHOST_WHITE),
-                Cell::new(format!("{} GB", self.nodes_to_start * GB_PER_NODE)).fg(GHOST_WHITE),
-            ]);
-            let memory_use_val = if self.node_stats.memory_usage_mb as f64 / 1024_f64 > 1.0 {
-                format!(
-                    "{:.2} GB",
-                    self.node_stats.memory_usage_mb as f64 / 1024_f64
-                )
-            } else {
-                format!("{} MB", self.node_stats.memory_usage_mb)
-            };
-
-            let memory_use_row = Row::new(vec![
-                Cell::new("Memory Use".to_string()).fg(GHOST_WHITE),
-                Cell::new(memory_use_val).fg(GHOST_WHITE),
-            ]);
-
-            let connection_mode_string = match self.connection_mode {
-                ConnectionMode::HomeNetwork => "Home Network",
-                ConnectionMode::UPnP => "UPnP",
-                ConnectionMode::CustomPorts => &format!(
-                    "Custom Ports  {}-{}",
-                    self.port_from.unwrap_or(PORT_MIN),
-                    self.port_to.unwrap_or(PORT_MIN + PORT_ALLOCATION)
-                ),
-                ConnectionMode::Automatic => "Automatic",
-            };
-
-            let connection_mode_row = Row::new(vec![
-                Cell::new("Connection".to_string()).fg(GHOST_WHITE),
-                Cell::new(connection_mode_string).fg(LIGHT_PERIWINKLE),
-            ]);
-
-            let stats_rows = vec![storage_allocated_row, memory_use_row, connection_mode_row];
-            let stats_width = [Constraint::Length(5)];
-            let column_constraints = [Constraint::Length(23), Constraint::Fill(1)];
-            let stats_table = Table::new(stats_rows, stats_width).widths(column_constraints);
-
-            // Combine "Nanos Earned" and "Username" into a single row
-            let discord_username_placeholder = "Username: "; // Used to calculate the width of the username column
-            let discord_username_title = Span::styled(
-                discord_username_placeholder,
-                Style::default().fg(VIVID_SKY_BLUE),
-            );
-
-            let discord_username = if !self.discord_username.is_empty() {
-                Span::styled(
-                    self.discord_username.clone(),
-                    Style::default().fg(VIVID_SKY_BLUE),
-                )
-                .bold()
-            } else {
-                Span::styled(
-                    "[Ctrl+B] to set".to_string(),
-                    Style::default().fg(GHOST_WHITE),
-                )
-            };
-
-            let total_nanos_earned_and_discord_row = Row::new(vec![
-                Cell::new("Nanos Earned".to_string()).fg(VIVID_SKY_BLUE),
-                Cell::new(self.node_stats.forwarded_rewards.to_string())
-                    .fg(VIVID_SKY_BLUE)
-                    .bold(),
-                Cell::new(
-                    Line::from(vec![discord_username_title, discord_username])
-                        .alignment(Alignment::Right),
-                ),
-            ]);
-
-            let nanos_discord_rows = vec![total_nanos_earned_and_discord_row];
-            let nanos_discord_width = [Constraint::Length(5)];
-            let column_constraints = [
-                Constraint::Length(23),
-                Constraint::Fill(1),
-                Constraint::Length(
-                    (discord_username_placeholder.len() + self.discord_username.len()) as u16,
-                ),
-            ];
-            let nanos_discord_table =
-                Table::new(nanos_discord_rows, nanos_discord_width).widths(column_constraints);
-
-            let inner_area = combined_block.inner(layout[1]);
-            let device_layout = Layout::new(
-                Direction::Vertical,
-                vec![Constraint::Length(5), Constraint::Length(1)],
+        let storage_allocated_row = Row::new(vec![
+            Cell::new("Storage Allocated".to_string()).fg(GHOST_WHITE),
+            Cell::new(format!("{} GB", self.nodes_to_start * GB_PER_NODE)).fg(GHOST_WHITE),
+        ]);
+        let memory_use_val = if self.node_stats.memory_usage_mb as f64 / 1024_f64 > 1.0 {
+            format!(
+                "{:.2} GB",
+                self.node_stats.memory_usage_mb as f64 / 1024_f64
             )
-            .split(inner_area);
-
-            // Render both tables inside the combined block
-            f.render_widget(stats_table, device_layout[0]);
-            f.render_widget(nanos_discord_table, device_layout[1]);
+        } else {
+            format!("{} MB", self.node_stats.memory_usage_mb)
         };
+
+        let memory_use_row = Row::new(vec![
+            Cell::new("Memory Use".to_string()).fg(GHOST_WHITE),
+            Cell::new(memory_use_val).fg(GHOST_WHITE),
+        ]);
+
+        let connection_mode_string = match self.connection_mode {
+            ConnectionMode::HomeNetwork => "Home Network",
+            ConnectionMode::UPnP => "UPnP",
+            ConnectionMode::CustomPorts => &format!(
+                "Custom Ports  {}-{}",
+                self.port_from.unwrap_or(PORT_MIN),
+                self.port_to.unwrap_or(PORT_MIN + PORT_ALLOCATION)
+            ),
+            ConnectionMode::Automatic => "Automatic",
+        };
+
+        let connection_mode_row = Row::new(vec![
+            Cell::new("Connection".to_string()).fg(GHOST_WHITE),
+            Cell::new(connection_mode_string).fg(LIGHT_PERIWINKLE),
+        ]);
+
+        let stats_rows = vec![storage_allocated_row, memory_use_row, connection_mode_row];
+        let stats_width = [Constraint::Length(5)];
+        let column_constraints = [Constraint::Length(23), Constraint::Fill(1)];
+        let stats_table = Table::new(stats_rows, stats_width).widths(column_constraints);
+
+        // Combine "Nanos Earned" and "Username" into a single row
+        let discord_username_placeholder = "Username: "; // Used to calculate the width of the username column
+        let discord_username_no_username = "[Ctrl+B] to set";
+        let discord_username_title = Span::styled(
+            discord_username_placeholder,
+            Style::default().fg(VIVID_SKY_BLUE),
+        );
+
+        let discord_username = if !self.discord_username.is_empty() {
+            Span::styled(
+                self.discord_username.clone(),
+                Style::default().fg(VIVID_SKY_BLUE),
+            )
+            .bold()
+        } else {
+            Span::styled(
+                discord_username_no_username,
+                Style::default().fg(GHOST_WHITE),
+            )
+        };
+
+        let total_nanos_earned_and_discord_row = Row::new(vec![
+            Cell::new("Nanos Earned".to_string()).fg(VIVID_SKY_BLUE),
+            Cell::new(self.node_stats.forwarded_rewards.to_string())
+                .fg(VIVID_SKY_BLUE)
+                .bold(),
+            Cell::new(
+                Line::from(vec![discord_username_title, discord_username])
+                    .alignment(Alignment::Right),
+            ),
+        ]);
+
+        let nanos_discord_rows = vec![total_nanos_earned_and_discord_row];
+        let nanos_discord_width = [Constraint::Length(5)];
+        let column_constraints = [
+            Constraint::Length(23),
+            Constraint::Fill(1),
+            Constraint::Length(
+                discord_username_placeholder.len() as u16
+                    + if !self.discord_username.is_empty() {
+                        self.discord_username.len() as u16
+                    } else {
+                        discord_username_no_username.len() as u16
+                    },
+            ),
+        ];
+        let nanos_discord_table =
+            Table::new(nanos_discord_rows, nanos_discord_width).widths(column_constraints);
+
+        let inner_area = combined_block.inner(layout[1]);
+        let device_layout = Layout::new(
+            Direction::Vertical,
+            vec![Constraint::Length(5), Constraint::Length(1)],
+        )
+        .split(inner_area);
+
+        // Render both tables inside the combined block
+        f.render_widget(stats_table, device_layout[0]);
+        f.render_widget(nanos_discord_table, device_layout[1]);
 
         // ==== Node Status =====
 

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -551,7 +551,18 @@ impl Component for Status {
                 layout[1],
             );
         } else {
-            // Device Status as a table
+            // Device Status as a block with two tables so we can shrink the screen
+            // and preserve as much as we can information
+
+            let combined_block = Block::default()
+                .title(" Device Status ")
+                .bold()
+                .title_style(Style::default().fg(GHOST_WHITE))
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1))
+                .style(Style::default().fg(VERY_LIGHT_AZURE));
+
+            f.render_widget(combined_block.clone(), layout[1]);
 
             let storage_allocated_row = Row::new(vec![
                 Cell::new("Storage Allocated".to_string()).fg(GHOST_WHITE),
@@ -584,11 +595,16 @@ impl Component for Status {
 
             let connection_mode_row = Row::new(vec![
                 Cell::new("Connection".to_string()).fg(GHOST_WHITE),
-                Cell::new(connection_mode_string).fg(GHOST_WHITE),
+                Cell::new(connection_mode_string).fg(LIGHT_PERIWINKLE),
             ]);
 
-            // Combine "Nanos Earned" and "Discord Username" into a single row
-            let discord_username_placeholder = "Discord Username: "; // Used to calculate the width of the username column
+            let stats_rows = vec![storage_allocated_row, memory_use_row, connection_mode_row];
+            let stats_width = [Constraint::Length(5)];
+            let column_constraints = [Constraint::Length(23), Constraint::Fill(1)];
+            let stats_table = Table::new(stats_rows, stats_width).widths(column_constraints);
+
+            // Combine "Nanos Earned" and "Username" into a single row
+            let discord_username_placeholder = "Username: "; // Used to calculate the width of the username column
             let discord_username_title = Span::styled(
                 discord_username_placeholder,
                 Style::default().fg(VIVID_SKY_BLUE),
@@ -618,13 +634,8 @@ impl Component for Status {
                 ),
             ]);
 
-            let stats_rows = vec![
-                storage_allocated_row,
-                memory_use_row,
-                connection_mode_row,
-                total_nanos_earned_and_discord_row,
-            ];
-            let stats_width = [Constraint::Length(5)];
+            let nanos_discord_rows = vec![total_nanos_earned_and_discord_row];
+            let nanos_discord_width = [Constraint::Length(5)];
             let column_constraints = [
                 Constraint::Length(23),
                 Constraint::Fill(1),
@@ -632,18 +643,19 @@ impl Component for Status {
                     (discord_username_placeholder.len() + self.discord_username.len()) as u16,
                 ),
             ];
-            let stats_table = Table::new(stats_rows, stats_width)
-                .block(
-                    Block::default()
-                        .title(" Device Status ")
-                        .bold()
-                        .title_style(Style::default().fg(GHOST_WHITE))
-                        .borders(Borders::ALL)
-                        .padding(Padding::horizontal(1))
-                        .style(Style::default().fg(VERY_LIGHT_AZURE)),
-                )
-                .widths(column_constraints);
-            f.render_widget(stats_table, layout[1]);
+            let nanos_discord_table =
+                Table::new(nanos_discord_rows, nanos_discord_width).widths(column_constraints);
+
+            let inner_area = combined_block.inner(layout[1]);
+            let device_layout = Layout::new(
+                Direction::Vertical,
+                vec![Constraint::Length(5), Constraint::Length(1)],
+            )
+            .split(inner_area);
+
+            // Render both tables inside the combined block
+            f.render_widget(stats_table, device_layout[0]);
+            f.render_widget(nanos_discord_table, device_layout[1]);
         };
 
         // ==== Node Status =====
@@ -705,10 +717,10 @@ impl Component for Status {
             );
         } else {
             let node_widths = [
-                Constraint::Max(15),
-                Constraint::Min(40),
-                Constraint::Max(10),
-                Constraint::Max(10),
+                Constraint::Length(11),
+                Constraint::Fill(1),
+                Constraint::Length(9),
+                Constraint::Length(8),
             ];
             let table = Table::new(node_rows.clone(), node_widths)
                 .column_spacing(2)
@@ -735,7 +747,11 @@ impl Component for Status {
 
         let footer = Footer::default();
         let footer_state = if !node_rows.is_empty() {
-            &mut NodesToStart::Configured
+            if !self.get_running_nodes().is_empty() {
+                &mut NodesToStart::Running
+            } else {
+                &mut NodesToStart::Configured
+            }
         } else {
             &mut NodesToStart::NotConfigured
         };


### PR DESCRIPTION
### Description

When we shrink the screen size under 80 columns, we try to preserve as much information as we can without cropping text.
On Device Information, we use two tables inside a main block, so we can shrink the last row as much as we can without affecting the rest of the information.
On nodes listing, now the information has a fixed width, except from the node hash that takes as much space as it can. Is the element that shrinks.
On the footer, we separate elements by two spaces to make it compact.

We also changed the coloring of the footer depending on the status: configured/running/not configured.


https://github.com/user-attachments/assets/c9a31987-02c4-4ae4-9d2f-3739d98690ba

