### PR TITLE
fix(launchpad): some error handling when sn_node_manager fails

### DIFF
--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -269,7 +269,7 @@ impl Component for Options {
 
         // Reset All Nodes
         let reset_legend = " Begin Reset ";
-        let reset_key = " [Ctrl+ R] ";
+        let reset_key = " [Ctrl+R] ";
         let block4 = Block::default()
             .title(" Reset All Nodes ")
             .title_style(Style::default().bold().fg(GHOST_WHITE))
@@ -302,8 +302,8 @@ impl Component for Options {
         .style(Style::default().fg(GHOST_WHITE));
 
         // Quit
-        let quit_legend = " Quit ";
-        let quit_key = " [Q] ";
+        let quit_legend = "Quit ";
+        let quit_key = "[Q] ";
         let block5 = Block::default()
             .style(Style::default().fg(GHOST_WHITE))
             .borders(Borders::ALL)

--- a/node-launchpad/src/components/popup/change_drive.rs
+++ b/node-launchpad/src/components/popup/change_drive.rs
@@ -128,7 +128,8 @@ impl ChangeDrivePopup {
             .iter()
             .map(|(drive_name, mountpoint, space, available)| {
                 let size_str = format!("{:.2} GB", *space as f64 / 1e9);
-                let has_enough_space = *space >= (GB_PER_NODE * GB * self.nodes_to_start) as u64;
+                let has_enough_space = *space as u128
+                    >= (GB_PER_NODE as u128 * GB as u128 * self.nodes_to_start as u128);
                 DriveItem {
                     name: drive_name.to_string(),
                     mountpoint: mountpoint.clone(),

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -367,7 +367,7 @@ impl Component for Status {
                 StatusActions::ErrorLoadingNodeRegistry { raw_error }
                 | StatusActions::ErrorGettingNodeRegistryPath { raw_error } => {
                     self.error_popup = Some(ErrorPopup::new(
-                        " Error ".to_string(),
+                        "Error".to_string(),
                         "Error getting node registry path".to_string(),
                         raw_error,
                     ));
@@ -379,7 +379,7 @@ impl Component for Status {
                 }
                 StatusActions::ErrorScalingUpNodes { raw_error } => {
                     self.error_popup = Some(ErrorPopup::new(
-                        " Error ".to_string(),
+                        "Erro ".to_string(),
                         "Error adding new nodes".to_string(),
                         raw_error,
                     ));
@@ -391,7 +391,7 @@ impl Component for Status {
                 }
                 StatusActions::ErrorStoppingNodes { raw_error } => {
                     self.error_popup = Some(ErrorPopup::new(
-                        " Error ".to_string(),
+                        "Error".to_string(),
                         "Error stopping nodes".to_string(),
                         raw_error,
                     ));
@@ -403,7 +403,7 @@ impl Component for Status {
                 }
                 StatusActions::ErrorResettingNodes { raw_error } => {
                     self.error_popup = Some(ErrorPopup::new(
-                        " Error ".to_string(),
+                        "Error".to_string(),
                         "Error resetting nodes".to_string(),
                         raw_error,
                     ));

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -406,7 +406,7 @@ async fn add_nodes(
                         StatusActions::ErrorScalingUpNodes {
                             raw_error: "When trying to add a node, we failed.\n\n\
                                  Maybe you ran out of disk space?\n\n\
-                                 Maybe you need to change the port range\n\n"
+                                 Maybe you need to change the port range?\n\n"
                                 .to_string(),
                         },
                     )) {
@@ -423,12 +423,13 @@ async fn add_nodes(
         }
     }
     if retry_count >= NODE_ADD_MAX_RETRIES {
-        if let Err(err) = action_sender.send(Action::StatusActions(StatusActions::ErrorScalingUpNodes {
-            raw_error: format!(
-                "When trying to assign an available port to run a node, we reached the maximum amount of retries ({}).",
-                NODE_ADD_MAX_RETRIES
-            ),
-        }))
+        if let Err(err) =
+            action_sender.send(Action::StatusActions(StatusActions::ErrorScalingUpNodes {
+                raw_error: format!(
+                    "When trying run a node, we reached the maximum amount of retries ({}).",
+                    NODE_ADD_MAX_RETRIES
+                ),
+            }))
         {
             error!("Error while sending action: {err:?}");
         }

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -17,7 +17,7 @@ use sn_releases::{self, ReleaseType, SafeReleaseRepoActions};
 pub const PORT_MAX: u32 = 65535;
 pub const PORT_MIN: u32 = 1024;
 
-const PORT_ASSIGNMENT_MAX_RETRIES: u32 = 5;
+const NODE_ADD_MAX_RETRIES: u32 = 5;
 
 /// Stop the specified services
 pub fn stop_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
@@ -331,7 +331,7 @@ async fn add_nodes(
 ) {
     let mut retry_count = 0;
 
-    while nodes_to_add > 0 && retry_count < PORT_ASSIGNMENT_MAX_RETRIES {
+    while nodes_to_add > 0 && retry_count < NODE_ADD_MAX_RETRIES {
         // Find the next available port
         while used_ports.contains(current_port) && *current_port <= max_port {
             *current_port += 1;
@@ -395,16 +395,42 @@ async fn add_nodes(
                         "Port {} is being used, retrying with a different port. Attempt {}/{}",
                         current_port,
                         retry_count + 1,
-                        PORT_ASSIGNMENT_MAX_RETRIES
+                        NODE_ADD_MAX_RETRIES
                     );
-                    *current_port += 1;
-                    retry_count += 1;
+                } else if err
+                    .to_string()
+                    .contains("Failed to add one or more services")
+                    && retry_count >= NODE_ADD_MAX_RETRIES
+                {
+                    if let Err(err) = action_sender.send(Action::StatusActions(
+                        StatusActions::ErrorScalingUpNodes {
+                            raw_error: "When trying to add a node, we failed.\n\n\
+                                 Maybe you ran out of disk space?\n\n\
+                                 Maybe you need to change the port range\n\n"
+                                .to_string(),
+                        },
+                    )) {
+                        error!("Error while sending action: {err:?}");
+                    }
                 } else {
                     error!("Range of ports to be used {:?}", *current_port..max_port);
                     error!("Error while adding node on port {}: {err:?}", current_port);
-                    retry_count += 1;
                 }
+                // In case of error, we increase the port and the retry count
+                *current_port += 1;
+                retry_count += 1;
             }
+        }
+    }
+    if retry_count >= NODE_ADD_MAX_RETRIES {
+        if let Err(err) = action_sender.send(Action::StatusActions(StatusActions::ErrorScalingUpNodes {
+            raw_error: format!(
+                "When trying to assign an available port to run a node, we reached the maximum amount of retries ({}).",
+                NODE_ADD_MAX_RETRIES
+            ),
+        }))
+        {
+            error!("Error while sending action: {err:?}");
         }
     }
 }


### PR DESCRIPTION
### Description

We handle the error when we ran out of disk space or actually, when the installation of some binaries on Windows fail.

Minor copy fixes on `Options` screen.