### PR TITLE
feat: remove version string restriction

### DIFF
--- a/sn_peers_acquisition/src/lib.rs
+++ b/sn_peers_acquisition/src/lib.rs
@@ -15,8 +15,6 @@ use lazy_static::lazy_static;
 use libp2p::{multiaddr::Protocol, Multiaddr};
 use rand::{seq::SliceRandom, thread_rng};
 use reqwest::Client;
-#[cfg(feature = "network-contacts")]
-use sn_protocol::version::get_network_version;
 use std::time::Duration;
 use tracing::*;
 use url::Url;
@@ -24,11 +22,8 @@ use url::Url;
 #[cfg(feature = "network-contacts")]
 lazy_static! {
     // URL containing the multi-addresses of the bootstrap nodes.
-    pub static ref NETWORK_CONTACTS_URL: String = {
-        let version = get_network_version();
-        let version_prefix = if !version.is_empty() { format!("{version}-") } else { version.to_string() };
-        format!("https://sn-testnet.s3.eu-west-2.amazonaws.com/{version_prefix}network-contacts")
-    };
+    pub static ref NETWORK_CONTACTS_URL: String =
+       "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts".to_string();
 }
 
 // The maximum number of retries to be performed while trying to get peers from a URL.

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -13,8 +13,7 @@ lazy_static! {
     /// The node version used during Identify Behaviour.
     pub static ref IDENTIFY_NODE_VERSION_STR: String =
         format!(
-            "safe{}/node/{}/{}",
-            write_network_version_with_slash(),
+            "safe/node/{}/{}",
             get_truncate_version_str(),
             get_key_version_str(),
         );
@@ -22,8 +21,7 @@ lazy_static! {
     /// The client version used during Identify Behaviour.
     pub static ref IDENTIFY_CLIENT_VERSION_STR: String =
         format!(
-            "safe{}/client/{}/{}",
-            write_network_version_with_slash(),
+            "safe/client/{}/{}",
             get_truncate_version_str(),
             get_key_version_str(),
         );
@@ -31,8 +29,7 @@ lazy_static! {
     /// The req/response protocol version
     pub static ref REQ_RESPONSE_VERSION_STR: String =
         format!(
-            "/safe{}/node/{}/{}",
-            write_network_version_with_slash(),
+            "/safe/node/{}/{}",
             get_truncate_version_str(),
             get_key_version_str(),
         );
@@ -40,40 +37,10 @@ lazy_static! {
     /// The identify protocol version
     pub static ref IDENTIFY_PROTOCOL_STR: String =
         format!(
-            "safe{}/{}/{}",
-            write_network_version_with_slash(),
+            "safe/{}/{}",
             get_truncate_version_str(),
             get_key_version_str(),
         );
-}
-
-/// Get the network version string.
-/// If the network version mode env variable is set to `restricted`, then the git branch is used as the version.
-/// Else any non empty string is used as the version string.
-/// If the env variable is empty or not set, then we do not apply any network versioning.
-pub fn get_network_version() -> &'static str {
-    // Set this env variable to provide custom network versioning. If it is set to 'restricted', then the git branch name
-    // is used as the version string. Else we directly use the passed in string as the version.
-    match option_env!("NETWORK_VERSION_MODE") {
-        Some(value) => {
-            if value == "restricted" {
-                sn_build_info::git_branch()
-            } else {
-                value
-            }
-        }
-        _ => "",
-    }
-}
-
-/// Helper to write the network version with `/` appended if it is not empty
-fn write_network_version_with_slash() -> String {
-    let version = get_network_version();
-    if version.is_empty() {
-        version.to_string()
-    } else {
-        format!("/{version}")
-    }
 }
 
 // Protocol support shall be downward compatible for patch only version update.


### PR DESCRIPTION
remove the possibility of string/branch restriction in protocol v as we dont use this anywhere now.

This is NOT marked as breaking, as - so long as its unused - the versions are the same in both cases