### PR TITLE
ci: nightly releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,251 @@
+name: nightly release
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every night at midnight UTC
+  workflow_dispatch:    # This also allows the workflow to be triggered manually
+
+env:
+  WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    name: build
+    environment: stable
+    env:
+      FOUNDATION_PK: ${{ vars.FOUNDATION_PK }}
+      GENESIS_PK: ${{ vars.GENESIS_PK }}
+      GENESIS_SK: ${{ secrets.GENESIS_SK }}
+      NETWORK_ROYALTIES_PK: ${{ vars.NETWORK_ROYALTIES_PK }}
+      PAYMENT_FORWARD_PK: ${{ vars.PAYMENT_FORWARD_PK }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: cargo-bins/cargo-binstall@main
+      - shell: bash
+        run: cargo binstall --no-confirm just
+
+      - name: build nightly release artifacts
+        shell: bash
+        run: |
+          just build-release-artifacts "${{ matrix.target }}" "true"
+
+      - uses: actions/upload-artifact@main
+        with:
+          name: safe_network-${{ matrix.target }}
+          path: |
+            artifacts
+            !artifacts/.cargo-lock
+
+      - name: post notification to slack on failure
+        if: ${{ failure() }}
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Release Failed"
+
+  s3-release:
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    name: s3 release
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-pc-windows-msvc
+          path: artifacts/x86_64-pc-windows-msvc/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-unknown-linux-musl
+          path: artifacts/x86_64-unknown-linux-musl/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-apple-darwin
+          path: artifacts/x86_64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-aarch64-apple-darwin
+          path: artifacts/aarch64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-arm-unknown-linux-musleabi
+          path: artifacts/arm-unknown-linux-musleabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-armv7-unknown-linux-musleabihf
+          path: artifacts/armv7-unknown-linux-musleabihf/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-aarch64-unknown-linux-musl
+          path: artifacts/aarch64-unknown-linux-musl/release
+
+      - uses: cargo-bins/cargo-binstall@main
+      - name: install just
+        shell: bash
+        run: cargo binstall --no-confirm just
+
+      - name: remove latest nightly release
+        shell: bash
+        run: |
+          just delete-s3-bin "faucet" "nightly"
+          just delete-s3-bin "nat-detection" "nightly"
+          just delete-s3-bin "node-launchpad" "nightly"
+          just delete-s3-bin "safe" "nightly"
+          just delete-s3-bin "safenode" "nightly"
+          just delete-s3-bin "safenode_rpc_client" "nightly"
+          just delete-s3-bin "safenode-manager" "nightly"
+          just delete-s3-bin "safenodemand" "nightly"
+          just delete-s3-bin "sn_auditor" "nightly"
+
+      - name: upload binaries to S3
+        shell: bash
+        run: |
+          version=$(date +"%Y.%m.%d")
+          just package-bin "faucet" "$version"
+          just package-bin "nat-detection" "$version"
+          just package-bin "node-launchpad" "$version"
+          just package-bin "safe" "$version"
+          just package-bin "safenode" "$version"
+          just package-bin "safenode_rpc_client" "$version"
+          just package-bin "safenode-manager" "$version"
+          just package-bin "safenodemand" "$version"
+          just package-bin "sn_auditor" "$version"
+          just upload-all-packaged-bins-to-s3
+
+          rm -rf packaged_bins
+          just package-bin "faucet" "nightly"
+          just package-bin "nat-detection" "nightly"
+          just package-bin "node-launchpad" "nightly"
+          just package-bin "safe" "nightly"
+          just package-bin "safenode" "nightly"
+          just package-bin "safenode_rpc_client" "nightly"
+          just package-bin "safenode-manager" "nightly"
+          just package-bin "safenodemand" "nightly"
+          just package-bin "sn_auditor" "nightly"
+          just upload-all-packaged-bins-to-s3
+
+  github-release:
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    name: github release
+    runs-on: ubuntu-latest
+    needs: [s3-release]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-pc-windows-msvc
+          path: artifacts/x86_64-pc-windows-msvc/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-unknown-linux-musl
+          path: artifacts/x86_64-unknown-linux-musl/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-x86_64-apple-darwin
+          path: artifacts/x86_64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-aarch64-apple-darwin
+          path: artifacts/aarch64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-arm-unknown-linux-musleabi
+          path: artifacts/arm-unknown-linux-musleabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-armv7-unknown-linux-musleabihf
+          path: artifacts/armv7-unknown-linux-musleabihf/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_network-aarch64-unknown-linux-musl
+          path: artifacts/aarch64-unknown-linux-musl/release
+
+      - uses: cargo-bins/cargo-binstall@main
+      - name: install just
+        shell: bash
+        run: cargo binstall --no-confirm just
+
+      - name: set package version
+        shell: bash
+        run: |
+          version=$(date +"%Y.%m.%d")
+          echo "PACKAGE_VERSION=$version" >> $GITHUB_ENV
+
+      - name: package release artifacts
+        shell: bash
+        run: just package-all-architectures
+
+      - name: delete existing nightly release
+        env:
+          GITHUB_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+        run: |
+          releases=$(gh api repos/${{ github.repository }}/releases --paginate)
+          echo "$releases" | jq -c '.[]' | while read release; do
+            tag_name=$(echo $release | jq -r '.tag_name')
+            release_id=$(echo $release | jq -r '.id')
+            
+            if [[ $tag_name == nightly* ]]; then
+              echo "deleting nightly release $tag_name"
+              gh api -X DELETE repos/${{ github.repository }}/releases/$release_id
+              exit 0
+            fi
+          done
+
+      - name: create new nightly release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+        with:
+          tag_name: nightly-${{ env.PACKAGE_VERSION }}
+          release_name: "${{ env.PACKAGE_VERSION }} Nightly Release"
+          body: |
+            Nightly release of the Autonomi binary set, built from the `main` branch.
+
+            These binaries should be compatible with the stable network, but they should be considered experimental.
+
+            For the most reliable experience, prefer the latest stable release.
+          draft: false
+          prerelease: true
+
+      - name: upload artifacts as assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+        shell: bash
+        run: |
+          (
+            cd packaged_architectures
+            ls | xargs gh release upload nightly-${{ env.PACKAGE_VERSION }}
+          )
+
+      - name: post notification to slack on failure
+        if: ${{ failure() }}
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Nightly Release Failed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,9 @@ dependencies = [
  "color-eyre",
  "futures",
  "libp2p",
+ "sn_build_info",
  "sn_networking",
+ "sn_protocol",
  "tokio",
  "tracing",
  "tracing-log 0.2.0",
@@ -4758,7 +4760,9 @@ dependencies = [
  "signal-hook",
  "sn-node-manager",
  "sn-releases",
+ "sn_build_info",
  "sn_peers_acquisition",
+ "sn_protocol",
  "sn_service_management",
  "strip-ansi-escapes",
  "strum",
@@ -6986,6 +6990,7 @@ dependencies = [
  "serde_json",
  "service-manager",
  "sn-releases",
+ "sn_build_info",
  "sn_logging",
  "sn_peers_acquisition",
  "sn_protocol",
@@ -7034,9 +7039,11 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
+ "sn_build_info",
  "sn_client",
  "sn_logging",
  "sn_peers_acquisition",
+ "sn_protocol",
  "tiny_http",
  "tokio",
  "tracing",
@@ -7059,6 +7066,8 @@ dependencies = [
 name = "sn_build_info"
 version = "0.1.13"
 dependencies = [
+ "chrono",
+ "tracing",
  "vergen",
 ]
 
@@ -7368,6 +7377,7 @@ dependencies = [
  "hex 0.4.3",
  "libp2p",
  "libp2p-identity",
+ "sn_build_info",
  "sn_client",
  "sn_logging",
  "sn_node",

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -13,6 +13,9 @@ version = "0.2.5"
 name = "nat-detection"
 path = "src/main.rs"
 
+[features]
+nightly = []
+
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
@@ -28,7 +31,9 @@ libp2p = { version = "0.54.1", features = [
     "macros",
     "upnp",
 ] }
+sn_build_info = { path = "../sn_build_info", version = "0.1.13" }
 sn_networking = { path = "../sn_networking", version = "0.18.2" }
+sn_protocol = { path = "../sn_protocol", version = "0.17.9" }
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = { version = "~0.1.26" }
 tracing-log = "0.2.0"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -14,6 +14,9 @@ build = "build.rs"
 name = "node-launchpad"
 path = "src/bin/tui/main.rs"
 
+[features]
+nightly = []
+
 [dependencies]
 atty = "0.2.14"
 better-panic = "0.3.0"
@@ -48,8 +51,10 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 signal-hook = "0.3.17"
+sn_build_info = { path = "../sn_build_info", version = "0.1.13" }
 sn-node-manager = { version = "0.10.4", path = "../sn_node_manager" }
 sn_peers_acquisition = { version = "0.5.1", path = "../sn_peers_acquisition" }
+sn_protocol = { path = "../sn_protocol", version = "0.17.9" }
 sn-releases = "~0.2.6"
 sn_service_management = { version = "0.3.12", path = "../sn_service_management" }
 strip-ansi-escapes = "0.2.0"

--- a/node-launchpad/src/utils.rs
+++ b/node-launchpad/src/utils.rs
@@ -14,15 +14,6 @@ use tracing_subscriber::{
     self, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
 };
 
-const VERSION_MESSAGE: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    "-",
-    env!("VERGEN_GIT_DESCRIBE"),
-    " (",
-    env!("VERGEN_BUILD_DATE"),
-    ")"
-);
-
 pub fn initialize_panic_handler() -> Result<()> {
     let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default()
         .panic_section(format!(
@@ -131,19 +122,4 @@ macro_rules! trace_dbg {
     ($ex:expr) => {
         trace_dbg!(level: tracing::Level::DEBUG, $ex)
     };
-}
-
-pub fn version() -> String {
-    let author = clap::crate_authors!();
-
-    let data_dir_path = get_launchpad_data_dir_path().unwrap().display().to_string();
-
-    format!(
-        "\
-{VERSION_MESSAGE}
-
-Authors: {author}
-
-Data directory: {data_dir_path}"
-    )
 }

--- a/sn_auditor/Cargo.toml
+++ b/sn_auditor/Cargo.toml
@@ -16,6 +16,7 @@ local-discovery = [
     "sn_peers_acquisition/local-discovery",
 ]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
+nightly = []
 open-metrics = ["sn_client/open-metrics"]
 websockets = ["sn_client/websockets"]
 svg-dag = ["graphviz-rust", "dag-collection"]
@@ -31,9 +32,11 @@ graphviz-rust = { version = "0.9.0", optional = true }
 lazy_static = "1.4.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 serde_json = "1.0.108"
+sn_build_info = { path = "../sn_build_info", version = "0.1.13" }
 sn_client = { path = "../sn_client", version = "0.110.1" }
 sn_logging = { path = "../sn_logging", version = "0.2.34" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.5.1" }
+sn_protocol = { path = "../sn_protocol", version = "0.17.9" }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tracing = { version = "~0.1.26" }
 tokio = { version = "1.32.0", features = [

--- a/sn_build_info/Cargo.toml
+++ b/sn_build_info/Cargo.toml
@@ -9,9 +9,17 @@ name = "sn_build_info"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.1.13"
+build = "build.rs"
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 
+[features]
+nightly = []
+
 [lints]
 workspace = true
+
+[dependencies]
+chrono = "0.4"
+tracing = { version = "~0.1.26" }

--- a/sn_build_info/build.rs
+++ b/sn_build_info/build.rs
@@ -5,6 +5,8 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+use std::fs;
+use std::path::Path;
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,6 +19,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Emit the annotated tag of the current commit, or fall back to abbreviated commit object.
         .git_describe(true, false, None)
         .emit()?;
+
+    let release_info_path = Path::new("../release-cycle-info");
+    let contents =
+        fs::read_to_string(release_info_path).expect("Failed to read release-cycle-info");
+
+    let mut year = String::new();
+    let mut month = String::new();
+    let mut cycle = String::new();
+    let mut counter = String::new();
+
+    for line in contents.lines() {
+        if line.starts_with("release-year:") {
+            year = line
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+        } else if line.starts_with("release-month:") {
+            month = line
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+        } else if line.starts_with("release-cycle:") {
+            cycle = line
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+        } else if line.starts_with("release-cycle-counter:") {
+            counter = line
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+        }
+    }
+
+    println!("cargo:rustc-env=RELEASE_YEAR={year}");
+    println!("cargo:rustc-env=RELEASE_MONTH={month}");
+    println!("cargo:rustc-env=RELEASE_CYCLE={cycle}");
+    println!("cargo:rustc-env=RELEASE_CYCLE_COUNTER={counter}");
 
     Ok(())
 }

--- a/sn_build_info/src/lib.rs
+++ b/sn_build_info/src/lib.rs
@@ -6,14 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use chrono::Utc;
+use tracing::debug;
+
 /// Git information separated by slashes: `<sha> / <branch> / <describe>`
 pub const fn git_info() -> &'static str {
     concat!(
-        env!("VERGEN_GIT_SHA"),
-        " / ",
         env!("VERGEN_GIT_BRANCH"),
         " / ",
-        env!("VERGEN_GIT_DESCRIBE"),
+        env!("VERGEN_GIT_SHA"),
         " / ",
         env!("VERGEN_BUILD_DATE")
     )
@@ -32,4 +33,78 @@ pub const fn git_branch() -> &'static str {
 /// Shortened SHA-1 hash.
 pub const fn git_sha() -> &'static str {
     env!("VERGEN_GIT_SHA")
+}
+
+/// Nightly version format: YYYY.MM.DD
+pub fn nightly_version() -> String {
+    let now = Utc::now();
+    now.format("%Y.%m.%d").to_string()
+}
+
+/// Git information for nightly builds: `<date> / <branch> / <sha>`
+pub fn nightly_git_info() -> String {
+    format!("{} / {} / {}", nightly_version(), git_branch(), git_sha(),)
+}
+
+pub fn package_version() -> String {
+    format!(
+        "{}.{}.{}.{}",
+        env!("RELEASE_YEAR"),
+        env!("RELEASE_MONTH"),
+        env!("RELEASE_CYCLE"),
+        env!("RELEASE_CYCLE_COUNTER")
+    )
+}
+
+pub fn full_version_info(
+    app_name: &str,
+    crate_version: &str,
+    protocol_version: Option<&str>,
+) -> String {
+    let mut info = format!("{app_name} v{crate_version}");
+
+    if let Some(version) = protocol_version {
+        info.push_str(&format!("\nNetwork version: {version}"));
+    }
+
+    info.push_str(&format!(
+        "\nPackage version: {}\nGit info: {}",
+        package_version(),
+        git_info()
+    ));
+
+    info
+}
+
+pub fn full_nightly_version_info(app_name: &str, protocol_version: Option<&str>) -> String {
+    let mut info = format!("{app_name} -- Nightly Release {}", nightly_version(),);
+    if let Some(version) = protocol_version {
+        info.push_str(&format!("\nNetwork version: {version}"));
+    }
+    info.push_str(&format!("\nGit info: {} / {}", git_branch(), git_sha(),));
+    info
+}
+
+pub fn version_string(
+    app_name: &str,
+    crate_version: &str,
+    protocol_version: Option<&str>,
+) -> String {
+    if cfg!(feature = "nightly") {
+        full_nightly_version_info(app_name, protocol_version)
+    } else {
+        full_version_info(app_name, crate_version, protocol_version)
+    }
+}
+
+pub fn log_version_info(crate_version: &str, protocol_version: &str) {
+    if cfg!(feature = "nightly") {
+        debug!("nightly build info: {}", nightly_git_info());
+        debug!("network version: {protocol_version}");
+    } else {
+        debug!("version: {crate_version}");
+        debug!("network version: {protocol_version}");
+        debug!("package version: {}", package_version());
+        debug!("git info: {}", git_info());
+    }
 }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -27,6 +27,7 @@ local-discovery = [
 ]
 metrics = ["sn_logging/process-metrics"]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
+nightly = []
 open-metrics = ["sn_client/open-metrics"]
 
 [dependencies]

--- a/sn_cli/src/bin/subcommands/mod.rs
+++ b/sn_cli/src/bin/subcommands/mod.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 // Please do not remove the blank lines in these doc comments.
 // They are used for inserting line breaks when the help menu is rendered in the UI.
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(disable_version_flag = true)]
 pub(crate) struct Opt {
     /// Specify the logging output destination.
     ///
@@ -49,7 +49,7 @@ pub(crate) struct Opt {
 
     /// Available sub commands.
     #[clap(subcommand)]
-    pub cmd: SubCmd,
+    pub cmd: Option<SubCmd>,
 
     /// The maximum duration to wait for a connection to the network before timing out.
     #[clap(long = "timeout", global = true, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_secs)?) })]
@@ -60,6 +60,23 @@ pub(crate) struct Opt {
     /// This may increase operation speed, but offers no guarantees that operations were successful.
     #[clap(global = true, long = "no-verify", short = 'x')]
     pub no_verify: bool,
+
+    /// Print the crate version.
+    #[clap(long)]
+    pub crate_version: bool,
+
+    /// Print the network protocol version.
+    #[clap(long)]
+    pub protocol_version: bool,
+
+    /// Print the package version.
+    #[clap(long)]
+    #[cfg(not(feature = "nightly"))]
+    pub package_version: bool,
+
+    /// Print version information.
+    #[clap(long)]
+    pub version: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/sn_faucet/Cargo.toml
+++ b/sn_faucet/Cargo.toml
@@ -15,6 +15,7 @@ default = ["gifting"]
 distribution = ["base64", "bitcoin", "minreq"]
 gifting = []
 initial-data = ["reqwest", "futures"]
+nightly = []
 
 [[bin]]
 path = "src/main.rs"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -15,14 +15,15 @@ path = "src/bin/safenode/main.rs"
 
 [features]
 default = ["metrics", "upnp", "reward-forward", "open-metrics"]
+encrypt-records = ["sn_networking/encrypt-records"]
 local-discovery = ["sn_networking/local-discovery"]
-otlp = ["sn_logging/otlp"]
 metrics = ["sn_logging/process-metrics"]
 network-contacts = ["sn_peers_acquisition/network-contacts"]
+nightly = []
 open-metrics = ["sn_networking/open-metrics", "prometheus-client"]
-encrypt-records = ["sn_networking/encrypt-records"]
-upnp = ["sn_networking/upnp"]
+otlp = ["sn_logging/otlp"]
 reward-forward = ["sn_transfers/reward-forward"]
+upnp = ["sn_networking/upnp"]
 
 [dependencies]
 assert_fs = "1.0.0"

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -11,15 +11,17 @@ extern crate tracing;
 
 mod rpc_service;
 
-use clap::Parser;
-use eyre::{eyre, Result};
+use clap::{command, Parser};
+use color_eyre::{eyre::eyre, Result};
 use libp2p::{identity::Keypair, PeerId};
 #[cfg(feature = "metrics")]
 use sn_logging::metrics::init_metrics;
 use sn_logging::{Level, LogFormat, LogOutputDest, ReloadHandle};
 use sn_node::{Marker, NodeBuilder, NodeEvent, NodeEventsReceiver};
 use sn_peers_acquisition::PeersArgs;
-use sn_protocol::{node::get_safenode_root_dir, node_rpc::NodeCtrl};
+use sn_protocol::{
+    node::get_safenode_root_dir, node_rpc::NodeCtrl, version::IDENTIFY_PROTOCOL_STR,
+};
 use std::{
     env,
     io::Write,
@@ -65,7 +67,7 @@ pub fn parse_log_output(val: &str) -> Result<LogOutputDestArg> {
 // Please do not remove the blank lines in these doc comments.
 // They are used for inserting line breaks when the help menu is rendered in the UI.
 #[derive(Parser, Debug)]
-#[clap(name = "safenode cli", version = env!("CARGO_PKG_VERSION"))]
+#[command(disable_version_flag = true)]
 struct Opt {
     /// Specify whether the node is operating from a home network and situated behind a NAT without port forwarding
     /// capabilities. Setting this to true, activates hole-punching to facilitate direct connections from other nodes.
@@ -177,11 +179,56 @@ struct Opt {
         required_if_eq("metrics_server_port", "0")
     )]
     enable_metrics_server: bool,
+
+    /// Print the crate version.
+    #[clap(long)]
+    crate_version: bool,
+
+    /// Print the network protocol version.
+    #[clap(long)]
+    protocol_version: bool,
+
+    /// Print the package version.
+    #[cfg(not(feature = "nightly"))]
+    #[clap(long)]
+    package_version: bool,
+
+    /// Print version information.
+    #[clap(long)]
+    version: bool,
 }
 
 fn main() -> Result<()> {
     color_eyre::install()?;
     let opt = Opt::parse();
+
+    if opt.version {
+        println!(
+            "{}",
+            sn_build_info::version_string(
+                "Autonomi Node",
+                env!("CARGO_PKG_VERSION"),
+                Some(&IDENTIFY_PROTOCOL_STR)
+            )
+        );
+        return Ok(());
+    }
+
+    if opt.crate_version {
+        println!("Crate version: {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    if opt.protocol_version {
+        println!("Network version: {}", *IDENTIFY_PROTOCOL_STR);
+        return Ok(());
+    }
+
+    #[cfg(not(feature = "nightly"))]
+    if opt.package_version {
+        println!("Package version: {}", sn_build_info::package_version());
+        return Ok(());
+    }
 
     let node_socket_addr = SocketAddr::new(opt.ip, opt.port);
     let (root_dir, keypair) = get_root_dir_and_keypair(&opt.root_dir)?;
@@ -197,10 +244,8 @@ fn main() -> Result<()> {
         env!("CARGO_PKG_VERSION")
     );
     info!("\n{}\n{}", msg, "=".repeat(msg.len()));
-    debug!(
-        "safenode built with git version: {}",
-        sn_build_info::git_info()
-    );
+
+    sn_build_info::log_version_info(env!("CARGO_PKG_VERSION"), &IDENTIFY_PROTOCOL_STR);
 
     info!("Node started with initial_peers {bootstrap_peers:?}");
 

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -22,6 +22,7 @@ chaos = []
 default = ["quic"]
 local-discovery = []
 network-contacts = []
+nightly = []
 open-metrics = []
 otlp = []
 quic = []
@@ -44,6 +45,7 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.7.0"
+sn_build_info = { path = "../sn_build_info", version = "0.1.13" }
 sn_logging = { path = "../sn_logging", version = "0.2.34" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.5.1" }
 sn_protocol = { path = "../sn_protocol", version = "0.17.9" }

--- a/sn_node_manager/src/local.rs
+++ b/sn_node_manager/src/local.rs
@@ -62,11 +62,18 @@ impl Launcher for LocalSafeLauncher {
 
     fn launch_faucet(&self, genesis_multiaddr: &Multiaddr) -> Result<u32> {
         info!("Launching the faucet server...");
+        debug!("Using genesis_multiaddr: {}", genesis_multiaddr.to_string());
         let args = vec![
             "--peer".to_string(),
             genesis_multiaddr.to_string(),
             "server".to_string(),
         ];
+
+        debug!(
+            "Using faucet binary: {}",
+            self.faucet_bin_path.to_string_lossy()
+        );
+        debug!("Using args: {}", args.join(" "));
         let child = Command::new(self.faucet_bin_path.clone())
             .args(args)
             .stdout(Stdio::inherit())
@@ -369,8 +376,8 @@ pub async fn run_network(
 
     if !options.join {
         println!("Launching the faucet server...");
-        let pid = launcher.launch_faucet(&bootstrap_peers[0])?;
         let version = get_bin_version(&options.faucet_bin_path)?;
+        let pid = launcher.launch_faucet(&bootstrap_peers[0])?;
         let faucet = FaucetServiceData {
             faucet_path: options.faucet_bin_path,
             local: true,

--- a/sn_node_rpc_client/Cargo.toml
+++ b/sn_node_rpc_client/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.6.29"
 name = "safenode_rpc_client"
 path = "src/main.rs"
 
+[features]
+nightly = []
+
 [dependencies]
 assert_fs = "1.0.0"
 async-trait = "0.1"
@@ -23,6 +26,7 @@ color-eyre = "0.6.2"
 hex = "~0.4.3"
 libp2p = { version = "0.54.1", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
+sn_build_info = { path = "../sn_build_info", version = "0.1.13" }
 sn_client = { path = "../sn_client", version = "0.110.1" }
 sn_logging = { path = "../sn_logging", version = "0.2.34" }
 sn_node = { path = "../sn_node", version = "0.111.2" }


### PR DESCRIPTION
- 7639624c6 **chore: standardise versioning for binaries**

  The RFC for the release process stipulated there should be four versioning arguments:
  * --version
  * --crate-version
  * --package-version
  * --network-version

  Here, `--crate-version` is the semantic version of the crate, `--package-version` is the release
  cycle version, e.g., `2024.09.1.1`, and `--network-version` prints the compatible network protocol.
  The `--version` argument will then print all of this information. The `--package-version` argument
  does not apply to the nightly release.

  The approach for printing the version information is to provide our own `version` flag, by using the
  `disable_version_flag` attribute with `clap`. If you want to use `clap`, all the information needs
  to be completely static and available at compile time. This is convoluted, especially for things
  like the network protocol version and the crate version, and it would have led to a lot of
  repetition. We can avoid the difficulty by providing the information dynamically, and we can use the
  `sn_build_info` crate to define the version string once. On binaries that used subcommands, for the
  versioning to work correctly, the subcommand needs to be made optional.

  The `get_bin_version` helper used by the node manager was updated parse the new versioning
  information from both stable and nightly releases. Now, the function can handle different
  `--version` output formats by extracting the version number for stable releases prefixed with a 'v'
  and the date for nightly releases.

  Since we are going to introduce a nightly build, this commit also introduces a nightly feature,
  which will control what versioning information is used. For the nightly, the binaries will be
  versioned with the date on which they are built. The `--package-version` argument does not apply to
  the nightly release; it is not necessary if all the binaries have the same version, which is the
  date.

- 73194e3b2 **ci: nightly releases**

  The nightly release will build the binary set from the `main` branch every night at midnight UTC.

  The workflow:

  * Builds the binaries with the `nightly` feature, which versions them using the current date, rather
    than a Semantic Version.
  * Uploads packaged binaries to S3, again with the date for the version.
  * Also uploads packaged binaries to S3 with 'nightly' as the version, which will always be the
    latest. The previous 'nightly' version will be deleted from the bucket.
  * Creates a Github Release and uploads archives with the binaries packaged by architecture, as per
    the stable release. To prevent our releases page being flooded, the previous nightly release will
    be deleted before the current one is created.