### PR TITLE
fix: increase timeout to 10 mins

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,13 +59,13 @@ jobs:
           cargo run --bin safe --release -- --log-output-dest=data-dir wallet receive --file transfer_hex
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       - name: Start a client to carry out chunk actions
         run: cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources" --retry-strategy quick
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       # Client FoldersApi tests against local network
       - name: Client FoldersApi tests against local network
@@ -85,19 +85,19 @@ jobs:
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register create -n baobao
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       - name: Start a client to get a register
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register get -n baobao
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       - name: Start a client to edit a register
         run: cargo run --bin safe --release -- --log-output-dest=data-dir register edit -n baobao wood
         env:
           SN_LOG: "all"
-        timeout-minutes: 2
+        timeout-minutes: 10
 
       - name: Stop the local network and upload logs
         if: always()


### PR DESCRIPTION
### Description

Found that the nightly e2e tests are failing in github actions, due to not able to start the client within 2 mins, have increased the timeout to 10 mins. 

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).
