### PR TITLE
fix(launchpad): nat mode only when first time automatic

### DIFF
--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -183,7 +183,8 @@ impl Status {
 
     /// Only run NAT detection if we haven't determined the status yet and we haven't failed more than 3 times.
     fn should_we_run_nat_detection(&self) -> bool {
-        !self.is_nat_status_determined
+        self.connection_mode == ConnectionMode::Automatic
+            && !self.is_nat_status_determined
             && self.error_while_running_nat_detection < MAX_ERRORS_WHILE_RUNNING_NAT_DETECTION
     }
 


### PR DESCRIPTION
### Description

We execute NAT detection only when we are in Connection Mode Automatic and only on the first time.