### PR TITLE
fix(launchpad): disable node selection

### DIFF
--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -181,7 +181,8 @@ impl Status {
         );
 
         if !self.node_services.is_empty() && self.node_table_state.selected().is_none() {
-            self.node_table_state.select(Some(0));
+            // self.node_table_state.select(Some(0));
+            self.node_table_state.select(None);
         }
 
         Ok(())
@@ -207,7 +208,7 @@ impl Status {
             .collect()
     }
 
-    fn select_next_table_item(&mut self) {
+    fn _select_next_table_item(&mut self) {
         let i = match self.node_table_state.selected() {
             Some(i) => {
                 if i >= self.node_services.len() - 1 {
@@ -221,7 +222,7 @@ impl Status {
         self.node_table_state.select(Some(i));
     }
 
-    fn select_previous_table_item(&mut self) {
+    fn _select_previous_table_item(&mut self) {
         let i = match self.node_table_state.selected() {
             Some(i) => {
                 if i == 0 {
@@ -411,10 +412,10 @@ impl Component for Status {
                     return Ok(Some(Action::SwitchScene(Scene::ManageNodesPopUp)));
                 }
                 StatusActions::PreviousTableItem => {
-                    self.select_previous_table_item();
+                    // self.select_previous_table_item();
                 }
                 StatusActions::NextTableItem => {
-                    self.select_next_table_item();
+                    // self.select_next_table_item();
                 }
                 StatusActions::StartNodes => {
                     debug!("Got action to start nodes");


### PR DESCRIPTION
### Description

We disable node selection on status screen. Will be available when we can apply an action on individual nodes.