### PR TITLE
feat(metrics): shunned count across time frames

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run network tests
         timeout-minutes: 25
-        run: cargo test --release --package sn_networking
+        run: cargo test --release --package sn_networking --features="open-metrics"
 
       - name: Run protocol tests
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Run network tests
         timeout-minutes: 25
-        run: cargo test --release -p sn_networking
+        run: cargo test --release -p sn_networking --features="open-metrics"
 
       - name: Run protocol tests
         timeout-minutes: 25

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -6,10 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "open-metrics")]
-use crate::metrics::NetworkMetricsRecorder;
-#[cfg(feature = "open-metrics")]
-use crate::metrics_service::run_metrics_server;
 use crate::{
     bootstrap::{ContinuousBootstrap, BOOTSTRAP_INTERVAL},
     circular_vec::CircularVec,
@@ -26,6 +22,10 @@ use crate::{
     replication_fetcher::ReplicationFetcher,
     target_arch::{interval, spawn, Instant},
     GetRecordError, Network, CLOSE_GROUP_SIZE,
+};
+#[cfg(feature = "open-metrics")]
+use crate::{
+    metrics::service::run_metrics_server, metrics::NetworkMetricsRecorder, MetricsRegistries,
 };
 use crate::{transport, NodeIssue};
 use futures::future::Either;
@@ -46,7 +46,7 @@ use libp2p::{
     Multiaddr, PeerId,
 };
 #[cfg(feature = "open-metrics")]
-use prometheus_client::{metrics::info::Info, registry::Registry};
+use prometheus_client::metrics::info::Info;
 use sn_protocol::{
     messages::{ChunkProof, Nonce, Request, Response},
     storage::{try_deserialize_record, RetryStrategy},
@@ -257,9 +257,7 @@ pub struct NetworkBuilder {
     concurrency_limit: Option<usize>,
     initial_peers: Vec<Multiaddr>,
     #[cfg(feature = "open-metrics")]
-    metrics_metadata_registry: Option<Registry>,
-    #[cfg(feature = "open-metrics")]
-    metrics_registry: Option<Registry>,
+    metrics_registries: Option<MetricsRegistries>,
     #[cfg(feature = "open-metrics")]
     metrics_server_port: Option<u16>,
     #[cfg(feature = "upnp")]
@@ -278,9 +276,7 @@ impl NetworkBuilder {
             concurrency_limit: None,
             initial_peers: Default::default(),
             #[cfg(feature = "open-metrics")]
-            metrics_metadata_registry: None,
-            #[cfg(feature = "open-metrics")]
-            metrics_registry: None,
+            metrics_registries: None,
             #[cfg(feature = "open-metrics")]
             metrics_server_port: None,
             #[cfg(feature = "upnp")]
@@ -308,18 +304,11 @@ impl NetworkBuilder {
         self.initial_peers = initial_peers;
     }
 
-    /// Set the Registry that will be served at the `/metadata` endpoint. This Registry should contain only the static
-    /// info about the peer. Configure the `metrics_server_port` to enable the metrics server.
-    #[cfg(feature = "open-metrics")]
-    pub fn metrics_metadata_registry(&mut self, metrics_metadata_registry: Registry) {
-        self.metrics_metadata_registry = Some(metrics_metadata_registry);
-    }
-
-    /// Set the Registry that will be served at the `/metrics` endpoint.
+    /// Set the registries used inside the metrics server.
     /// Configure the `metrics_server_port` to enable the metrics server.
     #[cfg(feature = "open-metrics")]
-    pub fn metrics_registry(&mut self, metrics_registry: Registry) {
-        self.metrics_registry = Some(metrics_registry);
+    pub fn metrics_registries(&mut self, registries: MetricsRegistries) {
+        self.metrics_registries = Some(registries);
     }
 
     #[cfg(feature = "open-metrics")]
@@ -479,11 +468,11 @@ impl NetworkBuilder {
         );
 
         #[cfg(feature = "open-metrics")]
-        let mut metrics_registry = self.metrics_registry.unwrap_or_default();
+        let mut metrics_registries = self.metrics_registries.unwrap_or_default();
 
         // ==== Transport ====
         #[cfg(feature = "open-metrics")]
-        let main_transport = transport::build_transport(&self.keypair, &mut metrics_registry);
+        let main_transport = transport::build_transport(&self.keypair, &mut metrics_registries);
         #[cfg(not(feature = "open-metrics"))]
         let main_transport = transport::build_transport(&self.keypair);
         let transport = if !self.local {
@@ -513,18 +502,18 @@ impl NetworkBuilder {
             .boxed();
 
         #[cfg(feature = "open-metrics")]
-        let network_metrics = if let Some(port) = self.metrics_server_port {
-            let network_metrics = NetworkMetricsRecorder::new(&mut metrics_registry);
-            let mut metadata_registry = self.metrics_metadata_registry.unwrap_or_default();
-            let network_metadata_sub_registry =
-                metadata_registry.sub_registry_with_prefix("sn_networking");
+        let metrics_recorder = if let Some(port) = self.metrics_server_port {
+            let metrics_recorder = NetworkMetricsRecorder::new(&mut metrics_registries);
+            let metadata_sub_reg = metrics_registries
+                .metadata
+                .sub_registry_with_prefix("sn_networking");
 
-            network_metadata_sub_registry.register(
+            metadata_sub_reg.register(
                 "peer_id",
                 "Identifier of a peer of the network",
                 Info::new(vec![("peer_id".to_string(), peer_id.to_string())]),
             );
-            network_metadata_sub_registry.register(
+            metadata_sub_reg.register(
                 "identify_protocol_str",
                 "The protocol version string that is used to connect to the correct network",
                 Info::new(vec![(
@@ -533,8 +522,8 @@ impl NetworkBuilder {
                 )]),
             );
 
-            run_metrics_server(metrics_registry, metadata_registry, port);
-            Some(network_metrics)
+            run_metrics_server(metrics_registries, port);
+            Some(metrics_recorder)
         } else {
             None
         };
@@ -576,9 +565,9 @@ impl NetworkBuilder {
                     #[cfg(feature = "open-metrics")]
                     let mut node_record_store = node_record_store;
                     #[cfg(feature = "open-metrics")]
-                    if let Some(metrics) = &network_metrics {
+                    if let Some(metrics_recorder) = &metrics_recorder {
                         node_record_store = node_record_store
-                            .set_record_count_metric(metrics.records_stored.clone());
+                            .set_record_count_metric(metrics_recorder.records_stored.clone());
                     }
 
                     let store = UnifiedRecordStore::Node(node_record_store);
@@ -682,7 +671,7 @@ impl NetworkBuilder {
             external_address_manager,
             replication_fetcher,
             #[cfg(feature = "open-metrics")]
-            network_metrics,
+            metrics_recorder,
             // kept here to ensure we can push messages to the channel
             // and not block the processing thread unintentionally
             network_cmd_sender: network_swarm_cmd_sender.clone(),
@@ -733,7 +722,7 @@ pub struct SwarmDriver {
     /// The peers that are closer to our PeerId. Includes self.
     pub(crate) replication_fetcher: ReplicationFetcher,
     #[cfg(feature = "open-metrics")]
-    pub(crate) network_metrics: Option<NetworkMetricsRecorder>,
+    pub(crate) metrics_recorder: Option<NetworkMetricsRecorder>,
 
     network_cmd_sender: mpsc::Sender<NetworkSwarmCmd>,
     pub(crate) local_cmd_sender: mpsc::Sender<LocalSwarmCmd>,
@@ -998,8 +987,8 @@ impl SwarmDriver {
     pub(crate) fn record_metrics(&self, marker: Marker) {
         marker.log();
         #[cfg(feature = "open-metrics")]
-        if let Some(network_metrics) = self.network_metrics.as_ref() {
-            network_metrics.record_from_marker(marker)
+        if let Some(metrics_recorder) = self.metrics_recorder.as_ref() {
+            metrics_recorder.record_from_marker(marker)
         }
     }
 

--- a/sn_networking/src/event/mod.rs
+++ b/sn_networking/src/event/mod.rs
@@ -227,8 +227,10 @@ impl SwarmDriver {
         self.send_event(NetworkEvent::PeerAdded(added_peer, self.peers_in_rt));
 
         #[cfg(feature = "open-metrics")]
-        if let Some(metrics) = &self.network_metrics {
-            metrics.peers_in_routing_table.set(self.peers_in_rt as i64);
+        if let Some(metrics_recorder) = &self.metrics_recorder {
+            metrics_recorder
+                .peers_in_routing_table
+                .set(self.peers_in_rt as i64);
         }
     }
 
@@ -243,8 +245,10 @@ impl SwarmDriver {
         self.send_event(NetworkEvent::PeerRemoved(removed_peer, self.peers_in_rt));
 
         #[cfg(feature = "open-metrics")]
-        if let Some(metrics) = &self.network_metrics {
-            metrics.peers_in_routing_table.set(self.peers_in_rt as i64);
+        if let Some(metrics_recorder) = &self.metrics_recorder {
+            metrics_recorder
+                .peers_in_routing_table
+                .set(self.peers_in_rt as i64);
         }
     }
 
@@ -284,8 +288,8 @@ impl SwarmDriver {
         let estimated_network_size =
             Self::estimate_network_size(peers_in_non_full_buckets, num_of_full_buckets);
         #[cfg(feature = "open-metrics")]
-        if let Some(metrics) = &self.network_metrics {
-            let _ = metrics
+        if let Some(metrics_recorder) = &self.metrics_recorder {
+            let _ = metrics_recorder
                 .estimated_network_size
                 .set(estimated_network_size as i64);
         }

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -33,8 +33,8 @@ impl SwarmDriver {
         // This does not record all the events. `SwarmEvent::Behaviour(_)` are skipped. Hence `.record()` has to be
         // called individually on each behaviour.
         #[cfg(feature = "open-metrics")]
-        if let Some(metrics) = &self.network_metrics {
-            metrics.record(&event);
+        if let Some(metrics_recorder) = &self.metrics_recorder {
+            metrics_recorder.record(&event);
         }
         let start = Instant::now();
         let event_string;
@@ -47,8 +47,8 @@ impl SwarmDriver {
             }
             SwarmEvent::Behaviour(NodeEvent::Kademlia(kad_event)) => {
                 #[cfg(feature = "open-metrics")]
-                if let Some(metrics) = &self.network_metrics {
-                    metrics.record(&kad_event);
+                if let Some(metrics_recorder) = &self.metrics_recorder {
+                    metrics_recorder.record(&kad_event);
                 }
                 event_string = "kad_event";
                 self.handle_kad_event(kad_event)?;
@@ -69,8 +69,8 @@ impl SwarmDriver {
             #[cfg(feature = "upnp")]
             SwarmEvent::Behaviour(NodeEvent::Upnp(upnp_event)) => {
                 #[cfg(feature = "open-metrics")]
-                if let Some(metrics) = &self.network_metrics {
-                    metrics.record(&upnp_event);
+                if let Some(metrics_recorder) = &self.metrics_recorder {
+                    metrics_recorder.record(&upnp_event);
                 }
                 event_string = "upnp_event";
                 info!(?upnp_event, "UPnP event");
@@ -84,8 +84,8 @@ impl SwarmDriver {
 
             SwarmEvent::Behaviour(NodeEvent::RelayServer(event)) => {
                 #[cfg(feature = "open-metrics")]
-                if let Some(metrics) = &self.network_metrics {
-                    metrics.record(&(*event));
+                if let Some(metrics_recorder) = &self.metrics_recorder {
+                    metrics_recorder.record(&(*event));
                 }
 
                 event_string = "relay_server_event";
@@ -109,8 +109,8 @@ impl SwarmDriver {
             SwarmEvent::Behaviour(NodeEvent::Identify(iden)) => {
                 // Record the Identify event for metrics if the feature is enabled.
                 #[cfg(feature = "open-metrics")]
-                if let Some(metrics) = &self.network_metrics {
-                    metrics.record(&(*iden));
+                if let Some(metrics_recorder) = &self.metrics_recorder {
+                    metrics_recorder.record(&(*iden));
                 }
                 event_string = "identify";
 
@@ -643,7 +643,7 @@ impl SwarmDriver {
     /// Record the metrics on update of connection state.
     fn record_connection_metrics(&self) {
         #[cfg(feature = "open-metrics")]
-        if let Some(metrics) = &self.network_metrics {
+        if let Some(metrics) = &self.metrics_recorder {
             metrics
                 .open_connections
                 .set(self.live_connected_peers.len() as i64);

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -19,8 +19,6 @@ mod external_address;
 mod log_markers;
 #[cfg(feature = "open-metrics")]
 mod metrics;
-#[cfg(feature = "open-metrics")]
-mod metrics_service;
 mod network_discovery;
 mod record_store;
 mod record_store_api;
@@ -35,8 +33,6 @@ use cmd::LocalSwarmCmd;
 use xor_name::XorName;
 
 // re-export arch dependent deps for use in the crate, or above
-pub use target_arch::{interval, sleep, spawn, Instant, Interval};
-
 pub use self::{
     cmd::{NodeIssue, SwarmLocalState},
     driver::{
@@ -47,6 +43,9 @@ pub use self::{
     record_store::{calculate_cost_for_records, NodeRecordStore},
     transfers::{get_raw_signed_spends_from_record, get_signed_spend_from_record},
 };
+#[cfg(feature = "open-metrics")]
+pub use metrics::service::MetricsRegistries;
+pub use target_arch::{interval, sleep, spawn, Instant, Interval};
 
 use self::{cmd::NetworkSwarmCmd, error::Result};
 use backoff::{Error as BackoffError, ExponentialBackoff};

--- a/sn_networking/src/metrics/bad_node.rs
+++ b/sn_networking/src/metrics/bad_node.rs
@@ -1,0 +1,293 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::target_arch::interval;
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+use prometheus_client::metrics::{family::Family, gauge::Gauge};
+use std::time::{Duration, Instant};
+use strum::IntoEnumIterator;
+
+const UPDATE_INTERVAL: Duration = Duration::from_secs(20);
+
+/// A struct to record the the number of reports against our node across different time frames.
+pub struct ShunnedCountAcrossTimeFrames {
+    metric: Family<TimeFrame, Gauge>,
+    tracked_values: Vec<TrackedValue>,
+}
+
+struct TrackedValue {
+    time: Instant,
+    least_bucket_it_fits_in: TimeFrameType,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct TimeFrame {
+    time_frame: TimeFrameType,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, EncodeLabelValue, strum::EnumIter)]
+pub enum TimeFrameType {
+    LastTenMinutes,
+    LastHour,
+    LastSixHours,
+    LastDay,
+    LastWeek,
+    Indefinite,
+}
+
+impl TimeFrameType {
+    #[cfg(not(test))]
+    fn get_duration_sec(&self) -> u64 {
+        match self {
+            TimeFrameType::LastTenMinutes => 10 * 60,
+            TimeFrameType::LastHour => 60 * 60,
+            TimeFrameType::LastSixHours => 6 * 60 * 60,
+            TimeFrameType::LastDay => 24 * 60 * 60,
+            TimeFrameType::LastWeek => 7 * 24 * 60 * 60,
+            TimeFrameType::Indefinite => u64::MAX,
+        }
+    }
+
+    #[cfg(test)]
+    fn get_duration_sec(&self) -> u64 {
+        match self {
+            TimeFrameType::LastTenMinutes => 2,
+            TimeFrameType::LastHour => 4,
+            TimeFrameType::LastSixHours => 6,
+            TimeFrameType::LastDay => 8,
+            TimeFrameType::LastWeek => 10,
+            TimeFrameType::Indefinite => u64::MAX,
+        }
+    }
+
+    fn next_time_frame(&self) -> Self {
+        match self {
+            TimeFrameType::LastTenMinutes => TimeFrameType::LastHour,
+            TimeFrameType::LastHour => TimeFrameType::LastSixHours,
+            TimeFrameType::LastSixHours => TimeFrameType::LastDay,
+            TimeFrameType::LastDay => TimeFrameType::LastWeek,
+            TimeFrameType::LastWeek => TimeFrameType::Indefinite,
+            TimeFrameType::Indefinite => TimeFrameType::Indefinite,
+        }
+    }
+}
+
+impl ShunnedCountAcrossTimeFrames {
+    pub fn spawn_background_task(
+        time_based_shunned_count: Family<TimeFrame, Gauge>,
+    ) -> tokio::sync::mpsc::Sender<()> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+
+        tokio::spawn(async move {
+            let mut shunned_metrics = ShunnedCountAcrossTimeFrames {
+                metric: time_based_shunned_count,
+                tracked_values: Vec::new(),
+            };
+            let mut update_interval = interval(UPDATE_INTERVAL);
+            update_interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = rx.recv() => {
+                        shunned_metrics.record_shunned();
+
+                    }
+                    _ = update_interval.tick() => {
+                        shunned_metrics.update();
+                    }
+                }
+            }
+        });
+        tx
+    }
+
+    pub fn record_shunned(&mut self) {
+        let now = Instant::now();
+        self.tracked_values.push(TrackedValue {
+            time: now,
+            least_bucket_it_fits_in: TimeFrameType::LastTenMinutes,
+        });
+
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            self.metric.get_or_create(&time_frame).inc();
+        }
+    }
+
+    pub fn update(&mut self) {
+        let now = Instant::now();
+        let mut idx_to_remove = Vec::new();
+
+        for (idx, tracked_value) in self.tracked_values.iter_mut().enumerate() {
+            let time_elapsed_since_adding = now.duration_since(tracked_value.time).as_secs();
+
+            if time_elapsed_since_adding > tracked_value.least_bucket_it_fits_in.get_duration_sec()
+            {
+                let time_frame = TimeFrame {
+                    time_frame: tracked_value.least_bucket_it_fits_in,
+                };
+                self.metric.get_or_create(&time_frame).dec();
+
+                let new_time_frame = tracked_value.least_bucket_it_fits_in.next_time_frame();
+                if new_time_frame == TimeFrameType::Indefinite {
+                    idx_to_remove.push(idx);
+                } else {
+                    tracked_value.least_bucket_it_fits_in = new_time_frame;
+                }
+            }
+        }
+        // remove the ones that are now indefinite
+        for idx in idx_to_remove {
+            self.tracked_values.remove(idx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_should_move_to_next_state() -> eyre::Result<()> {
+        let mut shunned_metrics = ShunnedCountAcrossTimeFrames {
+            metric: Family::default(),
+            tracked_values: Vec::new(),
+        };
+        shunned_metrics.record_shunned();
+
+        let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
+        assert!(matches!(current_state, TimeFrameType::LastTenMinutes));
+        // all the counters should be 1
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+        }
+
+        println!(
+            "current_state: {current_state:?}. Sleeping for {} sec",
+            current_state.get_duration_sec() + 1
+        );
+        std::thread::sleep(std::time::Duration::from_secs(
+            current_state.get_duration_sec() + 1,
+        ));
+        shunned_metrics.update();
+        let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
+        assert!(matches!(current_state, TimeFrameType::LastHour));
+        // all the counters except LastTenMinutes should be 1
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            if variant == TimeFrameType::LastTenMinutes {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 0);
+            } else {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+            }
+        }
+
+        println!(
+            "current_state: {current_state:?}. Sleeping for {} sec",
+            current_state.get_duration_sec() + 1
+        );
+        std::thread::sleep(std::time::Duration::from_secs(
+            current_state.get_duration_sec() + 1,
+        ));
+        shunned_metrics.update();
+        let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
+        assert!(matches!(current_state, TimeFrameType::LastSixHours));
+        // all the counters except LastTenMinutes and LastHour should be 1
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            if variant == TimeFrameType::LastTenMinutes || variant == TimeFrameType::LastHour {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 0);
+            } else {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+            }
+        }
+
+        println!(
+            "current_state: {current_state:?}. Sleeping for {} sec",
+            current_state.get_duration_sec() + 1
+        );
+        std::thread::sleep(std::time::Duration::from_secs(
+            current_state.get_duration_sec() + 1,
+        ));
+        shunned_metrics.update();
+        let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
+        assert!(matches!(current_state, TimeFrameType::LastDay));
+        // all the counters except LastTenMinutes, LastHour and LastSixHours should be 1
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            if variant == TimeFrameType::LastTenMinutes
+                || variant == TimeFrameType::LastHour
+                || variant == TimeFrameType::LastSixHours
+            {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 0);
+            } else {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+            }
+        }
+
+        println!(
+            "current_state: {current_state:?}. Sleeping for {} sec",
+            current_state.get_duration_sec() + 1
+        );
+        std::thread::sleep(std::time::Duration::from_secs(
+            current_state.get_duration_sec() + 1,
+        ));
+        shunned_metrics.update();
+        let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
+        assert!(matches!(current_state, TimeFrameType::LastWeek));
+        // all the counters except LastTenMinutes, LastHour, LastSixHours and LastDay should be 1
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            if variant == TimeFrameType::LastTenMinutes
+                || variant == TimeFrameType::LastHour
+                || variant == TimeFrameType::LastSixHours
+                || variant == TimeFrameType::LastDay
+            {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 0);
+            } else {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+            }
+        }
+
+        println!(
+            "current_state: {current_state:?}. Sleeping for {} sec",
+            current_state.get_duration_sec() + 1
+        );
+        std::thread::sleep(std::time::Duration::from_secs(
+            current_state.get_duration_sec() + 1,
+        ));
+        shunned_metrics.update();
+        assert_eq!(shunned_metrics.tracked_values.len(), 0);
+        // all the counters except Indefinite should be 0
+        for variant in TimeFrameType::iter() {
+            let time_frame = TimeFrame {
+                time_frame: variant,
+            };
+            if variant == TimeFrameType::Indefinite {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 1);
+            } else {
+                assert_eq!(shunned_metrics.metric.get_or_create(&time_frame).get(), 0);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/sn_networking/src/metrics/bad_node.rs
+++ b/sn_networking/src/metrics/bad_node.rs
@@ -94,7 +94,7 @@ impl ShunnedCountAcrossTimeFrames {
             loop {
                 tokio::select! {
                     _ = rx.recv() => {
-                        shunned_metrics.record_shunned();
+                        shunned_metrics.record_shunned_metric();
 
                     }
                     _ = update_interval.tick() => {
@@ -106,7 +106,7 @@ impl ShunnedCountAcrossTimeFrames {
         tx
     }
 
-    pub fn record_shunned(&mut self) {
+    pub fn record_shunned_metric(&mut self) {
         let now = Instant::now();
         self.tracked_values.push(TrackedValue {
             time: now,
@@ -160,7 +160,7 @@ mod tests {
             metric: Family::default(),
             tracked_values: Vec::new(),
         };
-        shunned_metrics.record_shunned();
+        shunned_metrics.record_shunned_metric();
 
         let current_state = shunned_metrics.tracked_values[0].least_bucket_it_fits_in;
         assert!(matches!(current_state, TimeFrameType::LastTenMinutes));

--- a/sn_networking/src/metrics/mod.rs
+++ b/sn_networking/src/metrics/mod.rs
@@ -6,20 +6,21 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{log_markers::Marker, target_arch::sleep};
-use libp2p::metrics::{Metrics as Libp2pMetrics, Recorder};
+// Implementation to record `libp2p::upnp::Event` metrics
+mod bad_node;
 #[cfg(feature = "upnp")]
-use prometheus_client::metrics::family::Family;
+mod upnp;
+
+use crate::{log_markers::Marker, target_arch::sleep};
+use bad_node::{ShunnedCountAcrossTimeFrames, TimeFrame};
+use libp2p::metrics::{Metrics as Libp2pMetrics, Recorder};
 use prometheus_client::{
+    metrics::family::Family,
     metrics::{counter::Counter, gauge::Gauge},
     registry::Registry,
 };
 use sysinfo::{Pid, ProcessRefreshKind, System};
 use tokio::time::Duration;
-
-// Implementation to record `libp2p::upnp::Event` metrics
-#[cfg(feature = "upnp")]
-mod upnp;
 
 const UPDATE_INTERVAL: Duration = Duration::from_secs(15);
 const TO_MB: u64 = 1_000_000;
@@ -49,11 +50,16 @@ pub(crate) struct NetworkMetricsRecorder {
 
     // bad node metrics
     bad_peers_count: Counter,
+    #[allow(dead_code)] // This is updated by the background task
+    shunned_across_time_frames: Family<TimeFrame, Gauge>,
     shunned_count: Counter,
 
     // system info
     process_memory_used_mb: Gauge,
     process_cpu_usage_percentage: Gauge,
+
+    // helpers
+    shunned_report_notifier: tokio::sync::mpsc::Sender<()>,
 }
 
 impl NetworkMetricsRecorder {
@@ -92,6 +98,16 @@ impl NetworkMetricsRecorder {
             "peers_in_routing_table",
             "The total number of peers in our routing table",
             peers_in_routing_table.clone(),
+        );
+
+        let shunned_count_across_time_frames = Family::default();
+        let shunned_report_notifier = ShunnedCountAcrossTimeFrames::spawn_background_task(
+            shunned_count_across_time_frames.clone(),
+        );
+        sub_registry.register(
+            "shunned_count_across_time_frames",
+            "The number of peers that have been shunned across different time frames",
+            shunned_count_across_time_frames.clone(),
         );
 
         let shunned_count = Counter::default();
@@ -180,10 +196,13 @@ impl NetworkMetricsRecorder {
             live_time,
 
             bad_peers_count,
+            shunned_across_time_frames: shunned_count_across_time_frames,
             shunned_count,
 
             process_memory_used_mb,
             process_cpu_usage_percentage,
+
+            shunned_report_notifier,
         };
 
         network_metrics.system_metrics_recorder_task();
@@ -227,6 +246,9 @@ impl NetworkMetricsRecorder {
             }
             Marker::FlaggedAsBadNode { .. } => {
                 let _ = self.shunned_count.inc();
+                if let Err(err) = self.shunned_report_notifier.try_send(()) {
+                    debug!("Failed to send shunned report via notifier: {err:?}");
+                }
             }
             Marker::StoreCost {
                 cost,

--- a/sn_networking/src/metrics/service.rs
+++ b/sn_networking/src/metrics/service.rs
@@ -105,6 +105,16 @@ impl MetricService {
             error!("Failed to encode the standard metrics Registry {err:?}");
             NetworkError::NetworkMetricError
         })?;
+
+        // remove the EOF line from the response
+        let mut buffer = response.body().split("\n").collect::<Vec<&str>>();
+        let _ = buffer.pop();
+        let _ = buffer.pop();
+        buffer.push("\n");
+        let mut buffer = buffer.join("\n");
+        let _ = buffer.pop();
+        *response.body_mut() = buffer;
+
         let extended_registry = self.get_extended_metrics_registry();
         let extended_registry = extended_registry
             .lock()

--- a/sn_networking/src/metrics/upnp.rs
+++ b/sn_networking/src/metrics/upnp.rs
@@ -1,3 +1,11 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]

--- a/sn_networking/src/transport/other.rs
+++ b/sn_networking/src/transport/other.rs
@@ -1,7 +1,7 @@
+#[cfg(feature = "open-metrics")]
+use crate::MetricsRegistries;
 #[cfg(feature = "websockets")]
 use futures::future::Either;
-#[cfg(feature = "open-metrics")]
-use libp2p::metrics::Registry;
 #[cfg(feature = "websockets")]
 use libp2p::{core::upgrade, noise, yamux};
 use libp2p::{
@@ -12,11 +12,11 @@ use libp2p::{
 
 pub(crate) fn build_transport(
     keypair: &Keypair,
-    #[cfg(feature = "open-metrics")] registry: &mut Registry,
+    #[cfg(feature = "open-metrics")] registries: &mut MetricsRegistries,
 ) -> transport::Boxed<(PeerId, StreamMuxerBox)> {
     let trans = generate_quic_transport(keypair);
     #[cfg(feature = "open-metrics")]
-    let trans = libp2p::metrics::BandwidthTransport::new(trans, registry);
+    let trans = libp2p::metrics::BandwidthTransport::new(trans, &mut registries.standard_metrics);
 
     #[cfg(feature = "websockets")]
     // Using a closure here due to the complex return type

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -693,8 +693,8 @@ impl Node {
         );
 
         #[cfg(feature = "open-metrics")]
-        if let Some(node_metrics) = self.node_metrics() {
-            let _ = node_metrics
+        if let Some(metrics_recorder) = self.metrics_recorder() {
+            let _ = metrics_recorder
                 .current_reward_wallet_balance
                 .set(new_balance as i64);
         }


### PR DESCRIPTION
- adds a new `/metrics_extended` endpoint. It contains all the same metrics from `/metrics` with a few more detailed ones.
- A new endpoint was added because we do not want to overwhelm our monitoring setup. If a metric is useful to us, we can move it to `/metrics`
- Adds a shunned count metrics that is split across time frames. This is useful to tell if we were recently marked as bad by others.