### PR TITLE
feat: use EVM_NETWROK=local var to fetch local network deta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ name = "evm_testnet"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs-next",
  "evmlib",
  "tokio",
 ]
@@ -2745,11 +2746,13 @@ name = "evmlib"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "dirs-next",
  "getrandom 0.2.15",
  "rand 0.8.5",
  "serde",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8729,9 +8732,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 name = "test_utils"
 version = "0.4.6"
 dependencies = [
- "autonomi",
  "color-eyre",
- "const-hex",
  "dirs-next",
  "evmlib",
  "libp2p 0.54.1",

--- a/autonomi/README.md
+++ b/autonomi/README.md
@@ -26,20 +26,18 @@ autonomi = { path = "../autonomi", version = "0.1.0" }
 cargo run --bin evm_testnet
 ```
 
-Take note of the console output for the next step (`RPC URL`, `Payment token address` & `Chunk payments address`).
-
-3. Run a local network with the `local-discovery` feature and pass the EVM params:
+3. Run a local network with the `local-discovery` feature and use the local evm node. 
 
 ```sh
-cargo run --bin=safenode-manager --features=local-discovery -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-custom --rpc-url <RPC_URL> --payment-token-address <TOKEN_ADDRESS> --chunk-payments-address <CONTRACT_ADDRESS>
+cargo run --bin=safenode-manager --features=local-discovery -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-local
 ```
 
 4. Then run the tests with the `local` feature and pass the EVM params again:
 
 ```sh
-$ RPC_URL=<RPC_URL> PAYMENT_TOKEN_ADDRESS=<TOKEN_ADDRESS> CHUNK_PAYMENTS_ADDRESS=<CONTRACT_ADDRESS> cargo test --package=autonomi --features=local
+$ EVM_NETWORK=local cargo test --package=autonomi --features=local
 # Or with logs
-$ RUST_LOG=autonomi RPC_URL=<RPC_URL> PAYMENT_TOKEN_ADDRESS=<TOKEN_ADDRESS> CHUNK_PAYMENTS_ADDRESS=<CONTRACT_ADDRESS> cargo test --package=autonomi --features=local -- --nocapture
+$ RUST_LOG=autonomi EVM_NETWORK=local cargo test --package=autonomi --features=local -- --nocapture
 ```
 
 ### Using a live testnet or mainnet

--- a/autonomi/tests/wallet.rs
+++ b/autonomi/tests/wallet.rs
@@ -2,13 +2,15 @@ mod common;
 
 use const_hex::traits::FromHex;
 use evmlib::common::{Address, Amount};
+use evmlib::utils::evm_network_from_env;
 use evmlib::wallet::Wallet;
-use test_utils::evm::{evm_network_from_env, get_funded_wallet};
+use test_utils::evm::get_funded_wallet;
 
 #[tokio::test]
 async fn from_private_key() {
     let private_key = "0xdb1049e76a813c94be0df47ec3e20533ca676b1b9fef2ddbce9daa117e4da4aa";
-    let network = evm_network_from_env();
+    let network =
+        evm_network_from_env().expect("Could not get EVM network from environment variables");
     let wallet = Wallet::new_from_private_key(network, private_key).unwrap();
 
     assert_eq!(
@@ -19,7 +21,8 @@ async fn from_private_key() {
 
 #[tokio::test]
 async fn send_tokens() {
-    let network = evm_network_from_env();
+    let network =
+        evm_network_from_env().expect("Could not get EVM network from environment variables");
     let wallet = get_funded_wallet();
 
     let receiving_wallet = Wallet::new_with_random_wallet(network);

--- a/evm_testnet/Cargo.toml
+++ b/evm_testnet/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.1.0"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib" }
 tokio = { version = "1.40", features = ["rt-multi-thread", "signal"] }
 

--- a/evm_testnet/src/main.rs
+++ b/evm_testnet/src/main.rs
@@ -39,9 +39,12 @@ async fn start_node(genesis_wallet: Option<Address>) {
         transfer_funds(&testnet, genesis).await;
     }
 
-    print_testnet_details(&testnet, genesis_wallet).await;
+    let testnet_data = TestnetData::new(&testnet, genesis_wallet).await;
+    testnet_data.save_csv();
+    testnet_data.print();
     keep_alive(testnet).await;
 
+    TestnetData::remove_csv();
     println!("Ethereum node stopped.");
 }
 
@@ -71,35 +74,83 @@ async fn transfer_funds(testnet: &Testnet, genesis_wallet: Address) {
         .await;
 }
 
-async fn print_testnet_details(testnet: &Testnet, genesis_wallet: Option<Address>) {
-    let network = testnet.to_network();
-
-    println!("RPC URL: {}", network.rpc_url());
-    println!("Payment token address: {}", network.payment_token_address());
-    println!(
-        "Chunk payments address: {}",
-        network.chunk_payments_address()
-    );
-    println!(
-        "Deployer wallet private key: {}",
-        testnet.default_wallet_private_key()
-    );
-
-    if let Some(genesis) = genesis_wallet {
-        let tokens = balance_of_tokens(genesis, &network)
-            .await
-            .unwrap_or(Amount::MIN);
-
-        let gas = balance_of_gas_tokens(genesis, &network)
-            .await
-            .unwrap_or(Amount::MIN);
-
-        println!("Genesis wallet balance (atto): (tokens: {tokens}, gas: {gas})");
-    }
-}
-
 async fn keep_alive<T>(variable: T) {
     let _ = tokio::signal::ctrl_c().await;
     println!("Received Ctrl-C, stopping...");
     drop(variable);
+}
+
+#[derive(Debug)]
+struct TestnetData {
+    rpc_url: String,
+    payment_token_address: String,
+    chunk_payments_address: String,
+    deployer_wallet_private_key: String,
+    tokens_and_gas: Option<(Amount, Amount)>,
+}
+
+impl TestnetData {
+    async fn new(testnet: &Testnet, genesis_wallet: Option<Address>) -> Self {
+        let network = testnet.to_network();
+
+        let tokens_and_gas = if let Some(genesis) = genesis_wallet {
+            let tokens = balance_of_tokens(genesis, &network)
+                .await
+                .unwrap_or(Amount::MIN);
+
+            let gas = balance_of_gas_tokens(genesis, &network)
+                .await
+                .unwrap_or(Amount::MIN);
+            Some((tokens, gas))
+        } else {
+            None
+        };
+        Self {
+            rpc_url: network.rpc_url().to_string(),
+            payment_token_address: network.payment_token_address().to_string(),
+            chunk_payments_address: network.chunk_payments_address().to_string(),
+            deployer_wallet_private_key: testnet.default_wallet_private_key(),
+            tokens_and_gas,
+        }
+    }
+
+    fn print(&self) {
+        println!("RPC URL: {}", self.rpc_url);
+        println!("Payment token address: {}", self.payment_token_address);
+        println!("Chunk payments address: {}", self.chunk_payments_address);
+        println!(
+            "Deployer wallet private key: {}",
+            self.deployer_wallet_private_key
+        );
+        if let Some((tokens, gas)) = self.tokens_and_gas {
+            println!("Genesis wallet balance (atto): (tokens: {tokens}, gas: {gas})");
+        }
+    }
+
+    fn save_csv(&self) {
+        let path = dirs_next::data_dir()
+            .expect("Could not get data_dir to save evm testnet data")
+            .join("safe");
+        if !path.exists() {
+            std::fs::create_dir_all(&path).expect("Could not create safe directory");
+        }
+        let path = path.join("evm_testnet_data.csv");
+
+        let csv = format!(
+            "{},{},{}",
+            self.rpc_url, self.payment_token_address, self.chunk_payments_address
+        );
+        std::fs::write(&path, csv).expect("Could not write to evm_testnet_data.csv file");
+        println!("EVM testnet data saved to: {path:?}");
+    }
+
+    fn remove_csv() {
+        let path = dirs_next::data_dir()
+            .expect("Could not get data_dir to remove evm testnet data")
+            .join("safe")
+            .join("evm_testnet_data.csv");
+        if path.exists() {
+            std::fs::remove_file(&path).expect("Could not remove evm_testnet_data.csv file");
+        }
+    }
 }

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -10,8 +10,10 @@ version = "0.1.0"
 
 [dependencies]
 alloy = { version = "0.4.2", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
+dirs-next = "~2.0.0"
 serde = "1.0"
 thiserror = "1.0"
+tracing = { version = "~0.1.26" }
 tokio = "1.38.0"
 rand = "0.8.5"
 

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -5,6 +5,9 @@ use alloy::transports::http::reqwest;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+#[macro_use]
+extern crate tracing;
+
 pub mod common;
 pub mod contract;
 pub mod cryptography;

--- a/evmlib/src/testnet.rs
+++ b/evmlib/src/testnet.rs
@@ -60,6 +60,7 @@ pub fn start_node() -> AnvilInstance {
     // Spin up a local Anvil node.
     // Requires you to have Foundry installed: https://book.getfoundry.sh/getting-started/installation
     Anvil::new()
+        .port(4343_u16)
         .try_spawn()
         .expect("Could not spawn Anvil node")
 }

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -1,8 +1,16 @@
 use crate::common::{Address, Hash};
 use crate::{CustomNetwork, Network};
+use dirs_next::data_dir;
 use rand::Rng;
 use std::env;
-use std::env::VarError;
+
+pub const EVM_TESTNET_CSV_FILENAME: &str = "evm_testnet_data.csv";
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to get EVM network")]
+    FailedToGetEvmNetwork,
+}
 
 /// Generate a random Address.
 pub fn dummy_address() -> Address {
@@ -15,17 +23,59 @@ pub fn dummy_hash() -> Hash {
 }
 
 /// Get the `Network` from environment variables
-pub fn evm_network_from_env() -> Result<Network, VarError> {
-    const EVM_VARS: [&str; 3] = ["RPC_URL", "PAYMENT_TOKEN_ADDRESS", "CHUNK_PAYMENTS_ADDRESS"];
-    let custom_vars_exist = EVM_VARS.iter().all(|var| env::var(var).is_ok());
+pub fn evm_network_from_env() -> Result<Network, Error> {
+    let evm_vars = ["RPC_URL", "PAYMENT_TOKEN_ADDRESS", "CHUNK_PAYMENTS_ADDRESS"]
+        .iter()
+        .map(|var| env::var(var).map_err(|_| Error::FailedToGetEvmNetwork))
+        .collect::<Result<Vec<String>, Error>>();
 
-    if custom_vars_exist {
+    let use_local_evm = std::env::var("EVM_NETWORK")
+        .map(|v| v == "local")
+        .unwrap_or(false);
+    let use_arbitrum_one = std::env::var("EVM_NETWORK")
+        .map(|v| v == "arbitrum-one")
+        .unwrap_or(false);
+
+    if use_arbitrum_one {
+        Ok(Network::ArbitrumOne)
+    } else if use_local_evm {
+        local_evm_network_from_csv()
+    } else if let Ok(evm_vars) = evm_vars {
         Ok(Network::Custom(CustomNetwork::new(
-            &env::var(EVM_VARS[0])?,
-            &env::var(EVM_VARS[1])?,
-            &env::var(EVM_VARS[2])?,
+            &evm_vars[0],
+            &evm_vars[1],
+            &evm_vars[2],
         )))
     } else {
         Ok(Network::ArbitrumOne)
+    }
+}
+
+/// Get the `Network::Custom` from the local EVM testnet CSV file
+pub fn local_evm_network_from_csv() -> Result<Network, Error> {
+    // load the csv
+    let csv_path = data_dir()
+        .ok_or(Error::FailedToGetEvmNetwork)
+        .inspect_err(|_| error!("Failed to get data dir when fetching evm testnet CSV file"))?
+        .join("safe")
+        .join(EVM_TESTNET_CSV_FILENAME);
+
+    if !csv_path.exists() {
+        error!("evm data csv path does not exist {:?}", csv_path);
+        return Err(Error::FailedToGetEvmNetwork);
+    }
+
+    let csv = std::fs::read_to_string(&csv_path)
+        .map_err(|_| Error::FailedToGetEvmNetwork)
+        .inspect_err(|_| error!("Failed to read evm testnet CSV file"))?;
+    let parts: Vec<&str> = csv.split(',').collect();
+    match parts.as_slice() {
+        [rpc_url, payment_token_address, chunk_payments_address] => Ok(Network::Custom(
+            CustomNetwork::new(rpc_url, payment_token_address, chunk_payments_address),
+        )),
+        _ => {
+            error!("Invalid data in evm testnet CSV file");
+            Err(Error::FailedToGetEvmNetwork)
+        }
     }
 }

--- a/sn_logging/src/layers.rs
+++ b/sn_logging/src/layers.rs
@@ -266,6 +266,8 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
         if contains_keyword_all_sn_logs || contains_keyword_verbose_sn_logs {
             let mut t = BTreeMap::from_iter(vec![
                 // bins
+                ("autonomi_cli".to_string(), Level::TRACE),
+                ("evm_testnet".to_string(), Level::TRACE),
                 ("faucet".to_string(), Level::TRACE),
                 ("safenode".to_string(), Level::TRACE),
                 ("safenode_rpc_client".to_string(), Level::TRACE),
@@ -273,8 +275,10 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
                 ("safenode_manager".to_string(), Level::TRACE),
                 ("safenodemand".to_string(), Level::TRACE),
                 // libs
-                ("sn_build_info".to_string(), Level::TRACE),
                 ("autonomi".to_string(), Level::TRACE),
+                ("evmlib".to_string(), Level::TRACE),
+                ("sn_evm".to_string(), Level::TRACE),
+                ("sn_build_info".to_string(), Level::TRACE),
                 ("sn_client".to_string(), Level::TRACE),
                 ("sn_faucet".to_string(), Level::TRACE),
                 ("sn_logging".to_string(), Level::TRACE),

--- a/sn_node/tests/common/client.rs
+++ b/sn_node/tests/common/client.rs
@@ -11,9 +11,9 @@ use eyre::Result;
 use sn_peers_acquisition::parse_peer_addr;
 use sn_protocol::safenode_proto::{NodeInfoRequest, RestartRequest};
 use sn_service_management::{get_local_node_registry_path, NodeRegistry};
-use std::env;
 use std::{net::SocketAddr, path::Path};
-use test_utils::{evm::evm_network_from_env, testnet::DeploymentInventory};
+use test_utils::evm::get_funded_wallet;
+use test_utils::testnet::DeploymentInventory;
 use tokio::sync::Mutex;
 use tonic::Request;
 use tracing::{debug, info};
@@ -147,16 +147,7 @@ impl LocalNetwork {
     }
 
     fn get_funded_wallet() -> evmlib::wallet::Wallet {
-        let network = evm_network_from_env();
-        // Default deployer wallet of the testnet.
-        const DEFAULT_WALLET_PRIVATE_KEY: &str =
-            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-
-        let private_key =
-            env::var("EVM_PRIVATE_KEY").unwrap_or(DEFAULT_WALLET_PRIVATE_KEY.to_string());
-
-        evmlib::wallet::Wallet::new_from_private_key(network, &private_key)
-            .expect("Invalid private key")
+        get_funded_wallet()
     }
 
     // Restart a local node by sending in the SafenodeRpcCmd::Restart to the node's RPC endpoint.

--- a/sn_node_manager/src/bin/cli/main.rs
+++ b/sn_node_manager/src/bin/cli/main.rs
@@ -1223,6 +1223,11 @@ async fn main() -> Result<()> {
                 evm_network,
                 skip_validation: _,
             } => {
+                let evm_network = if let Some(evm_network) = evm_network {
+                    Some(evm_network.try_into()?)
+                } else {
+                    None
+                };
                 cmd::local::join(
                     build,
                     count,
@@ -1240,7 +1245,7 @@ async fn main() -> Result<()> {
                     peers,
                     rpc_port,
                     rewards_address,
-                    evm_network.map(|v| v.into()),
+                    evm_network,
                     true,
                     verbosity,
                 )
@@ -1267,6 +1272,11 @@ async fn main() -> Result<()> {
                 evm_network,
                 skip_validation: _,
             } => {
+                let evm_network = if let Some(evm_network) = evm_network {
+                    Some(evm_network.try_into()?)
+                } else {
+                    None
+                };
                 cmd::local::run(
                     build,
                     clean,
@@ -1284,7 +1294,7 @@ async fn main() -> Result<()> {
                     owner_prefix,
                     rpc_port,
                     rewards_address,
-                    evm_network.map(|v| v.into()),
+                    evm_network,
                     true,
                     verbosity,
                 )
@@ -1368,6 +1378,8 @@ async fn main() -> Result<()> {
 
 fn get_log_builder(level: Level) -> Result<LogBuilder> {
     let logging_targets = vec![
+        ("evmlib".to_string(), level),
+        ("evm_testnet".to_string(), level),
         ("sn_peers_acquisition".to_string(), level),
         ("sn_node_manager".to_string(), level),
         ("safenode_manager".to_string(), level),

--- a/sn_node_manager/src/bin/cli/subcommands/evm_network.rs
+++ b/sn_node_manager/src/bin/cli/subcommands/evm_network.rs
@@ -1,7 +1,17 @@
+// Copyright (C) 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
 use clap::Subcommand;
-use sn_evm::{EvmNetwork, EvmNetworkCustom};
+use color_eyre::eyre::Result;
+use sn_evm::{utils::local_evm_network_from_csv, EvmNetwork, EvmNetworkCustom};
 
 #[derive(Subcommand, Clone, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum EvmNetworkCommand {
     /// Use the Arbitrum One network
     EvmArbitrumOne,
@@ -20,22 +30,30 @@ pub enum EvmNetworkCommand {
         #[arg(long, short)]
         chunk_payments_address: String,
     },
+
+    /// Use the local EVM testnet, loaded from a CSV file.
+    EvmLocal,
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<EvmNetwork> for EvmNetworkCommand {
-    fn into(self) -> EvmNetwork {
+impl TryInto<EvmNetwork> for EvmNetworkCommand {
+    type Error = color_eyre::eyre::Error;
+
+    fn try_into(self) -> Result<EvmNetwork> {
         match self {
-            Self::EvmArbitrumOne => EvmNetwork::ArbitrumOne,
+            Self::EvmArbitrumOne => Ok(EvmNetwork::ArbitrumOne),
+            Self::EvmLocal => {
+                let network = local_evm_network_from_csv()?;
+                Ok(network)
+            }
             Self::EvmCustom {
                 rpc_url,
                 payment_token_address,
                 chunk_payments_address,
-            } => EvmNetwork::Custom(EvmNetworkCustom::new(
+            } => Ok(EvmNetwork::Custom(EvmNetworkCustom::new(
                 &rpc_url,
                 &payment_token_address,
                 &chunk_payments_address,
-            )),
+            ))),
         }
     }
 }

--- a/sn_node_manager/src/bin/cli/subcommands/mod.rs
+++ b/sn_node_manager/src/bin/cli/subcommands/mod.rs
@@ -1,1 +1,9 @@
+// Copyright (C) 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
 pub mod evm_network;

--- a/sn_node_manager/src/local.rs
+++ b/sn_node_manager/src/local.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::add_services::config::PortRange;
+#[cfg(feature = "faucet")]
+use crate::helpers::get_username;
 use crate::helpers::{
     check_port_availability, get_bin_version, get_start_port_if_applicable, increment_port_option,
 };
@@ -16,19 +18,15 @@ use colored::Colorize;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 #[cfg(test)]
 use mockall::automock;
-
 use sn_evm::{EvmNetwork, RewardsAddress};
 use sn_logging::LogFormat;
+#[cfg(feature = "faucet")]
+use sn_service_management::FaucetServiceData;
 use sn_service_management::{
     control::ServiceControl,
     rpc::{RpcActions, RpcClient},
     NodeRegistry, NodeServiceData, ServiceStatus,
 };
-
-#[cfg(feature = "faucet")]
-use crate::helpers::get_username;
-#[cfg(feature = "faucet")]
-use sn_service_management::FaucetServiceData;
 #[cfg(feature = "faucet")]
 use sn_transfers::get_faucet_data_dir;
 

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -11,9 +11,7 @@ version = "0.4.6"
 
 
 [dependencies]
-autonomi = { path ="../autonomi", version = "0.1" }
 color-eyre = "~0.6.2"
-const-hex = "1.12.0"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.1" }
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }

--- a/test_utils/src/evm.rs
+++ b/test_utils/src/evm.rs
@@ -6,45 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use const_hex::ToHexExt;
-use evmlib::CustomNetwork;
+use evmlib::utils::evm_network_from_env;
 use std::env;
 
-fn get_var_or_panic(var: &str) -> String {
-    env::var(var).unwrap_or_else(|_| panic!("{var} environment variable needs to be set"))
-}
-
-pub fn evm_network_from_env() -> evmlib::Network {
-    let evm_network = env::var("EVM_NETWORK").ok();
-    let arbitrum_flag = evm_network.as_deref() == Some("arbitrum-one");
-
-    let (rpc_url, payment_token_address, chunk_payments_address) = if arbitrum_flag {
-        (
-            evmlib::Network::ArbitrumOne.rpc_url().to_string(),
-            evmlib::Network::ArbitrumOne
-                .payment_token_address()
-                .encode_hex_with_prefix(),
-            evmlib::Network::ArbitrumOne
-                .chunk_payments_address()
-                .encode_hex_with_prefix(),
-        )
-    } else {
-        (
-            get_var_or_panic("RPC_URL"),
-            get_var_or_panic("PAYMENT_TOKEN_ADDRESS"),
-            get_var_or_panic("CHUNK_PAYMENTS_ADDRESS"),
-        )
-    };
-
-    evmlib::Network::Custom(CustomNetwork::new(
-        &rpc_url,
-        &payment_token_address,
-        &chunk_payments_address,
-    ))
-}
-
 pub fn get_funded_wallet() -> evmlib::wallet::Wallet {
-    let network = evm_network_from_env();
+    let network =
+        evm_network_from_env().expect("Failed to get EVM network from environment variables");
     // Default deployer wallet of the testnet.
     const DEFAULT_WALLET_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";


### PR DESCRIPTION
- Write local evm node details to a CSV 
- This would allow us to get the details from other applications without parsing/hardcoding the values (e.g,. the GH action to run local networks)
- Use `EVM_NETWROK=local` to get the values from the CSV
- `safenode-manager` now supports `evm-local` flag to read from CSV