### PR TITLE
fix(launchpad): storing Discord lowercase username

### DIFF
--- a/node-launchpad/src/components/popup/beta_programme.rs
+++ b/node-launchpad/src/components/popup/beta_programme.rs
@@ -58,14 +58,15 @@ impl BetaProgramme {
     fn capture_inputs(&mut self, key: KeyEvent) -> Vec<Action> {
         let send_back = match key.code {
             KeyCode::Enter => {
-                let username = self.discord_input_filed.value().to_string();
+                let username = self.discord_input_filed.value().to_string().to_lowercase();
+                self.discord_input_filed = username.clone().into();
 
                 debug!(
                     "Got Enter, saving the discord username {username:?}  and switching to DiscordIdAlreadySet, and Home Scene",
                 );
                 self.state = BetaProgrammeState::DiscordIdAlreadySet;
                 vec![
-                    Action::StoreDiscordUserName(self.discord_input_filed.value().to_string()),
+                    Action::StoreDiscordUserName(username.clone()),
                     Action::OptionsActions(OptionsActions::UpdateBetaProgrammeUsername(username)),
                     Action::SwitchScene(Scene::Status),
                 ]

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -299,7 +299,7 @@ impl Component for Status {
                     self.lock_registry = Some(LockRegistryState::ResettingNodes);
                     info!("Resetting safenode services because the Discord Username was reset.");
                     let action_sender = self.get_actions_sender()?;
-                    reset_nodes(action_sender, true);
+                    reset_nodes(action_sender, false);
                 }
             }
             Action::StoreStorageDrive(ref drive_mountpoint, ref _drive_name) => {


### PR DESCRIPTION
### Description

We handle lowercase usernames for Discord, so the users get their nanos correctly reported.

We also don't start nodes after we change the username. We just reset.