### PR TITLE
fix(node_manager): lowercase owner for discord

### DIFF
--- a/sn_node_manager/src/add_services/mod.rs
+++ b/sn_node_manager/src/add_services/mod.rs
@@ -79,7 +79,12 @@ pub async fn add_node(
     }
 
     let owner = match &options.owner {
-        Some(owner) => Some(owner.to_lowercase()),
+        Some(owner) => {
+            if owner.chars().any(|c| c.is_uppercase()) {
+                warn!("Owner name ({owner}) contains uppercase characters and will be converted to lowercase");
+            }
+            Some(owner.to_lowercase())
+        }
         None => None,
     };
 

--- a/sn_node_manager/src/add_services/mod.rs
+++ b/sn_node_manager/src/add_services/mod.rs
@@ -78,6 +78,11 @@ pub async fn add_node(
         check_port_availability(port_option, &node_registry.nodes)?;
     }
 
+    let owner = match &options.owner {
+        Some(owner) => Some(owner.to_lowercase()),
+        None => None,
+    };
+
     let safenode_file_name = options
         .safenode_src_path
         .file_name()
@@ -221,7 +226,7 @@ pub async fn add_node(
             name: service_name.clone(),
             node_ip: options.node_ip,
             node_port,
-            owner: options.owner.clone(),
+            owner: owner.clone(),
             rpc_socket_addr,
             safenode_path: service_safenode_path.clone(),
             service_user: options.user.clone(),
@@ -256,7 +261,7 @@ pub async fn add_node(
                     number: node_number,
                     reward_balance: None,
                     rpc_socket_addr,
-                    owner: options.owner.clone(),
+                    owner: owner.clone(),
                     peer_id: None,
                     pid: None,
                     safenode_path: service_safenode_path,

--- a/sn_node_manager/src/add_services/tests.rs
+++ b/sn_node_manager/src/add_services/tests.rs
@@ -4066,7 +4066,7 @@ async fn add_node_should_add_the_node_with_upnp_enabled() -> Result<()> {
 }
 
 #[tokio::test]
-async fn add_node_should_assign_an_owner() -> Result<()> {
+async fn add_node_should_assign_an_owner_in_lowercase() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
@@ -4155,7 +4155,7 @@ async fn add_node_should_assign_an_owner() -> Result<()> {
             local: false,
             log_format: None,
             metrics_port: None,
-            owner: Some("discord_username".to_string()),
+            owner: Some("Discord_Username".to_string()),
             node_ip: None,
             node_port: None,
             rpc_address: None,


### PR DESCRIPTION
### Description

We use owner in lowercase to be able to compute scores accordingly on Discord.

Related https://github.com/maidsafe/dags-service/pull/7
Related https://github.com/maidsafe/safe_network/pull/2180