### PR TITLE
fix(test): use separate wallets to prevent payment failures

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -556,135 +556,134 @@ jobs:
   #         log_file_prefix: safe_test_logs_token_distribution
   #         platform: ${{ matrix.os }}
 
-  # churn:
-  #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-  #   name: Network churning tests
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - os: ubuntu-latest
-  #           node_data_path: /home/runner/.local/share/safe/node
-  #           safe_path: /home/runner/.local/share/safe
-  #         - os: windows-latest
-  #           node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
-  #           safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
-  #         - os: macos-latest
-  #           node_data_path: /Users/runner/Library/Application Support/safe/node
-  #           safe_path: /Users/runner/Library/Application Support/safe
-  #   steps:
-  #     - uses: actions/checkout@v4
+  churn:
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    name: Network churning tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node_data_path: /home/runner/.local/share/safe/node
+            safe_path: /home/runner/.local/share/safe
+          - os: windows-latest
+            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe\\node
+            safe_path: C:\\Users\\runneradmin\\AppData\\Roaming\\safe
+          - os: macos-latest
+            node_data_path: /Users/runner/Library/Application Support/safe/node
+            safe_path: /Users/runner/Library/Application Support/safe
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
 
-  #     - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
-  #     - name: Build binaries
-  #       run: cargo build --release --features local --bin safenode
-  #       timeout-minutes: 30
+      - name: Build binaries
+        run: cargo build --release --features local --bin safenode
+        timeout-minutes: 30
 
-  #     - name: Build faucet binaries
-  #       run: cargo build --release --features="local,gifting" --bin faucet
-  #       timeout-minutes: 30
+      - name: Build churn tests
+        run: cargo test --release -p sn_node --features=local --test data_with_churn --no-run
+        env:
+          # only set the target dir for windows to bypass the linker issue.
+          # happens if we build the node manager via testnet action
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 30
 
-  #     - name: Build churn tests
-  #       run: cargo test --release -p sn_node --features=local --test data_with_churn --no-run
-  #       env:
-  #         # only set the target dir for windows to bypass the linker issue.
-  #         # happens if we build the node manager via testnet action
-  #         CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-  #       timeout-minutes: 30
+      - name: Start a local network
+        uses: maidsafe/sn-local-testnet-action@evm-dev
+        with:
+          action: start
+          enable-evm-testnet: true
+          node-path: target/release/safenode
+          platform: ${{ matrix.os }}
+          build: true
 
-  #     - name: Start a local network
-  #       uses: maidsafe/sn-local-testnet-action@main
-  #       with:
-  #         action: start
-  #         interval: 2000
-  #         node-path: target/release/safenode
-  #         faucet-path: target/release/faucet
-  #         platform: ${{ matrix.os }}
-  #         build: true
+      - name: Check if SAFE_PEERS and EVM_NETWORK are set
+        shell: bash
+        run: |
+          if [[ -z "$SAFE_PEERS" ]]; then
+            echo "The SAFE_PEERS variable has not been set"
+            exit 1
+          elif [[ -z "$EVM_NETWORK" ]]; then
+            echo "The EVM_NETWORK variable has not been set"
+            exit 1
+          else
+            echo "SAFE_PEERS has been set to $SAFE_PEERS"
+            echo "EVM_NETWORK has been set to $EVM_NETWORK"
+          fi
 
-  #     - name: Check SAFE_PEERS was set
-  #       shell: bash
-  #       run: |
-  #         if [[ -z "$SAFE_PEERS" ]]; then
-  #           echo "The SAFE_PEERS variable has not been set"
-  #           exit 1
-  #         else
-  #           echo "SAFE_PEERS has been set to $SAFE_PEERS"
-  #         fi
+      - name: Chunks data integrity during nodes churn
+        run: cargo test --release -p sn_node --features=local --test data_with_churn -- --nocapture
+        env:
+          TEST_DURATION_MINS: 5
+          TEST_TOTAL_CHURN_CYCLES: 15
+          SN_LOG: "all"
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 30
 
-  #     - name: Chunks data integrity during nodes churn
-  #       run: cargo test --release -p sn_node --features="local" --test data_with_churn -- --nocapture
-  #       env:
-  #         TEST_DURATION_MINS: 5
-  #         TEST_TOTAL_CHURN_CYCLES: 15
-  #         SN_LOG: "all"
-  #         CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-  #       timeout-minutes: 30
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/sn-local-testnet-action@evm-dev
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_churn
+          platform: ${{ matrix.os }}
 
-  #     - name: Stop the local network and upload logs
-  #       if: always()
-  #       uses: maidsafe/sn-local-testnet-action@main
-  #       with:
-  #         action: stop
-  #         log_file_prefix: safe_test_logs_churn
-  #         platform: ${{ matrix.os }}
+      - name: Verify restart of nodes using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of restarts
+        # TODO: make this use an env var, or relate to testnet size
+        run: |
+          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Restart $restart_count nodes"
+          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "PeerRemovedFromRoutingTable $peer_removed times"
+          if [ $peer_removed -lt $restart_count ]; then
+            echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
+            exit 1
+          fi
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          echo "Node dir count is $node_count"
 
-  #     - name: Verify restart of nodes using rg
-  #       shell: bash
-  #       timeout-minutes: 1
-  #       # get the counts, then the specific line, and then the digit count only
-  #       # then check we have an expected level of restarts
-  #       # TODO: make this use an env var, or relate to testnet size
-  #       run: |
-  #         restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
-  #           rg "(\d+) matches" | rg "\d+" -o)
-  #         echo "Restart $restart_count nodes"
-  #         peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
-  #           rg "(\d+) matches" | rg "\d+" -o)
-  #         echo "PeerRemovedFromRoutingTable $peer_removed times"
-  #         if [ $peer_removed -lt $restart_count ]; then
-  #           echo "PeerRemovedFromRoutingTable times of: $peer_removed is less than the restart count of: $restart_count"
-  #           exit 1
-  #         fi
-  #         node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-  #         echo "Node dir count is $node_count"
+        # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
+        # if [ $restart_count -lt $node_count ]; then
+        #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
+        #   exit 1
+        # fi
 
-  #       # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
-  #       # if [ $restart_count -lt $node_count ]; then
-  #       #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
-  #       #   exit 1
-  #       # fi
+      - name: Verify data replication using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of replication
+        # TODO: make this use an env var, or relate to testnet size
+        run: |
+          fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Carried out $fetching_attempt_count fetching attempts"
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          if [ $fetching_attempt_count -lt $node_count ]; then
+            echo "Replication fetching attempts of: $fetching_attempt_count is less than the node count of: $node_count"
+            exit 1
+          fi
 
-  #     - name: Verify data replication using rg
-  #       shell: bash
-  #       timeout-minutes: 1
-  #       # get the counts, then the specific line, and then the digit count only
-  #       # then check we have an expected level of replication
-  #       # TODO: make this use an env var, or relate to testnet size
-  #       run: |
-  #         fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
-  #           rg "(\d+) matches" | rg "\d+" -o)
-  #         echo "Carried out $fetching_attempt_count fetching attempts"
-  #         node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-  #         if [ $fetching_attempt_count -lt $node_count ]; then
-  #           echo "Replication fetching attempts of: $fetching_attempt_count is less than the node count of: $node_count"
-  #           exit 1
-  #         fi
-
-  #     # Only error out after uploading the logs
-  #     - name: Don't log raw data
-  #       if: matrix.os != 'windows-latest' # causes error
-  #       shell: bash
-  #       timeout-minutes: 10
-  #       run: |
-  #         if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
-  #         then
-  #           echo "We are logging an extremely large data"
-  #           exit 1
-  #         fi
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.safe_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi
 
   verify_data_location_routing_table:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/evmlib/src/contract/network_token.rs
+++ b/evmlib/src/contract/network_token.rs
@@ -54,6 +54,7 @@ where
 
     /// Get the raw token balance of an address.
     pub async fn balance_of(&self, account: Address) -> Result<U256, Error> {
+        debug!("Getting balance of account: {account:?}");
         let balance = self
             .contract
             .balanceOf(account)
@@ -61,37 +62,48 @@ where
             .await
             .inspect_err(|err| error!("Error getting balance of account: {err:?}"))?
             ._0;
+        debug!("Balance of account: {account} is {balance}");
         Ok(balance)
     }
 
     /// Approve spender to spend a raw amount of tokens.
     pub async fn approve(&self, spender: Address, value: U256) -> Result<TxHash, Error> {
-        let tx_hash = self
-            .contract
-            .approve(spender, value)
-            .send()
-            .await
-            .inspect_err(|err| {
-                error!("Error approving spender to spend raw amt of tokens: {err:?}")
-            })?
-            .watch()
-            .await
-            .inspect_err(|err| error!("Error watching approve tx: {err:?}"))?;
+        debug!("Approving spender to spend raw amt of tokens: {value}");
+        let call = self.contract.approve(spender, value);
+        let pending_tx_builder = call.send().await.inspect_err(|err| {
+            error!(
+                "Error approving spender {spender:?} to spend raw amt of tokens {value}:  {err:?}"
+            )
+        })?;
+
+        let pending_tx_hash = *pending_tx_builder.tx_hash();
+        debug!("The approval from sender {spender:?} is pending with tx_hash: {pending_tx_hash:?}",);
+        let tx_hash = pending_tx_builder.watch().await.inspect_err(|err| {
+            error!("Error watching approve tx with hash {pending_tx_hash:?}:  {err:?}")
+        })?;
+
+        debug!("Approve tx with hash {tx_hash:?} is successful");
 
         Ok(tx_hash)
     }
 
     /// Transfer a raw amount of tokens.
     pub async fn transfer(&self, receiver: Address, amount: U256) -> Result<TxHash, Error> {
-        let tx_hash = self
-            .contract
-            .transfer(receiver, amount)
-            .send()
-            .await
-            .inspect_err(|err| error!("Error transferring raw amt of tokens: {err:?}"))?
-            .watch()
-            .await
-            .inspect_err(|err| error!("Error watching transfer tx: {err:?}"))?;
+        debug!("Transferring raw amt of tokens: {amount} to {receiver:?}");
+        let call = self.contract.transfer(receiver, amount);
+        let pending_tx_builder = call.send().await.inspect_err(|err| {
+            error!("Error transferring raw amt of tokens to {receiver:?}: {err:?}")
+        })?;
+
+        let pending_tx_hash = *pending_tx_builder.tx_hash();
+        debug!(
+            "The transfer to receiver {receiver:?} is pending with tx_hash: {pending_tx_hash:?}"
+        );
+        let tx_hash = pending_tx_builder.watch().await.inspect_err(|err| {
+            error!("Error watching transfer tx with hash {pending_tx_hash:?}: {err:?}")
+        })?;
+
+        debug!("Transfer tx with hash {tx_hash:?} is successful");
 
         Ok(tx_hash)
     }

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -13,6 +13,7 @@ use crate::common::{
     NodeRestart,
 };
 use autonomi::{Client, Wallet};
+use common::client::transfer_to_new_wallet;
 use eyre::{bail, ErrReport, Result};
 use rand::Rng;
 use self_encryption::MAX_CHUNK_SIZE;
@@ -30,6 +31,8 @@ use test_utils::gen_random_data;
 use tokio::{sync::RwLock, task::JoinHandle, time::sleep};
 use tracing::{debug, error, info, trace, warn};
 use xor_name::XorName;
+
+const TOKENS_TO_TRANSFER: usize = 10000000;
 
 const EXTRA_CHURN_COUNT: u32 = 5;
 const CHURN_CYCLES: u32 = 2;
@@ -108,11 +111,11 @@ async fn data_availability_during_churn() -> Result<()> {
         if chunks_only { " (Chunks only)" } else { "" }
     );
 
-    let (client, wallet) = get_client_and_funded_wallet().await;
+    let (client, main_wallet) = get_client_and_funded_wallet().await;
 
     info!(
-        "Client and wallet created. Wallet address: {:?}",
-        wallet.address()
+        "Client and wallet created. Main wallet address: {:?}",
+        main_wallet.address()
     );
 
     // Shared bucket where we keep track of content created/stored on the network
@@ -121,9 +124,10 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to create Registers and CashNotes at random locations,
     // at a higher frequency than the churning events
     let create_register_handle = if !chunks_only {
+        let register_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
         let create_register_handle = create_registers_task(
             client.clone(),
-            wallet.clone(),
+            register_wallet,
             Arc::clone(&content),
             churn_period,
         );
@@ -135,10 +139,11 @@ async fn data_availability_during_churn() -> Result<()> {
     println!("Uploading some chunks before carry out node churning");
     info!("Uploading some chunks before carry out node churning");
 
+    let chunk_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
     // Spawn a task to store Chunks at random locations, at a higher frequency than the churning events
     let store_chunks_handle = store_chunks_task(
         client.clone(),
-        wallet.clone(),
+        chunk_wallet,
         Arc::clone(&content),
         churn_period,
     );

--- a/test_utils/src/evm.rs
+++ b/test_utils/src/evm.rs
@@ -6,10 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use evmlib::{utils::network_from_env, Network};
+use color_eyre::{
+    eyre::{bail, Context},
+    Result,
+};
+use evmlib::{utils::network_from_env, wallet::Wallet, Network};
 use std::env;
 
-pub fn get_funded_wallet() -> evmlib::wallet::Wallet {
+pub fn get_funded_wallet() -> Wallet {
     let network = network_from_env().expect("Failed to get EVM network from environment variables");
     if matches!(network, Network::ArbitrumOne) {
         panic!("You're trying to use ArbitrumOne network. Use a custom network for testing.");
@@ -20,6 +24,15 @@ pub fn get_funded_wallet() -> evmlib::wallet::Wallet {
 
     let private_key = env::var("EVM_PRIVATE_KEY").unwrap_or(DEFAULT_WALLET_PRIVATE_KEY.to_string());
 
-    evmlib::wallet::Wallet::new_from_private_key(network, &private_key)
-        .expect("Invalid private key")
+    Wallet::new_from_private_key(network, &private_key).expect("Invalid private key")
+}
+
+pub fn get_new_wallet() -> Result<Wallet> {
+    let network =
+        network_from_env().wrap_err("Failed to get EVM network from environment variables")?;
+    if matches!(network, Network::ArbitrumOne) {
+        bail!("You're trying to use ArbitrumOne network. Use a custom network for testing.");
+    }
+
+    Ok(Wallet::new_with_random_wallet(network))
 }


### PR DESCRIPTION
- the churn test was failing because we were using the same wallet concurrently. This caused one tx to go out before the other one got confirmed.
