### PR TITLE
feat(node): kill nodes running on host with little spare CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8256,6 +8256,7 @@ dependencies = [
  "sn_service_management",
  "sn_transfers",
  "strum",
+ "sysinfo",
  "tempfile",
  "test_utils",
  "thiserror",

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -60,6 +60,7 @@ sn_registers = { path = "../sn_registers", version = "0.3.21" }
 sn_transfers = { path = "../sn_transfers", version = "0.19.3" }
 sn_service_management = { path = "../sn_service_management", version = "0.3.14" }
 sn_evm = { path = "../sn_evm", version = "0.1" }
+sysinfo = { version = "0.30.8", default-features = false }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = [
     "io-util",


### PR DESCRIPTION
This pull request includes a small change to the `sn_node/Cargo.toml` file. The change adds a new dependency on the `sysinfo` crate with version `0.30.8` and disables the default features.

* [`sn_node/Cargo.toml`](diffhunk://#diff-e255381d82815cad4f0b0eaab942daafe80d19b247510a636789fdaa83310b52R63): Added a new dependency on `sysinfo` with version `0.30.8` and disabled default features.