### PR TITLE
API 3rd party transaction signer integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 name = "autonomi"
 version = "0.1.2"
 dependencies = [
+ "alloy",
  "bip39",
  "blsttc",
  "bytes",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -21,6 +21,7 @@ fs = ["tokio/fs", "data"]
 local = ["sn_networking/local", "test_utils/local", "sn_evm/local"]
 registers = ["data"]
 loud = []
+external-signer = ["sn_evm/external-signer", "data"]
 
 [dependencies]
 bip39 = "2.0.0"
@@ -53,6 +54,7 @@ wasm-bindgen-futures = "0.4.43"
 serde-wasm-bindgen = "0.6.5"
 
 [dev-dependencies]
+alloy = { version = "0.4.2", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
 eyre = "0.6.5"
 sha2 = "0.10.6"
 sn_logging = { path = "../sn_logging", version = "0.2.33" }

--- a/autonomi/src/client/data.rs
+++ b/autonomi/src/client/data.rs
@@ -37,6 +37,8 @@ pub enum PutError {
     VaultXorName,
     #[error("A network error occurred.")]
     Network(#[from] NetworkError),
+    #[error("Error occurred during cost estimation.")]
+    CostError(#[from] CostError),
     #[error("Error occurred during payment.")]
     PayError(#[from] PayError),
     #[error("Failed to serialize {0}")]

--- a/autonomi/src/client/external_signer.rs
+++ b/autonomi/src/client/external_signer.rs
@@ -1,0 +1,97 @@
+use crate::client::data::{DataAddr, PutError};
+use crate::client::utils::extract_quote_payments;
+use crate::self_encryption::encrypt;
+use crate::Client;
+use bytes::Bytes;
+use sn_evm::{ProofOfPayment, QuotePayment};
+use sn_protocol::storage::Chunk;
+use std::collections::HashMap;
+use xor_name::XorName;
+
+#[allow(unused_imports)]
+pub use sn_evm::external_signer::*;
+use sn_networking::PayeeQuote;
+
+impl Client {
+    /// Upload a piece of data to the network. This data will be self-encrypted.
+    /// Payment will not be done automatically as opposed to the regular `data_put`, so the proof of payment has to be provided.
+    /// Returns the Data Address at which the data was stored.
+    pub async fn data_put_with_proof_of_payment(
+        &self,
+        data: Bytes,
+        proof: HashMap<XorName, ProofOfPayment>,
+    ) -> Result<DataAddr, PutError> {
+        let (data_map_chunk, chunks, _) = encrypt_data(data)?;
+        self.upload_data_map(&proof, &data_map_chunk).await?;
+        self.upload_chunks(&chunks, &proof).await?;
+        Ok(*data_map_chunk.address().xorname())
+    }
+
+    /// Get quotes for certain content addresses.
+    /// Returns a cost map, data payments to be executed and a list of free chunks.
+    pub async fn get_quotes_for_content_addrs(
+        &self,
+        content_addrs: impl Iterator<Item = XorName>,
+    ) -> Result<
+        (
+            HashMap<XorName, PayeeQuote>,
+            Vec<QuotePayment>,
+            Vec<XorName>,
+        ),
+        PutError,
+    > {
+        let cost_map = self.get_store_quotes(content_addrs).await?;
+        let (quote_payments, free_chunks) = extract_quote_payments(&cost_map);
+        Ok((cost_map, quote_payments, free_chunks))
+    }
+
+    async fn upload_data_map(
+        &self,
+        payment_proofs: &HashMap<XorName, ProofOfPayment>,
+        data_map_chunk: &Chunk,
+    ) -> Result<(), PutError> {
+        let map_xor_name = data_map_chunk.name();
+
+        if let Some(proof) = payment_proofs.get(map_xor_name) {
+            debug!("Uploading data map chunk: {map_xor_name:?}");
+            self.chunk_upload_with_payment(data_map_chunk.clone(), proof.clone())
+                .await
+                .inspect_err(|err| error!("Error uploading data map chunk: {err:?}"))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn upload_chunks(
+        &self,
+        chunks: &[Chunk],
+        payment_proofs: &HashMap<XorName, ProofOfPayment>,
+    ) -> Result<(), PutError> {
+        debug!("Uploading {} chunks", chunks.len());
+        for chunk in chunks {
+            if let Some(proof) = payment_proofs.get(chunk.name()) {
+                let address = *chunk.address();
+                self.chunk_upload_with_payment(chunk.clone(), proof.clone())
+                    .await
+                    .inspect_err(|err| error!("Error uploading chunk {address:?} :{err:?}"))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn encrypt_data(data: Bytes) -> Result<(Chunk, Vec<Chunk>, Vec<XorName>), PutError> {
+    let now = sn_networking::target_arch::Instant::now();
+    let result = encrypt(data)?;
+
+    debug!("Encryption took: {:.2?}", now.elapsed());
+
+    let map_xor_name = *result.0.address().xorname();
+    let mut xor_names = vec![map_xor_name];
+
+    for chunk in &result.1 {
+        xor_names.push(*chunk.name());
+    }
+
+    Ok((result.0, result.1, xor_names))
+}

--- a/autonomi/src/client/external_signer.rs
+++ b/autonomi/src/client/external_signer.rs
@@ -80,6 +80,9 @@ impl Client {
     }
 }
 
+/// Encrypts data as chunks.
+///
+/// Returns the data map chunk, file chunks and a list of all content addresses including the data map.
 pub fn encrypt_data(data: Bytes) -> Result<(Chunk, Vec<Chunk>, Vec<XorName>), PutError> {
     let now = sn_networking::target_arch::Instant::now();
     let result = encrypt(data)?;

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -12,6 +12,8 @@ pub mod address;
 pub mod archive;
 #[cfg(feature = "data")]
 pub mod data;
+#[cfg(feature = "external-signer")]
+pub mod external_signer;
 #[cfg(feature = "fs")]
 pub mod fs;
 #[cfg(feature = "registers")]

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -229,7 +229,7 @@ async fn fetch_store_quote(
 }
 
 /// Form to be executed payments and already executed payments from a cost map.
-fn extract_quote_payments(
+pub(crate) fn extract_quote_payments(
     cost_map: &HashMap<XorName, PayeeQuote>,
 ) -> (Vec<QuotePayment>, Vec<XorName>) {
     let mut to_be_paid = vec![];

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -6,16 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    num::NonZero,
-};
+use std::{collections::HashMap, num::NonZero};
 
 use bytes::Bytes;
 use libp2p::kad::{Quorum, Record};
 use rand::{thread_rng, Rng};
 use self_encryption::{decrypt_full_set, DataMap, EncryptedChunk};
-use sn_evm::{EvmWallet, ProofOfPayment, QuoteHash, QuotePayment, TxHash};
+use sn_evm::{EvmWallet, ProofOfPayment, QuotePayment};
 use sn_networking::{
     GetRecordCfg, Network, NetworkError, PayeeQuote, PutRecordCfg, VerificationKind,
 };
@@ -26,12 +23,12 @@ use sn_protocol::{
 };
 use xor_name::XorName;
 
-use crate::self_encryption::DataMapLevel;
-
 use super::{
     data::{CostError, GetError, PayError, PutError},
     Client,
 };
+use crate::self_encryption::DataMapLevel;
+use crate::utils::payment_proof_from_quotes_and_payments;
 
 impl Client {
     /// Fetch and decrypt all chunks in the data map.
@@ -163,7 +160,7 @@ impl Client {
             .await
             .map_err(|err| PayError::from(err.0))?;
 
-        let proofs = construct_proofs(&cost_map, &payments);
+        let proofs = payment_proof_from_quotes_and_payments(&cost_map, &payments);
 
         trace!(
             "Chunk payments of {} chunks completed. {} chunks were free / already paid for",
@@ -248,25 +245,4 @@ pub(crate) fn extract_quote_payments(
     }
 
     (to_be_paid, already_paid)
-}
-
-/// Construct payment proofs from cost map and payments map.
-fn construct_proofs(
-    cost_map: &HashMap<XorName, PayeeQuote>,
-    payments: &BTreeMap<QuoteHash, TxHash>,
-) -> HashMap<XorName, ProofOfPayment> {
-    cost_map
-        .iter()
-        .filter_map(|(xor_name, (_, _, quote))| {
-            payments.get(&quote.hash()).map(|tx_hash| {
-                (
-                    *xor_name,
-                    ProofOfPayment {
-                        quote: quote.clone(),
-                        tx_hash: *tx_hash,
-                    },
-                )
-            })
-        })
-        .collect()
 }

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -35,11 +35,14 @@ extern crate tracing;
 pub mod client;
 #[cfg(feature = "data")]
 mod self_encryption;
+mod utils;
 
 pub use sn_evm::get_evm_network_from_env;
 pub use sn_evm::EvmNetwork;
 pub use sn_evm::EvmWallet as Wallet;
 pub use sn_evm::RewardsAddress;
+#[cfg(feature = "external-signer")]
+pub use utils::payment_proof_from_quotes_and_payments;
 
 #[doc(no_inline)] // Place this under 'Re-exports' in the docs.
 pub use bytes::Bytes;

--- a/autonomi/src/utils.rs
+++ b/autonomi/src/utils.rs
@@ -1,0 +1,24 @@
+use sn_evm::{ProofOfPayment, QuoteHash, TxHash};
+use sn_networking::PayeeQuote;
+use std::collections::{BTreeMap, HashMap};
+use xor_name::XorName;
+
+pub fn payment_proof_from_quotes_and_payments(
+    quotes: &HashMap<XorName, PayeeQuote>,
+    payments: &BTreeMap<QuoteHash, TxHash>,
+) -> HashMap<XorName, ProofOfPayment> {
+    quotes
+        .iter()
+        .filter_map(|(xor_name, (_, _, quote))| {
+            payments.get(&quote.hash()).map(|tx_hash| {
+                (
+                    *xor_name,
+                    ProofOfPayment {
+                        quote: quote.clone(),
+                        tx_hash: *tx_hash,
+                    },
+                )
+            })
+        })
+        .collect()
+}

--- a/autonomi/tests/external_signer.rs
+++ b/autonomi/tests/external_signer.rs
@@ -1,0 +1,91 @@
+#![cfg(feature = "external-signer")]
+
+use alloy::network::TransactionBuilder;
+use alloy::providers::Provider;
+use autonomi::Client;
+use sn_evm::{QuoteHash, TxHash};
+use sn_logging::LogBuilder;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use test_utils::evm::get_funded_wallet;
+use test_utils::{gen_random_data, peers_from_env};
+use tokio::time::sleep;
+
+// Example of how put would be done using external signers.
+#[tokio::test]
+async fn external_signer_put() -> eyre::Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("external_signer_put", false);
+
+    let client = Client::connect(&peers_from_env()?).await?;
+    let wallet = get_funded_wallet();
+    let data = gen_random_data(1024 * 1024 * 10);
+
+    let (quotes, quote_payments, _free_chunks) = client.get_quotes_for_data(data.clone()).await?;
+
+    // Form quotes payment transaction data
+    let pay_for_quotes_calldata = autonomi::client::external_signer::pay_for_quotes_calldata(
+        wallet.network(),
+        quote_payments.into_iter(),
+    )?;
+
+    // Init an external wallet provider. In the webapp, this would be MetaMask for example
+    let provider = wallet.to_provider();
+
+    // Form approve to spend tokens transaction data
+    let approve_calldata = autonomi::client::external_signer::approve_to_spend_tokens_calldata(
+        wallet.network(),
+        pay_for_quotes_calldata.approve_spender,
+        pay_for_quotes_calldata.approve_amount,
+    );
+
+    // Prepare approve to spend tokens transaction
+    let transaction_request = provider
+        .transaction_request()
+        .with_to(approve_calldata.1)
+        .with_input(approve_calldata.0);
+
+    // Send approve to spend tokens transaction
+    let _tx_hash = provider
+        .send_transaction(transaction_request)
+        .await?
+        .watch()
+        .await?;
+
+    let mut payments: BTreeMap<QuoteHash, TxHash> = Default::default();
+
+    // Execute all quote payment transactions in batches
+    for (calldata, quote_hashes) in pay_for_quotes_calldata.batched_calldata_map {
+        // Prepare batched quote payments transaction
+        let transaction_request = provider
+            .transaction_request()
+            .with_to(pay_for_quotes_calldata.to)
+            .with_input(calldata);
+
+        // Send batched quote payments transaction
+        let tx_hash = provider
+            .send_transaction(transaction_request)
+            .await?
+            .watch()
+            .await?;
+
+        // Add to payments to be later use to construct the proofs
+        for quote_hash in quote_hashes {
+            payments.insert(quote_hash, tx_hash);
+        }
+    }
+
+    // Payment proofs
+    let proofs = autonomi::payment_proof_from_quotes_and_payments(&quotes, &payments);
+
+    let addr = client
+        .data_put_with_proof_of_payment(data.clone(), proofs)
+        .await?;
+
+    sleep(Duration::from_secs(10)).await;
+
+    let data_fetched = client.data_get(addr).await?;
+    assert_eq!(data, data_fetched, "data fetched should match data put");
+
+    Ok(())
+}

--- a/autonomi/tests/put.rs
+++ b/autonomi/tests/put.rs
@@ -8,17 +8,12 @@
 
 #![cfg(feature = "data")]
 
-use alloy::network::TransactionBuilder;
-use alloy::providers::Provider;
 use autonomi::Client;
 use eyre::Result;
-use sn_evm::{ProofOfPayment, QuoteHash, TxHash};
 use sn_logging::LogBuilder;
-use std::collections::HashMap;
 use std::time::Duration;
 use test_utils::{evm::get_funded_wallet, gen_random_data, peers_from_env};
 use tokio::time::sleep;
-use xor_name::XorName;
 
 #[tokio::test]
 async fn put() -> Result<()> {
@@ -29,104 +24,6 @@ async fn put() -> Result<()> {
     let data = gen_random_data(1024 * 1024 * 10);
 
     let addr = client.data_put(data.clone(), &wallet).await?;
-
-    sleep(Duration::from_secs(10)).await;
-
-    let data_fetched = client.data_get(addr).await?;
-    assert_eq!(data, data_fetched, "data fetched should match data put");
-
-    Ok(())
-}
-
-// Example of how put would be done using external signers.
-#[cfg(feature = "external-signer")]
-#[tokio::test]
-async fn external_signer_put() -> Result<()> {
-    let _log_appender_guard =
-        LogBuilder::init_single_threaded_tokio_test("external_signer_put", false);
-
-    let client = Client::connect(&peers_from_env()?).await?;
-    let wallet = get_funded_wallet();
-    let data = gen_random_data(1024 * 1024 * 10);
-
-    // Encrypt the data as chunks
-    let (_data_map_chunk, _chunks, xor_names) =
-        autonomi::client::external_signer::encrypt_data(data.clone())?;
-
-    let (quotes, quote_payments, _skipped_chunks) = client
-        .get_quotes_for_content_addrs(xor_names.into_iter())
-        .await?;
-
-    // Form quotes payment transaction data
-    let pay_for_quotes_calldata = autonomi::client::external_signer::pay_for_quotes_calldata(
-        wallet.network(),
-        quote_payments.into_iter(),
-    )?;
-
-    let provider = wallet.to_provider();
-
-    // Form approve to spend tokens transaction data
-    let approve_calldata = autonomi::client::external_signer::approve_to_spend_tokens_calldata(
-        wallet.network(),
-        pay_for_quotes_calldata.approve_spender,
-        pay_for_quotes_calldata.approve_amount,
-    );
-
-    // Prepare approve to spend tokens transaction
-    let transaction_request = provider
-        .transaction_request()
-        .with_to(approve_calldata.1)
-        .with_input(approve_calldata.0);
-
-    // Send approve to spend tokens transaction
-    let _tx_hash = provider
-        .send_transaction(transaction_request)
-        .await?
-        .watch()
-        .await?;
-
-    let mut payments: HashMap<QuoteHash, TxHash> = HashMap::new();
-
-    // Execute all quote payment transactions in batches
-    for (calldata, quote_hashes) in pay_for_quotes_calldata.batched_calldata_map {
-        // Prepare batched quote payments transaction
-        let transaction_request = provider
-            .transaction_request()
-            .with_to(pay_for_quotes_calldata.to)
-            .with_input(calldata);
-
-        // Send batched quote payments transaction
-        let tx_hash = provider
-            .send_transaction(transaction_request)
-            .await?
-            .watch()
-            .await?;
-
-        // Add to payments to be later use to construct the proofs
-        for quote_hash in quote_hashes {
-            payments.insert(quote_hash, tx_hash);
-        }
-    }
-
-    // Payment proofs
-    let proofs: HashMap<XorName, ProofOfPayment> = quotes
-        .iter()
-        .filter_map(|(xor_name, (_, _, quote))| {
-            payments.get(&quote.hash()).map(|tx_hash| {
-                (
-                    *xor_name,
-                    ProofOfPayment {
-                        quote: quote.clone(),
-                        tx_hash: *tx_hash,
-                    },
-                )
-            })
-        })
-        .collect();
-
-    let addr = client
-        .data_put_with_proof_of_payment(data.clone(), proofs)
-        .await?;
 
     sleep(Duration::from_secs(10)).await;
 

--- a/autonomi/tests/put.rs
+++ b/autonomi/tests/put.rs
@@ -8,12 +8,17 @@
 
 #![cfg(feature = "data")]
 
+use alloy::network::TransactionBuilder;
+use alloy::providers::Provider;
 use autonomi::Client;
 use eyre::Result;
+use sn_evm::{ProofOfPayment, QuoteHash, TxHash};
 use sn_logging::LogBuilder;
+use std::collections::HashMap;
 use std::time::Duration;
 use test_utils::{evm::get_funded_wallet, gen_random_data, peers_from_env};
 use tokio::time::sleep;
+use xor_name::XorName;
 
 #[tokio::test]
 async fn put() -> Result<()> {
@@ -24,6 +29,104 @@ async fn put() -> Result<()> {
     let data = gen_random_data(1024 * 1024 * 10);
 
     let addr = client.data_put(data.clone(), &wallet).await?;
+
+    sleep(Duration::from_secs(10)).await;
+
+    let data_fetched = client.data_get(addr).await?;
+    assert_eq!(data, data_fetched, "data fetched should match data put");
+
+    Ok(())
+}
+
+// Example of how put would be done using external signers.
+#[cfg(feature = "external-signer")]
+#[tokio::test]
+async fn external_signer_put() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("external_signer_put", false);
+
+    let client = Client::connect(&peers_from_env()?).await?;
+    let wallet = get_funded_wallet();
+    let data = gen_random_data(1024 * 1024 * 10);
+
+    // Encrypt the data as chunks
+    let (_data_map_chunk, _chunks, xor_names) =
+        autonomi::client::external_signer::encrypt_data(data.clone())?;
+
+    let (quotes, quote_payments, _skipped_chunks) = client
+        .get_quotes_for_content_addrs(xor_names.into_iter())
+        .await?;
+
+    // Form quotes payment transaction data
+    let pay_for_quotes_calldata = autonomi::client::external_signer::pay_for_quotes_calldata(
+        wallet.network(),
+        quote_payments.into_iter(),
+    )?;
+
+    let provider = wallet.to_provider();
+
+    // Form approve to spend tokens transaction data
+    let approve_calldata = autonomi::client::external_signer::approve_to_spend_tokens_calldata(
+        wallet.network(),
+        pay_for_quotes_calldata.approve_spender,
+        pay_for_quotes_calldata.approve_amount,
+    );
+
+    // Prepare approve to spend tokens transaction
+    let transaction_request = provider
+        .transaction_request()
+        .with_to(approve_calldata.1)
+        .with_input(approve_calldata.0);
+
+    // Send approve to spend tokens transaction
+    let _tx_hash = provider
+        .send_transaction(transaction_request)
+        .await?
+        .watch()
+        .await?;
+
+    let mut payments: HashMap<QuoteHash, TxHash> = HashMap::new();
+
+    // Execute all quote payment transactions in batches
+    for (calldata, quote_hashes) in pay_for_quotes_calldata.batched_calldata_map {
+        // Prepare batched quote payments transaction
+        let transaction_request = provider
+            .transaction_request()
+            .with_to(pay_for_quotes_calldata.to)
+            .with_input(calldata);
+
+        // Send batched quote payments transaction
+        let tx_hash = provider
+            .send_transaction(transaction_request)
+            .await?
+            .watch()
+            .await?;
+
+        // Add to payments to be later use to construct the proofs
+        for quote_hash in quote_hashes {
+            payments.insert(quote_hash, tx_hash);
+        }
+    }
+
+    // Payment proofs
+    let proofs: HashMap<XorName, ProofOfPayment> = quotes
+        .iter()
+        .filter_map(|(xor_name, (_, _, quote))| {
+            payments.get(&quote.hash()).map(|tx_hash| {
+                (
+                    *xor_name,
+                    ProofOfPayment {
+                        quote: quote.clone(),
+                        tx_hash: *tx_hash,
+                    },
+                )
+            })
+        })
+        .collect();
+
+    let addr = client
+        .data_put_with_proof_of_payment(data.clone(), proofs)
+        .await?;
 
     sleep(Duration::from_secs(10)).await;
 

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 [features]
 wasm-bindgen = ["alloy/wasm-bindgen"]
 local = []
+external_signer = []
 
 [dependencies]
 alloy = { version = "0.4.2", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 [features]
 wasm-bindgen = ["alloy/wasm-bindgen"]
 local = []
-external_signer = []
+external-signer = []
 
 [dependencies]
 alloy = { version = "0.4.2", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }

--- a/evmlib/src/common.rs
+++ b/evmlib/src/common.rs
@@ -16,3 +16,4 @@ pub type QuoteHash = Hash;
 pub type Amount = U256;
 pub type QuotePayment = (QuoteHash, Address, Amount);
 pub type EthereumWallet = alloy::network::EthereumWallet;
+pub type Calldata = alloy::primitives::Bytes;

--- a/evmlib/src/contract/data_payments/mod.rs
+++ b/evmlib/src/contract/data_payments/mod.rs
@@ -9,9 +9,10 @@
 pub mod error;
 
 use crate::common;
-use crate::common::{Address, TxHash};
+use crate::common::{Address, Calldata, TxHash};
 use crate::contract::data_payments::error::Error;
 use crate::contract::data_payments::DataPaymentsContract::DataPaymentsContractInstance;
+use alloy::network::TransactionBuilder;
 use alloy::providers::{Network, Provider};
 use alloy::sol;
 use alloy::transports::Transport;
@@ -64,6 +65,33 @@ where
         &self,
         data_payments: I,
     ) -> Result<TxHash, Error> {
+        let (calldata, to) = self.pay_for_quotes_calldata(data_payments)?;
+
+        let transaction_request = self
+            .contract
+            .provider()
+            .transaction_request()
+            .with_to(to)
+            .with_input(calldata);
+
+        let tx_hash = self
+            .contract
+            .provider()
+            .send_transaction(transaction_request)
+            .await?
+            .watch()
+            .await?;
+
+        Ok(tx_hash)
+    }
+
+    /// Pay for quotes.
+    /// Input: (quote_id, reward_address, amount).
+    /// Returns the transaction calldata.
+    pub fn pay_for_quotes_calldata<I: IntoIterator<Item = common::QuotePayment>>(
+        &self,
+        data_payments: I,
+    ) -> Result<(Calldata, Address), Error> {
         let data_payments: Vec<DataPayments::DataPayment> = data_payments
             .into_iter()
             .map(|(hash, addr, amount)| DataPayments::DataPayment {
@@ -74,26 +102,15 @@ where
             .collect();
 
         if data_payments.len() > MAX_TRANSFERS_PER_TRANSACTION {
-            error!(
-                "Data payments limit exceeded: {} > {}",
-                data_payments.len(),
-                MAX_TRANSFERS_PER_TRANSACTION
-            );
             return Err(Error::TransferLimitExceeded);
         }
 
-        let tx_hash = self
+        let calldata = self
             .contract
             .submitDataPayments(data_payments)
-            .send()
-            .await
-            .inspect_err(|e| error!("Failed to submit data payments during pay_for_quotes: {e:?}"))?
-            .watch()
-            .await
-            .inspect_err(|e| {
-                error!("Failed to watch data payments during pay_for_quotes: {e:?}")
-            })?;
+            .calldata()
+            .to_owned();
 
-        Ok(tx_hash)
+        Ok((calldata, *self.contract.address()))
     }
 }

--- a/evmlib/src/external_signer.rs
+++ b/evmlib/src/external_signer.rs
@@ -18,11 +18,10 @@ use std::collections::HashMap;
 pub enum Error {
     #[error("Network token contract error: {0}")]
     NetworkTokenContract(#[from] network_token::Error),
-    #[error("Chunk payments contract error: {0}")]
-    ChunkPaymentsContract(#[from] data_payments::error::Error),
+    #[error("Data payments contract error: {0}")]
+    DataPaymentsContract(#[from] data_payments::error::Error),
 }
 
-#[allow(dead_code)]
 /// Approve an address / smart contract to spend this wallet's payment tokens.
 ///
 /// Returns the transaction calldata (input, to).
@@ -36,7 +35,6 @@ pub fn approve_to_spend_tokens_calldata(
     network_token.approve_calldata(spender, value)
 }
 
-#[allow(dead_code)]
 /// Transfer payment tokens from the supplied wallet to an address.
 ///
 /// Returns the transaction calldata (input, to).
@@ -50,7 +48,6 @@ pub fn transfer_tokens_calldata(
     network_token.transfer_calldata(receiver, amount)
 }
 
-#[allow(dead_code)]
 pub struct PayForQuotesCalldataReturnType {
     pub batched_calldata_map: HashMap<Calldata, Vec<QuoteHash>>,
     pub to: Address,
@@ -58,7 +55,6 @@ pub struct PayForQuotesCalldataReturnType {
     pub approve_amount: Amount,
 }
 
-#[allow(dead_code)]
 /// Use this wallet to pay for chunks in batched transfer transactions.
 /// If the amount of transfers is more than one transaction can contain, the transfers will be split up over multiple transactions.
 ///

--- a/evmlib/src/external_signer.rs
+++ b/evmlib/src/external_signer.rs
@@ -52,10 +52,10 @@ pub fn transfer_tokens_calldata(
 
 #[allow(dead_code)]
 pub struct PayForQuotesCalldataReturnType {
-    batched_calldata_map: HashMap<Calldata, Vec<QuoteHash>>,
-    to: Address,
-    approve_spender: Address,
-    approve_amount: Amount,
+    pub batched_calldata_map: HashMap<Calldata, Vec<QuoteHash>>,
+    pub to: Address,
+    pub approve_spender: Address,
+    pub approve_amount: Amount,
 }
 
 #[allow(dead_code)]
@@ -71,7 +71,7 @@ pub fn pay_for_quotes_calldata<T: IntoIterator<Item = QuotePayment>>(
 
     let total_amount = payments.iter().map(|(_, _, amount)| amount).sum();
 
-    let approve_spender = *network.data_payments_address();
+    let approve_to = *network.data_payments_address();
     let approve_amount = total_amount;
 
     let provider = http_provider(network.rpc_url().clone());
@@ -92,7 +92,7 @@ pub fn pay_for_quotes_calldata<T: IntoIterator<Item = QuotePayment>>(
     Ok(PayForQuotesCalldataReturnType {
         batched_calldata_map: calldata_map,
         to: *data_payments.contract.address(),
-        approve_spender,
+        approve_spender: approve_to,
         approve_amount,
     })
 }

--- a/evmlib/src/external_signer.rs
+++ b/evmlib/src/external_signer.rs
@@ -1,0 +1,98 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::common::{Address, Amount, Calldata, QuoteHash, QuotePayment, U256};
+use crate::contract::data_payments::{DataPaymentsHandler, MAX_TRANSFERS_PER_TRANSACTION};
+use crate::contract::network_token::NetworkToken;
+use crate::contract::{data_payments, network_token};
+use crate::utils::http_provider;
+use crate::Network;
+use std::collections::HashMap;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Network token contract error: {0}")]
+    NetworkTokenContract(#[from] network_token::Error),
+    #[error("Chunk payments contract error: {0}")]
+    ChunkPaymentsContract(#[from] data_payments::error::Error),
+}
+
+#[allow(dead_code)]
+/// Approve an address / smart contract to spend this wallet's payment tokens.
+///
+/// Returns the transaction calldata (input, to).
+pub fn approve_to_spend_tokens_calldata(
+    network: &Network,
+    spender: Address,
+    value: U256,
+) -> (Calldata, Address) {
+    let provider = http_provider(network.rpc_url().clone());
+    let network_token = NetworkToken::new(*network.payment_token_address(), provider);
+    network_token.approve_calldata(spender, value)
+}
+
+#[allow(dead_code)]
+/// Transfer payment tokens from the supplied wallet to an address.
+///
+/// Returns the transaction calldata (input, to).
+pub fn transfer_tokens_calldata(
+    network: &Network,
+    receiver: Address,
+    amount: U256,
+) -> (Calldata, Address) {
+    let provider = http_provider(network.rpc_url().clone());
+    let network_token = NetworkToken::new(*network.payment_token_address(), provider);
+    network_token.transfer_calldata(receiver, amount)
+}
+
+#[allow(dead_code)]
+pub struct PayForQuotesCalldataReturnType {
+    batched_calldata_map: HashMap<Calldata, Vec<QuoteHash>>,
+    to: Address,
+    approve_spender: Address,
+    approve_amount: Amount,
+}
+
+#[allow(dead_code)]
+/// Use this wallet to pay for chunks in batched transfer transactions.
+/// If the amount of transfers is more than one transaction can contain, the transfers will be split up over multiple transactions.
+///
+/// Returns PayForQuotesCalldataReturnType, containing calldata of the transaction batches along with the approval details for the spender.
+pub fn pay_for_quotes_calldata<T: IntoIterator<Item = QuotePayment>>(
+    network: &Network,
+    payments: T,
+) -> Result<PayForQuotesCalldataReturnType, Error> {
+    let payments: Vec<_> = payments.into_iter().collect();
+
+    let total_amount = payments.iter().map(|(_, _, amount)| amount).sum();
+
+    let approve_spender = *network.data_payments_address();
+    let approve_amount = total_amount;
+
+    let provider = http_provider(network.rpc_url().clone());
+    let data_payments = DataPaymentsHandler::new(*network.data_payments_address(), provider);
+
+    // Divide transfers over multiple transactions if they exceed the max per transaction.
+    let chunks = payments.chunks(MAX_TRANSFERS_PER_TRANSACTION);
+
+    let mut calldata_map: HashMap<Calldata, Vec<QuoteHash>> = HashMap::new();
+
+    for batch in chunks {
+        let quote_payments = batch.to_vec();
+        let (calldata, _) = data_payments.pay_for_quotes_calldata(quote_payments.clone())?;
+        let quote_hashes = quote_payments.into_iter().map(|(qh, _, _)| qh).collect();
+        calldata_map.insert(calldata, quote_hashes);
+    }
+
+    Ok(PayForQuotesCalldataReturnType {
+        batched_calldata_map: calldata_map,
+        to: *data_payments.contract.address(),
+        approve_spender,
+        approve_amount,
+    })
+}

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -22,6 +22,8 @@ pub mod common;
 pub mod contract;
 pub mod cryptography;
 pub(crate) mod event;
+#[cfg(feature = "external_signer")]
+pub mod external_signer;
 pub mod testnet;
 pub mod transaction;
 pub mod utils;

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -22,7 +22,7 @@ pub mod common;
 pub mod contract;
 pub mod cryptography;
 pub(crate) mod event;
-#[cfg(feature = "external_signer")]
+#[cfg(feature = "external-signer")]
 pub mod external_signer;
 pub mod testnet;
 pub mod transaction;

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -10,6 +10,12 @@
 
 use crate::common::{Address, Hash};
 use crate::{CustomNetwork, Network};
+use alloy::network::Ethereum;
+use alloy::providers::fillers::{
+    BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+};
+use alloy::providers::{Identity, ProviderBuilder, ReqwestProvider};
+use alloy::transports::http::{reqwest, Client, Http};
 use dirs_next::data_dir;
 use rand::Rng;
 use std::env;
@@ -142,4 +148,21 @@ fn local_evm_network_from_csv() -> Result<Network, Error> {
             ))
         }
     }
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn http_provider(
+    rpc_url: reqwest::Url,
+) -> FillProvider<
+    JoinFill<
+        Identity,
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+    >,
+    ReqwestProvider,
+    Http<Client>,
+    Ethereum,
+> {
+    ProviderBuilder::new()
+        .with_recommended_fillers()
+        .on_http(rpc_url)
 }

--- a/evmlib/src/wallet.rs
+++ b/evmlib/src/wallet.rs
@@ -10,6 +10,7 @@ use crate::common::{Address, QuoteHash, QuotePayment, TxHash, U256};
 use crate::contract::data_payments::{DataPaymentsHandler, MAX_TRANSFERS_PER_TRANSACTION};
 use crate::contract::network_token::NetworkToken;
 use crate::contract::{data_payments, network_token};
+use crate::utils::http_provider;
 use crate::Network;
 use alloy::network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
 use alloy::providers::fillers::{
@@ -129,23 +130,6 @@ fn from_private_key(private_key: &str) -> Result<EthereumWallet, Error> {
 }
 
 // TODO(optimization): Find a way to reuse/persist contracts and/or a provider without the wallet nonce going out of sync
-
-#[allow(clippy::type_complexity)]
-fn http_provider(
-    rpc_url: reqwest::Url,
-) -> FillProvider<
-    JoinFill<
-        Identity,
-        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-    >,
-    ReqwestProvider,
-    Http<Client>,
-    Ethereum,
-> {
-    ProviderBuilder::new()
-        .with_recommended_fillers()
-        .on_http(rpc_url)
-}
 
 #[allow(clippy::type_complexity)]
 fn http_provider_with_wallet(

--- a/sn_evm/Cargo.toml
+++ b/sn_evm/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 [features]
 test-utils = []
 local = ["evmlib/local"]
+external-signer = ["evmlib/external-signer"]
 
 [dependencies]
 custom_debug = "~0.6.1"

--- a/sn_evm/src/lib.rs
+++ b/sn_evm/src/lib.rs
@@ -12,6 +12,8 @@ extern crate tracing;
 pub use evmlib::common::Address as RewardsAddress;
 pub use evmlib::common::QuotePayment;
 pub use evmlib::common::{QuoteHash, TxHash};
+#[cfg(feature = "external-signer")]
+pub use evmlib::external_signer;
 pub use evmlib::utils;
 pub use evmlib::utils::get_evm_network_from_env;
 pub use evmlib::utils::{DATA_PAYMENTS_ADDRESS, PAYMENT_TOKEN_ADDRESS, RPC_URL};


### PR DESCRIPTION
The goal of this PR is to allow 3rd party wallet apps to sign (and send) transactions that would otherwise be automatically signed and send within the API with the private key of a wallet.

3rd party wallet apps do not expose the private key of a wallet, so we can't pass that to the API. Alternative API endpoints have to be provided that allow us to skip automatic data payments and submit proof of payments directly instead.

The transaction input data will still be formed in the API however, to make the signing and sending of transactions from the 3rd party wallet side as easy as possible.