### PR TITLE
feat(node): using different storage dir for different network

### DIFF
--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -52,8 +52,8 @@ use sn_protocol::{
     messages::{ChunkProof, Nonce, Request, Response},
     storage::{try_deserialize_record, RetryStrategy},
     version::{
-        IDENTIFY_CLIENT_VERSION_STR, IDENTIFY_NODE_VERSION_STR, IDENTIFY_PROTOCOL_STR,
-        REQ_RESPONSE_VERSION_STR,
+        get_key_version_str, IDENTIFY_CLIENT_VERSION_STR, IDENTIFY_NODE_VERSION_STR,
+        IDENTIFY_PROTOCOL_STR, REQ_RESPONSE_VERSION_STR,
     },
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
 };
@@ -364,7 +364,8 @@ impl NetworkBuilder {
 
         let store_cfg = {
             // Configures the disk_store to store records under the provided path and increase the max record size
-            let storage_dir_path = root_dir.join("record_store");
+            // The storage dir is appendixed with key_version str to avoid bringing records from old network into new
+            let storage_dir_path = root_dir.join(format!("record_store_{}", get_key_version_str()));
             if let Err(error) = std::fs::create_dir_all(&storage_dir_path) {
                 return Err(NetworkError::FailedToCreateRecordStoreDir {
                     path: storage_dir_path,

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -58,7 +58,7 @@ fn get_truncate_version_str() -> String {
 /// Get the PKs version string.
 /// If the public key mis-configed via env variable,
 /// it shall result in being rejected to join by the network
-fn get_key_version_str() -> String {
+pub fn get_key_version_str() -> String {
     let mut f_k_str = FOUNDATION_PK.to_hex();
     let _ = f_k_str.split_off(6);
     let mut g_k_str = GENESIS_PK.to_hex();


### PR DESCRIPTION
### Description

storage dir using network key_version as appendix to avoid bring record from old network into new one.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
