### PR TITLE
refactor(autonomi): change error to debug log

### DIFF
--- a/autonomi/src/client/vault.rs
+++ b/autonomi/src/client/vault.rs
@@ -70,7 +70,7 @@ impl Client {
             .get_record_from_network(scratch_key, &get_cfg)
             .await
             .inspect_err(|err| {
-                error!("Failed to fetch vault {network_address:?} from network: {err}");
+                debug!("Failed to fetch vault {network_address:?} from network: {err}");
             })?;
 
         let pad = try_deserialize_record::<Scratchpad>(&record)


### PR DESCRIPTION
When we fetch the vault for the first time, it won't exist so an error
is expected in this case. I've observed that the logs will print this as
an error, but it's expected behavior.
