### PR TITLE
feat: user data stored in vault

### DIFF
--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/maidsafe/safe_network"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["data"]
+default = ["data", "vault"]
 full = ["data", "registers", "vault"]
 data = []
-vault = ["data"]
+vault = ["data", "registers"]
 fs = ["tokio/fs", "data"]
 local = ["sn_networking/local", "test_utils/local", "sn_evm/local"]
 registers = ["data"]

--- a/autonomi/src/client/data.rs
+++ b/autonomi/src/client/data.rs
@@ -39,7 +39,7 @@ pub enum PutError {
     Network(#[from] NetworkError),
     #[error("Error occurred during payment.")]
     PayError(#[from] PayError),
-    #[error("Failed to serialize {0}")]
+    #[error("Serialization error: {0}")]
     Serialization(String),
     #[error("A wallet error occurred.")]
     Wallet(#[from] sn_evm::EvmError),
@@ -82,6 +82,8 @@ pub enum CostError {
     CouldNotGetStoreQuote(XorName),
     #[error("Could not get store costs: {0:?}")]
     CouldNotGetStoreCosts(NetworkError),
+    #[error("Failed to serialize {0}")]
+    Serialization(String),
 }
 
 impl Client {

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -18,6 +18,8 @@ pub mod fs;
 pub mod registers;
 #[cfg(feature = "vault")]
 pub mod vault;
+#[cfg(feature = "vault")]
+pub mod vault_user_data;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/autonomi/src/client/vault_user_data.rs
+++ b/autonomi/src/client/vault_user_data.rs
@@ -84,10 +84,12 @@ impl Client {
         &self,
         secret_key: &SecretKey,
     ) -> Result<UserData, UserDataVaultGetError> {
-        let (bytes, version) = self.fetch_and_decrypt_vault(secret_key).await?;
+        let (bytes, content_type) = self.fetch_and_decrypt_vault(secret_key).await?;
 
-        if version != *USER_DATA_VAULT_CONTENT_IDENTIFIER {
-            return Err(UserDataVaultGetError::UnsupportedVaultContentType(version));
+        if content_type != *USER_DATA_VAULT_CONTENT_IDENTIFIER {
+            return Err(UserDataVaultGetError::UnsupportedVaultContentType(
+                content_type,
+            ));
         }
 
         let vault = UserData::from_bytes(bytes).map_err(|e| {

--- a/autonomi/src/client/vault_user_data.rs
+++ b/autonomi/src/client/vault_user_data.rs
@@ -1,0 +1,118 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use super::archive::ArchiveAddr;
+use super::data::GetError;
+use super::data::PutError;
+use super::registers::RegisterAddress;
+use super::vault::VaultError;
+use super::Client;
+use crate::client::vault::{app_name_to_version, VaultContentVersion};
+use bls::SecretKey;
+use serde::{Deserialize, Serialize};
+use sn_evm::EvmWallet;
+use sn_protocol::Bytes;
+
+use std::sync::LazyLock;
+
+/// Vault content version for UserDataVault
+pub static USER_DATA_VAULT_CONTENT_VERSION: LazyLock<VaultContentVersion> =
+    LazyLock::new(|| app_name_to_version("UserData"));
+
+/// UserData is stored in Vaults and contains most of a user's private data:
+/// It allows users to keep track of only the key to their User Data Vault
+/// while having the rest kept on the Network encrypted in a Vault for them
+/// Using User Data Vault is optional, one can decide to keep all their data locally instead.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct UserData {
+    /// The register secret key hex encoded
+    pub register_sk: Option<String>,
+    /// Owned register addresses
+    pub registers: HashSet<RegisterAddress>,
+    /// Owned file archive addresses
+    pub file_archives: HashSet<ArchiveAddr>,
+
+    /// Owner register names, providing it is optional
+    pub register_names: HashMap<String, RegisterAddress>,
+    /// Owned file archive addresses along with a name for that archive providing it is optional
+    pub file_archive_names: HashMap<String, ArchiveAddr>,
+}
+
+/// Errors that can occur during the get operation.
+#[derive(Debug, thiserror::Error)]
+pub enum UserDataVaultGetError {
+    #[error("Vault error: {0}")]
+    Vault(#[from] VaultError),
+    #[error("Unsupported vault content version: {0}")]
+    UnsupportedVaultContentVersion(VaultContentVersion),
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+    #[error("Get error: {0}")]
+    GetError(#[from] GetError),
+}
+
+impl UserData {
+    /// Create a new empty UserData
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// To bytes
+    pub fn to_bytes(&self) -> Result<Bytes, rmp_serde::encode::Error> {
+        let bytes = rmp_serde::to_vec(&self)?;
+        Ok(Bytes::from(bytes))
+    }
+
+    /// From bytes
+    pub fn from_bytes(bytes: Bytes) -> Result<Self, rmp_serde::decode::Error> {
+        let vault_content = rmp_serde::from_slice(&bytes)?;
+        Ok(vault_content)
+    }
+}
+
+impl Client {
+    /// Get the user data from the vault
+    pub async fn get_user_data_from_vault(
+        &self,
+        secret_key: &SecretKey,
+    ) -> Result<UserData, UserDataVaultGetError> {
+        let (bytes, version) = self.fetch_and_decrypt_vault(secret_key).await?;
+
+        if version != *USER_DATA_VAULT_CONTENT_VERSION {
+            return Err(UserDataVaultGetError::UnsupportedVaultContentVersion(
+                version,
+            ));
+        }
+
+        let vault = UserData::from_bytes(bytes).map_err(|e| {
+            UserDataVaultGetError::Serialization(format!(
+                "Failed to deserialize vault content: {e}"
+            ))
+        })?;
+
+        Ok(vault)
+    }
+
+    /// Put the user data to the vault
+    pub async fn put_user_data_to_vault(
+        &self,
+        secret_key: &SecretKey,
+        wallet: &EvmWallet,
+        user_data: UserData,
+    ) -> Result<(), PutError> {
+        let bytes = user_data
+            .to_bytes()
+            .map_err(|e| PutError::Serialization(format!("Failed to serialize user data: {e}")))?;
+        self.write_bytes_to_vault(bytes, wallet, secret_key, *USER_DATA_VAULT_CONTENT_VERSION)
+            .await?;
+        Ok(())
+    }
+}

--- a/autonomi/tests/fs.rs
+++ b/autonomi/tests/fs.rs
@@ -104,8 +104,7 @@ async fn file_into_vault() -> Result<()> {
     let ap_archive_fetched = autonomi::client::archive::Archive::from_bytes(ap)?;
 
     assert_eq!(
-        archive.iter().count(),
-        ap_archive_fetched.iter().count(),
+        archive, ap_archive_fetched,
         "archive fetched should match archive put"
     );
 

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -1238,7 +1238,7 @@ mod tests {
         let owner_sk = SecretKey::random();
         let owner_pk = owner_sk.public_key();
 
-        let mut scratchpad = Scratchpad::new(owner_pk);
+        let mut scratchpad = Scratchpad::new(owner_pk, 0);
 
         let _next_version =
             scratchpad.update_and_sign(unencrypted_scratchpad_data.clone(), &owner_sk);
@@ -1283,8 +1283,7 @@ mod tests {
             let decrypted_data = scratchpad.decrypt_data(&owner_sk)?;
 
             assert_eq!(
-                decrypted_data,
-                Some(unencrypted_scratchpad_data),
+                decrypted_data, unencrypted_scratchpad_data,
                 "Stored scratchpad data should match original"
             );
         }

--- a/sn_protocol/src/error.rs
+++ b/sn_protocol/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
     /// The provided SecretyKey failed to decrypt the data
     #[error("Failed to derive CipherText from encrypted_data")]
     ScratchpadCipherTextFailed,
+    /// The provided cypher text is invalid
+    #[error("Provided cypher text is invalid")]
+    ScratchpadCipherTextInvalid,
 
     // ---------- payment errors
     #[error("There was an error getting the storecost from kademlia store")]

--- a/sn_protocol/src/lib.rs
+++ b/sn_protocol/src/lib.rs
@@ -32,7 +32,10 @@ pub use error::Error;
 use storage::ScratchpadAddress;
 
 use self::storage::{ChunkAddress, RegisterAddress, SpendAddress};
-use bytes::Bytes;
+
+/// Re-export of Bytes used throughout the protocol
+pub use bytes::Bytes;
+
 use libp2p::{
     kad::{KBucketDistance as Distance, KBucketKey as Key, RecordKey},
     multiaddr::Protocol,

--- a/sn_protocol/src/storage/scratchpad.rs
+++ b/sn_protocol/src/storage/scratchpad.rs
@@ -23,8 +23,8 @@ pub struct Scratchpad {
     /// Network address. Omitted when serialising and
     /// calculated from the `encrypted_data` when deserialising.
     address: ScratchpadAddress,
-    /// Data version
-    version: u64,
+    /// Data encoding: custom apps using scratchpad should use this so they can identify the type of data they are storing
+    data_encoding: u64,
     /// Contained data. This should be encrypted
     #[debug(skip)]
     encrypted_data: Bytes,
@@ -37,11 +37,11 @@ pub struct Scratchpad {
 
 impl Scratchpad {
     /// Creates a new instance of `Scratchpad`.
-    pub fn new(owner: PublicKey, version: u64) -> Self {
+    pub fn new(owner: PublicKey, data_encoding: u64) -> Self {
         Self {
             address: ScratchpadAddress::new(owner),
             encrypted_data: Bytes::new(),
-            version,
+            data_encoding,
             counter: 0,
             signature: None,
         }
@@ -52,9 +52,9 @@ impl Scratchpad {
         self.counter
     }
 
-    /// Return the current version
-    pub fn version(&self) -> u64 {
-        self.version
+    /// Return the current data encoding
+    pub fn data_encoding(&self) -> u64 {
+        self.data_encoding
     }
 
     /// Increments the counter value.


### PR DESCRIPTION
- UserData can now be stored on the Network in a Vault so no need to keep addresses and register keys around
- JS bindings to get_user_data_from_vault and put_user_data_to_vault allowing the webapp to make use of this
- Autonomi API still offers lower level APIs to create custom vaults. To differenciate those a u64 hash of the app name is used in Scratchpad
- Chose to allow UserData to include names for data we keep track of: namely Registers and Archives. Although it is optional. 
- Improved the API of vault which returned clunky options instead of managing underlying errors
- exposed Bytes used throughout sn_protocol's API as higher level libs should were using the original lib leading to possible future problems if the dependencies versions mismatch