### PR TITLE
chore: accumulate register at the network level during split

### DIFF
--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -743,6 +743,8 @@ impl Node {
         // get spends from the network at the address for that unique pubkey
         let network_spends = match self.network().get_raw_spends(spend_addr).await {
             Ok(spends) => spends,
+            // Fixme: We don't return SplitRecord Error for spends, instead we return NetworkError::DoubleSpendAttempt.
+            // The fix should also consider/change all the places we try to get spends, for eg `get_raw_signed_spends_from_record` etc.
             Err(NetworkError::GetRecordError(GetRecordError::SplitRecord { result_map })) => {
                 warn!("Got a split record (double spend) for {unique_pubkey:?} from the network");
                 let mut spends = vec![];


### PR DESCRIPTION
- If we don't handle a split register at the lower level, then we keep retrying until the get retires run out
- Also it is upto the caller to make sure to merge the split record, which is hard to perform at every caller. e.g., replication fetch, during PUT verification etc.

I wanted to keep the network layer not exposed to the "data types", but we've already got Spends being accumulated there, and since we don't have any tests for spends right now, I did not attempt to change the current design. Maybe we should rearrange things later (when tests for spends are enabled) to make sure that the network layer stays clean.
