### PR TITLE
chore(networking): reduce MAX_RECORDS_CACHE_SIZE to 25

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -57,7 +57,7 @@ use xor_name::XorName;
 const MAX_RECORDS_COUNT: usize = 16 * 1024;
 
 /// The maximum number of records to cache in memory.
-const MAX_RECORDS_CACHE_SIZE: usize = 100;
+const MAX_RECORDS_CACHE_SIZE: usize = 25;
 
 /// File name of the recorded historical quoting metrics.
 const HISTORICAL_QUOTING_METRICS_FILENAME: &str = "historic_quoting_metrics";


### PR DESCRIPTION
100 Is excessive, and w/o spends being written just now it's more likely maxmally sized records
