### PR TITLE
chore: reduce max records cache size

### DIFF
--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -57,7 +57,7 @@ use xor_name::XorName;
 const MAX_RECORDS_COUNT: usize = 16 * 1024;
 
 /// The maximum number of records to cache in memory.
-const MAX_RECORDS_CACHE_SIZE: usize = 100;
+const MAX_RECORDS_CACHE_SIZE: usize = 25;
 
 /// File name of the recorded historical quoting metrics.
 const HISTORICAL_QUOTING_METRICS_FILENAME: &str = "historic_quoting_metrics";

--- a/sn_node/src/bin/safenode/main.rs
+++ b/sn_node/src/bin/safenode/main.rs
@@ -24,7 +24,9 @@ use sn_logging::{Level, LogFormat, LogOutputDest, ReloadHandle};
 use sn_node::{Marker, NodeBuilder, NodeEvent, NodeEventsReceiver};
 use sn_peers_acquisition::PeersArgs;
 use sn_protocol::{
-    node::get_safenode_root_dir, node_rpc::{NodeCtrl, StopResult}, version::IDENTIFY_PROTOCOL_STR,
+    node::get_safenode_root_dir,
+    node_rpc::{NodeCtrl, StopResult},
+    version::IDENTIFY_PROTOCOL_STR,
 };
 use std::{
     env,
@@ -530,7 +532,9 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
                         })
                         .await
                     {
-                        error!("Failed to send node control msg to safenode bin main thread: {err}");
+                        error!(
+                            "Failed to send node control msg to safenode bin main thread: {err}"
+                        );
                         break;
                     }
                 }

--- a/sn_node/src/bin/safenode/rpc_service.rs
+++ b/sn_node/src/bin/safenode/rpc_service.rs
@@ -202,7 +202,14 @@ impl SafeNode for SafeNodeRpcService {
         };
 
         let delay = Duration::from_millis(request.get_ref().delay_millis);
-        match self.ctrl_tx.send(NodeCtrl::Stop { delay, result: StopResult::Success(cause.to_string()) }).await {
+        match self
+            .ctrl_tx
+            .send(NodeCtrl::Stop {
+                delay,
+                result: StopResult::Success(cause.to_string()),
+            })
+            .await
+        {
             Ok(()) => Ok(Response::new(StopResponse {})),
             Err(err) => Err(Status::new(
                 Code::Internal,


### PR DESCRIPTION
Using a larger chunk size resulted in the node having a larger memory footprint due to the size of the records cache.

This was originally in PR #2272 but that PR was being targetted at `main` rather than the RC branch.
