### PR TITLE
MetaMask JS bindings & example

### DIFF
--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -75,6 +75,7 @@ js-sys = "0.3.70"
 test_utils = { path = "../test_utils" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-web = "0.1.3"
+xor_name = { version = "5.0.0", features = ["serialize-hex"] }
 
 [lints]
 workspace = true

--- a/autonomi/README.md
+++ b/autonomi/README.md
@@ -26,7 +26,7 @@ autonomi = { path = "../autonomi", version = "0.1.0" }
 cargo run --bin evm_testnet
 ```
 
-3. Run a local network with the `local` feature and use the local evm node. 
+3. Run a local network with the `local` feature and use the local evm node.
 
 ```sh
 cargo run --bin=safenode-manager --features=local -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-local
@@ -63,34 +63,56 @@ RUST_LOG=autonomi EVM_NETWORK=arbitrum-one EVM_PRIVATE_KEY=<PRIVATE_KEY> cargo t
 ### WebAssembly
 
 To run a WASM test
+
 - Install `wasm-pack`
-- Make sure your Rust supports the `wasm32-unknown-unknown` target. (If you have `rustup`: `rustup target add wasm32-unknown-unknown`.)
-- Pass a bootstrap peer via `SAFE_PEERS`. This *has* to be the websocket address, e.g. `/ip4/<ip>/tcp/<port>/ws/p2p/<peer ID>`.
+- Make sure your Rust supports the `wasm32-unknown-unknown` target. (If you
+  have `rustup`: `rustup target add wasm32-unknown-unknown`.)
+- Pass a bootstrap peer via `SAFE_PEERS`. This *has* to be the websocket address,
+  e.g. `/ip4/<ip>/tcp/<port>/ws/p2p/<peer ID>`.
     - As well as the other environment variables needed for EVM payments (e.g. `RPC_URL`).
 - Optionally specify the specific test, e.g. `-- put` to run `put()` in `wasm.rs` only.
 
 Example:
+
 ```sh
 SAFE_PEERS=/ip4/<ip>/tcp/<port>/ws/p2p/<peer ID> wasm-pack test --release --firefox autonomi --features=data,files --test wasm -- put
 ```
 
 #### Test from JS in the browser
 
-`wasm-pack test` does not execute JavaScript, but runs mostly WebAssembly. Again make sure the environment variables are set and build the JS package:
+`wasm-pack test` does not execute JavaScript, but runs mostly WebAssembly. Again make sure the environment variables are
+set and build the JS package:
 
 ```sh
 wasm-pack build --dev --target=web autonomi --features=vault
 ```
 
 Then cd into `autonomi/tests-js`, and use `npm` to install and serve the test html file.
+
 ```
 cd autonomi/tests-js
 npm install
 npm run serve
 ```
 
-Then go to `http://127.0.0.1:8080/tests-js` in the browser. Here, enter a `ws` multiaddr of a local node and press 'run'.
+Then go to `http://127.0.0.1:8080/tests-js` in the browser. Here, enter a `ws` multiaddr of a local node and press '
+run'.
 
+#### MetaMask example
+
+There is a MetaMask example for doing a simple put operation.
+
+Build the package with the `external-signer` feature (and again with the env variables) and run a webserver, e.g. with
+Python:
+
+```sh
+wasm-pack build --dev --target=web autonomi --features=external-signer
+python -m http.server --directory=autonomi 8000
+```
+
+Then visit `http://127.0.0.1:8000/examples/metamask` in your (modern) browser.
+
+Here, enter a `ws` multiaddr of a local node and press 'run'.
 
 ## Faucet (local)
 

--- a/autonomi/examples/metamask/index.html
+++ b/autonomi/examples/metamask/index.html
@@ -1,0 +1,26 @@
+<html>
+
+<head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+</head>
+
+<body>
+<!-- credits: https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html -->
+<script type="module">
+    import {externalSignerPut} from "./index.js";
+
+    async function run() {
+        document.getElementById("btn-run").disabled = true;
+        const peerAddr = document.getElementById('peer_id').value;
+        await externalSignerPut(peerAddr);
+    }
+
+    document.getElementById("btn-run").addEventListener("click", run, false);
+</script>
+
+<label for="peer_id">Peer MultiAddr: <input type="text" id="peer_id"/></label>
+<button id="btn-run">Run</button>
+<span id="progress"></span>
+</body>
+
+</html>

--- a/autonomi/examples/metamask/index.js
+++ b/autonomi/examples/metamask/index.js
@@ -1,0 +1,114 @@
+import init, * as autonomi from '../../pkg/autonomi.js';
+
+export async function externalSignerPut(peerAddr) {
+    try {
+        // Check if MetaMask (window.ethereum) is available
+        if (typeof window.ethereum === 'undefined') {
+            throw new Error('MetaMask is not installed');
+        }
+
+        // Request account access from MetaMask
+        const accounts = await window.ethereum.request({method: 'eth_requestAccounts'});
+        const sender = accounts[0]; // Get the first account
+
+        // Setup API client
+        await init();
+
+        autonomi.logInit("autonomi=trace");
+
+        const client = await autonomi.Client.connect([peerAddr]);
+
+        // Random bytes to be uploaded
+        const data = [...Array(16)].map(() => Math.floor(Math.random() * 9));
+
+        // Get quotes and payment information (this would need actual implementation)
+        const [quotes, quotePayments, free_chunks] = await client.getQuotes(data);
+
+        // Get the EVM network
+        let evmNetwork = autonomi.getEvmNetwork();
+
+        // Form quotes payment calldata
+        const payForQuotesCalldata = autonomi.getPayForQuotesCalldata(
+            evmNetwork,
+            quotePayments
+        );
+
+        // Form approve to spend tokens calldata
+        const approveCalldata = autonomi.getApproveToSpendTokensCalldata(
+            evmNetwork,
+            payForQuotesCalldata.approve_spender,
+            payForQuotesCalldata.approve_amount
+        );
+
+        // Approve to spend tokens
+        await sendTransaction({
+            from: sender,
+            to: approveCalldata[1],
+            data: approveCalldata[0]
+        });
+
+        let payments = {};
+
+        // Execute batched quote payment transactions
+        for (const [calldata, quoteHashes] of payForQuotesCalldata.batched_calldata_map) {
+            const txHash = await sendTransaction({
+                from: sender,
+                to: payForQuotesCalldata.to,
+                data: calldata
+            });
+
+            // Record the transaction hashes for each quote
+            quoteHashes.forEach(quoteHash => {
+                payments[quoteHash] = txHash;
+            });
+        }
+
+        // Generate payment proof
+        const proof = autonomi.getPaymentProofFromQuotesAndPayments(quotes, payments);
+
+        // Submit the data with proof of payment
+        const addr = await client.dataPutWithProof(data, proof);
+
+        // Wait for a few seconds to allow data to propagate
+        await new Promise(resolve => setTimeout(resolve, 10000));
+
+        // Fetch the data back
+        const fetchedData = await client.dataGet(addr);
+        const originalData = new Uint8Array(data);
+
+        if (fetchedData === originalData) {
+            console.log("Fetched data matches the original data!");
+        } else {
+            throw new Error("Fetched data does not match original data!")
+        }
+
+        console.log("Data successfully put and verified!");
+
+    } catch (error) {
+        console.error("An error occurred:", error);
+    }
+}
+
+// Helper function to send a transaction through MetaMask using Ethereum JSON-RPC
+async function sendTransaction({from, to, data}) {
+    const transactionParams = {
+        from: from,      // Sender address
+        to: to,          // Destination address
+        data: data,      // Calldata (transaction input)
+    };
+
+    try {
+        // Send the transaction via MetaMask and get the transaction hash
+        const txHash = await window.ethereum.request({
+            method: 'eth_sendTransaction',
+            params: [transactionParams]
+        });
+
+        console.log(`Transaction sent with hash: ${txHash}`);
+        return txHash; // Return the transaction hash
+
+    } catch (error) {
+        console.error("Failed to send transaction:", error);
+        throw error;
+    }
+}

--- a/autonomi/examples/metamask/index.js
+++ b/autonomi/examples/metamask/index.js
@@ -18,8 +18,8 @@ export async function externalSignerPut(peerAddr) {
 
         const client = await autonomi.Client.connect([peerAddr]);
 
-        // Random bytes to be uploaded
-        const data = [...Array(16)].map(() => Math.floor(Math.random() * 9));
+        // Generate 1MB of random bytes in a Uint8Array
+        const data = new Uint8Array(1024 * 1024).map(() => Math.floor(Math.random() * 256));
 
         // Get quotes and payment information (this would need actual implementation)
         const [quotes, quotePayments, free_chunks] = await client.getQuotes(data);
@@ -40,22 +40,30 @@ export async function externalSignerPut(peerAddr) {
             payForQuotesCalldata.approve_amount
         );
 
+        console.log("Sending approve transaction..");
+
         // Approve to spend tokens
-        await sendTransaction({
+        let txHash = await sendTransaction({
             from: sender,
             to: approveCalldata[1],
             data: approveCalldata[0]
         });
 
+        await waitForTransactionConfirmation(txHash);
+
         let payments = {};
 
         // Execute batched quote payment transactions
         for (const [calldata, quoteHashes] of payForQuotesCalldata.batched_calldata_map) {
-            const txHash = await sendTransaction({
+            console.log("Sending batched data payment transaction..");
+
+            let txHash = await sendTransaction({
                 from: sender,
                 to: payForQuotesCalldata.to,
                 data: calldata
             });
+
+            await waitForTransactionConfirmation(txHash);
 
             // Record the transaction hashes for each quote
             quoteHashes.forEach(quoteHash => {
@@ -74,9 +82,8 @@ export async function externalSignerPut(peerAddr) {
 
         // Fetch the data back
         const fetchedData = await client.dataGet(addr);
-        const originalData = new Uint8Array(data);
 
-        if (fetchedData === originalData) {
+        if (fetchedData.toString() === data.toString()) {
             console.log("Fetched data matches the original data!");
         } else {
             throw new Error("Fetched data does not match original data!")
@@ -110,5 +117,33 @@ async function sendTransaction({from, to, data}) {
     } catch (error) {
         console.error("Failed to send transaction:", error);
         throw error;
+    }
+}
+
+async function waitForTransactionConfirmation(txHash) {
+    const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+    // Poll for the transaction receipt
+    while (true) {
+        // Query the transaction receipt
+        const receipt = await window.ethereum.request({
+            method: 'eth_getTransactionReceipt',
+            params: [txHash],
+        });
+
+        // If the receipt is found, the transaction has been mined
+        if (receipt !== null) {
+            // Check if the transaction was successful (status is '0x1')
+            if (receipt.status === '0x1') {
+                console.log('Transaction successful!', receipt);
+                return receipt; // Return the transaction receipt
+            } else {
+                console.log('Transaction failed!', receipt);
+                throw new Error('Transaction failed');
+            }
+        }
+
+        // Wait for 1 second before checking again
+        await delay(1000);
     }
 }

--- a/autonomi/src/client/external_signer.rs
+++ b/autonomi/src/client/external_signer.rs
@@ -3,8 +3,7 @@ use crate::client::utils::extract_quote_payments;
 use crate::self_encryption::encrypt;
 use crate::Client;
 use bytes::Bytes;
-use sn_evm::{ProofOfPayment, QuotePayment};
-use sn_networking::PayeeQuote;
+use sn_evm::{PaymentQuote, ProofOfPayment, QuotePayment};
 use sn_protocol::storage::Chunk;
 use std::collections::HashMap;
 use xor_name::XorName;
@@ -34,7 +33,7 @@ impl Client {
         data: Bytes,
     ) -> Result<
         (
-            HashMap<XorName, PayeeQuote>,
+            HashMap<XorName, PaymentQuote>,
             Vec<QuotePayment>,
             Vec<XorName>,
         ),
@@ -42,7 +41,14 @@ impl Client {
     > {
         // Encrypt the data as chunks
         let (_data_map_chunk, _chunks, xor_names) = encrypt_data(data)?;
-        let cost_map = self.get_store_quotes(xor_names.into_iter()).await?;
+
+        let cost_map: HashMap<XorName, PaymentQuote> = self
+            .get_store_quotes(xor_names.into_iter())
+            .await?
+            .into_iter()
+            .map(|(name, (_, _, q))| (name, q))
+            .collect();
+
         let (quote_payments, free_chunks) = extract_quote_payments(&cost_map);
         Ok((cost_map, quote_payments, free_chunks))
     }

--- a/autonomi/src/utils.rs
+++ b/autonomi/src/utils.rs
@@ -1,15 +1,14 @@
-use sn_evm::{ProofOfPayment, QuoteHash, TxHash};
-use sn_networking::PayeeQuote;
+use sn_evm::{PaymentQuote, ProofOfPayment, QuoteHash, TxHash};
 use std::collections::{BTreeMap, HashMap};
 use xor_name::XorName;
 
 pub fn payment_proof_from_quotes_and_payments(
-    quotes: &HashMap<XorName, PayeeQuote>,
+    quotes: &HashMap<XorName, PaymentQuote>,
     payments: &BTreeMap<QuoteHash, TxHash>,
 ) -> HashMap<XorName, ProofOfPayment> {
     quotes
         .iter()
-        .filter_map(|(xor_name, (_, _, quote))| {
+        .filter_map(|(xor_name, quote)| {
             payments.get(&quote.hash()).map(|tx_hash| {
                 (
                     *xor_name,

--- a/evmlib/src/external_signer.rs
+++ b/evmlib/src/external_signer.rs
@@ -12,6 +12,7 @@ use crate::contract::network_token::NetworkToken;
 use crate::contract::{data_payments, network_token};
 use crate::utils::http_provider;
 use crate::Network;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(thiserror::Error, Debug)]
@@ -48,6 +49,7 @@ pub fn transfer_tokens_calldata(
     network_token.transfer_calldata(receiver, amount)
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct PayForQuotesCalldataReturnType {
     pub batched_calldata_map: HashMap<Calldata, Vec<QuoteHash>>,
     pub to: Address,
@@ -67,7 +69,7 @@ pub fn pay_for_quotes_calldata<T: IntoIterator<Item = QuotePayment>>(
 
     let total_amount = payments.iter().map(|(_, _, amount)| amount).sum();
 
-    let approve_to = *network.data_payments_address();
+    let approve_spender = *network.data_payments_address();
     let approve_amount = total_amount;
 
     let provider = http_provider(network.rpc_url().clone());
@@ -88,7 +90,7 @@ pub fn pay_for_quotes_calldata<T: IntoIterator<Item = QuotePayment>>(
     Ok(PayForQuotesCalldataReturnType {
         batched_calldata_map: calldata_map,
         to: *data_payments.contract.address(),
-        approve_spender: approve_to,
+        approve_spender,
         approve_amount,
     })
 }

--- a/sn_evm/src/lib.rs
+++ b/sn_evm/src/lib.rs
@@ -10,6 +10,7 @@
 extern crate tracing;
 
 pub use evmlib::common::Address as RewardsAddress;
+pub use evmlib::common::Address as EvmAddress;
 pub use evmlib::common::QuotePayment;
 pub use evmlib::common::{QuoteHash, TxHash};
 #[cfg(feature = "external-signer")]


### PR DESCRIPTION
Adds the necessary WASM bindings for MetaMask integration and add a JavaScript example of a simple put operation using MetaMask.

### Running the MetaMask example:

1. Make sure that you have MetaMask installed in your browser.
2. Run a local network with websockets enabled.
3. Depending on the EVM network you are using for the test, make sure that the network has been added to MetaMask and that you have some gas and payment tokens in your account. (I can send some for Arb Sepolia or Arb One)
4. Build the WASM pkg using the correct EVM network (don't use the local setting here, you need to define the RPC_URL etc manually as ENV vars if you want to use a local EVM network):

Using `Arbitrum Sepolia` for this example.

```bash
RPC_URL="https://sepolia-rollup.arbitrum.io/rpc" PAYMENT_TOKEN_ADDRESS="0x4bc1aCE0E66170375462cB4E6Af42Ad4D5EC689C" DATA_PAYMENTS_ADDRESS="0xe6D6bB5Fa796baA8c1ADc439Ac0fd66fd2A1858b" wasm-pack build --dev --target=web autonomi --features=external-signer
```

5. Start a webserver using Python for example:

Run this command inside the `safe_network` repo.

```
python3 -m http.server 8000 -d autonomi
```

6. Visit http://localhost:8000/examples/metamask/
7. Make sure that you have the right network selected in MetaMask!
8. Enter a `ws` multiaddr of a local node and press `run`.