### PR TITLE
fix(network): return kad event dropped if we cannot get the query id

### DIFF
--- a/sn_networking/src/event/kad.rs
+++ b/sn_networking/src/event/kad.rs
@@ -412,6 +412,7 @@ impl SwarmDriver {
 
             let expected_answers = get_quorum_value(&cfg.get_quorum);
             trace!("Expecting {expected_answers:?} answers to exceed {expected_get_range:?} for record {pretty_key:?} task {query_id:?}, received {responded_peers} so far");
+        } else {
             // return error if the entry cannot be found
             return Err(NetworkError::ReceivedKademliaEventDropped {
                 query_id,


### PR DESCRIPTION
- we were emitting this error incorrectly..