### PR TITLE
User data in encrypted Vaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,8 @@ version = "0.2.0"
 dependencies = [
  "alloy",
  "bip39",
+ "blst",
+ "blstrs 0.7.1",
  "blsttc",
  "bytes",
  "console_error_panic_hook",
@@ -1421,7 +1423,23 @@ dependencies = [
  "byte-slice-cast",
  "ff 0.12.1",
  "group 0.12.1",
- "pairing",
+ "pairing 0.22.0",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "serde",
  "subtle",
@@ -1434,12 +1452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1186a39763321a0b73d1a10aa4fc067c5d042308509e8f6cc31d2c2a7ac61ac2"
 dependencies = [
  "blst",
- "blstrs",
+ "blstrs 0.6.2",
  "ff 0.12.1",
  "group 0.12.1",
  "hex 0.4.3",
  "hex_fmt",
- "pairing",
+ "pairing 0.22.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -2847,6 +2865,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3780,7 +3799,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
+ "rand 0.8.5",
  "rand_core 0.6.4",
+ "rand_xorshift 0.3.0",
  "subtle",
 ]
 
@@ -6081,6 +6102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
  "group 0.12.1",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
 ]
 
 [[package]]

--- a/autonomi-cli/Cargo.toml
+++ b/autonomi-cli/Cargo.toml
@@ -27,6 +27,7 @@ harness = false
 autonomi = { path = "../autonomi", version = "0.2.0", features = [
     "data",
     "fs",
+    "vault",
     "registers",
     "loud",
 ] }

--- a/autonomi-cli/Cargo.toml
+++ b/autonomi-cli/Cargo.toml
@@ -47,6 +47,7 @@ tracing = { version = "~0.1.26" }
 sn_peers_acquisition = { path = "../sn_peers_acquisition", version = "0.5.4" }
 sn_build_info = { path = "../sn_build_info", version = "0.1.16" }
 sn_logging = { path = "../sn_logging", version = "0.2.37" }
+walkdir = "2.5.0"
 
 [dev-dependencies]
 autonomi = { path = "../autonomi", version = "0.2.0", features = [

--- a/autonomi-cli/src/access/data_dir.rs
+++ b/autonomi-cli/src/access/data_dir.rs
@@ -6,7 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use color_eyre::eyre::{eyre, Context, Result};
+use color_eyre::{
+    eyre::{eyre, Context, Result},
+    Section,
+};
 use std::path::PathBuf;
 
 pub fn get_client_data_dir_path() -> Result<PathBuf> {
@@ -14,6 +17,12 @@ pub fn get_client_data_dir_path() -> Result<PathBuf> {
         .ok_or_else(|| eyre!("Failed to obtain data dir, your OS might not be supported."))?;
     home_dirs.push("safe");
     home_dirs.push("autonomi");
-    std::fs::create_dir_all(home_dirs.as_path()).wrap_err("Failed to create data dir")?;
+    std::fs::create_dir_all(home_dirs.as_path())
+        .wrap_err("Failed to create data dir")
+        .with_suggestion(|| {
+            format!(
+                "make sure you have the correct permissions to access the data dir: {home_dirs:?}"
+            )
+        })?;
     Ok(home_dirs)
 }

--- a/autonomi-cli/src/access/keys.rs
+++ b/autonomi-cli/src/access/keys.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use autonomi::client::registers::RegisterSecretKey;
+use autonomi::client::vault::VaultSecretKey;
 use autonomi::{get_evm_network_from_env, Wallet};
 use color_eyre::eyre::{Context, Result};
 use color_eyre::Section;
@@ -49,6 +50,12 @@ pub fn get_secret_key() -> Result<String> {
         .wrap_err("Failed to read secret key from file")
         .with_suggestion(|| format!("make sure you've provided the {SECRET_KEY_ENV} env var or have the key in a file at {key_path:?}"))
         .with_suggestion(|| "the secret key should be a hex encoded string of your evm wallet private key")
+}
+
+pub fn get_vault_secret_key() -> Result<VaultSecretKey> {
+    let secret_key = get_secret_key()?;
+    autonomi::client::vault::derive_vault_key(&secret_key)
+        .wrap_err("Failed to derive vault secret key from EVM secret key")
 }
 
 pub fn create_register_signing_key_file(key: RegisterSecretKey) -> Result<PathBuf> {

--- a/autonomi-cli/src/access/mod.rs
+++ b/autonomi-cli/src/access/mod.rs
@@ -9,3 +9,4 @@
 pub mod data_dir;
 pub mod keys;
 pub mod network;
+pub mod user_data;

--- a/autonomi-cli/src/access/user_data.rs
+++ b/autonomi-cli/src/access/user_data.rs
@@ -22,12 +22,12 @@ use super::{
 };
 
 pub fn get_local_user_data() -> Result<UserData> {
-    let register_key = get_register_signing_key()?;
+    let register_sk = get_register_signing_key().map(|k| k.to_hex()).ok();
     let registers = get_local_registers()?;
     let file_archives = get_local_file_archives()?;
 
     let user_data = UserData {
-        register_sk: Some(register_key.to_hex()),
+        register_sk,
         registers,
         file_archives,
     };

--- a/autonomi-cli/src/access/user_data.rs
+++ b/autonomi-cli/src/access/user_data.rs
@@ -1,0 +1,91 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::collections::HashMap;
+
+use autonomi::client::{
+    address::{addr_to_str, str_to_addr},
+    archive::ArchiveAddr,
+    registers::RegisterAddress,
+    vault_user_data::UserData,
+};
+use color_eyre::eyre::Result;
+
+use super::{data_dir::get_client_data_dir_path, keys::get_register_signing_key};
+
+pub fn get_local_user_data() -> Result<UserData> {
+    let register_key = get_register_signing_key()?;
+    let registers = get_local_registers()?;
+    let file_archives = get_local_file_archives()?;
+
+    let user_data = UserData {
+        register_sk: Some(register_key.to_hex()),
+        registers,
+        file_archives,
+    };
+    Ok(user_data)
+}
+
+pub fn get_local_registers() -> Result<HashMap<RegisterAddress, String>> {
+    let data_dir = get_client_data_dir_path()?;
+    let user_data_path = data_dir.join("user_data");
+    let registers_path = user_data_path.join("registers");
+    std::fs::create_dir_all(&registers_path)?;
+
+    let mut registers = HashMap::new();
+    for entry in walkdir::WalkDir::new(registers_path)
+        .min_depth(1)
+        .max_depth(1)
+    {
+        let entry = entry?;
+        let file_name = entry.file_name().to_string_lossy();
+        let register_address = RegisterAddress::from_hex(&file_name)?;
+        let file_content = std::fs::read_to_string(entry.path())?;
+        let register_name = file_content;
+        registers.insert(register_address, register_name);
+    }
+    Ok(registers)
+}
+
+pub fn get_local_file_archives() -> Result<HashMap<ArchiveAddr, String>> {
+    let data_dir = get_client_data_dir_path()?;
+    let user_data_path = data_dir.join("user_data");
+    let file_archives_path = user_data_path.join("file_archives");
+    std::fs::create_dir_all(&file_archives_path)?;
+
+    let mut file_archives = HashMap::new();
+    for entry in walkdir::WalkDir::new(file_archives_path)
+        .min_depth(1)
+        .max_depth(1)
+    {
+        let entry = entry?;
+        let file_name = entry.file_name().to_string_lossy();
+        let file_archive_address = str_to_addr(&file_name)?;
+        let file_archive_name = std::fs::read_to_string(entry.path())?;
+        file_archives.insert(file_archive_address, file_archive_name);
+    }
+    Ok(file_archives)
+}
+
+pub fn write_local_register(register: &RegisterAddress, name: &str) -> Result<()> {
+    let data_dir = get_client_data_dir_path()?;
+    let user_data_path = data_dir.join("user_data");
+    let registers_path = user_data_path.join("registers");
+    std::fs::create_dir_all(&registers_path)?;
+    std::fs::write(registers_path.join(register.to_hex()), name)?;
+    Ok(())
+}
+
+pub fn write_local_file_archive(archive: &ArchiveAddr, name: &str) -> Result<()> {
+    let data_dir = get_client_data_dir_path()?;
+    let user_data_path = data_dir.join("user_data");
+    let file_archives_path = user_data_path.join("file_archives");
+    std::fs::create_dir_all(&file_archives_path)?;
+    std::fs::write(file_archives_path.join(addr_to_str(*archive)), name)?;
+    Ok(())
+}

--- a/autonomi-cli/src/commands.rs
+++ b/autonomi-cli/src/commands.rs
@@ -123,10 +123,23 @@ pub enum VaultCmd {
     Cost,
 
     /// Create a vault at a deterministic address based on your `SECRET_KEY`.
+    /// Pushing an encrypted backup of your local user data to the network
     Create,
 
+    /// Load an existing vault from the network.
+    /// Use this when loading your user data to a new device.
+    /// You need to have your original `SECRET_KEY` to load the vault.
+    Load,
+
     /// Sync vault with the network, including registers and files.
-    Sync,
+    /// Loads existing user data from the network and merges it with your local user data.
+    /// Pushes your local user data to the network.
+    Sync {
+        /// Force push your local user data to the network.
+        /// This will overwrite any existing data in your vault.
+        #[arg(short, long)]
+        force: bool,
+    },
 }
 
 pub async fn handle_subcommand(opt: Opt) -> Result<()> {
@@ -159,9 +172,10 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             RegisterCmd::List => register::list(),
         },
         SubCmd::Vault { command } => match command {
-            VaultCmd::Cost => vault::cost(peers.await?),
-            VaultCmd::Create => vault::create(peers.await?),
-            VaultCmd::Sync => vault::sync(peers.await?),
+            VaultCmd::Cost => vault::cost(peers.await?).await,
+            VaultCmd::Create => vault::create(peers.await?).await,
+            VaultCmd::Load => vault::load(peers.await?).await,
+            VaultCmd::Sync { force } => vault::sync(peers.await?, force).await,
         },
     }
 }

--- a/autonomi-cli/src/commands.rs
+++ b/autonomi-cli/src/commands.rs
@@ -140,7 +140,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Download { addr, dest_file } => {
                 file::download(&addr, &dest_file, peers.await?).await
             }
-            FileCmd::List => file::list(peers.await?),
+            FileCmd::List => file::list(),
         },
         SubCmd::Register { command } => match command {
             RegisterCmd::GenerateKey { overwrite } => register::generate_key(overwrite),
@@ -156,7 +156,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 value,
             } => register::edit(address, name, &value, peers.await?).await,
             RegisterCmd::Get { address, name } => register::get(address, name, peers.await?).await,
-            RegisterCmd::List => register::list(peers.await?),
+            RegisterCmd::List => register::list(),
         },
         SubCmd::Vault { command } => match command {
             VaultCmd::Cost => vault::cost(peers.await?),

--- a/autonomi-cli/src/commands/file.rs
+++ b/autonomi-cli/src/commands/file.rs
@@ -11,6 +11,7 @@ use autonomi::client::address::addr_to_str;
 use autonomi::Multiaddr;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use color_eyre::Section;
 use std::path::PathBuf;
 
 pub async fn cost(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
@@ -28,6 +29,7 @@ pub async fn cost(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
     info!("Total cost: {cost} for file: {file}");
     Ok(())
 }
+
 pub async fn upload(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
     let wallet = crate::keys::load_evm_wallet()?;
     let mut client = crate::actions::connect_to_network(peers).await?;
@@ -43,28 +45,42 @@ pub async fn upload(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
         .wrap_err("Failed to upload file")?;
     let addr = addr_to_str(xor_name);
 
-    println!("Successfully uploaded: {file}");
-    println!("At address: {addr}");
-    info!("Successfully uploaded: {file} at address: {addr}");
-    if let Ok(()) = upload_completed_tx.send(()) {
-        let summary = upload_summary_thread.await?;
-        if summary.record_count == 0 {
-            println!("All chunks already exist on the network");
-        } else {
-            println!("Number of chunks uploaded: {}", summary.record_count);
-            println!("Total cost: {} AttoTokens", summary.tokens_spent);
-        }
-        info!("Summary for upload of file {file} at {addr:?}: {summary:?}");
+    if let Err(e) = upload_completed_tx.send(()) {
+        error!("Failed to send upload completed event: {e:?}");
+        eprintln!("Failed to send upload completed event: {e:?}");
     }
+
+    let summary = upload_summary_thread.await?;
+    if summary.record_count == 0 {
+        println!("All chunks already exist on the network.");
+    } else {
+        println!("Successfully uploaded: {file}");
+        println!("At address: {addr}");
+        info!("Successfully uploaded: {file} at address: {addr}");
+        println!("Number of chunks uploaded: {}", summary.record_count);
+        println!("Total cost: {} AttoTokens", summary.tokens_spent);
+    }
+    info!("Summary for upload of file {file} at {addr:?}: {summary:?}");
+
+    crate::user_data::write_local_file_archive(&xor_name, file)
+        .wrap_err("Failed to save file to local user data")
+        .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")?;
+    info!("Saved file to local user data");
 
     Ok(())
 }
+
 pub async fn download(addr: &str, dest_path: &str, peers: Vec<Multiaddr>) -> Result<()> {
     let mut client = crate::actions::connect_to_network(peers).await?;
     crate::actions::download(addr, dest_path, &mut client).await
 }
 
-pub fn list(_peers: Vec<Multiaddr>) -> Result<()> {
-    println!("The file list feature is coming soon!");
+pub fn list() -> Result<()> {
+    println!("Retrieving local user data...");
+    let file_archives = crate::user_data::get_local_file_archives()?;
+    println!("✅ You have {} file archive(s):", file_archives.len());
+    for (addr, name) in file_archives {
+        println!("{}: {}", name, addr_to_str(addr));
+    }
     Ok(())
 }

--- a/autonomi-cli/src/commands/file.rs
+++ b/autonomi-cli/src/commands/file.rs
@@ -39,8 +39,13 @@ pub async fn upload(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
     println!("Uploading data to network...");
     info!("Uploading file: {file}");
 
+    let dir_path = PathBuf::from(file);
+    let name = dir_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or(file.to_string());
     let xor_name = client
-        .dir_upload(PathBuf::from(file), &wallet)
+        .dir_upload(dir_path, &wallet)
         .await
         .wrap_err("Failed to upload file")?;
     let addr = addr_to_str(xor_name);
@@ -62,7 +67,7 @@ pub async fn upload(file: &str, peers: Vec<Multiaddr>) -> Result<()> {
     }
     info!("Summary for upload of file {file} at {addr:?}: {summary:?}");
 
-    crate::user_data::write_local_file_archive(&xor_name, file)
+    crate::user_data::write_local_file_archive(&xor_name, &name)
         .wrap_err("Failed to save file to local user data")
         .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")?;
     info!("Saved file to local user data");

--- a/autonomi-cli/src/commands/vault.rs
+++ b/autonomi-cli/src/commands/vault.rs
@@ -7,19 +7,96 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use autonomi::Multiaddr;
+use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use color_eyre::Section;
 
-pub fn cost(_peers: Vec<Multiaddr>) -> Result<()> {
-    println!("The vault feature is coming soon!");
+pub async fn cost(peers: Vec<Multiaddr>) -> Result<()> {
+    let client = crate::actions::connect_to_network(peers).await?;
+    let vault_sk = crate::keys::get_vault_secret_key()?;
+
+    println!("Getting cost to create a new vault...");
+    let total_cost = client.vault_cost(&vault_sk).await?;
+
+    if total_cost.is_zero() {
+        println!("Vault already exists, modifying an existing vault is free");
+    } else {
+        println!("Cost to create a new vault: {total_cost} AttoTokens");
+    }
     Ok(())
 }
 
-pub fn create(_peers: Vec<Multiaddr>) -> Result<()> {
-    println!("The vault feature is coming soon!");
+pub async fn create(peers: Vec<Multiaddr>) -> Result<()> {
+    let client = crate::actions::connect_to_network(peers).await?;
+    let wallet = crate::keys::load_evm_wallet()?;
+    let vault_sk = crate::keys::get_vault_secret_key()?;
+
+    println!("Retrieving local user data...");
+    let local_user_data = crate::user_data::get_local_user_data()?;
+    let file_archives_len = local_user_data.file_archives.len();
+    let registers_len = local_user_data.registers.len();
+
+    println!("Pushing to network vault...");
+    let total_cost = client
+        .put_user_data_to_vault(&vault_sk, &wallet, local_user_data)
+        .await?;
+
+    if total_cost.is_zero() {
+        println!("✅ Successfully pushed user data to existing vault");
+    } else {
+        println!("✅ Successfully created new vault containing local user data");
+    }
+
+    println!("Total cost: {total_cost} AttoTokens");
+    println!("Vault contains {file_archives_len} file archive(s) and {registers_len} register(s)");
     Ok(())
 }
 
-pub fn sync(_peers: Vec<Multiaddr>) -> Result<()> {
-    println!("The vault feature is coming soon!");
+pub async fn sync(peers: Vec<Multiaddr>, force: bool) -> Result<()> {
+    let client = crate::actions::connect_to_network(peers).await?;
+    let vault_sk = crate::keys::get_vault_secret_key()?;
+    let wallet = crate::keys::load_evm_wallet()?;
+
+    println!("Fetching vault from network...");
+    let net_user_data = client
+        .get_user_data_from_vault(&vault_sk)
+        .await
+        .wrap_err("Failed to fetch vault from network")
+        .with_suggestion(|| "Make sure you have already created a vault on the network")?;
+
+    if force {
+        println!("The force flag was provided, overwriting user data in the vault with local user data...");
+    } else {
+        println!("Syncing vault with local user data...");
+        crate::user_data::write_local_user_data(&net_user_data)?;
+    }
+
+    println!("Pushing local user data to network vault...");
+    let local_user_data = crate::user_data::get_local_user_data()?;
+    let file_archives_len = local_user_data.file_archives.len();
+    let registers_len = local_user_data.registers.len();
+    client
+        .put_user_data_to_vault(&vault_sk, &wallet, local_user_data)
+        .await?;
+
+    println!("✅ Successfully synced vault");
+    println!("Vault contains {file_archives_len} file archive(s) and {registers_len} register(s)");
+    Ok(())
+}
+
+pub async fn load(peers: Vec<Multiaddr>) -> Result<()> {
+    let client = crate::actions::connect_to_network(peers).await?;
+    let vault_sk = crate::keys::get_vault_secret_key()?;
+
+    println!("Retrieving vault from network...");
+    let user_data = client.get_user_data_from_vault(&vault_sk).await?;
+    println!("Writing user data to disk...");
+    crate::user_data::write_local_user_data(&user_data)?;
+
+    println!(
+        "✅ Successfully loaded vault with {} file archive(s) and {} register(s)",
+        user_data.file_archives.len(),
+        user_data.registers.len()
+    );
     Ok(())
 }

--- a/autonomi-cli/src/main.rs
+++ b/autonomi-cli/src/main.rs
@@ -18,6 +18,7 @@ mod utils;
 pub use access::data_dir;
 pub use access::keys;
 pub use access::network;
+pub use access::user_data;
 
 use clap::Parser;
 use color_eyre::Result;

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -52,6 +52,7 @@ futures = "0.3.30"
 wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.43"
 serde-wasm-bindgen = "0.6.5"
+sha2 = "0.10.6"
 
 [dev-dependencies]
 alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -53,6 +53,8 @@ wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.43"
 serde-wasm-bindgen = "0.6.5"
 sha2 = "0.10.6"
+blst = "0.3.13"
+blstrs = "0.7.1"
 
 [dev-dependencies]
 alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }

--- a/autonomi/src/client/data.rs
+++ b/autonomi/src/client/data.rs
@@ -33,8 +33,6 @@ pub type ChunkAddr = XorName;
 pub enum PutError {
     #[error("Failed to self-encrypt data.")]
     SelfEncryption(#[from] crate::self_encryption::Error),
-    #[error("Error getting Vault XorName data.")]
-    VaultXorName,
     #[error("A network error occurred.")]
     Network(#[from] NetworkError),
     #[error("Error occurred during cost estimation.")]
@@ -47,6 +45,8 @@ pub enum PutError {
     Wallet(#[from] sn_evm::EvmError),
     #[error("The vault owner key does not match the client's public key")]
     VaultBadOwner,
+    #[error("Payment unexpectedly invalid for {0:?}")]
+    PaymentUnexpectedlyInvalid(NetworkAddress),
 }
 
 /// Errors that can occur during the pay operation.

--- a/autonomi/src/client/data.rs
+++ b/autonomi/src/client/data.rs
@@ -45,6 +45,8 @@ pub enum PutError {
     Serialization(String),
     #[error("A wallet error occurred.")]
     Wallet(#[from] sn_evm::EvmError),
+    #[error("The vault owner key does not match the client's public key")]
+    VaultBadOwner,
 }
 
 /// Errors that can occur during the pay operation.

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -20,8 +20,6 @@ pub mod fs;
 pub mod registers;
 #[cfg(feature = "vault")]
 pub mod vault;
-#[cfg(feature = "vault")]
-pub mod vault_user_data;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/autonomi/src/client/vault.rs
+++ b/autonomi/src/client/vault.rs
@@ -105,7 +105,7 @@ impl Client {
                 debug!("Got multiple scratchpads for {scratch_key:?}");
                 let mut pads = result_map
                     .values()
-                    .map(|(record, _)| try_deserialize_record::<Scratchpad>(&record))
+                    .map(|(record, _)| try_deserialize_record::<Scratchpad>(record))
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(|_| VaultError::CouldNotDeserializeVaultScratchPad(scratch_address))?;
 

--- a/autonomi/src/client/vault.rs
+++ b/autonomi/src/client/vault.rs
@@ -149,6 +149,11 @@ impl Client {
             );
 
             is_new = false;
+
+            if existing_data.owner() != &client_pk {
+                return Err(PutError::VaultBadOwner);
+            }
+
             existing_data
         } else {
             trace!("new scratchpad creation");
@@ -156,6 +161,8 @@ impl Client {
         };
 
         let _next_count = scratch.update_and_sign(data, secret_key);
+        debug_assert!(scratch.is_valid(), "Must be valid after being signed. This is a bug, please report it by opening an issue on our github");
+
         let scratch_address = scratch.network_address();
         let scratch_key = scratch_address.to_record_key();
 

--- a/autonomi/src/client/vault/key.rs
+++ b/autonomi/src/client/vault/key.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sha2::{Digest, Sha256};
+
+/// Secret key to decrypt vault content
+pub type VaultSecretKey = bls::SecretKey;
+
+#[derive(Debug, thiserror::Error)]
+pub enum VaultKeyError {
+    #[error("Failed to sign message: {0}")]
+    FailedToSignMessage(#[from] sn_evm::cryptography::SignError),
+    #[error("Failed to generate vault secret key: {0}")]
+    FailedToGenerateVaultSecretKey(String),
+}
+
+/// Message used to generate the vault secret key from the EVM secret key
+const VAULT_SECRET_KEY_SEED: &[u8] = b"Massive Array of Internet Disks Secure Access For Everyone";
+
+/// Derives the vault secret key from the EVM secret key hex string
+/// The EVM secret key is used to sign a message and the signature is hashed to derive the vault secret key
+/// Being able to derive the vault secret key from the EVM secret key allows users to only keep track of one key: the EVM secret key
+pub fn derive_vault_key(evm_sk_hex: &str) -> Result<VaultSecretKey, VaultKeyError> {
+    let signature = sn_evm::cryptography::sign_message(evm_sk_hex, VAULT_SECRET_KEY_SEED)
+        .map_err(VaultKeyError::FailedToSignMessage)?;
+    let hash = hash_to_32b(&signature);
+
+    // NB TODO: not sure this is safe, we should ask Mav or find a better way to do this!
+    let root_sk = bls::SecretKey::default();
+    let unique_key = root_sk.derive_child(&hash);
+    Ok(unique_key)
+}
+
+fn hash_to_32b(msg: &[u8]) -> [u8; 32] {
+    let mut sha = Sha256::new();
+    sha.update(msg);
+    sha.finalize().into()
+}

--- a/autonomi/src/client/vault/key.rs
+++ b/autonomi/src/client/vault/key.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use blst::min_pk::SecretKey as BlstSecretKey;
 use sha2::{Digest, Sha256};
 
 /// Secret key to decrypt vault content
@@ -17,6 +18,10 @@ pub enum VaultKeyError {
     FailedToSignMessage(#[from] sn_evm::cryptography::SignError),
     #[error("Failed to generate vault secret key: {0}")]
     FailedToGenerateVaultSecretKey(String),
+    #[error("Failed to convert blst secret key to blsttc secret key: {0}")]
+    BlsConversionError(#[from] bls::Error),
+    #[error("Failed to generate blst secret key")]
+    KeyGenerationError,
 }
 
 /// Message used to generate the vault secret key from the EVM secret key
@@ -28,16 +33,24 @@ const VAULT_SECRET_KEY_SEED: &[u8] = b"Massive Array of Internet Disks Secure Ac
 pub fn derive_vault_key(evm_sk_hex: &str) -> Result<VaultSecretKey, VaultKeyError> {
     let signature = sn_evm::cryptography::sign_message(evm_sk_hex, VAULT_SECRET_KEY_SEED)
         .map_err(VaultKeyError::FailedToSignMessage)?;
-    let hash = hash_to_32b(&signature);
 
-    // NB TODO: not sure this is safe, we should ask Mav or find a better way to do this!
-    let root_sk = bls::SecretKey::default();
-    let unique_key = root_sk.derive_child(&hash);
-    Ok(unique_key)
+    let blst_key = derive_secret_key_from_seed(&signature)?;
+    let vault_sk = blst_to_blsttc(&blst_key)?;
+    Ok(vault_sk)
 }
 
-fn hash_to_32b(msg: &[u8]) -> [u8; 32] {
-    let mut sha = Sha256::new();
-    sha.update(msg);
-    sha.finalize().into()
+/// Convert a blst secret key to a blsttc secret key and pray that endianness is the same
+fn blst_to_blsttc(sk: &BlstSecretKey) -> Result<bls::SecretKey, VaultKeyError> {
+    let sk_bytes = sk.to_bytes();
+    let sk = bls::SecretKey::from_bytes(sk_bytes).map_err(VaultKeyError::BlsConversionError)?;
+    Ok(sk)
+}
+
+fn derive_secret_key_from_seed(seed: &[u8]) -> Result<BlstSecretKey, VaultKeyError> {
+    let mut hasher = Sha256::new();
+    hasher.update(seed);
+    let hashed_seed = hasher.finalize();
+    let sk =
+        BlstSecretKey::key_gen(&hashed_seed, &[]).map_err(|_| VaultKeyError::KeyGenerationError)?;
+    Ok(sk)
 }

--- a/autonomi/src/client/wasm.rs
+++ b/autonomi/src/client/wasm.rs
@@ -2,7 +2,9 @@ use libp2p::Multiaddr;
 use wasm_bindgen::prelude::*;
 
 use super::address::{addr_to_str, str_to_addr};
-use super::vault_user_data::UserData;
+
+#[cfg(feature = "vault")]
+use super::vault::UserData;
 
 #[wasm_bindgen(js_name = Client)]
 pub struct JsClient(super::Client);

--- a/evmlib/src/cryptography.rs
+++ b/evmlib/src/cryptography.rs
@@ -8,8 +8,56 @@
 
 use crate::common::Hash;
 use alloy::primitives::keccak256;
+use alloy::signers::k256::ecdsa::{signature, RecoveryId, Signature, SigningKey};
+use alloy::signers::local::PrivateKeySigner;
 
 /// Hash data using Keccak256.
 pub fn hash<T: AsRef<[u8]>>(data: T) -> Hash {
     keccak256(data.as_ref())
+}
+
+/// Sign error
+#[derive(Debug, thiserror::Error)]
+pub enum SignError {
+    #[error("Failed to parse EVM secret key: {0}")]
+    InvalidEvmSecretKey(String),
+    #[error("Failed to sign message: {0}")]
+    Signature(#[from] signature::Error),
+}
+
+/// Sign a message with an EVM secret key.
+pub fn sign_message(evm_secret_key_str: &str, message: &[u8]) -> Result<Vec<u8>, SignError> {
+    let signer: PrivateKeySigner =
+        evm_secret_key_str
+            .parse::<PrivateKeySigner>()
+            .map_err(|err| {
+                error!("Error parsing EVM secret key: {err}");
+                SignError::InvalidEvmSecretKey(err.to_string())
+            })?;
+
+    let message_hash = to_eth_signed_message_hash(message);
+    let (signature, _) = sign_message_recoverable(&signer.into_credential(), message_hash)?;
+    Ok(signature.to_vec())
+}
+
+/// Hash a message using Keccak256, then add the Ethereum prefix and hash it again.
+fn to_eth_signed_message_hash<T: AsRef<[u8]>>(message: T) -> [u8; 32] {
+    const PREFIX: &str = "\x19Ethereum Signed Message:\n32";
+
+    let hashed_message = hash(message);
+
+    let mut eth_message = Vec::with_capacity(PREFIX.len() + 32);
+    eth_message.extend_from_slice(PREFIX.as_bytes());
+    eth_message.extend_from_slice(hashed_message.as_slice());
+
+    hash(eth_message).into()
+}
+
+/// Sign a message with a recoverable public key.
+fn sign_message_recoverable<T: AsRef<[u8]>>(
+    secret_key: &SigningKey,
+    message: T,
+) -> Result<(Signature, RecoveryId), signature::Error> {
+    let hash = to_eth_signed_message_hash(message);
+    secret_key.sign_prehash_recoverable(&hash)
 }

--- a/sn_evm/src/lib.rs
+++ b/sn_evm/src/lib.rs
@@ -13,6 +13,7 @@ pub use evmlib::common::Address as RewardsAddress;
 pub use evmlib::common::Address as EvmAddress;
 pub use evmlib::common::QuotePayment;
 pub use evmlib::common::{QuoteHash, TxHash};
+pub use evmlib::cryptography;
 #[cfg(feature = "external-signer")]
 pub use evmlib::external_signer;
 pub use evmlib::utils;

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -396,7 +396,8 @@ impl Node {
     ) -> Result<()> {
         // owner PK is defined herein, so as long as record key and this match, we're good
         let addr = scratchpad.address();
-        debug!("Validating and storing scratchpad {addr:?}");
+        let count = scratchpad.count();
+        debug!("Validating and storing scratchpad {addr:?} with count {count}");
 
         // check if the deserialized value's RegisterAddress matches the record's key
         let scratchpad_key = NetworkAddress::ScratchpadAddress(*addr).to_record_key();

--- a/sn_node/src/put_validation.rs
+++ b/sn_node/src/put_validation.rs
@@ -137,10 +137,22 @@ impl Node {
                 store_scratchpad_result
             }
             RecordKind::Scratchpad => {
-                error!("Scratchpad should not be validated at this point");
-                Err(Error::InvalidPutWithoutPayment(
-                    PrettyPrintRecordKey::from(&record.key).into_owned(),
-                ))
+                // make sure we already have this scratchpad locally, else reject it as first time upload needs payment
+                let key = record.key.clone();
+                let scratchpad = try_deserialize_record::<Scratchpad>(&record)?;
+                let net_addr = NetworkAddress::ScratchpadAddress(*scratchpad.address());
+                let pretty_key = PrettyPrintRecordKey::from(&key);
+                trace!("Got record to store without payment for scratchpad at {pretty_key:?}");
+                if !self.validate_key_and_existence(&net_addr, &key).await? {
+                    warn!("Ignore store without payment for scratchpad at {pretty_key:?}");
+                    return Err(Error::InvalidPutWithoutPayment(
+                        PrettyPrintRecordKey::from(&record.key).into_owned(),
+                    ));
+                }
+
+                // store the scratchpad
+                self.validate_and_store_scratchpad_record(scratchpad, key, false)
+                    .await
             }
             RecordKind::Spend => {
                 let record_key = record.key.clone();
@@ -387,7 +399,6 @@ impl Node {
     /// Check Counter: It MUST ensure that the new counter value is strictly greater than the currently stored value to prevent replay attacks.
     /// Verify Signature: It MUST use the public key to verify the BLS12-381 signature against the content hash and the counter.
     /// Accept or Reject: If all verifications succeed, the node MUST accept the packet and replace any previous version. Otherwise, it MUST reject the update.
-
     pub(crate) async fn validate_and_store_scratchpad_record(
         &self,
         scratchpad: Scratchpad,

--- a/sn_protocol/src/storage/scratchpad.rs
+++ b/sn_protocol/src/storage/scratchpad.rs
@@ -52,6 +52,11 @@ impl Scratchpad {
         self.counter
     }
 
+    /// Set counter manually
+    pub fn set_count(&mut self, c: u64) {
+        self.counter = c;
+    }
+
     /// Return the current data encoding
     pub fn data_encoding(&self) -> u64 {
         self.data_encoding

--- a/sn_protocol/src/storage/scratchpad.rs
+++ b/sn_protocol/src/storage/scratchpad.rs
@@ -141,3 +141,17 @@ impl Scratchpad {
         self.encrypted_data.len()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scratchpad_is_valid() {
+        let sk = SecretKey::random();
+        let pk = sk.public_key();
+        let mut scratchpad = Scratchpad::new(pk, 42);
+        scratchpad.update_and_sign(Bytes::from_static(b"data to be encrypted"), &sk);
+        assert!(scratchpad.is_valid());
+    }
+}

--- a/sn_protocol/src/storage/scratchpad.rs
+++ b/sn_protocol/src/storage/scratchpad.rs
@@ -52,11 +52,6 @@ impl Scratchpad {
         self.counter
     }
 
-    /// Set counter manually
-    pub fn set_count(&mut self, c: u64) {
-        self.counter = c;
-    }
-
     /// Return the current data encoding
     pub fn data_encoding(&self) -> u64 {
         self.data_encoding


### PR DESCRIPTION
- Node side Vault Upgrade implementation (previously only supported paying for vault but not accepting updates)
- CLI integration of local disk user data
    - now `register list` and `file list` commands show previously uploaded data addresses
- CLI integration of vaults to backup the local user data to disk

```
Usage: autonomi vault [OPTIONS] <COMMAND>

Commands:
  cost    Estimate cost to create a vault
  create  Create a vault at a deterministic address based on your `SECRET_KEY`. Pushing an encrypted
          backup of your local user data to the network
  load    Load an existing vault from the network. Use this when loading your user data to a new
          device. You need to have your original `SECRET_KEY` to load the vault
  sync    Sync vault with the network, including registers and files. Loads existing user data from
          the network and merges it with your local user data. Pushes your local user data to the
          network
  help    Print this message or the help of the given subcommand(s)
```

- Vault key generation from EVM secret key signature => meaning apps without access to the key itself but with signing capabilities like metamask or hardware wallets can also use this feature!

AFTER THIS PR USER ONLY NEED TO KEEP TRACK OF **1 SINGLE KEY** (EVM key) to access everything Autonomi related:
- register secret key (encrypted in the vault)
- previously uploaded data addresses (encrypted in the vault)
- previously uploaded register addresses (encrypted in the vault)
- vault key (generated from evm key sig)
