### PR TITLE
feat: print rewards address in `status --details`

### DIFF
--- a/sn_node_manager/src/lib.rs
+++ b/sn_node_manager/src/lib.rs
@@ -424,12 +424,7 @@ pub async fn status_report(
                 node.reward_balance
                     .map_or("-".to_string(), |b| b.to_string())
             );
-            println!(
-                "Owner: {}",
-                node.owner
-                    .as_ref()
-                    .map_or("-".to_string(), |o| o.to_string())
-            );
+            println!("Rewards address: {}", node.rewards_address);
             println!();
         }
 


### PR DESCRIPTION
This is a utility for the user's reference.

The owner name field is removed from the output. It doesn't serve much purpose without the Discord link.