### PR TITLE
fix(launchpad): throbber stops after a while

### DIFF
--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -179,8 +179,7 @@ impl Status<'_> {
                     // Update status based on current node status
                     item.status = match node_item.status {
                         ServiceStatus::Running => {
-                            // Call calc_next on the spinner state
-                            item.spinner_state.calc_next();
+                            NodeItem::update_spinner_state(&mut item.spinner_state);
                             NodeStatus::Running
                         }
                         ServiceStatus::Stopped => NodeStatus::Stopped,
@@ -190,7 +189,7 @@ impl Status<'_> {
 
                     // Starting is not part of ServiceStatus so we do it manually
                     if let Some(LockRegistryState::StartingNodes) = self.lock_registry {
-                        item.spinner_state.calc_next();
+                        NodeItem::update_spinner_state(&mut item.spinner_state);
                         item.status = NodeStatus::Starting;
                     }
 
@@ -1029,6 +1028,16 @@ pub struct NodeItem<'a> {
 }
 
 impl NodeItem<'_> {
+    fn update_spinner_state(state: &mut ThrobberState) {
+        // Call calc_next on the spinner state
+        // https://github.com/arkbig/throbber-widgets-tui/issues/19
+        if state.index() == i8::MAX {
+            *state = ThrobberState::default();
+        } else {
+            state.calc_next();
+        }
+    }
+
     fn render_as_row(&mut self, index: usize, area: Rect, f: &mut Frame<'_>) -> Row {
         let mut row_style = Style::default().fg(GHOST_WHITE);
         let mut spinner_state = self.spinner_state.clone();
@@ -1100,7 +1109,7 @@ impl NodeItem<'_> {
             ),
             self.status.to_string(),
         ];
-        let throbber_area = Rect::new(area.width - 2, area.y + 2 + index as u16, 1, 1);
+        let throbber_area = Rect::new(area.width - 3, area.y + 2 + index as u16, 1, 1);
 
         f.render_stateful_widget(self.spinner.clone(), throbber_area, &mut spinner_state);
 


### PR DESCRIPTION
After ~ 2 minutes (127 seconds), the throbber stops swirling. 

Looks like a [bug in the component ](https://github.com/arkbig/throbber-widgets-tui/issues/19)

We reset the state and we encapsulate the function for future replacement.