### PR TITLE
Reduce ChunkVerificationIntensity per node

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -5,9 +5,9 @@ on:
   # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [ main, alpha*, beta*, rc* ]
+    branches: [main, alpha*, beta*, rc*]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 env:
   SAFE_DATA_PATH: /home/runner/.local/share/safe
@@ -126,6 +126,9 @@ jobs:
       - name: Assert we've reloaded some chunks
         run: rg "Existing record found" $RESTART_TEST_NODE_DATA_PATH
 
+      - name: Wait at least 1min for replication to happen # it is throttled to once/30s.
+        run: sleep 60
+
       - name: Verify data replication using rg
         shell: bash
         timeout-minutes: 1
@@ -232,7 +235,7 @@ jobs:
 
       # Logging of handling time is on Trace level,
       # meanwhile the local_network startup tool sets the logging level on Debug.
-      # 
+      #
       # - name: Check node swarm_driver handling statistics
       #   shell: bash
       #   # With the latest improvements, swarm_driver will be in high chance

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -811,19 +811,24 @@ jobs:
         # Otherwise kad will remove a `dropped out node` directly from RT.
         # So, the detection of the removal explicity will now have much less chance,
         # due to the removal of connection_issue tracking.
+        #
+        # With the further reduction of replication frequency,
+        # it now becomes harder to detect a `dropped out node` as a `failed to replicate` node.
+        # Hence now remove the assertion check and replace with a print out only.
         run: |
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          echo "Node dir count is $node_count"
           restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "Restart $restart_count nodes"
+          if ! rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats
+          then
+            echo "No peer removal count found"
+            exit 0
+          fi
           peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
             rg "(\d+) matches" | rg "\d+" -o)
           echo "PeerRemovedFromRoutingTable $peer_removed times"
-          if [ -z "$peer_removed" ]; then
-            echo "No peer removal count found"
-            exit 1
-          fi
-          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-          echo "Node dir count is $node_count"
 
       # Only error out after uploading the logs
       - name: Don't log raw data

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -42,7 +42,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 
 /// Time before considering the connection timed out.
-pub const CONNECT_TIMEOUT_SECS: u64 = 20;
+pub const CONNECT_TIMEOUT_SECS: u64 = 10;
 
 const CLIENT_EVENT_CHANNEL_SIZE: usize = 100;
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -29,6 +29,7 @@ use sn_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use std::{
+    cmp::Ordering,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     time::Duration,
@@ -980,26 +981,30 @@ impl SwarmDriver {
         let acceptable_distance_range = self.get_request_range();
         let target_key = target_address.as_kbucket_key();
 
-        let peers = self
+        let sorted_peers: Vec<_> = self
             .swarm
             .behaviour_mut()
             .kademlia
             .get_closest_local_peers(&target_key)
-            .filter_map(|key| {
-                // here we compare _bucket_, not the exact distance.
-                // We want to include peers that are just outside the range
-                // Such that we can and will exceed the range in a search eventually
-                if acceptable_distance_range.ilog2() < target_key.distance(&key).ilog2() {
-                    return None;
+            .collect();
+
+        // Binary search to find the index where we exceed the acceptable range
+        let split_index = sorted_peers
+            .binary_search_by(|key| {
+                let distance = target_key.distance(key);
+                if distance >= acceptable_distance_range {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
                 }
-
-                // Map KBucketKey<PeerId> to PeerId.
-                let peer_id = key.into_preimage();
-                Some(peer_id)
             })
-            .collect::<Vec<_>>();
+            .unwrap_or_else(|x| x);
 
-        peers
+        // Convert KBucketKey<PeerId> to PeerId for all peers within range
+        sorted_peers[..split_index]
+            .iter()
+            .map(|key| key.into_preimage())
+            .collect()
     }
 
     /// From all local peers, returns any within current get_range for a given key

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -141,7 +141,7 @@ pub enum LocalSwarmCmd {
     /// NOTE: This does result in outgoing messages, but is produced locally
     TriggerIntervalReplication,
     /// Triggers unrelevant record cleanup
-    TriggerUnrelevantRecordCleanup,
+    TriggerIrrelevantRecordCleanup,
 }
 
 /// Commands to send to the Swarm
@@ -292,7 +292,7 @@ impl Debug for LocalSwarmCmd {
             LocalSwarmCmd::TriggerIntervalReplication => {
                 write!(f, "LocalSwarmCmd::TriggerIntervalReplication")
             }
-            LocalSwarmCmd::TriggerUnrelevantRecordCleanup => {
+            LocalSwarmCmd::TriggerIrrelevantRecordCleanup => {
                 write!(f, "LocalSwarmCmd::TriggerUnrelevantRecordCleanup")
             }
         }
@@ -848,13 +848,13 @@ impl SwarmDriver {
                     self.send_event(NetworkEvent::KeysToFetchForReplication(new_keys_to_fetch));
                 }
             }
-            LocalSwarmCmd::TriggerUnrelevantRecordCleanup => {
-                cmd_string = "TriggerUnrelevantRecordCleanup";
+            LocalSwarmCmd::TriggerIrrelevantRecordCleanup => {
+                cmd_string = "TriggerIrrelevantRecordCleanup";
                 self.swarm
                     .behaviour_mut()
                     .kademlia
                     .store_mut()
-                    .cleanup_unrelevant_records();
+                    .cleanup_irrelevant_records();
             }
         }
 

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -43,8 +43,8 @@ const MAX_CONTINUOUS_HDD_WRITE_ERROR: usize = 5;
 // Shall be synced with `sn_node::PERIODIC_REPLICATION_INTERVAL_MAX_S`
 const REPLICATION_TIMEOUT: Duration = Duration::from_secs(45);
 
-// Add this constant at the top of the file with other constants
-const MIN_REPLICATION_INTERVAL: Duration = Duration::from_secs(60); // one minute
+// Throttles replication to at most once every 30 seconds
+const MIN_REPLICATION_INTERVAL_S: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum NodeIssue {
@@ -1043,7 +1043,7 @@ impl SwarmDriver {
     fn try_interval_replication(&mut self) -> Result<()> {
         // Add a last_replication field to track the last time replication was performed
         if let Some(last_replication) = self.last_replication {
-            if last_replication.elapsed() < MIN_REPLICATION_INTERVAL {
+            if last_replication.elapsed() < MIN_REPLICATION_INTERVAL_S {
                 info!("Skipping replication as minimum interval hasn't elapsed");
                 return Ok(());
             }

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -121,7 +121,7 @@ pub const MAX_PACKET_SIZE: usize = 1024 * 1024 * 5; // the chunk size is 1mb, so
 // Timeout for requests sent/received through the request_response behaviour.
 const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(30);
 // Sets the keep-alive timeout of idle connections.
-const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(30);
+const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 // Inverval of resending identify to connected peers.
 const RESEND_IDENTIFY_INVERVAL: Duration = Duration::from_secs(3600);

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -720,6 +720,7 @@ impl NetworkBuilder {
             replication_targets: Default::default(),
             range_distances: VecDeque::with_capacity(GET_RANGE_STORAGE_LIMIT),
             first_contact_made: false,
+            last_replication: None,
         };
 
         let network = Network::new(
@@ -818,6 +819,9 @@ pub struct SwarmDriver {
     pub(crate) quotes_history: BTreeMap<PeerId, PaymentQuote>,
     pub(crate) replication_targets: BTreeMap<PeerId, Instant>,
 
+    /// when was the last replication event
+    /// This allows us to throttle replication no matter how it is triggered
+    pub(crate) last_replication: Option<Instant>,
     // The recent range_distances calculated by the node
     // Each update is generated when there is a routing table change
     // We use the largest of these X_STORAGE_LIMIT values as our X distance.

--- a/sn_networking/src/event/mod.rs
+++ b/sn_networking/src/event/mod.rs
@@ -146,7 +146,7 @@ pub enum NetworkEvent {
     /// Carry out chunk proof check against the specified record and peer
     ChunkProofVerification {
         peer_id: PeerId,
-        keys_to_verify: Vec<NetworkAddress>,
+        key_to_verify: NetworkAddress,
     },
 }
 
@@ -208,7 +208,7 @@ impl Debug for NetworkEvent {
             }
             NetworkEvent::ChunkProofVerification {
                 peer_id,
-                keys_to_verify,
+                key_to_verify: keys_to_verify,
             } => {
                 write!(
                     f,

--- a/sn_networking/src/event/request_response.rs
+++ b/sn_networking/src/event/request_response.rs
@@ -250,14 +250,19 @@ impl SwarmDriver {
 
                 if keys_to_verify.is_empty() {
                     debug!("No valid candidate to be checked against peer {holder:?}");
-                } else if let Err(error) = event_sender
-                    .send(NetworkEvent::ChunkProofVerification {
-                        peer_id: holder,
-                        keys_to_verify,
-                    })
-                    .await
-                {
-                    error!("SwarmDriver failed to send event: {}", error);
+                } else {
+                    // choose one random key to verify
+                    let key_to_verify =
+                        keys_to_verify[OsRng.gen_range(0..keys_to_verify.len())].clone();
+                    if let Err(error) = event_sender
+                        .send(NetworkEvent::ChunkProofVerification {
+                            peer_id: holder,
+                            key_to_verify,
+                        })
+                        .await
+                    {
+                        error!("SwarmDriver failed to send event: {}", error);
+                    }
                 }
 
                 // In additon to verify the sender, we also verify a random close node.
@@ -281,14 +286,20 @@ impl SwarmDriver {
 
                         if keys_to_verify.is_empty() {
                             debug!("No valid candidate to be checked against peer {candidate:?}");
-                        } else if let Err(error) = event_sender
-                            .send(NetworkEvent::ChunkProofVerification {
-                                peer_id: candidate_peer_id,
-                                keys_to_verify,
-                            })
-                            .await
-                        {
-                            error!("SwarmDriver failed to send event: {}", error);
+                        } else {
+                            // choose one random key to verify
+                            let key_to_verify =
+                                keys_to_verify[OsRng.gen_range(0..keys_to_verify.len())].clone();
+
+                            if let Err(error) = event_sender
+                                .send(NetworkEvent::ChunkProofVerification {
+                                    peer_id: candidate_peer_id,
+                                    key_to_verify,
+                                })
+                                .await
+                            {
+                                error!("SwarmDriver failed to send event: {}", error);
+                            }
                         }
 
                         break;

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -1152,8 +1152,8 @@ impl Network {
         self.send_local_swarm_cmd(LocalSwarmCmd::QuoteVerification { quotes });
     }
 
-    pub fn trigger_unrelevant_record_cleanup(&self) {
-        self.send_local_swarm_cmd(LocalSwarmCmd::TriggerUnrelevantRecordCleanup)
+    pub fn trigger_irrelevant_record_cleanup(&self) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::TriggerIrrelevantRecordCleanup)
     }
 
     /// Helper to send NetworkSwarmCmd

--- a/sn_networking/src/record_store.rs
+++ b/sn_networking/src/record_store.rs
@@ -454,7 +454,7 @@ impl NodeRecordStore {
     // those `out of range` records shall be cleaned up.
     // This is to avoid `over-quoting` during restart, when RT is not fully populated,
     // result in mis-calculation of relevant records.
-    pub fn cleanup_unrelevant_records(&mut self) {
+    pub fn cleanup_irrelevant_records(&mut self) {
         let accumulated_records = self.records.len();
         if accumulated_records < MAX_RECORDS_COUNT * 6 / 10 {
             return;

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -159,12 +159,12 @@ impl UnifiedRecordStore {
         };
     }
 
-    pub(crate) fn cleanup_unrelevant_records(&mut self) {
+    pub(crate) fn cleanup_irrelevant_records(&mut self) {
         match self {
             Self::Client(_store) => {
-                warn!("Calling cleanup_unrelevant_records at Client. This should not happen");
+                warn!("Calling cleanup_irrelevant_records at Client. This should not happen");
             }
-            Self::Node(store) => store.cleanup_unrelevant_records(),
+            Self::Node(store) => store.cleanup_irrelevant_records(),
         }
     }
 }

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -45,7 +45,7 @@ use sn_evm::EvmNetwork;
 
 /// Interval to trigger replication of all records to all peers.
 /// This is the max time it should take. Minimum interval at any node will be half this
-pub const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 45;
+pub const PERIODIC_REPLICATION_INTERVAL_MAX_S: u64 = 180;
 
 /// Interval to trigger bad node detection.
 /// This is the max time it should take. Minimum interval at any node will be half this

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -485,12 +485,12 @@ impl Node {
             }
             NetworkEvent::ChunkProofVerification {
                 peer_id,
-                keys_to_verify,
+                key_to_verify,
             } => {
                 event_header = "ChunkProofVerification";
                 let network = self.network().clone();
 
-                debug!("Going to verify chunk {keys_to_verify:?} against peer {peer_id:?}");
+                debug!("Going to verify data peer {peer_id:?}");
 
                 let _handle = spawn(async move {
                     // To avoid the peer is in the process of getting the copy via replication,
@@ -498,7 +498,7 @@ impl Node {
                     // Only report the node as bad when ALL the verification attempts failed.
                     let mut attempts = 0;
                     while attempts < MAX_CHUNK_PROOF_VERIFY_ATTEMPTS {
-                        if chunk_proof_verify_peer(&network, peer_id, &keys_to_verify).await {
+                        if chunk_proof_verify_peer(&network, peer_id, &key_to_verify).await {
                             return;
                         }
                         // Replication interval is 22s - 45s.
@@ -768,44 +768,36 @@ impl Node {
     }
 }
 
-async fn chunk_proof_verify_peer(
-    network: &Network,
-    peer_id: PeerId,
-    keys: &[NetworkAddress],
-) -> bool {
-    for key in keys.iter() {
-        let check_passed = if let Ok(Some(record)) =
-            network.get_local_record(&key.to_record_key()).await
-        {
-            let nonce = thread_rng().gen::<u64>();
-            let expected_proof = ChunkProof::new(&record.value, nonce);
-            debug!("To verify peer {peer_id:?}, chunk_proof for {key:?} is {expected_proof:?}");
+async fn chunk_proof_verify_peer(network: &Network, peer_id: PeerId, key: &NetworkAddress) -> bool {
+    let check_passed = if let Ok(Some(record)) =
+        network.get_local_record(&key.to_record_key()).await
+    {
+        let nonce = thread_rng().gen::<u64>();
+        let expected_proof = ChunkProof::new(&record.value, nonce);
+        debug!("To verify peer {peer_id:?}, chunk_proof for {key:?} is {expected_proof:?}");
 
-            let request = Request::Query(Query::GetChunkExistenceProof {
-                key: key.clone(),
-                nonce,
-            });
-            let responses = network
-                .send_and_get_responses(&[peer_id], &request, true)
-                .await;
-            let n_verified = responses
-                .into_iter()
-                .filter_map(|(peer, resp)| {
-                    received_valid_chunk_proof(key, &expected_proof, peer, resp)
-                })
-                .count();
+        let request = Request::Query(Query::GetChunkExistenceProof {
+            key: key.clone(),
+            nonce,
+        });
+        let responses = network
+            .send_and_get_responses(&[peer_id], &request, true)
+            .await;
+        let n_verified = responses
+            .into_iter()
+            .filter_map(|(peer, resp)| received_valid_chunk_proof(key, &expected_proof, peer, resp))
+            .count();
 
-            n_verified >= 1
-        } else {
-            error!(
+        n_verified >= 1
+    } else {
+        error!(
                  "To verify peer {peer_id:?} Could not get ChunkProof for {key:?} as we don't have the record locally."
             );
-            true
-        };
+        true
+    };
 
-        if !check_passed {
-            return false;
-        }
+    if !check_passed {
+        return false;
     }
 
     true

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -272,9 +272,9 @@ impl Node {
                 tokio::time::interval(UPTIME_METRICS_UPDATE_INTERVAL);
             let _ = uptime_metrics_update_interval.tick().await; // first tick completes immediately
 
-            let mut unrelevant_records_cleanup_interval =
+            let mut irrelevant_records_cleanup_interval =
                 tokio::time::interval(UNRELEVANT_RECORDS_CLEANUP_INTERVAL);
-            let _ = unrelevant_records_cleanup_interval.tick().await; // first tick completes immediately
+            let _ = irrelevant_records_cleanup_interval.tick().await; // first tick completes immediately
 
             loop {
                 let peers_connected = &peers_connected;
@@ -333,11 +333,11 @@ impl Node {
                             let _ = metrics_recorder.uptime.set(metrics_recorder.started_instant.elapsed().as_secs() as i64);
                         }
                     }
-                    _ = unrelevant_records_cleanup_interval.tick() => {
+                    _ = irrelevant_records_cleanup_interval.tick() => {
                         let network = self.network().clone();
 
                         let _handle = spawn(async move {
-                            Self::trigger_unrelevant_record_cleanup(network);
+                            Self::trigger_irrelevant_record_cleanup(network);
                         });
                     }
                 }

--- a/sn_node/src/replication.rs
+++ b/sn_node/src/replication.rs
@@ -29,8 +29,8 @@ impl Node {
     }
 
     /// Cleanup unrelevant records if accumulated too many.
-    pub(crate) fn trigger_unrelevant_record_cleanup(network: Network) {
-        network.trigger_unrelevant_record_cleanup()
+    pub(crate) fn trigger_irrelevant_record_cleanup(network: Network) {
+        network.trigger_irrelevant_record_cleanup()
     }
 
     /// Get the Record from a peer or from the network without waiting.


### PR DESCRIPTION
(Last commit is new)

We were looping over all chunks (one at a time), a) printing that to logs! (a lot of reads), and b) causing probably longer lasting feedback loops here based upon replication... 

here we more simply verify only one key at once (chosen at random), and could then just increase the amount of ndoes we verify against... instead of scrutinizing one for potentially thousands of keys!

================================================================================

Will be replaced by the PR https://github.com/maidsafe/safe_network/pull/2336