### PR TITLE
feat(autonomi): support prepaid put operations

### DIFF
--- a/autonomi-cli/src/commands/vault.rs
+++ b/autonomi-cli/src/commands/vault.rs
@@ -40,7 +40,7 @@ pub async fn create(peers: Vec<Multiaddr>) -> Result<()> {
 
     println!("Pushing to network vault...");
     let total_cost = client
-        .put_user_data_to_vault(&vault_sk, &wallet, local_user_data)
+        .put_user_data_to_vault(&vault_sk, wallet.into(), local_user_data)
         .await?;
 
     if total_cost.is_zero() {
@@ -82,7 +82,7 @@ pub async fn sync(peers: Vec<Multiaddr>, force: bool) -> Result<()> {
     let private_file_archives_len = local_user_data.private_file_archives.len();
     let registers_len = local_user_data.registers.len();
     client
-        .put_user_data_to_vault(&vault_sk, &wallet, local_user_data)
+        .put_user_data_to_vault(&vault_sk, wallet.into(), local_user_data)
         .await?;
 
     println!("✅ Successfully synced vault");

--- a/autonomi/src/client/archive.rs
+++ b/autonomi/src/client/archive.rs
@@ -168,7 +168,7 @@ impl Client {
         let bytes = archive
             .into_bytes()
             .map_err(|e| PutError::Serialization(format!("Failed to serialize archive: {e:?}")))?;
-        self.data_put(bytes, wallet).await
+        self.data_put(bytes, wallet.into()).await
     }
 
     /// Get the cost to upload an archive

--- a/autonomi/src/client/archive_private.rs
+++ b/autonomi/src/client/archive_private.rs
@@ -19,9 +19,9 @@ use super::{
     data_private::PrivateDataAccess,
     Client,
 };
+use crate::client::payment::PaymentOption;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use sn_evm::EvmWallet;
 
 /// The address of a private archive
 /// Contains the [`PrivateDataAccess`] leading to the [`PrivateArchive`] data
@@ -130,11 +130,11 @@ impl Client {
     pub async fn private_archive_put(
         &self,
         archive: PrivateArchive,
-        wallet: &EvmWallet,
+        payment_option: PaymentOption,
     ) -> Result<PrivateArchiveAccess, PutError> {
         let bytes = archive
             .into_bytes()
             .map_err(|e| PutError::Serialization(format!("Failed to serialize archive: {e:?}")))?;
-        self.private_data_put(bytes, wallet).await
+        self.private_data_put(bytes, payment_option).await
     }
 }

--- a/autonomi/src/client/external_signer.rs
+++ b/autonomi/src/client/external_signer.rs
@@ -1,36 +1,23 @@
-use crate::client::data::{DataAddr, PutError};
+use crate::client::data::PutError;
 use crate::client::utils::extract_quote_payments;
 use crate::self_encryption::encrypt;
 use crate::Client;
 use bytes::Bytes;
-use sn_evm::{PaymentQuote, ProofOfPayment, QuotePayment};
+use sn_evm::{PaymentQuote, QuotePayment};
 use sn_protocol::storage::Chunk;
 use std::collections::HashMap;
 use xor_name::XorName;
 
+use crate::utils::cost_map_to_quotes;
 #[allow(unused_imports)]
 pub use sn_evm::external_signer::*;
 
 impl Client {
-    /// Upload a piece of data to the network. This data will be self-encrypted.
-    /// Payment will not be done automatically as opposed to the regular `data_put`, so the proof of payment has to be provided.
-    /// Returns the Data Address at which the data was stored.
-    pub async fn data_put_with_proof_of_payment(
-        &self,
-        data: Bytes,
-        proof: HashMap<XorName, ProofOfPayment>,
-    ) -> Result<DataAddr, PutError> {
-        let (data_map_chunk, chunks, _) = encrypt_data(data)?;
-        self.upload_data_map(&proof, &data_map_chunk).await?;
-        self.upload_chunks(&chunks, &proof).await?;
-        Ok(*data_map_chunk.address().xorname())
-    }
-
     /// Get quotes for data.
     /// Returns a cost map, data payments to be executed and a list of free (already paid for) chunks.
-    pub async fn get_quotes_for_data(
+    pub async fn get_quotes_for_content_addresses(
         &self,
-        data: Bytes,
+        content_addrs: impl Iterator<Item = XorName>,
     ) -> Result<
         (
             HashMap<XorName, PaymentQuote>,
@@ -39,59 +26,18 @@ impl Client {
         ),
         PutError,
     > {
-        // Encrypt the data as chunks
-        let (_data_map_chunk, _chunks, xor_names) = encrypt_data(data)?;
-
-        let cost_map: HashMap<XorName, PaymentQuote> = self
-            .get_store_quotes(xor_names.into_iter())
-            .await?
-            .into_iter()
-            .map(|(name, (_, _, q))| (name, q))
-            .collect();
-
+        let cost_map = self.get_store_quotes(content_addrs).await?;
         let (quote_payments, free_chunks) = extract_quote_payments(&cost_map);
-        Ok((cost_map, quote_payments, free_chunks))
-    }
+        let quotes = cost_map_to_quotes(cost_map);
 
-    async fn upload_data_map(
-        &self,
-        payment_proofs: &HashMap<XorName, ProofOfPayment>,
-        data_map_chunk: &Chunk,
-    ) -> Result<(), PutError> {
-        let map_xor_name = data_map_chunk.name();
-
-        if let Some(proof) = payment_proofs.get(map_xor_name) {
-            debug!("Uploading data map chunk: {map_xor_name:?}");
-            self.chunk_upload_with_payment(data_map_chunk.clone(), proof.clone())
-                .await
-                .inspect_err(|err| error!("Error uploading data map chunk: {err:?}"))
-        } else {
-            Ok(())
-        }
-    }
-
-    async fn upload_chunks(
-        &self,
-        chunks: &[Chunk],
-        payment_proofs: &HashMap<XorName, ProofOfPayment>,
-    ) -> Result<(), PutError> {
-        debug!("Uploading {} chunks", chunks.len());
-        for chunk in chunks {
-            if let Some(proof) = payment_proofs.get(chunk.name()) {
-                let address = *chunk.address();
-                self.chunk_upload_with_payment(chunk.clone(), proof.clone())
-                    .await
-                    .inspect_err(|err| error!("Error uploading chunk {address:?} :{err:?}"))?;
-            }
-        }
-        Ok(())
+        Ok((quotes, quote_payments, free_chunks))
     }
 }
 
 /// Encrypts data as chunks.
 ///
 /// Returns the data map chunk, file chunks and a list of all content addresses including the data map.
-fn encrypt_data(data: Bytes) -> Result<(Chunk, Vec<Chunk>, Vec<XorName>), PutError> {
+pub fn encrypt_data(data: Bytes) -> Result<(Chunk, Vec<Chunk>, Vec<XorName>), PutError> {
     let now = sn_networking::target_arch::Instant::now();
     let result = encrypt(data)?;
 

--- a/autonomi/src/client/fs.rs
+++ b/autonomi/src/client/fs.rs
@@ -154,7 +154,7 @@ impl Client {
 
         // upload archive
         let archive_serialized = archive.into_bytes()?;
-        let arch_addr = self.data_put(archive_serialized, wallet).await?;
+        let arch_addr = self.data_put(archive_serialized, wallet.into()).await?;
 
         info!("Complete archive upload completed in {:?}", start.elapsed());
         #[cfg(feature = "loud")]
@@ -175,7 +175,7 @@ impl Client {
 
         let data = tokio::fs::read(path).await?;
         let data = Bytes::from(data);
-        let addr = self.data_put(data, wallet).await?;
+        let addr = self.data_put(data, wallet.into()).await?;
         Ok(addr)
     }
 

--- a/autonomi/src/client/fs_private.rs
+++ b/autonomi/src/client/fs_private.rs
@@ -102,7 +102,9 @@ impl Client {
 
         // upload archive
         let archive_serialized = archive.into_bytes()?;
-        let arch_addr = self.private_data_put(archive_serialized, wallet).await?;
+        let arch_addr = self
+            .private_data_put(archive_serialized, wallet.into())
+            .await?;
 
         info!(
             "Complete private archive upload completed in {:?}",
@@ -126,7 +128,7 @@ impl Client {
 
         let data = tokio::fs::read(path).await?;
         let data = Bytes::from(data);
-        let addr = self.private_data_put(data, wallet).await?;
+        let addr = self.private_data_put(data, wallet.into()).await?;
         Ok(addr)
     }
 }

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 pub mod address;
+pub mod payment;
 
 #[cfg(feature = "data")]
 pub mod archive;

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -1,0 +1,49 @@
+use crate::client::data::PayError;
+use crate::Client;
+use sn_evm::{EvmWallet, ProofOfPayment};
+use std::collections::HashMap;
+use xor_name::XorName;
+
+/// Contains the proof of payment for XOR addresses.
+pub type Receipt = HashMap<XorName, ProofOfPayment>;
+
+/// Payment options for data payments.
+#[derive(Clone)]
+pub enum PaymentOption {
+    Wallet(EvmWallet),
+    Receipt(Receipt),
+}
+
+impl From<EvmWallet> for PaymentOption {
+    fn from(value: EvmWallet) -> Self {
+        PaymentOption::Wallet(value)
+    }
+}
+
+impl From<&EvmWallet> for PaymentOption {
+    fn from(value: &EvmWallet) -> Self {
+        PaymentOption::Wallet(value.clone())
+    }
+}
+
+impl From<Receipt> for PaymentOption {
+    fn from(value: Receipt) -> Self {
+        PaymentOption::Receipt(value)
+    }
+}
+
+impl Client {
+    pub(crate) async fn pay_for_content_addrs(
+        &self,
+        content_addrs: impl Iterator<Item = XorName>,
+        payment_option: PaymentOption,
+    ) -> Result<Receipt, PayError> {
+        match payment_option {
+            PaymentOption::Wallet(wallet) => {
+                let (receipt, _) = self.pay(content_addrs, &wallet).await?;
+                Ok(receipt)
+            }
+            PaymentOption::Receipt(receipt) => Ok(receipt),
+        }
+    }
+}

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -6,12 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client::payment::Receipt;
+use crate::utils::receipt_from_cost_map_and_payments;
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
 use libp2p::kad::{Quorum, Record};
 use rand::{thread_rng, Rng};
 use self_encryption::{decrypt_full_set, DataMap, EncryptedChunk};
-use sn_evm::{EvmWallet, PaymentQuote, ProofOfPayment, QuotePayment};
+use sn_evm::{EvmWallet, ProofOfPayment, QuotePayment};
 use sn_networking::{
     GetRecordCfg, Network, NetworkError, PayeeQuote, PutRecordCfg, VerificationKind,
 };
@@ -28,7 +30,6 @@ use super::{
     Client,
 };
 use crate::self_encryption::DataMapLevel;
-use crate::utils::payment_proof_from_quotes_and_payments;
 
 impl Client {
     /// Fetch and decrypt all chunks in the data map.
@@ -160,13 +161,8 @@ impl Client {
         &self,
         content_addrs: impl Iterator<Item = XorName>,
         wallet: &EvmWallet,
-    ) -> Result<(HashMap<XorName, ProofOfPayment>, Vec<XorName>), PayError> {
-        let cost_map = self
-            .get_store_quotes(content_addrs)
-            .await?
-            .into_iter()
-            .map(|(name, (_, _, q))| (name, q))
-            .collect();
+    ) -> Result<(Receipt, Vec<XorName>), PayError> {
+        let cost_map = self.get_store_quotes(content_addrs).await?;
 
         let (quote_payments, skipped_chunks) = extract_quote_payments(&cost_map);
 
@@ -187,7 +183,7 @@ impl Client {
         drop(lock_guard);
         debug!("Unlocked wallet");
 
-        let proofs = payment_proof_from_quotes_and_payments(&cost_map, &payments);
+        let proofs = receipt_from_cost_map_and_payments(cost_map, &payments);
 
         trace!(
             "Chunk payments of {} chunks completed. {} chunks were free / already paid for",
@@ -254,12 +250,12 @@ async fn fetch_store_quote(
 
 /// Form to be executed payments and already executed payments from a cost map.
 pub(crate) fn extract_quote_payments(
-    cost_map: &HashMap<XorName, PaymentQuote>,
+    cost_map: &HashMap<XorName, PayeeQuote>,
 ) -> (Vec<QuotePayment>, Vec<XorName>) {
     let mut to_be_paid = vec![];
     let mut already_paid = vec![];
 
-    for (chunk_address, quote) in cost_map.iter() {
+    for (chunk_address, (_, _, quote)) in cost_map.iter() {
         if quote.cost.is_zero() {
             already_paid.push(*chunk_address);
         } else {

--- a/autonomi/src/client/vault.rs
+++ b/autonomi/src/client/vault.rs
@@ -11,12 +11,13 @@ pub mod user_data;
 
 pub use key::{derive_vault_key, VaultSecretKey};
 pub use user_data::UserData;
-use xor_name::XorName;
 
+use super::data::CostError;
 use crate::client::data::PutError;
+use crate::client::payment::PaymentOption;
 use crate::client::Client;
 use libp2p::kad::{Quorum, Record};
-use sn_evm::{Amount, AttoTokens, EvmWallet};
+use sn_evm::{Amount, AttoTokens};
 use sn_networking::{GetRecordCfg, GetRecordError, NetworkError, PutRecordCfg, VerificationKind};
 use sn_protocol::storage::{
     try_serialize_record, RecordKind, RetryStrategy, Scratchpad, ScratchpadAddress,
@@ -26,8 +27,6 @@ use sn_protocol::{storage::try_deserialize_record, NetworkAddress};
 use std::collections::HashSet;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use tracing::info;
-
-use super::data::CostError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum VaultError {
@@ -171,35 +170,15 @@ impl Client {
     pub async fn write_bytes_to_vault(
         &self,
         data: Bytes,
-        wallet: &EvmWallet,
+        payment_option: PaymentOption,
         secret_key: &VaultSecretKey,
         content_type: VaultContentType,
     ) -> Result<AttoTokens, PutError> {
         let mut total_cost = AttoTokens::zero();
-        let client_pk = secret_key.public_key();
 
-        let pad_res = self.get_vault_from_network(secret_key).await;
-        let mut is_new = true;
-
-        let mut scratch = if let Ok(existing_data) = pad_res {
-            info!("Scratchpad already exists, returning existing data");
-
-            info!(
-                "scratch already exists, is version {:?}",
-                existing_data.count()
-            );
-
-            is_new = false;
-
-            if existing_data.owner() != &client_pk {
-                return Err(PutError::VaultBadOwner);
-            }
-
-            existing_data
-        } else {
-            trace!("new scratchpad creation");
-            Scratchpad::new(client_pk, content_type)
-        };
+        let (mut scratch, is_new) = self
+            .get_or_create_scratchpad(secret_key, content_type)
+            .await?;
 
         let _ = scratch.update_and_sign(data, secret_key);
         debug_assert!(scratch.is_valid(), "Must be valid after being signed. This is a bug, please report it by opening an issue on our github");
@@ -210,21 +189,18 @@ impl Client {
         info!("Writing to vault at {scratch_address:?}",);
 
         let record = if is_new {
-            let scratch_xor = [&scratch_address]
-                .iter()
-                .filter_map(|f| f.as_xorname())
-                .collect::<Vec<XorName>>();
-            let (payment_proofs, _) = self
-                .pay(scratch_xor.iter().cloned(), wallet)
+            let receipt = self
+                .pay_for_content_addrs(scratch.to_xor_name_vec().into_iter(), payment_option)
                 .await
                 .inspect_err(|err| {
                     error!("Failed to pay for new vault at addr: {scratch_address:?} : {err}");
                 })?;
 
-            let proof = match payment_proofs.values().next() {
+            let proof = match receipt.values().next() {
                 Some(proof) => proof,
                 None => return Err(PutError::PaymentUnexpectedlyInvalid(scratch_address)),
             };
+
             total_cost = proof.quote.cost;
 
             Record {
@@ -279,5 +255,39 @@ impl Client {
             })?;
 
         Ok(total_cost)
+    }
+
+    /// Returns an existing scratchpad or creates a new one if it does not exist.
+    pub async fn get_or_create_scratchpad(
+        &self,
+        secret_key: &VaultSecretKey,
+        content_type: VaultContentType,
+    ) -> Result<(Scratchpad, bool), PutError> {
+        let client_pk = secret_key.public_key();
+
+        let pad_res = self.get_vault_from_network(secret_key).await;
+        let mut is_new = true;
+
+        let scratch = if let Ok(existing_data) = pad_res {
+            info!("Scratchpad already exists, returning existing data");
+
+            info!(
+                "scratch already exists, is version {:?}",
+                existing_data.count()
+            );
+
+            is_new = false;
+
+            if existing_data.owner() != &client_pk {
+                return Err(PutError::VaultBadOwner);
+            }
+
+            existing_data
+        } else {
+            trace!("new scratchpad creation");
+            Scratchpad::new(client_pk, content_type)
+        };
+
+        Ok((scratch, is_new))
     }
 }

--- a/autonomi/src/client/wasm.rs
+++ b/autonomi/src/client/wasm.rs
@@ -81,7 +81,7 @@ impl JsClient {
     #[wasm_bindgen(js_name = dataPut)]
     pub async fn data_put(&self, data: Vec<u8>, wallet: &JsWallet) -> Result<String, JsError> {
         let data = crate::Bytes::from(data);
-        let xorname = self.0.data_put(data, &wallet.0).await?;
+        let xorname = self.0.data_put(data, (&wallet.0).into()).await?;
 
         Ok(addr_to_str(xorname))
     }
@@ -284,7 +284,7 @@ mod vault {
 #[cfg(feature = "external-signer")]
 mod external_signer {
     use super::*;
-    use crate::payment_proof_from_quotes_and_payments;
+    use crate::receipt_from_quotes_and_payments;
     use sn_evm::external_signer::{approve_to_spend_tokens_calldata, pay_for_quotes_calldata};
     use sn_evm::EvmNetwork;
     use sn_evm::ProofOfPayment;
@@ -377,7 +377,7 @@ mod external_signer {
     ) -> Result<JsValue, JsError> {
         let quotes: HashMap<XorName, PaymentQuote> = serde_wasm_bindgen::from_value(quotes)?;
         let payments: BTreeMap<QuoteHash, TxHash> = serde_wasm_bindgen::from_value(payments)?;
-        let proof = payment_proof_from_quotes_and_payments(&quotes, &payments);
+        let proof = receipt_from_quotes_and_payments(&quotes, &payments);
         let js_value = serde_wasm_bindgen::to_value(&proof)?;
         Ok(js_value)
     }

--- a/autonomi/src/client/wasm.rs
+++ b/autonomi/src/client/wasm.rs
@@ -440,21 +440,6 @@ mod external_signer {
 
     #[wasm_bindgen(js_class = Client)]
     impl JsClient {
-        /// Encrypt data.
-        ///
-        /// # Example
-        ///
-        /// ```js
-        /// const [dataMapChunk, dataChunks, [chunkAddresses]] = await client.encryptData(data);
-        /// ``
-        #[wasm_bindgen(js_name = encryptData)]
-        pub async fn encrypt_data(&self, data: Vec<u8>) -> Result<JsValue, JsError> {
-            let data = crate::Bytes::from(data);
-            let result = encrypt_data(data)?;
-            let js_value = serde_wasm_bindgen::to_value(&result)?;
-            Ok(js_value)
-        }
-
         /// Get quotes for given chunk addresses.
         ///
         /// # Example
@@ -500,6 +485,21 @@ mod external_signer {
             let xorname = self.0.data_put(data, receipt.into()).await?;
             Ok(addr_to_str(xorname))
         }
+    }
+
+    /// Encrypt data.
+    ///
+    /// # Example
+    ///
+    /// ```js
+    /// const [dataMapChunk, dataChunks, [chunkAddresses]] = client.encryptData(data);
+    /// ``
+    #[wasm_bindgen(js_name = encryptData)]
+    pub fn encrypt(data: Vec<u8>) -> Result<JsValue, JsError> {
+        let data = crate::Bytes::from(data);
+        let result = encrypt_data(data)?;
+        let js_value = serde_wasm_bindgen::to_value(&result)?;
+        Ok(js_value)
     }
 
     /// Get the calldata for paying for quotes.

--- a/autonomi/src/client/wasm.rs
+++ b/autonomi/src/client/wasm.rs
@@ -1,7 +1,7 @@
+use super::address::{addr_to_str, str_to_addr};
+use crate::client::data_private::PrivateDataAccess;
 use libp2p::Multiaddr;
 use wasm_bindgen::prelude::*;
-
-use super::address::{addr_to_str, str_to_addr};
 
 #[cfg(feature = "vault")]
 use super::vault::UserData;
@@ -86,11 +86,37 @@ impl JsClient {
         Ok(addr_to_str(xorname))
     }
 
+    /// Upload private data to the network.
+    ///
+    /// Returns the `PrivateDataAccess` chunk of the data.
+    #[wasm_bindgen(js_name = privateDataPut)]
+    pub async fn private_data_put(
+        &self,
+        data: Vec<u8>,
+        wallet: &JsWallet,
+    ) -> Result<JsValue, JsError> {
+        let data = crate::Bytes::from(data);
+        let private_data_access = self.0.private_data_put(data, (&wallet.0).into()).await?;
+        let js_value = serde_wasm_bindgen::to_value(&private_data_access)?;
+
+        Ok(js_value)
+    }
+
     /// Fetch the data from the network.
     #[wasm_bindgen(js_name = dataGet)]
     pub async fn data_get(&self, addr: String) -> Result<Vec<u8>, JsError> {
         let addr = str_to_addr(&addr)?;
         let data = self.0.data_get(addr).await?;
+
+        Ok(data.to_vec())
+    }
+
+    /// Fetch the data from the network.
+    #[wasm_bindgen(js_name = privateDataGet)]
+    pub async fn private_data_get(&self, private_data_access: JsValue) -> Result<Vec<u8>, JsError> {
+        let private_data_access: PrivateDataAccess =
+            serde_wasm_bindgen::from_value(private_data_access)?;
+        let data = self.0.private_data_get(private_data_access).await?;
 
         Ok(data.to_vec())
     }
@@ -172,6 +198,79 @@ mod archive {
             let addr = self.0.archive_put(archive.0.clone(), &wallet.0).await?;
 
             Ok(addr_to_str(addr))
+        }
+    }
+}
+
+mod archive_private {
+    use super::*;
+    use crate::client::archive_private::{PrivateArchive, PrivateArchiveAccess};
+    use crate::client::data_private::PrivateDataAccess;
+    use std::path::PathBuf;
+    use wasm_bindgen::JsValue;
+
+    /// Structure mapping paths to data addresses.
+    #[wasm_bindgen(js_name = PrivateArchive)]
+    pub struct JsPrivateArchive(PrivateArchive);
+
+    #[wasm_bindgen(js_class = PrivateArchive)]
+    impl JsPrivateArchive {
+        /// Create a new private archive.
+        #[wasm_bindgen(constructor)]
+        pub fn new() -> Self {
+            Self(PrivateArchive::new())
+        }
+
+        /// Add a new file to the private archive.
+        #[wasm_bindgen(js_name = addNewFile)]
+        pub fn add_new_file(&mut self, path: String, data_map: JsValue) -> Result<(), JsError> {
+            let path = PathBuf::from(path);
+            let data_map: PrivateDataAccess = serde_wasm_bindgen::from_value(data_map)?;
+            self.0.add_new_file(path, data_map);
+
+            Ok(())
+        }
+
+        #[wasm_bindgen]
+        pub fn map(&self) -> Result<JsValue, JsError> {
+            let files = serde_wasm_bindgen::to_value(self.0.map())?;
+            Ok(files)
+        }
+    }
+
+    #[wasm_bindgen(js_class = Client)]
+    impl JsClient {
+        /// Fetch a private archive from the network.
+        #[wasm_bindgen(js_name = privateArchiveGet)]
+        pub async fn private_archive_get(
+            &self,
+            private_archive_access: JsValue,
+        ) -> Result<JsPrivateArchive, JsError> {
+            let private_archive_access: PrivateArchiveAccess =
+                serde_wasm_bindgen::from_value(private_archive_access)?;
+            let archive = self.0.private_archive_get(private_archive_access).await?;
+            let archive = JsPrivateArchive(archive);
+
+            Ok(archive)
+        }
+
+        /// Upload a private archive to the network.
+        ///
+        /// Returns the `PrivateArchiveAccess` chunk of the archive.
+        #[wasm_bindgen(js_name = privateArchivePut)]
+        pub async fn private_archive_put(
+            &self,
+            archive: &JsPrivateArchive,
+            wallet: &JsWallet,
+        ) -> Result<JsValue, JsError> {
+            let private_archive_access = self
+                .0
+                .private_archive_put(archive.0.clone(), (&wallet.0).into())
+                .await?;
+
+            let js_value = serde_wasm_bindgen::to_value(&private_archive_access)?;
+
+            Ok(js_value)
         }
     }
 }
@@ -273,7 +372,7 @@ mod vault {
             secret_key: &SecretKeyJs,
         ) -> Result<(), JsError> {
             self.0
-                .put_user_data_to_vault(&secret_key.0, &wallet.0, user_data.0.clone())
+                .put_user_data_to_vault(&secret_key.0, (&wallet.0).into(), user_data.0.clone())
                 .await?;
 
             Ok(())
@@ -284,10 +383,12 @@ mod vault {
 #[cfg(feature = "external-signer")]
 mod external_signer {
     use super::*;
+    use crate::client::address::str_to_addr;
+    use crate::client::external_signer::encrypt_data;
+    use crate::client::payment::Receipt;
     use crate::receipt_from_quotes_and_payments;
     use sn_evm::external_signer::{approve_to_spend_tokens_calldata, pay_for_quotes_calldata};
     use sn_evm::EvmNetwork;
-    use sn_evm::ProofOfPayment;
     use sn_evm::QuotePayment;
     use sn_evm::{Amount, PaymentQuote};
     use sn_evm::{EvmAddress, QuoteHash, TxHash};
@@ -298,38 +399,64 @@ mod external_signer {
 
     #[wasm_bindgen(js_class = Client)]
     impl JsClient {
-        /// Get quotes for given data.
+        /// Encrypt data.
         ///
         /// # Example
         ///
         /// ```js
-        /// const [quotes, quotePayments, free_chunks] = await client.getQuotes(data);
+        /// const [dataMapChunk, dataChunks, [chunkAddresses]] = await client.encryptData(data);
         /// ``
-        #[wasm_bindgen(js_name = getQuotes)]
-        pub async fn get_quotes_for_data(&self, data: Vec<u8>) -> Result<JsValue, JsError> {
+        #[wasm_bindgen(js_name = encryptData)]
+        pub async fn encrypt_data(&self, data: Vec<u8>) -> Result<JsValue, JsError> {
             let data = crate::Bytes::from(data);
-            let result = self.0.get_quotes_for_data(data).await?;
+            let result = encrypt_data(data)?;
             let js_value = serde_wasm_bindgen::to_value(&result)?;
             Ok(js_value)
         }
 
-        /// Upload data with a proof of payment.
+        /// Get quotes for given chunk addresses.
         ///
         /// # Example
         ///
         /// ```js
-        /// const proof = getPaymentProofFromQuotesAndPayments(quotes, payments);
-        /// const addr = await client.dataPutWithProof(data, proof);
+        /// const [quotes, quotePayments, free_chunks] = await client.getQuotes(chunkAddresses);
+        /// ``
+        #[wasm_bindgen(js_name = getQuotes)]
+        pub async fn get_quotes(&self, chunk_addresses: Vec<String>) -> Result<JsValue, JsError> {
+            let mut xor_addresses: Vec<XorName> = vec![];
+
+            for chunk_address_str in &chunk_addresses {
+                let xor_address = str_to_addr(chunk_address_str)?;
+                xor_addresses.push(xor_address);
+            }
+
+            let result = self
+                .0
+                .get_quotes_for_content_addresses(xor_addresses.into_iter())
+                .await?;
+
+            let js_value = serde_wasm_bindgen::to_value(&result)?;
+
+            Ok(js_value)
+        }
+
+        /// Upload data with a receipt.
+        ///
+        /// # Example
+        ///
+        /// ```js
+        /// const receipt = getReceiptFromQuotesAndPayments(quotes, payments);
+        /// const addr = await client.dataPutWithReceipt(data, receipt);
         /// ```
-        #[wasm_bindgen(js_name = dataPutWithProof)]
-        pub async fn data_put_with_proof_of_payment(
+        #[wasm_bindgen(js_name = dataPutWithReceipt)]
+        pub async fn data_put_with_receipt(
             &self,
             data: Vec<u8>,
-            proof: JsValue,
+            receipt: JsValue,
         ) -> Result<String, JsError> {
             let data = crate::Bytes::from(data);
-            let proof: HashMap<XorName, ProofOfPayment> = serde_wasm_bindgen::from_value(proof)?;
-            let xorname = self.0.data_put_with_proof_of_payment(data, proof).await?;
+            let receipt: Receipt = serde_wasm_bindgen::from_value(receipt)?;
+            let xorname = self.0.data_put(data, receipt.into()).await?;
             Ok(addr_to_str(xorname))
         }
     }
@@ -370,15 +497,15 @@ mod external_signer {
     }
 
     /// Generate payment proof.
-    #[wasm_bindgen(js_name = getPaymentProofFromQuotesAndPayments)]
-    pub fn get_payment_proof_from_quotes_and_payments(
+    #[wasm_bindgen(js_name = getReceiptFromQuotesAndPayments)]
+    pub fn get_receipt_from_quotes_and_payments(
         quotes: JsValue,
         payments: JsValue,
     ) -> Result<JsValue, JsError> {
         let quotes: HashMap<XorName, PaymentQuote> = serde_wasm_bindgen::from_value(quotes)?;
         let payments: BTreeMap<QuoteHash, TxHash> = serde_wasm_bindgen::from_value(payments)?;
-        let proof = receipt_from_quotes_and_payments(&quotes, &payments);
-        let js_value = serde_wasm_bindgen::to_value(&proof)?;
+        let receipt = receipt_from_quotes_and_payments(&quotes, &payments);
+        let js_value = serde_wasm_bindgen::to_value(&receipt)?;
         Ok(js_value)
     }
 }

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -48,7 +48,7 @@ pub use sn_evm::EvmNetwork;
 pub use sn_evm::EvmWallet as Wallet;
 pub use sn_evm::RewardsAddress;
 #[cfg(feature = "external-signer")]
-pub use utils::payment_proof_from_quotes_and_payments;
+pub use utils::receipt_from_quotes_and_payments;
 
 #[doc(no_inline)] // Place this under 'Re-exports' in the docs.
 pub use bytes::Bytes;

--- a/autonomi/src/utils.rs
+++ b/autonomi/src/utils.rs
@@ -1,11 +1,27 @@
+use crate::client::payment::Receipt;
 use sn_evm::{PaymentQuote, ProofOfPayment, QuoteHash, TxHash};
+use sn_networking::PayeeQuote;
 use std::collections::{BTreeMap, HashMap};
 use xor_name::XorName;
 
-pub fn payment_proof_from_quotes_and_payments(
+pub fn cost_map_to_quotes(
+    cost_map: HashMap<XorName, PayeeQuote>,
+) -> HashMap<XorName, PaymentQuote> {
+    cost_map.into_iter().map(|(k, (_, _, v))| (k, v)).collect()
+}
+
+pub fn receipt_from_cost_map_and_payments(
+    cost_map: HashMap<XorName, PayeeQuote>,
+    payments: &BTreeMap<QuoteHash, TxHash>,
+) -> Receipt {
+    let quotes = cost_map_to_quotes(cost_map);
+    receipt_from_quotes_and_payments(&quotes, payments)
+}
+
+pub fn receipt_from_quotes_and_payments(
     quotes: &HashMap<XorName, PaymentQuote>,
     payments: &BTreeMap<QuoteHash, TxHash>,
-) -> HashMap<XorName, ProofOfPayment> {
+) -> Receipt {
     quotes
         .iter()
         .filter_map(|(xor_name, quote)| {

--- a/autonomi/tests/external_signer.rs
+++ b/autonomi/tests/external_signer.rs
@@ -2,7 +2,14 @@
 
 use alloy::network::TransactionBuilder;
 use alloy::providers::Provider;
-use autonomi::Client;
+use autonomi::client::archive::Metadata;
+use autonomi::client::archive_private::PrivateArchive;
+use autonomi::client::external_signer::encrypt_data;
+use autonomi::client::payment::Receipt;
+use autonomi::client::vault::user_data::USER_DATA_VAULT_CONTENT_IDENTIFIER;
+use autonomi::client::vault::VaultSecretKey;
+use autonomi::{receipt_from_quotes_and_payments, Client, Wallet};
+use bytes::Bytes;
 use sn_evm::{QuoteHash, TxHash};
 use sn_logging::LogBuilder;
 use std::collections::BTreeMap;
@@ -10,18 +17,21 @@ use std::time::Duration;
 use test_utils::evm::get_funded_wallet;
 use test_utils::{gen_random_data, peers_from_env};
 use tokio::time::sleep;
+use xor_name::XorName;
 
-// Example of how put would be done using external signers.
-#[tokio::test]
-async fn external_signer_put() -> eyre::Result<()> {
-    let _log_appender_guard =
-        LogBuilder::init_single_threaded_tokio_test("external_signer_put", false);
+async fn pay_for_data(client: &Client, wallet: &Wallet, data: Bytes) -> eyre::Result<Receipt> {
+    let (_data_map_chunk, _chunks, xor_names) = encrypt_data(data)?;
+    pay_for_content_addresses(client, wallet, xor_names.into_iter()).await
+}
 
-    let client = Client::connect(&peers_from_env()?).await?;
-    let wallet = get_funded_wallet();
-    let data = gen_random_data(1024 * 1024 * 10);
-
-    let (quotes, quote_payments, _free_chunks) = client.get_quotes_for_data(data.clone()).await?;
+async fn pay_for_content_addresses(
+    client: &Client,
+    wallet: &Wallet,
+    content_addrs: impl Iterator<Item = XorName>,
+) -> eyre::Result<Receipt> {
+    let (quotes, quote_payments, _free_chunks) = client
+        .get_quotes_for_content_addresses(content_addrs)
+        .await?;
 
     // Form quotes payment transaction data
     let pay_for_quotes_calldata = autonomi::client::external_signer::pay_for_quotes_calldata(
@@ -76,16 +86,100 @@ async fn external_signer_put() -> eyre::Result<()> {
     }
 
     // Payment proofs
-    let proofs = autonomi::payment_proof_from_quotes_and_payments(&quotes, &payments);
+    Ok(receipt_from_quotes_and_payments(&quotes, &payments))
+}
 
-    let addr = client
-        .data_put_with_proof_of_payment(data.clone(), proofs)
+// Example of how put would be done using external signers.
+#[tokio::test]
+async fn external_signer_put() -> eyre::Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("external_signer_put", false);
+
+    let client = Client::connect(&peers_from_env()?).await?;
+    let wallet = get_funded_wallet();
+    let data = gen_random_data(1024 * 1024 * 10);
+
+    let receipt = pay_for_data(&client, &wallet, data.clone()).await?;
+
+    sleep(Duration::from_secs(5)).await;
+
+    let private_data_access = client
+        .private_data_put(data.clone(), receipt.into())
         .await?;
 
-    sleep(Duration::from_secs(10)).await;
+    let mut private_archive = PrivateArchive::new();
+    private_archive.add_file("test-file".into(), private_data_access, Metadata::default());
 
-    let data_fetched = client.data_get(addr).await?;
-    assert_eq!(data, data_fetched, "data fetched should match data put");
+    let archive_serialized = private_archive.into_bytes()?;
+
+    let receipt = pay_for_data(&client, &wallet, archive_serialized.clone()).await?;
+
+    sleep(Duration::from_secs(5)).await;
+
+    let private_archive_access = client
+        .private_data_put(archive_serialized, receipt.into())
+        .await?;
+
+    let vault_key = VaultSecretKey::random();
+
+    let mut user_data = client
+        .get_user_data_from_vault(&vault_key)
+        .await
+        .unwrap_or_default();
+
+    user_data.add_private_file_archive_with_name(
+        private_archive_access.clone(),
+        "test-archive".to_string(),
+    );
+
+    let (scratch, is_new) = client
+        .get_or_create_scratchpad(&vault_key, *USER_DATA_VAULT_CONTENT_IDENTIFIER)
+        .await?;
+
+    assert!(is_new, "Scratchpad is not new");
+
+    let scratch_addresses = if is_new {
+        scratch.to_xor_name_vec()
+    } else {
+        vec![]
+    };
+
+    let receipt =
+        pay_for_content_addresses(&client, &wallet, scratch_addresses.into_iter()).await?;
+
+    sleep(Duration::from_secs(5)).await;
+
+    let _ = client
+        .put_user_data_to_vault(&vault_key, receipt.into(), user_data)
+        .await?;
+
+    let fetched_user_data = client.get_user_data_from_vault(&vault_key).await?;
+
+    let fetched_private_archive_access = fetched_user_data
+        .private_file_archives
+        .keys()
+        .next()
+        .expect("No private archive present in the UserData")
+        .clone();
+
+    let fetched_private_archive = client
+        .private_archive_get(fetched_private_archive_access)
+        .await?;
+
+    let (_, (fetched_private_file_access, _)) = fetched_private_archive
+        .map()
+        .iter()
+        .next()
+        .expect("No file present in private archive");
+
+    let fetched_private_file = client
+        .private_data_get(fetched_private_file_access.clone())
+        .await?;
+
+    assert_eq!(
+        fetched_private_file, data,
+        "Fetched private data is not identical to the uploaded data"
+    );
 
     Ok(())
 }

--- a/autonomi/tests/fs.rs
+++ b/autonomi/tests/fs.rs
@@ -93,7 +93,12 @@ async fn file_into_vault() -> Result<()> {
     let archive = client.archive_get(addr).await?;
     let set_version = 0;
     client
-        .write_bytes_to_vault(archive.into_bytes()?, &wallet, &client_sk, set_version)
+        .write_bytes_to_vault(
+            archive.into_bytes()?,
+            wallet.into(),
+            &client_sk,
+            set_version,
+        )
         .await?;
 
     // now assert over the stored account packet

--- a/autonomi/tests/put.rs
+++ b/autonomi/tests/put.rs
@@ -23,7 +23,7 @@ async fn put() -> Result<()> {
     let wallet = get_funded_wallet();
     let data = gen_random_data(1024 * 1024 * 10);
 
-    let addr = client.data_put(data.clone(), &wallet).await?;
+    let addr = client.data_put(data.clone(), wallet.into()).await?;
 
     sleep(Duration::from_secs(10)).await;
 

--- a/autonomi/tests/wasm.rs
+++ b/autonomi/tests/wasm.rs
@@ -25,7 +25,7 @@ async fn put() -> Result<(), Box<dyn std::error::Error>> {
     let wallet = get_funded_wallet();
     let data = gen_random_data(1024 * 1024 * 10);
 
-    let addr = client.data_put(data.clone(), &wallet).await?;
+    let addr = client.data_put(data.clone(), wallet.into()).await?;
 
     sleep(Duration::from_secs(10)).await;
 

--- a/sn_node/tests/data_with_churn.rs
+++ b/sn_node/tests/data_with_churn.rs
@@ -338,7 +338,7 @@ fn store_chunks_task(
             let mut retries = 1;
             loop {
                 match client
-                    .data_put(random_data.clone(), &wallet)
+                    .data_put(random_data.clone(), (&wallet).into())
                     .await
                     .inspect_err(|err| {
                         println!("Error to put chunk: {err:?}");

--- a/sn_node/tests/verify_data_location.rs
+++ b/sn_node/tests/verify_data_location.rs
@@ -332,7 +332,7 @@ async fn store_chunks(
 
         let random_bytes = Bytes::from(random_bytes);
 
-        client.data_put(random_bytes, wallet).await?;
+        client.data_put(random_bytes, wallet.into()).await?;
 
         uploaded_chunks_count += 1;
 

--- a/sn_protocol/src/storage/scratchpad.rs
+++ b/sn_protocol/src/storage/scratchpad.rs
@@ -126,9 +126,17 @@ impl Scratchpad {
         &self.address
     }
 
-    /// Returns the NetworkAddress
+    /// Returns the NetworkAddress.
     pub fn network_address(&self) -> NetworkAddress {
         NetworkAddress::ScratchpadAddress(self.address)
+    }
+
+    /// Returns a VEC with the XOR name.
+    pub fn to_xor_name_vec(&self) -> Vec<XorName> {
+        [self.network_address()]
+            .iter()
+            .filter_map(|f| f.as_xorname())
+            .collect::<Vec<XorName>>()
     }
 
     /// Returns the name.


### PR DESCRIPTION
Allows doing `put` operations with a `Receipt` as proof of payment instead of having to pass a `Wallet` and doing payments on the fly.

This is needed for web3 wallet support and also opens the doors to retrying put operations without having to pay again if we store the receipts somewhere.

You can run an integration test that puts a private file in a vault using receipts with this command (make sure to run a local network):

```
EVM_NETWORK=local cargo test --package=autonomi --features=local,data,vault,external-signer --test external_signer
```