### PR TITLE
fix: retain rewards address arg on upgrade

### DIFF
--- a/sn_node_manager/src/lib.rs
+++ b/sn_node_manager/src/lib.rs
@@ -2709,6 +2709,8 @@ mod tests {
                         OsString::from("--log-output-dest"),
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--upnp"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -2870,6 +2872,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--log-format"),
                         OsString::from("json"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3034,6 +3038,8 @@ mod tests {
                         OsString::from("--log-output-dest"),
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--home-network"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3195,6 +3201,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--ip"),
                         OsString::from("192.168.1.1"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3359,6 +3367,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--port"),
                         OsString::from("12000"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3520,6 +3530,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--max-archived-log-files"),
                         OsString::from("20"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3684,6 +3696,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--max-log-files"),
                         OsString::from("20"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -3845,6 +3859,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--metrics-server-port"),
                         OsString::from("12000"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -4009,6 +4025,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--metrics-server-port"),
                         OsString::from("12000"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -4173,6 +4191,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--owner"),
                         OsString::from("discord_username"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,
@@ -4337,6 +4357,8 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--owner"),
                         OsString::from("discord_username"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: true,
@@ -4498,6 +4520,186 @@ mod tests {
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--owner"),
                         OsString::from("discord_username"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                        OsString::from("evm-custom"),
+                        OsString::from("--rpc-url"),
+                        OsString::from("http://localhost:8545/"),
+                        OsString::from("--payment-token-address"),
+                        OsString::from("0x5FbDB2315678afecb367f032d93F642f64180aa3"),
+                        OsString::from("--data-payments-address"),
+                        OsString::from("0x8464135c8F25Da09e49BC8782676a84730C318bC"),
+                    ],
+                    autostart: true,
+                    contents: None,
+                    environment: None,
+                    label: "safenode1".parse()?,
+                    program: current_node_bin.to_path_buf(),
+                    username: Some("safe".to_string()),
+                    working_directory: None,
+                }),
+                eq(false),
+            )
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // after service restart
+        mock_service_control
+            .expect_start()
+            .with(eq("safenode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_service_control
+            .expect_wait()
+            .with(eq(3000))
+            .times(1)
+            .returning(|_| ());
+        mock_service_control
+            .expect_get_process_pid()
+            .with(eq(current_node_bin.to_path_buf().clone()))
+            .times(1)
+            .returning(|_| Ok(100));
+
+        mock_rpc_client.expect_node_info().times(1).returning(|| {
+            Ok(NodeInfo {
+                pid: 2000,
+                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
+                data_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+                log_path: PathBuf::from("/var/log/safenode/safenode1"),
+                version: target_version.to_string(),
+                uptime: std::time::Duration::from_secs(1), // the service was just started
+                wallet_balance: 0,
+            })
+        });
+        mock_rpc_client
+            .expect_network_info()
+            .times(1)
+            .returning(|| {
+                Ok(NetworkInfo {
+                    connected_peers: Vec::new(),
+                    listeners: Vec::new(),
+                })
+            });
+
+        let mut service_data = NodeServiceData {
+            auto_restart: true,
+            connected_peers: None,
+            data_dir_path: PathBuf::from("/var/safenode-manager/services/safenode1"),
+            evm_network: EvmNetwork::Custom(CustomNetwork {
+                rpc_url_http: "http://localhost:8545".parse()?,
+                payment_token_address: RewardsAddress::from_str(
+                    "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+                )?,
+                data_payments_address: RewardsAddress::from_str(
+                    "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+                )?,
+            }),
+            genesis: false,
+            home_network: false,
+            listen_addr: None,
+            local: false,
+            log_dir_path: PathBuf::from("/var/log/safenode/safenode1"),
+            log_format: None,
+            max_archived_log_files: None,
+            max_log_files: None,
+            metrics_port: None,
+            node_ip: None,
+            node_port: None,
+            number: 1,
+            owner: Some("discord_username".to_string()),
+            peer_id: Some(PeerId::from_str(
+                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
+            )?),
+            pid: Some(1000),
+            rewards_address: RewardsAddress::from_str(
+                "0x03B770D9cD32077cC0bF330c13C114a87643B124",
+            )?,
+            reward_balance: Some(AttoTokens::zero()),
+
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
+            safenode_path: current_node_bin.to_path_buf(),
+            service_name: "safenode1".to_string(),
+            status: ServiceStatus::Running,
+            upnp: false,
+            user: Some("safe".to_string()),
+            user_mode: false,
+            version: current_version.to_string(),
+        };
+        let service = NodeService::new(&mut service_data, Box::new(mock_rpc_client));
+
+        let mut service_manager = ServiceManager::new(
+            service,
+            Box::new(mock_service_control),
+            VerbosityLevel::Normal,
+        );
+
+        service_manager
+            .upgrade(UpgradeOptions {
+                auto_restart: true,
+                bootstrap_peers: Vec::new(),
+                env_variables: None,
+                force: false,
+                start_service: true,
+                target_bin_path: target_node_bin.to_path_buf(),
+                target_version: Version::parse(target_version).unwrap(),
+            })
+            .await?;
+
+        assert!(service_manager.service.service_data.auto_restart,);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn upgrade_should_retain_the_rewards_address() -> Result<()> {
+        let current_version = "0.1.0";
+        let target_version = "0.2.0";
+
+        let tmp_data_dir = assert_fs::TempDir::new()?;
+        let current_install_dir = tmp_data_dir.child("safenode_install");
+        current_install_dir.create_dir_all()?;
+
+        let current_node_bin = current_install_dir.child("safenode");
+        current_node_bin.write_binary(b"fake safenode binary")?;
+        let target_node_bin = tmp_data_dir.child("safenode");
+        target_node_bin.write_binary(b"fake safenode binary")?;
+
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        // before binary upgrade
+        mock_service_control
+            .expect_get_process_pid()
+            .with(eq(current_node_bin.to_path_buf().clone()))
+            .times(1)
+            .returning(|_| Ok(1000));
+        mock_service_control
+            .expect_stop()
+            .with(eq("safenode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // after binary upgrade
+        mock_service_control
+            .expect_uninstall()
+            .with(eq("safenode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_service_control
+            .expect_install()
+            .with(
+                eq(ServiceInstallCtx {
+                    args: vec![
+                        OsString::from("--rpc"),
+                        OsString::from("127.0.0.1:8081"),
+                        OsString::from("--root-dir"),
+                        OsString::from("/var/safenode-manager/services/safenode1"),
+                        OsString::from("--log-output-dest"),
+                        OsString::from("/var/log/safenode/safenode1"),
+                        OsString::from("--owner"),
+                        OsString::from("discord_username"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-custom"),
                         OsString::from("--rpc-url"),
                         OsString::from("http://localhost:8545/"),
@@ -4673,6 +4875,8 @@ mod tests {
                         OsString::from("--log-output-dest"),
                         OsString::from("/var/log/safenode/safenode1"),
                         OsString::from("--upnp"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
                         OsString::from("evm-arbitrum-one"),
                     ],
                     autostart: false,

--- a/sn_service_management/src/node.rs
+++ b/sn_service_management/src/node.rs
@@ -126,6 +126,11 @@ impl<'a> ServiceStateActions for NodeService<'a> {
             args.push(OsString::from(peers_str));
         }
 
+        args.push(OsString::from("--rewards-address"));
+        args.push(OsString::from(
+            self.service_data.rewards_address.to_string(),
+        ));
+
         args.push(OsString::from(self.service_data.evm_network.to_string()));
         if let EvmNetwork::Custom(custom_network) = &self.service_data.evm_network {
             args.push(OsString::from("--rpc-url"));


### PR DESCRIPTION
### Description

This is one of the new EVM arguments that were missing from being retained on an upgrade.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):