### PR TITLE
chore(launchpad): update ratatui and throbbber versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ dependencies = [
  "strsim",
  "terminal_size",
  "unicase",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1925,7 +1925,7 @@ dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -4436,8 +4436,14 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "tokio",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inferno"
@@ -6568,7 +6574,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "term",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -7091,24 +7097,24 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
+ "indoc",
  "instability",
  "itertools 0.13.0",
  "lru",
  "paste",
  "serde",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -8943,9 +8949,9 @@ dependencies = [
 
 [[package]]
 name = "throbber-widgets-tui"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad9e055cadd9da8b4a67662b962e3e67e96af491ae9cec7e88aaff92e7c3666"
+checksum = "1d36b5738d666a2b4c91b7c24998a8588db724b3107258343ebf8824bf55b06d"
 dependencies = [
  "rand 0.8.5",
  "ratatui",
@@ -9498,7 +9504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e785f863a3af4c800a2a669d0b64c879b538738e352607e2624d03f868dc01"
 dependencies = [
  "crossterm 0.27.0",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -9600,7 +9606,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -9608,6 +9614,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -44,7 +44,7 @@ libc = "0.2.148"
 log = "0.4.20"
 pretty_assertions = "1.4.0"
 prometheus-parse = "0.2.5"
-ratatui = { version = "0.28.1", features = ["serde", "macros", "unstable-widget-ref"] }
+ratatui = { version = "0.29.0", features = ["serde", "macros", "unstable-widget-ref"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }
@@ -69,7 +69,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "serde"] }
 tui-input = "0.8.0"
 which = "6.0.1"
 faccess = "0.2.4"
-throbber-widgets-tui = "0.7.0"
+throbber-widgets-tui = "0.8.0"
 regex = "1.11.0"
 
 [build-dependencies]

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -180,7 +180,7 @@ impl Status<'_> {
                     // Update status based on current node status
                     item.status = match node_item.status {
                         ServiceStatus::Running => {
-                            NodeItem::update_spinner_state(&mut item.spinner_state);
+                            item.spinner_state.calc_next();
                             NodeStatus::Running
                         }
                         ServiceStatus::Stopped => NodeStatus::Stopped,
@@ -190,7 +190,7 @@ impl Status<'_> {
 
                     // Starting is not part of ServiceStatus so we do it manually
                     if let Some(LockRegistryState::StartingNodes) = self.lock_registry {
-                        NodeItem::update_spinner_state(&mut item.spinner_state);
+                        item.spinner_state.calc_next();
                         item.status = NodeStatus::Starting;
                     }
 
@@ -848,7 +848,7 @@ impl Component for Status<'_> {
                 let table = Table::new(items, node_widths)
                     .header(header_row)
                     .column_spacing(1)
-                    .highlight_style(Style::default().bg(INDIGO))
+                    .row_highlight_style(Style::default().bg(INDIGO))
                     .highlight_spacing(HighlightSpacing::Always);
 
                 f.render_widget(table, inner_area);
@@ -1057,16 +1057,6 @@ pub struct NodeItem<'a> {
 }
 
 impl NodeItem<'_> {
-    fn update_spinner_state(state: &mut ThrobberState) {
-        // Call calc_next on the spinner state
-        // https://github.com/arkbig/throbber-widgets-tui/issues/19
-        if state.index() == i8::MAX {
-            *state = ThrobberState::default();
-        } else {
-            state.calc_next();
-        }
-    }
-
     fn render_as_row(&mut self, index: usize, area: Rect, f: &mut Frame<'_>) -> Row {
         let mut row_style = Style::default().fg(GHOST_WHITE);
         let mut spinner_state = self.spinner_state.clone();


### PR DESCRIPTION
### Description

`Ratatui` `0.28.1` -> `0.29.0`
`throbber-widgets-tui` `0.7.0` -> `0.8.0`

Release notes for ratatui: https://github.com/ratatui/ratatui/releases/tag/v0.29.0
Bugfix of our interest due to a user report bug: https://github.com/ratatui/ratatui/issues/1375