### PR TITLE
fix(launchpad): mbps vs mb units

### DIFF
--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -62,7 +62,7 @@ const NODE_WIDTH: usize = 10;
 const VERSION_WIDTH: usize = 7;
 const ATTOS_WIDTH: usize = 5;
 const MEMORY_WIDTH: usize = 7;
-const MBPS_WIDTH: usize = 15;
+const MB_WIDTH: usize = 15;
 const RECORDS_WIDTH: usize = 4;
 const PEERS_WIDTH: usize = 5;
 const CONNS_WIDTH: usize = 5;
@@ -216,8 +216,8 @@ impl Status<'_> {
                     {
                         item.attos = stats.rewards_wallet_balance;
                         item.memory = stats.memory_usage_mb;
-                        item.mbps = format!(
-                            "↓{:06.2} ↑{:06.2}",
+                        item.mb = format!(
+                            "↓{:06.02} ↑{:06.02}",
                             stats.bandwidth_inbound as f64 / (1024_f64 * 1024_f64),
                             stats.bandwidth_outbound as f64 / (1024_f64 * 1024_f64)
                         );
@@ -231,7 +231,7 @@ impl Status<'_> {
                         version: node_item.version.to_string(),
                         attos: 0,
                         memory: 0,
-                        mbps: "-".to_string(),
+                        mb: "-".to_string(),
                         records: 0,
                         peers: 0,
                         connections: 0,
@@ -265,7 +265,7 @@ impl Status<'_> {
                         version: node_item.version.to_string(),
                         attos: 0,
                         memory: 0,
-                        mbps: "-".to_string(),
+                        mb: "-".to_string(),
                         records: 0,
                         peers: 0,
                         connections: 0,
@@ -883,7 +883,7 @@ impl Component for Status<'_> {
                     Constraint::Min(VERSION_WIDTH as u16),
                     Constraint::Min(ATTOS_WIDTH as u16),
                     Constraint::Min(MEMORY_WIDTH as u16),
-                    Constraint::Min(MBPS_WIDTH as u16),
+                    Constraint::Min(MB_WIDTH as u16),
                     Constraint::Min(RECORDS_WIDTH as u16),
                     Constraint::Min(PEERS_WIDTH as u16),
                     Constraint::Min(CONNS_WIDTH as u16),
@@ -898,8 +898,7 @@ impl Component for Status<'_> {
                     Cell::new("Attos").fg(COOL_GREY),
                     Cell::new("Memory").fg(COOL_GREY),
                     Cell::new(
-                        format!("{}{}", " ".repeat(MBPS_WIDTH - "Mbps".len()), "Mbps")
-                            .fg(COOL_GREY),
+                        format!("{}{}", " ".repeat(MB_WIDTH - "Mb".len()), "Mb").fg(COOL_GREY),
                     ),
                     Cell::new("Recs").fg(COOL_GREY),
                     Cell::new("Peers").fg(COOL_GREY),
@@ -1127,7 +1126,7 @@ pub struct NodeItem<'a> {
     version: String,
     attos: usize,
     memory: usize,
-    mbps: String,
+    mb: String,
     records: usize,
     peers: usize,
     connections: usize,
@@ -1200,8 +1199,8 @@ impl NodeItem<'_> {
             ),
             format!(
                 "{}{}",
-                " ".repeat(MBPS_WIDTH.saturating_sub(self.mbps.to_string().len())),
-                self.mbps.to_string()
+                " ".repeat(MB_WIDTH.saturating_sub(self.mb.to_string().len())),
+                self.mb.to_string()
             ),
             format!(
                 "{}{}",


### PR DESCRIPTION
### Description

Corrected units on Launchpad: Mbps vs. Mb.

![Screenshot 2024-11-07 at 10 15 33](https://github.com/user-attachments/assets/e10dcd02-7548-49e8-8bb8-c42174c53b1f)
