### PR TITLE
feat(launchpad): node selection and log view

### DIFF
--- a/node-launchpad/.config/config.json5
+++ b/node-launchpad/.config/config.json5
@@ -17,6 +17,8 @@
       "<Ctrl-b>": {"StatusActions":"TriggerRewardsAddress"},
       "<Ctrl-B>": {"StatusActions":"TriggerRewardsAddress"},
       "<Ctrl-Shift-b>": {"StatusActions":"TriggerRewardsAddress"},
+      "<l>": {"StatusActions":"TriggerNodeLogs"},
+      "<L>": {"StatusActions":"TriggerNodeLogs"},
 
       "up" : {"StatusActions":"PreviousTableItem"},
       "down": {"StatusActions":"NextTableItem"},

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -61,6 +61,7 @@ pub enum StatusActions {
 
     TriggerManageNodes,
     TriggerRewardsAddress,
+    TriggerNodeLogs,
 
     PreviousTableItem,
     NextTableItem,

--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -41,9 +41,12 @@ impl StatefulWidget for Footer {
             Span::styled("[Ctrl+S] ", command_style),
             Span::styled("Start Nodes", text_style),
             Span::styled("  ", Style::default()),
+            Span::styled("[L] ", command_style),
+            Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),
+            Span::styled("  ", Style::default()),
             Span::styled("[Ctrl+X] ", command_style),
             Span::styled(
-                "Stop Nodes",
+                "Stop All",
                 if matches!(state, NodesToStart::Running) {
                     Style::default().fg(EUCALYPTUS)
                 } else {

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, path::PathBuf};
 
-use color_eyre::eyre::{eyre, Ok, Result};
+use color_eyre::eyre::Result;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Style, Stylize},
@@ -8,10 +8,9 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Row, Table},
     Frame,
 };
-use sn_releases::ReleaseType;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::{header::SelectedMenuItem, Component};
+use super::{header::SelectedMenuItem, utils::open_logs, Component};
 use crate::{
     action::{Action, OptionsActions},
     components::header::Header,
@@ -20,9 +19,7 @@ use crate::{
     style::{
         COOL_GREY, EUCALYPTUS, GHOST_WHITE, LIGHT_PERIWINKLE, VERY_LIGHT_AZURE, VIVID_SKY_BLUE,
     },
-    system,
 };
-use sn_node_manager::config::get_service_log_dir_path;
 
 #[derive(Clone)]
 pub struct Options {
@@ -416,15 +413,7 @@ impl Component for Options {
                     self.rewards_address = rewards_address;
                 }
                 OptionsActions::TriggerAccessLogs => {
-                    if let Err(e) = system::open_folder(
-                        get_service_log_dir_path(ReleaseType::NodeLaunchpad, None, None)?
-                            .to_str()
-                            .ok_or_else(|| {
-                                eyre!("We cannot get the log dir path for Node-Launchpad")
-                            })?,
-                    ) {
-                        error!("Failed to open folder: {}", e);
-                    }
+                    open_logs(None)?;
                 }
                 OptionsActions::TriggerUpdateNodes => {
                     return Ok(Some(Action::SwitchScene(Scene::UpgradeNodesPopUp)));

--- a/node-launchpad/src/components/utils.rs
+++ b/node-launchpad/src/components/utils.rs
@@ -6,7 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::system;
+use color_eyre::eyre::{self};
 use ratatui::prelude::*;
+use sn_node_manager::config::get_service_log_dir_path;
+use sn_releases::ReleaseType;
 
 /// helper function to create a centered rect using up certain percentage of the available rect `r`
 pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
@@ -40,4 +44,29 @@ pub fn centered_rect_fixed(x: u16, y: u16, r: Rect) -> Rect {
         Constraint::Fill(1),
     ])
     .split(popup_layout[1])[1]
+}
+
+/// Opens the logs folder for a given node service name or the default service log directory.
+///
+/// # Parameters
+///
+/// * `node_name`: Optional node service name. If `None`, the default service log directory is used.
+///
+/// # Returns
+///
+/// A `Result` indicating the success or failure of the operation.
+pub fn open_logs(node_name: Option<String>) -> Result<(), eyre::Report> {
+    let service_path = get_service_log_dir_path(ReleaseType::NodeLaunchpad, None, None)?
+        .to_string_lossy()
+        .into_owned();
+
+    let folder = if let Some(node_name) = node_name {
+        format!("{}/{}", service_path, node_name)
+    } else {
+        service_path.to_string()
+    };
+    if let Err(e) = system::open_folder(&folder) {
+        error!("Failed to open folder: {}", e);
+    }
+    Ok(())
 }

--- a/node-launchpad/src/style.rs
+++ b/node-launchpad/src/style.rs
@@ -21,7 +21,7 @@ pub const EUCALYPTUS: Color = Color::Indexed(115);
 pub const SIZZLING_RED: Color = Color::Indexed(197);
 pub const SPACE_CADET: Color = Color::Indexed(17);
 pub const DARK_GUNMETAL: Color = Color::Indexed(235); // 266 is incorrect
-pub const INDIGO: Color = Color::Indexed(60);
+pub const INDIGO: Color = Color::Indexed(24);
 pub const VIVID_SKY_BLUE: Color = Color::Indexed(45);
 pub const RED: Color = Color::Indexed(196);
 


### PR DESCRIPTION
### Description

Node selection enabled. Hitting `L` will show logs for the node.

![Screenshot 2024-11-07 at 12 05 38](https://github.com/user-attachments/assets/5531ef81-162f-4329-b4f9-e6c4e0e94379)
