### PR TITLE
feat: make LP multithreaded and limit local set to node mgmnt

### DIFF
--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -180,7 +180,9 @@ impl Status<'_> {
                 {
                     if let Some(status) = new_status {
                         item.status = status;
-                    } else {
+                    } else if item.status == NodeStatus::Updating {
+                        item.spinner_state.calc_next();
+                    } else if new_status != Some(NodeStatus::Updating) {
                         // Update status based on current node status
                         item.status = match node_item.status {
                             ServiceStatus::Running => {
@@ -1210,7 +1212,7 @@ impl NodeItem<'_> {
                             .add_modifier(Modifier::BOLD),
                     )
                     .throbber_set(throbber_widgets_tui::VERTICAL_BLOCK)
-                    .use_type(throbber_widgets_tui::WhichUse::Full);
+                    .use_type(throbber_widgets_tui::WhichUse::Spin);
             }
             _ => {}
         };

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -17,7 +17,7 @@ use crate::components::popup::port_range::PORT_ALLOCATION;
 use crate::config::get_launchpad_nodes_data_dir_path;
 use crate::connection_mode::ConnectionMode;
 use crate::error::ErrorPopup;
-use crate::node_mgmt::{upgrade_nodes, MaintainNodesArgs, UpgradeNodesArgs};
+use crate::node_mgmt::{MaintainNodesArgs, NodeManagement, NodeManagementTask, UpgradeNodesArgs};
 use crate::node_mgmt::{PORT_MAX, PORT_MIN};
 use crate::style::{COOL_GREY, INDIGO};
 use crate::tui::Event;
@@ -47,11 +47,8 @@ use std::{
     vec,
 };
 use strum::Display;
-use tokio::sync::mpsc::UnboundedSender;
-
-use super::super::node_mgmt::{maintain_n_running_nodes, reset_nodes, stop_nodes};
-
 use throbber_widgets_tui::{self, Throbber, ThrobberState};
+use tokio::sync::mpsc::UnboundedSender;
 
 pub const NODE_STAT_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 /// If nat detection fails for more than 3 times, we don't want to waste time running during every node start.
@@ -84,6 +81,8 @@ pub struct Status<'a> {
     // Nodes
     node_services: Vec<NodeServiceData>,
     items: Option<StatefulTable<NodeItem<'a>>>,
+    // Node Management
+    node_management: NodeManagement,
     // Amount of nodes
     nodes_to_start: usize,
     // Rewards address
@@ -137,6 +136,7 @@ impl Status<'_> {
             node_stats: NodeStats::default(),
             node_stats_last_update: Instant::now(),
             node_services: Default::default(),
+            node_management: NodeManagement::new()?,
             items: None,
             nodes_to_start: config.allocated_disk_space,
             lock_registry: None,
@@ -416,7 +416,11 @@ impl Component for Status<'_> {
                     self.lock_registry = Some(LockRegistryState::ResettingNodes);
                     info!("Resetting safenode services because the Rewards Address was reset.");
                     let action_sender = self.get_actions_sender()?;
-                    reset_nodes(action_sender, false);
+                    self.node_management
+                        .send_task(NodeManagementTask::ResetNodes {
+                            start_nodes_after_reset: false,
+                            action_sender,
+                        })?;
                 }
             }
             Action::StoreStorageDrive(ref drive_mountpoint, ref _drive_name) => {
@@ -424,7 +428,11 @@ impl Component for Status<'_> {
                 self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 info!("Resetting safenode services because the Storage Drive was changed.");
                 let action_sender = self.get_actions_sender()?;
-                reset_nodes(action_sender, false);
+                self.node_management
+                    .send_task(NodeManagementTask::ResetNodes {
+                        start_nodes_after_reset: false,
+                        action_sender,
+                    })?;
                 self.data_dir_path =
                     get_launchpad_nodes_data_dir_path(&drive_mountpoint.to_path_buf(), false)?;
             }
@@ -434,7 +442,11 @@ impl Component for Status<'_> {
                 self.connection_mode = connection_mode;
                 info!("Resetting safenode services because the Connection Mode range was changed.");
                 let action_sender = self.get_actions_sender()?;
-                reset_nodes(action_sender, false);
+                self.node_management
+                    .send_task(NodeManagementTask::ResetNodes {
+                        start_nodes_after_reset: false,
+                        action_sender,
+                    })?;
             }
             Action::StorePortRange(port_from, port_range) => {
                 debug!("Setting lock_registry to ResettingNodes");
@@ -443,7 +455,11 @@ impl Component for Status<'_> {
                 self.port_to = Some(port_range);
                 info!("Resetting safenode services because the Port Range was changed.");
                 let action_sender = self.get_actions_sender()?;
-                reset_nodes(action_sender, false);
+                self.node_management
+                    .send_task(NodeManagementTask::ResetNodes {
+                        start_nodes_after_reset: false,
+                        action_sender,
+                    })?;
             }
             Action::StatusActions(status_action) => match status_action {
                 StatusActions::NodesStatsObtained(stats) => {
@@ -604,7 +620,10 @@ impl Component for Status<'_> {
 
                     debug!("Calling maintain_n_running_nodes");
 
-                    maintain_n_running_nodes(maintain_nodes_args);
+                    self.node_management
+                        .send_task(NodeManagementTask::MaintainNodes {
+                            args: maintain_nodes_args,
+                        })?;
                 }
                 StatusActions::StopNodes => {
                     debug!("Got action to stop nodes");
@@ -622,7 +641,11 @@ impl Component for Status<'_> {
                     let action_sender = self.get_actions_sender()?;
                     info!("Stopping node service: {running_nodes:?}");
 
-                    stop_nodes(running_nodes, action_sender);
+                    self.node_management
+                        .send_task(NodeManagementTask::StopNodes {
+                            services: running_nodes,
+                            action_sender,
+                        })?;
                 }
                 StatusActions::TriggerRewardsAddress => {
                     if self.rewards_address.is_empty() {
@@ -664,7 +687,10 @@ impl Component for Status<'_> {
                     url: None,
                     version: None,
                 };
-                upgrade_nodes(upgrade_nodes_args);
+                self.node_management
+                    .send_task(NodeManagementTask::UpgradeNodes {
+                        args: upgrade_nodes_args,
+                    })?;
             }
             Action::OptionsActions(OptionsActions::ResetNodes) => {
                 debug!("Got action to reset nodes");
@@ -680,7 +706,11 @@ impl Component for Status<'_> {
                 self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 let action_sender = self.get_actions_sender()?;
                 info!("Got action to reset nodes");
-                reset_nodes(action_sender, false);
+                self.node_management
+                    .send_task(NodeManagementTask::ResetNodes {
+                        start_nodes_after_reset: false,
+                        action_sender,
+                    })?;
             }
             _ => {}
         }

--- a/node-launchpad/src/node_stats.rs
+++ b/node-launchpad/src/node_stats.rs
@@ -91,7 +91,7 @@ impl NodeStats {
             .collect::<Vec<_>>();
         if !node_details.is_empty() {
             debug!("Fetching stats from {} nodes", node_details.len());
-            tokio::task::spawn_local(async move {
+            tokio::spawn(async move {
                 Self::fetch_all_node_stats_inner(node_details, action_sender).await;
             });
         } else {


### PR DESCRIPTION
### Launchpad

#### Fixed
- Launchpad now runs on multiple threads and this would allow operations to be performed while nodes are being started, upgraded etc.