### PR TITLE
chore(test): re-enable can_store_after_restart test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -128,13 +128,26 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release --package sn_node --lib
 
+      # The `can_store_after_restart` can be executed with other package tests together and passing
+      # on local machine. However keeps failing (when executed together) on CI machines.
+      # This is most likely due to the setup and cocurrency issues of the tests.
+      # As the `record_store` is used in a single thread style, get the test passing executed
+      # and passing standalone is enough.
       - name: Run network tests (with encrypt-records)
         timeout-minutes: 25
-        run: cargo test --release --package sn_networking --features="open-metrics, encrypt-records"
+        run: cargo test --release --package sn_networking --features="open-metrics, encrypt-records" -- --skip can_store_after_restart
+
+      - name: Run network tests (with encrypt-records)
+        timeout-minutes: 5
+        run: cargo test --release --package sn_networking --features="open-metrics, encrypt-records" can_store_after_restart
 
       - name: Run network tests (without encrypt-records)
         timeout-minutes: 25
-        run: cargo test --release --package sn_networking --features="open-metrics"
+        run: cargo test --release --package sn_networking --features="open-metrics" -- --skip can_store_after_restart
+
+      - name: Run network tests (without encrypt-records)
+        timeout-minutes: 5
+        run: cargo test --release --package sn_networking --features="open-metrics" can_store_after_restart
 
       - name: Run protocol tests
         timeout-minutes: 25


### PR DESCRIPTION
### Description

re-enable can_store_after_restart test


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
