### PR TITLE
fix(launchpad): megabits

### DIFF
--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -37,13 +37,13 @@ impl StatefulWidget for Footer {
         let commands = vec![
             Span::styled("[Ctrl+G] ", Style::default().fg(GHOST_WHITE)),
             Span::styled("Manage Nodes", Style::default().fg(EUCALYPTUS)),
-            Span::styled("  ", Style::default()),
+            Span::styled(" ", Style::default()),
             Span::styled("[Ctrl+S] ", command_style),
             Span::styled("Start Nodes", text_style),
-            Span::styled("  ", Style::default()),
+            Span::styled(" ", Style::default()),
             Span::styled("[L] ", command_style),
             Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),
-            Span::styled("  ", Style::default()),
+            Span::styled(" ", Style::default()),
             Span::styled("[Ctrl+X] ", command_style),
             Span::styled(
                 "Stop All",

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -61,7 +61,7 @@ const NODE_WIDTH: usize = 10;
 const VERSION_WIDTH: usize = 7;
 const ATTOS_WIDTH: usize = 5;
 const MEMORY_WIDTH: usize = 7;
-const MB_WIDTH: usize = 15;
+const MBITS_WIDTH: usize = 13;
 const RECORDS_WIDTH: usize = 4;
 const PEERS_WIDTH: usize = 5;
 const CONNS_WIDTH: usize = 5;
@@ -220,10 +220,10 @@ impl Status<'_> {
                     {
                         item.attos = stats.rewards_wallet_balance;
                         item.memory = stats.memory_usage_mb;
-                        item.mb = format!(
-                            "↓{:06.02} ↑{:06.02}",
-                            stats.bandwidth_inbound as f64 / (1024_f64 * 1024_f64),
-                            stats.bandwidth_outbound as f64 / (1024_f64 * 1024_f64)
+                        item.mbits = format!(
+                            "↓{:0>5.0} ↑{:0>5.0}",
+                            (stats.bandwidth_inbound_rate * 8) as f64 / 1_000_000.0,
+                            (stats.bandwidth_outbound_rate * 8) as f64 / 1_000_000.0,
                         );
                         item.records = stats.max_records;
                         item.connections = stats.connections;
@@ -235,7 +235,7 @@ impl Status<'_> {
                         version: node_item.version.to_string(),
                         attos: 0,
                         memory: 0,
-                        mb: "-".to_string(),
+                        mbits: "-".to_string(),
                         records: 0,
                         peers: 0,
                         connections: 0,
@@ -269,7 +269,7 @@ impl Status<'_> {
                         version: node_item.version.to_string(),
                         attos: 0,
                         memory: 0,
-                        mb: "-".to_string(),
+                        mbits: "-".to_string(),
                         records: 0,
                         peers: 0,
                         connections: 0,
@@ -930,7 +930,7 @@ impl Component for Status<'_> {
                     Constraint::Min(VERSION_WIDTH as u16),
                     Constraint::Min(ATTOS_WIDTH as u16),
                     Constraint::Min(MEMORY_WIDTH as u16),
-                    Constraint::Min(MB_WIDTH as u16),
+                    Constraint::Min(MBITS_WIDTH as u16),
                     Constraint::Min(RECORDS_WIDTH as u16),
                     Constraint::Min(PEERS_WIDTH as u16),
                     Constraint::Min(CONNS_WIDTH as u16),
@@ -945,7 +945,8 @@ impl Component for Status<'_> {
                     Cell::new("Attos").fg(COOL_GREY),
                     Cell::new("Memory").fg(COOL_GREY),
                     Cell::new(
-                        format!("{}{}", " ".repeat(MB_WIDTH - "Mb".len()), "Mb").fg(COOL_GREY),
+                        format!("{}{}", " ".repeat(MBITS_WIDTH - "Mbits".len()), "Mbits")
+                            .fg(COOL_GREY),
                     ),
                     Cell::new("Recs").fg(COOL_GREY),
                     Cell::new("Peers").fg(COOL_GREY),
@@ -1179,7 +1180,7 @@ pub struct NodeItem<'a> {
     version: String,
     attos: usize,
     memory: usize,
-    mb: String,
+    mbits: String,
     records: usize,
     peers: usize,
     connections: usize,
@@ -1266,8 +1267,8 @@ impl NodeItem<'_> {
             ),
             format!(
                 "{}{}",
-                " ".repeat(MB_WIDTH.saturating_sub(self.mb.to_string().len())),
-                self.mb.to_string()
+                " ".repeat(MBITS_WIDTH.saturating_sub(self.mbits.to_string().len())),
+                self.mbits.to_string()
             ),
             format!(
                 "{}{}",


### PR DESCRIPTION
### Description

We fixed a but where we were using the current outbound/inbound metric to calculate << who knows what >>.
Now we use `Mbits`and we use outbound_ratio/inboud_ratio for it over a certain period of time (`NODE_STAT_UPDATE_INTERVAL`).

We use 5 digits because its unlikely for many folks to have 10Gbps, but its extremely rare for one to have 100Gbps, so maybe 00000 without decimal is best. Between >= 1 and <= 99999 Mbps

Thanks Shu!

![Screenshot 2024-11-08 at 18 39 10](https://github.com/user-attachments/assets/9f33f87c-176c-4481-b30a-0af10c65f2da)


We also modified a small alignment on the footer, but will be changed shortly.
