### PR TITLE
fix: Remove env var requirement for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ You should build from the `stable` branch, as follows:
 
 ```
 git checkout stable
-export FOUNDATION_PK=b20c916c7a28707018292f06dfdb66ab88ebcbad9c78d18135e843a91b1d66b875b24d2c27d8d1ad4637c2d5811896fe
-export GENESIS_PK=93f7355906fa8c1a639bac80f4619dbb4cf5f71c47827d1ff2c30f0d133f6b841859662cbf7e0bbceca0eb0f521f6ebc
-export NETWORK_ROYALTIES_PK=af451aa34a0d16c50eb217b91ab6b2ca75ef43b9c20449384ff1e90dbf8477351499cca985828e33b208805dadc80c63
-export PAYMENT_FORWARD_PK=adc6401588af49c60af6717a60546207abddb4e150014b4ab6c407ef6d7b3d3899b8892a91ab23042378b7b285e655fc
 cargo build --release --features=network-contacts --bin safenode
 ```
 

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -76,8 +76,11 @@ mod tests {
     #[test]
     fn test_print_version_strings() -> Result<(), Box<dyn std::error::Error>> {
         // Test and print all version strings
-        println!("\nIDENTIFY_CLIENT_VERSION_STR: {}", *IDENTIFY_CLIENT_VERSION_STR);
-        println!("REQ_RESPONSE_VERSION_STR: {}", *REQ_RESPONSE_VERSION_STR); 
+        println!(
+            "\nIDENTIFY_CLIENT_VERSION_STR: {}",
+            *IDENTIFY_CLIENT_VERSION_STR
+        );
+        println!("REQ_RESPONSE_VERSION_STR: {}", *REQ_RESPONSE_VERSION_STR);
         println!("IDENTIFY_PROTOCOL_STR: {}", *IDENTIFY_PROTOCOL_STR);
 
         // Test truncated version string

--- a/sn_protocol/src/version.rs
+++ b/sn_protocol/src/version.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use lazy_static::lazy_static;
-use sn_transfers::{FOUNDATION_PK, GENESIS_PK, NETWORK_ROYALTIES_PK};
 
 lazy_static! {
     /// The node version used during Identify Behaviour.
@@ -55,15 +54,40 @@ fn get_truncate_version_str() -> String {
     }
 }
 
+/// FIXME: Remove this once BEFORE next breaking release and fix this whole file
 /// Get the PKs version string.
 /// If the public key mis-configed via env variable,
 /// it shall result in being rejected to join by the network
 pub fn get_key_version_str() -> String {
-    let mut f_k_str = FOUNDATION_PK.to_hex();
-    let _ = f_k_str.split_off(6);
-    let mut g_k_str = GENESIS_PK.to_hex();
-    let _ = g_k_str.split_off(6);
-    let mut n_k_str = NETWORK_ROYALTIES_PK.to_hex();
-    let _ = n_k_str.split_off(6);
-    format!("{f_k_str}_{g_k_str}_{n_k_str}")
+    // let mut f_k_str = FOUNDATION_PK.to_hex();
+    // let _ = f_k_str.split_off(6);
+    // let mut g_k_str = GENESIS_PK.to_hex();
+    // let _ = g_k_str.split_off(6);
+    // let mut n_k_str = NETWORK_ROYALTIES_PK.to_hex();
+    // let _ = n_k_str.split_off(6);
+    // let s = format!("{f_k_str}_{g_k_str}_{n_k_str}");
+    // dbg!(&s);
+    "b20c91_93f735_af451a".to_string()
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_print_version_strings() -> Result<(), Box<dyn std::error::Error>> {
+        // Test and print all version strings
+        println!("\nIDENTIFY_CLIENT_VERSION_STR: {}", *IDENTIFY_CLIENT_VERSION_STR);
+        println!("REQ_RESPONSE_VERSION_STR: {}", *REQ_RESPONSE_VERSION_STR); 
+        println!("IDENTIFY_PROTOCOL_STR: {}", *IDENTIFY_PROTOCOL_STR);
+
+        // Test truncated version string
+        let truncated = get_truncate_version_str();
+        println!("\nTruncated version: {truncated}");
+
+        // Test key version string
+        let key_version = get_key_version_str();
+        println!("\nKey version string: {key_version}");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Description

This is a quick fix to remove the requirement for devs to publish static (non changing) env vars when building. 

### Related Issue

None

### Type of Change

Please mark the types of changes made in this pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
