### PR TITLE
feat(launchpad): node actions

### DIFF
--- a/node-launchpad/.config/config.json5
+++ b/node-launchpad/.config/config.json5
@@ -8,8 +8,8 @@
       "<h>": {"SwitchScene":"Help"},
       "<H>": {"SwitchScene":"Help"},
 
-      "<Ctrl-s>": {"StatusActions":"StartNodes"},
-      "<Ctrl-S>": {"StatusActions":"StartNodes"},
+      "<Ctrl-s>": {"StatusActions":"StartStopNode"},
+      "<Ctrl-S>": {"StatusActions":"StartStopNode"},
       "<Ctrl-Shift-s>": {"StatusActions":"StartNodes"},
       "<Ctrl-x>": {"StatusActions":"StopNodes"},
       "<Ctrl-X>": {"StatusActions":"StopNodes"},
@@ -19,6 +19,8 @@
       "<Ctrl-Shift-b>": {"StatusActions":"TriggerRewardsAddress"},
       "<l>": {"StatusActions":"TriggerNodeLogs"},
       "<L>": {"StatusActions":"TriggerNodeLogs"},
+      "<+>": {"StatusActions":"AddNode"},
+      "<->": {"StatusActions":"TriggerRemoveNode"},
 
       "up" : {"StatusActions":"PreviousTableItem"},
       "down": {"StatusActions":"NextTableItem"},

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -48,21 +48,54 @@ pub enum StatusActions {
     StopNodes,
     RemoveNodes,
     StartStopNode,
-    StartNodesCompleted,
-    StopNodesCompleted,
-    ResetNodesCompleted { trigger_start_node: bool },
+    StartNodesCompleted {
+        service_name: String,
+    },
+    StopNodesCompleted {
+        service_name: String,
+    },
+    ResetNodesCompleted {
+        trigger_start_node: bool,
+    },
+    RemoveNodesCompleted {
+        service_name: String,
+    },
+    AddNodesCompleted {
+        service_name: String,
+    },
     UpdateNodesCompleted,
-    RemovingNodesCompleted,
     SuccessfullyDetectedNatStatus,
     ErrorWhileRunningNatDetection,
-    ErrorLoadingNodeRegistry { raw_error: String },
-    ErrorGettingNodeRegistryPath { raw_error: String },
-    ErrorScalingUpNodes { raw_error: String },
-    ErrorStoppingNodes { raw_error: String },
-    ErrorResettingNodes { raw_error: String },
-    ErrorUpdatingNodes { raw_error: String },
-    ErrorRemovingNodes { raw_error: String },
-    ErrorStartingNodes { raw_error: String },
+    ErrorLoadingNodeRegistry {
+        raw_error: String,
+    },
+    ErrorGettingNodeRegistryPath {
+        raw_error: String,
+    },
+    ErrorScalingUpNodes {
+        raw_error: String,
+    },
+    ErrorResettingNodes {
+        raw_error: String,
+    },
+    ErrorUpdatingNodes {
+        raw_error: String,
+    },
+    ErrorAddingNodes {
+        raw_error: String,
+    },
+    ErrorStartingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
+    ErrorStoppingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
+    ErrorRemovingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
     NodesStatsObtained(NodeStats),
 
     TriggerManageNodes,

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -43,12 +43,16 @@ pub enum Action {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum StatusActions {
+    AddNode,
     StartNodes,
     StopNodes,
+    RemoveNodes,
+    StartStopNode,
     StartNodesCompleted,
     StopNodesCompleted,
     ResetNodesCompleted { trigger_start_node: bool },
     UpdateNodesCompleted,
+    RemovingNodesCompleted,
     SuccessfullyDetectedNatStatus,
     ErrorWhileRunningNatDetection,
     ErrorLoadingNodeRegistry { raw_error: String },
@@ -57,11 +61,14 @@ pub enum StatusActions {
     ErrorStoppingNodes { raw_error: String },
     ErrorResettingNodes { raw_error: String },
     ErrorUpdatingNodes { raw_error: String },
+    ErrorRemovingNodes { raw_error: String },
+    ErrorStartingNodes { raw_error: String },
     NodesStatsObtained(NodeStats),
 
     TriggerManageNodes,
     TriggerRewardsAddress,
     TriggerNodeLogs,
+    TriggerRemoveNode,
 
     PreviousTableItem,
     NextTableItem,

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -99,6 +99,7 @@ impl App {
             connection_mode,
             port_from: Some(port_from),
             port_to: Some(port_to),
+            storage_mountpoint: storage_mountpoint.clone(),
         };
 
         let status = Status::new(status_config).await?;

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -15,8 +15,9 @@ use crate::{
         options::Options,
         popup::{
             change_drive::ChangeDrivePopup, connection_mode::ChangeConnectionModePopUp,
-            manage_nodes::ManageNodes, port_range::PortRangePopUp, reset_nodes::ResetNodesPopup,
-            rewards_address::RewardsAddress, upgrade_nodes::UpgradeNodesPopUp,
+            manage_nodes::ManageNodes, port_range::PortRangePopUp, remove_node::RemoveNodePopUp,
+            reset_nodes::ResetNodesPopup, rewards_address::RewardsAddress,
+            upgrade_nodes::UpgradeNodesPopUp,
         },
         status::{Status, StatusConfig},
         Component,
@@ -121,6 +122,7 @@ impl App {
         let port_range = PortRangePopUp::new(connection_mode, port_from, port_to);
         let rewards_address = RewardsAddress::new(app_data.discord_username.clone());
         let upgrade_nodes = UpgradeNodesPopUp::new(app_data.nodes_to_start);
+        let remove_node = RemoveNodePopUp::default();
 
         Ok(Self {
             config,
@@ -148,6 +150,7 @@ impl App {
                 Box::new(reset_nodes),
                 Box::new(manage_nodes),
                 Box::new(upgrade_nodes),
+                Box::new(remove_node),
             ],
             should_quit: false,
             should_suspend: false,

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -122,7 +122,7 @@ impl App {
         let change_connection_mode = ChangeConnectionModePopUp::new(connection_mode)?;
         let port_range = PortRangePopUp::new(connection_mode, port_from, port_to);
         let rewards_address = RewardsAddress::new(app_data.discord_username.clone());
-        let upgrade_nodes = UpgradeNodesPopUp::new(app_data.nodes_to_start);
+        let upgrade_nodes = UpgradeNodesPopUp::new();
         let remove_node = RemoveNodePopUp::default();
 
         Ok(Self {

--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -35,11 +35,14 @@ impl StatefulWidget for Footer {
         };
 
         let commands = vec![
-            Span::styled("[Ctrl+G] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Manage Nodes", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[+] ", Style::default().fg(GHOST_WHITE)),
+            Span::styled("Add", Style::default().fg(EUCALYPTUS)),
+            Span::styled(" ", Style::default()),
+            Span::styled("[-] ", Style::default().fg(GHOST_WHITE)),
+            Span::styled("Remove", Style::default().fg(EUCALYPTUS)),
             Span::styled(" ", Style::default()),
             Span::styled("[Ctrl+S] ", command_style),
-            Span::styled("Start Nodes", text_style),
+            Span::styled("Start/Stop Node", text_style),
             Span::styled(" ", Style::default()),
             Span::styled("[L] ", command_style),
             Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),

--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -10,9 +10,10 @@ use crate::style::{COOL_GREY, EUCALYPTUS, GHOST_WHITE, LIGHT_PERIWINKLE};
 use ratatui::{prelude::*, widgets::*};
 
 pub enum NodesToStart {
-    Configured,
-    NotConfigured,
     Running,
+    NotRunning,
+    RunningSelected,
+    NotRunningSelected,
 }
 
 #[derive(Default)]
@@ -22,53 +23,99 @@ impl StatefulWidget for Footer {
     type State = NodesToStart;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let (text_style, command_style) = if matches!(state, NodesToStart::Configured) {
-            (
-                Style::default().fg(EUCALYPTUS),
-                Style::default().fg(GHOST_WHITE),
-            )
-        } else {
-            (
-                Style::default().fg(COOL_GREY),
-                Style::default().fg(LIGHT_PERIWINKLE),
-            )
-        };
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Length(3)])
+            .split(area);
+
+        let command_enabled = Style::default().fg(GHOST_WHITE);
+        let text_enabled = Style::default().fg(EUCALYPTUS);
+        let command_disabled = Style::default().fg(LIGHT_PERIWINKLE);
+        let text_disabled = Style::default().fg(COOL_GREY);
+
+        let mut remove_command_style = command_disabled;
+        let mut remove_text_style = text_disabled;
+        let mut start_stop_command_style = command_disabled;
+        let mut start_stop_text_style = text_disabled;
+        let mut open_logs_command_style = command_disabled;
+        let mut open_logs_text_style = text_disabled;
+        let mut stop_all_command_style = command_disabled;
+        let mut stop_all_text_style = text_disabled;
+
+        match state {
+            NodesToStart::Running => {
+                stop_all_command_style = command_enabled;
+                stop_all_text_style = text_enabled;
+            }
+            NodesToStart::RunningSelected => {
+                remove_command_style = command_enabled;
+                remove_text_style = text_enabled;
+                start_stop_command_style = command_enabled;
+                start_stop_text_style = text_enabled;
+                open_logs_command_style = command_enabled;
+                open_logs_text_style = text_enabled;
+                stop_all_command_style = command_enabled;
+                stop_all_text_style = text_enabled;
+            }
+            NodesToStart::NotRunning => {}
+            NodesToStart::NotRunningSelected => {
+                remove_command_style = command_enabled;
+                remove_text_style = text_enabled;
+                start_stop_command_style = command_enabled;
+                start_stop_text_style = text_enabled;
+                open_logs_command_style = command_enabled;
+                open_logs_text_style = text_enabled;
+            }
+        }
 
         let commands = vec![
-            Span::styled("[+] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Add", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[+] ", command_enabled),
+            Span::styled("Add", text_enabled),
             Span::styled(" ", Style::default()),
-            Span::styled("[-] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Remove", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[-] ", remove_command_style),
+            Span::styled("Remove", remove_text_style),
             Span::styled(" ", Style::default()),
-            Span::styled("[Ctrl+S] ", command_style),
-            Span::styled("Start/Stop Node", text_style),
+            Span::styled("[Ctrl+S] ", start_stop_command_style),
+            Span::styled("Start/Stop Node", start_stop_text_style),
             Span::styled(" ", Style::default()),
-            Span::styled("[L] ", command_style),
-            Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),
-            Span::styled(" ", Style::default()),
-            Span::styled("[Ctrl+X] ", command_style),
-            Span::styled(
-                "Stop All",
-                if matches!(state, NodesToStart::Running) {
-                    Style::default().fg(EUCALYPTUS)
-                } else {
-                    Style::default().fg(COOL_GREY)
-                },
-            ),
+            Span::styled("[L] ", open_logs_command_style),
+            Span::styled("Open Logs", open_logs_text_style),
         ];
 
-        let cell1 = Cell::from(Line::from(commands));
-        let row = Row::new(vec![cell1]);
+        let stop_all = vec![
+            Span::styled("[Ctrl+X] ", stop_all_command_style),
+            Span::styled("Stop All", stop_all_text_style),
+        ];
 
-        let table = Table::new(vec![row], vec![Constraint::Max(1)])
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(EUCALYPTUS))
-                    .padding(Padding::horizontal(1)),
-            )
-            .widths(vec![Constraint::Fill(1)]);
+        let total_width = (layout[0].width - 1) as usize;
+        let spaces = " ".repeat(total_width.saturating_sub(
+            commands.iter().map(|s| s.width()).sum::<usize>()
+                + stop_all.iter().map(|s| s.width()).sum::<usize>(),
+        ));
+
+        let commands_length = 6 + commands.iter().map(|s| s.width()).sum::<usize>() as u16;
+        let spaces_length = spaces.len().saturating_sub(6) as u16;
+        let stop_all_length = stop_all.iter().map(|s| s.width()).sum::<usize>() as u16;
+
+        let cell1 = Cell::from(Line::from(commands));
+        let cell2 = Cell::from(Line::raw(spaces));
+        let cell3 = Cell::from(Line::from(stop_all));
+        let row = Row::new(vec![cell1, cell2, cell3]);
+
+        let table = Table::new(
+            [row],
+            [
+                Constraint::Length(commands_length),
+                Constraint::Length(spaces_length),
+                Constraint::Length(stop_all_length),
+            ],
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(EUCALYPTUS))
+                .padding(Padding::horizontal(1)),
+        );
 
         StatefulWidget::render(table, area, buf, &mut TableState::default());
     }

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -68,7 +68,7 @@ impl Component for Options {
             .constraints(
                 [
                     Constraint::Length(1),
-                    Constraint::Length(7),
+                    Constraint::Length(5),
                     Constraint::Length(3),
                     Constraint::Length(3),
                     Constraint::Length(4),
@@ -93,7 +93,6 @@ impl Component for Options {
             .border_style(Style::default().fg(VERY_LIGHT_AZURE));
         let storage_drivename = Table::new(
             vec![
-                Row::new(vec![Line::from(vec![])]),
                 Row::new(vec![
                     Cell::from(
                         Line::from(vec![Span::styled(
@@ -177,7 +176,6 @@ impl Component for Options {
                         .alignment(Alignment::Right),
                     ),
                 ]),
-                Row::new(vec![Line::from(vec![])]),
             ],
             &[
                 Constraint::Length(18),

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -374,7 +374,7 @@ impl Component for Options {
                 | Scene::ChangePortsPopUp { .. }
                 | Scene::OptionsRewardsAddressPopUp
                 | Scene::ResetNodesPopUp
-                | Scene::UpgradeNodesPopUp => {
+                | Scene::UpgradeNodesPopUp { .. } => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -374,7 +374,7 @@ impl Component for Options {
                 | Scene::ChangePortsPopUp { .. }
                 | Scene::OptionsRewardsAddressPopUp
                 | Scene::ResetNodesPopUp
-                | Scene::UpgradeNodesPopUp { .. } => {
+                | Scene::UpgradeNodesPopUp => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));

--- a/node-launchpad/src/components/popup.rs
+++ b/node-launchpad/src/components/popup.rs
@@ -10,6 +10,7 @@ pub mod change_drive;
 pub mod connection_mode;
 pub mod manage_nodes;
 pub mod port_range;
+pub mod remove_node;
 pub mod reset_nodes;
 pub mod rewards_address;
 pub mod upgrade_nodes;

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -285,7 +285,7 @@ impl Component for ManageNodes {
         let help = Paragraph::new(vec![
             Line::raw(format!(
                 "Note: Each node will use a small amount of CPU Memory and Network Bandwidth. \
-                 We recommend starting no more than 5 at a time (max {MAX_NODE_COUNT} nodes)."
+                 We recommend starting no more than 2 at a time (max {MAX_NODE_COUNT} nodes)."
             )),
             Line::raw(""),
             Line::raw("▲▼ to change the number of nodes to start."),

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -165,7 +165,11 @@ impl Component for ManageNodes {
     fn update(&mut self, action: Action) -> Result<Option<Action>> {
         let send_back = match action {
             Action::SwitchScene(scene) => match scene {
-                Scene::ManageNodesPopUp => {
+                Scene::ManageNodesPopUp { amount_of_nodes } => {
+                    self.nodes_to_start_input = self
+                        .nodes_to_start_input
+                        .clone()
+                        .with_value(amount_of_nodes.to_string());
                     self.active = true;
                     self.old_value = self.nodes_to_start_input.value().to_string();
                     // set to entry input mode as we want to handle everything within our handle_key_events

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::super::{utils::centered_rect_fixed, Component};
 
-pub const GB_PER_NODE: usize = 35;
+pub const GB_PER_NODE: usize = 1;
 pub const MB: usize = 1000 * 1000;
 pub const GB: usize = MB * 1000;
 pub const MAX_NODE_COUNT: usize = 50;

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::super::{utils::centered_rect_fixed, Component};
 
-pub const GB_PER_NODE: usize = 1;
+pub const GB_PER_NODE: usize = 35;
 pub const MB: usize = 1000 * 1000;
 pub const GB: usize = MB * 1000;
 pub const MAX_NODE_COUNT: usize = 50;

--- a/node-launchpad/src/components/popup/upgrade_nodes.rs
+++ b/node-launchpad/src/components/popup/upgrade_nodes.rs
@@ -19,15 +19,15 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{prelude::*, widgets::*};
 
 pub struct UpgradeNodesPopUp {
-    nodes_to_start: usize,
+    amount_of_nodes: usize,
     /// Whether the component is active right now, capturing keystrokes + draw things.
     active: bool,
 }
 
 impl UpgradeNodesPopUp {
-    pub fn new(nodes_to_start: usize) -> Self {
+    pub fn new(amount_of_nodes: usize) -> Self {
         Self {
-            nodes_to_start,
+            amount_of_nodes,
             active: false,
         }
     }
@@ -68,10 +68,6 @@ impl Component for UpgradeNodesPopUp {
                     None
                 }
             },
-            Action::StoreNodesToStart(ref nodes_to_start) => {
-                self.nodes_to_start = *nodes_to_start;
-                None
-            }
             _ => None,
         };
         Ok(send_back)
@@ -114,9 +110,9 @@ impl Component for UpgradeNodesPopUp {
             Direction::Vertical,
             [
                 // for the text
-                Constraint::Length(9),
+                Constraint::Length(10),
                 // gap
-                Constraint::Length(4),
+                Constraint::Length(3),
                 // for the buttons
                 Constraint::Length(1),
             ],
@@ -139,10 +135,14 @@ impl Component for UpgradeNodesPopUp {
             Line::from(Span::styled(
                 format!(
                     "Upgrade time ~ {:.1?} mins ({:?} nodes * {:?} secs)",
-                    self.nodes_to_start * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
-                    self.nodes_to_start,
+                    self.amount_of_nodes * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
+                    self.amount_of_nodes,
                     node_mgmt::FIXED_INTERVAL / 1_000,
                 ),
+                Style::default().fg(LIGHT_PERIWINKLE),
+            )),
+            Line::from(Span::styled(
+                "plus, new binary download time.",
                 Style::default().fg(LIGHT_PERIWINKLE),
             )),
             Line::from(Span::styled("\n\n", Style::default())),

--- a/node-launchpad/src/components/popup/upgrade_nodes.rs
+++ b/node-launchpad/src/components/popup/upgrade_nodes.rs
@@ -19,17 +19,19 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{prelude::*, widgets::*};
 
 pub struct UpgradeNodesPopUp {
-    amount_of_nodes: usize,
     /// Whether the component is active right now, capturing keystrokes + draw things.
     active: bool,
 }
 
 impl UpgradeNodesPopUp {
-    pub fn new(amount_of_nodes: usize) -> Self {
-        Self {
-            amount_of_nodes,
-            active: false,
-        }
+    pub fn new() -> Self {
+        Self { active: false }
+    }
+}
+
+impl Default for UpgradeNodesPopUp {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -134,9 +136,7 @@ impl Component for UpgradeNodesPopUp {
             )),
             Line::from(Span::styled(
                 format!(
-                    "Upgrade time ~ {:.1?} mins ({:?} nodes * {:?} secs)",
-                    self.amount_of_nodes * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
-                    self.amount_of_nodes,
+                    "Upgrade time is {:.1?} seconds per node",
                     node_mgmt::FIXED_INTERVAL / 1_000,
                 ),
                 Style::default().fg(LIGHT_PERIWINKLE),

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -1253,19 +1253,31 @@ impl Component for Status<'_> {
 
         // ==== Footer =====
 
+        let selected = self
+            .items
+            .as_ref()
+            .and_then(|items| items.selected_item())
+            .is_some();
+
         let footer = Footer::default();
         let footer_state = if let Some(ref items) = self.items {
-            if !items.items.is_empty() || self.rewards_address.is_empty() {
+            if !items.items.is_empty() || !self.rewards_address.is_empty() {
                 if !self.get_running_nodes().is_empty() {
-                    &mut NodesToStart::Running
+                    if selected {
+                        &mut NodesToStart::RunningSelected
+                    } else {
+                        &mut NodesToStart::Running
+                    }
+                } else if selected {
+                    &mut NodesToStart::NotRunningSelected
                 } else {
-                    &mut NodesToStart::Configured
+                    &mut NodesToStart::NotRunning
                 }
             } else {
-                &mut NodesToStart::NotConfigured
+                &mut NodesToStart::NotRunning
             }
         } else {
-            &mut NodesToStart::NotConfigured
+            &mut NodesToStart::NotRunning
         };
         f.render_stateful_widget(footer, layout[3], footer_state);
 

--- a/node-launchpad/src/mode.rs
+++ b/node-launchpad/src/mode.rs
@@ -26,6 +26,7 @@ pub enum Scene {
     ManageNodesPopUp,
     ResetNodesPopUp,
     UpgradeNodesPopUp,
+    RemoveNodePopUp,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/node-launchpad/src/mode.rs
+++ b/node-launchpad/src/mode.rs
@@ -23,7 +23,9 @@ pub enum Scene {
     },
     StatusRewardsAddressPopUp,
     OptionsRewardsAddressPopUp,
-    ManageNodesPopUp,
+    ManageNodesPopUp {
+        amount_of_nodes: usize,
+    },
     ResetNodesPopUp,
     UpgradeNodesPopUp,
     RemoveNodePopUp,

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -754,9 +754,8 @@ async fn add_nodes(
             action_sender.clone(),
             Action::StatusActions(StatusActions::ErrorScalingUpNodes {
                 raw_error: format!(
-                    "When trying run a node, we reached the maximum amount of retries ({}).\n\
-                    Could this be a firewall blocking nodes starting?\n\
-                    Or ports on your router already in use?",
+                    "When trying to start a node, we reached the maximum amount of retries ({}).\n\
+                    Could this be a firewall blocking nodes starting or ports on your router already in use?",
                     NODE_ADD_MAX_RETRIES
                 ),
             }),

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -297,6 +297,21 @@ async fn upgrade_nodes(args: UpgradeNodesArgs) {
 }
 
 async fn remove_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
+    // First we stop the nodes
+    if let Err(err) =
+        sn_node_manager::cmd::node::stop(None, vec![], services.clone(), VerbosityLevel::Minimal)
+            .await
+    {
+        error!("Error while stopping services {err:?}");
+        send_action(
+            action_sender.clone(),
+            Action::StatusActions(StatusActions::ErrorRemovingNodes {
+                services: services.clone(),
+                raw_error: err.to_string(),
+            }),
+        );
+    }
+
     if let Err(err) =
         sn_node_manager::cmd::node::remove(false, vec![], services.clone(), VerbosityLevel::Minimal)
             .await

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -247,6 +247,24 @@ pub struct UpgradeNodesArgs {
 }
 
 async fn upgrade_nodes(args: UpgradeNodesArgs) {
+    // First we stop the Nodes
+    if let Err(err) = sn_node_manager::cmd::node::stop(
+        None,
+        vec![],
+        args.service_names.clone(),
+        VerbosityLevel::Minimal,
+    )
+    .await
+    {
+        error!("Error while stopping services {err:?}");
+        send_action(
+            args.action_sender.clone(),
+            Action::StatusActions(StatusActions::ErrorUpdatingNodes {
+                raw_error: err.to_string(),
+            }),
+        );
+    }
+
     if let Err(err) = sn_node_manager::cmd::node::upgrade(
         0, // will be overwrite by FIXED_INTERVAL
         args.do_not_start,

--- a/node-launchpad/src/system.rs
+++ b/node-launchpad/src/system.rs
@@ -160,3 +160,19 @@ pub fn get_available_space_b(storage_mountpoint: &PathBuf) -> Result<usize> {
 
     Ok(available_space_b)
 }
+
+// Gets the name of the drive given a mountpoint
+pub fn get_drive_name(storage_mountpoint: &PathBuf) -> Result<String> {
+    let disks = Disks::new_with_refreshed_list();
+    let name = disks
+        .list()
+        .iter()
+        .find(|disk| disk.mount_point() == storage_mountpoint)
+        .context("Cannot find the primary disk. Configuration file might be wrong.")?
+        .name()
+        .to_str()
+        .unwrap_or_default()
+        .to_string();
+
+    Ok(name)
+}

--- a/sn_node_manager/src/lib.rs
+++ b/sn_node_manager/src/lib.rs
@@ -269,7 +269,9 @@ impl<T: ServiceStateActions + Send> ServiceManager<T> {
                     // crate treats as an error. We then return our own error type, which allows us
                     // to handle it here and just proceed with removing the service from the
                     // registry.
-                    println!("The user appears to have removed the {name} service manually");
+                    if self.verbosity != VerbosityLevel::Minimal {
+                        println!("The user appears to have removed the {name} service manually");
+                    }
                 }
                 ServiceError::ServiceDoesNotExists(name) => {
                     warn!("The service {name} has most probably been removed already, it does not exists. Skipping the error.");


### PR DESCRIPTION
### Description

#### Internal crates
* Changes on `node-manager` to be less verbose (`Verbosity::Minimal` on calls)

### Main feature
* Now we can start/stop, add, remove individual nodes. For this we implemented a locking mechanism (semaphore) per node (`locked` on `NodeItem`). It's set to `true` before starting a `NodeManagementTask` and `false` when succeeds or returns with error. There are some helper functions for that effect.
 
#### Validation
* Validations when adding nodes (`[+]`) regarding the maximum amount of nodes and available disk space. Some helpers were created for the error messages.
* Validation of some edge cases like operations without nodes, when the application starts from scratch.
* New popup screen when trying to remove (`[-]`) a node. Gives a warning.

### Styling
* Changed footer style and behavior depending on the application state. Now is sort of flexible when shrinking the terminal (minimal resolution 80x24).

### Extras
* Some minor error message formatting.
* Changed the legend when upgrading nodes as is difficult to pass the amount of nodes between scenes. Instead of calculating total time of upgrade, we just mention how much takes per node.


### Bug fix 🐞 
* We added `CONNECTION_TIMEOUT_START` as a constant. We were using a hardcoded value as timeout when starting nodes that was making few RPC connection attempts and failing too early. 

🛑  Do not merge straight away so we squash and merge.