### PR TITLE
feat(networking): add bootstrap cache for peer discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ sn_node_manager/.vagrant
 uv.lock
 *.so
 *.pyc
-
-*.pyc
 *.swp
 
+/vendor/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "autonomi",
     "autonomi-cli",
+    "bootstrap_cache",
     "evmlib",
     "evm_testnet",
     "sn_build_info",

--- a/bootstrap_cache/Cargo.toml
+++ b/bootstrap_cache/Cargo.toml
@@ -18,8 +18,20 @@ tempfile = "3.8.1"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full", "sync"] }
 tracing = "0.1"
+url = "2.4.0"
 
 [dev-dependencies]
 wiremock = "0.5"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+nursery = "warn"
+unwrap_used = "warn"
+missing_docs_in_private_items = "warn"

--- a/bootstrap_cache/Cargo.toml
+++ b/bootstrap_cache/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bootstrap_cache"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0"
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
+description = "Bootstrap cache functionality for the Safe Network"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "5.0"
+fs2 = "0.4.3"
+libp2p = { version = "0.53", features = ["serde"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tempfile = "3.8.1"
+thiserror = "1.0"
+tokio = { version = "1.0", features = ["full", "sync"] }
+tracing = "0.1"
+
+[dev-dependencies]
+wiremock = "0.5"
+tokio = { version = "1.0", features = ["full", "test-util"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bootstrap_cache/README.md
+++ b/bootstrap_cache/README.md
@@ -18,7 +18,6 @@ A robust peer caching system for the Safe Network that provides persistent stora
 - Exponential backoff retry mechanism for lock acquisition
 
 ### Data Management
-- Peer expiry after 24 hours of inactivity
 - Automatic cleanup of stale and unreliable peers
 - Configurable maximum peer limit
 - Peer reliability tracking (success/failure counts)

--- a/bootstrap_cache/README.md
+++ b/bootstrap_cache/README.md
@@ -1,216 +1,161 @@
 # Bootstrap Cache
 
-A decentralized peer discovery and caching system for the Safe Network.
+A robust peer caching system for the Safe Network that provides persistent storage and management of network peer addresses. This crate handles peer discovery, caching, and reliability tracking with support for concurrent access across multiple processes.
 
 ## Features
 
-- **Decentralized Design**: No dedicated bootstrap nodes required
-- **Cross-Platform Support**: Works on Linux, macOS, and Windows
-- **Shared Cache**: System-wide cache file accessible by both nodes and clients
-- **Concurrent Access**: File locking for safe multi-process access
-- **Atomic Operations**: Safe cache updates using atomic file operations
-- **Initial Peer Discovery**: Fallback web endpoints for new/stale cache scenarios
-- **Comprehensive Error Handling**: Detailed error types and logging
-- **Circuit Breaker Pattern**: Intelligent failure handling with:
-  - Configurable failure thresholds and reset timeouts
-  - Exponential backoff for failed requests
-  - Automatic state transitions (closed → open → half-open)
-  - Protection against cascading failures
+### Storage and Accessibility
+- System-wide accessible cache location
+- Configurable primary cache location
+- Automatic fallback to user's home directory (`~/.safe/bootstrap_cache.json`)
+- Cross-process safe with file locking
+- Atomic write operations to prevent cache corruption
 
-### Peer Management
+### Concurrent Access
+- Thread-safe in-memory cache with `RwLock`
+- File system level locking for cross-process synchronization
+- Shared (read) and exclusive (write) lock support
+- Exponential backoff retry mechanism for lock acquisition
 
-The bootstrap cache implements a robust peer management system:
+### Data Management
+- Peer expiry after 24 hours of inactivity
+- Automatic cleanup of stale and unreliable peers
+- Configurable maximum peer limit
+- Peer reliability tracking (success/failure counts)
+- Atomic file operations for data integrity
 
-- **Peer Status Tracking**: Each peer's connection history is tracked, including:
-  - Success count: Number of successful connections
-  - Failure count: Number of failed connection attempts
-  - Last seen timestamp: When the peer was last successfully contacted
+## Configuration Options
 
-- **Automatic Cleanup**: The system automatically removes unreliable peers:
-  - Peers that fail 3 consecutive connection attempts are marked for removal
-  - Removal only occurs if there are at least 2 working peers available
-  - This ensures network connectivity is maintained even during temporary connection issues
-
-- **Duplicate Prevention**: The cache automatically prevents duplicate peer entries:
-  - Same IP and port combinations are only stored once
-  - Different ports on the same IP are treated as separate peers
-
-## Installation
-
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-bootstrap_cache = { version = "0.1.0" }
-```
-
-## Usage
-
-### Basic Example
+The `BootstrapConfig` struct provides the following configuration options:
 
 ```rust
-use bootstrap_cache::{BootstrapCache, CacheManager, InitialPeerDiscovery};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize the cache manager
-    let cache_manager = CacheManager::new()?;
-
-    // Try to read from the cache
-    let mut cache = match cache_manager.read_cache() {
-        Ok(cache) if !cache.is_stale() => cache,
-        _ => {
-            // Cache is stale or unavailable, fetch initial peers
-            let discovery = InitialPeerDiscovery::new();
-            let peers = discovery.fetch_peers().await?;
-            let cache = BootstrapCache {
-                last_updated: chrono::Utc::now(),
-                peers,
-            };
-            cache_manager.write_cache(&cache)?;
-            cache
-        }
-    };
-
-    println!("Found {} peers in cache", cache.peers.len());
-    Ok(())
+pub struct BootstrapConfig {
+    /// List of endpoints to fetch initial peers from
+    pub endpoints: Vec<String>,
+    
+    /// Maximum number of peers to maintain in the cache
+    pub max_peers: usize,
+    
+    /// Path where the cache file will be stored
+    pub cache_file_path: PathBuf,
+    
+    /// How long to wait for peer responses
+    pub peer_response_timeout: Duration,
+    
+    /// Interval between connection attempts
+    pub connection_interval: Duration,
+    
+    /// Maximum number of connection retries
+    pub max_retries: u32,
 }
 ```
 
-### Custom Endpoints
+### Option Details
 
+#### `endpoints`
+- List of URLs to fetch initial peers from when cache is empty
+- Example: `["https://sn-node1.s3.amazonaws.com/peers", "https://sn-node2.s3.amazonaws.com/peers"]`
+- Default: Empty vector (no endpoints)
+
+#### `max_peers`
+- Maximum number of peers to store in cache
+- When exceeded, oldest peers are removed first
+- Default: 1500 peers
+
+#### `cache_file_path`
+- Location where the cache file will be stored
+- Falls back to `~/.safe/bootstrap_cache.json` if primary location is not writable
+- Example: `/var/lib/safe/bootstrap_cache.json`
+
+#### `peer_response_timeout`
+- Maximum time to wait for a peer to respond
+- Affects peer reliability scoring
+- Default: 60 seconds
+
+#### `connection_interval`
+- Time to wait between connection attempts
+- Helps prevent network flooding
+- Default: 10 seconds
+
+#### `max_retries`
+- Maximum number of times to retry connecting to a peer
+- Affects peer reliability scoring
+- Default: 3 attempts
+
+## Usage Modes
+
+### Default Mode
 ```rust
-use bootstrap_cache::InitialPeerDiscovery;
-
-let discovery = InitialPeerDiscovery::with_endpoints(vec![
-    "http://custom1.example.com/peers.json".to_string(),
-    "http://custom2.example.com/peers.json".to_string(),
-]);
+let config = BootstrapConfig::default();
+let store = CacheStore::new(config).await?;
 ```
+- Uses default configuration
+- Loads peers from cache if available
+- Falls back to configured endpoints if cache is empty
 
-### Circuit Breaker Configuration
-
+### Test Network Mode
 ```rust
-use bootstrap_cache::{InitialPeerDiscovery, CircuitBreakerConfig};
-use std::time::Duration;
-
-// Create a custom circuit breaker configuration
-let config = CircuitBreakerConfig {
-    max_failures: 5,                            // Open after 5 failures
-    reset_timeout: Duration::from_secs(300),    // Wait 5 minutes before recovery
-    min_backoff: Duration::from_secs(1),        // Start with 1 second backoff
-    max_backoff: Duration::from_secs(60),       // Max backoff of 60 seconds
+let args = PeersArgs {
+    test_network: true,
+    peers: vec![/* test peers */],
+    ..Default::default()
 };
-
-// Initialize discovery with custom circuit breaker config
-let discovery = InitialPeerDiscovery::with_config(config);
+let store = CacheStore::from_args(args, config).await?;
 ```
+- Isolates from main network cache
+- Only uses explicitly provided peers
+- No cache persistence
 
-### Peer Management Example
-
+### Local Mode
 ```rust
-use bootstrap_cache::BootstrapCache;
-
-let mut cache = BootstrapCache::new();
-
-// Add a new peer
-cache.add_peer("192.168.1.1".to_string(), 8080);
-
-// Update peer status after connection attempts
-cache.update_peer_status("192.168.1.1", 8080, true);  // successful connection
-cache.update_peer_status("192.168.1.1", 8080, false); // failed connection
-
-// Clean up failed peers (only if we have at least 2 working peers)
-cache.cleanup_failed_peers();
+let args = PeersArgs {
+    local: true,
+    ..Default::default()
+};
+let store = CacheStore::from_args(args, config).await?;
 ```
+- Returns empty store
+- Suitable for local network testing
+- Uses mDNS for peer discovery
 
-## Cache File Location
-
-The cache file is stored in a system-wide location accessible to all processes:
-
-- **Linux**: `/var/safe/bootstrap_cache.json`
-- **macOS**: `/Library/Application Support/Safe/bootstrap_cache.json`
-- **Windows**: `C:\ProgramData\Safe\bootstrap_cache.json`
-
-## Cache File Format
-
-```json
-{
-    "last_updated": "2024-02-20T15:30:00Z",
-    "peers": [
-        {
-            "ip": "192.168.1.1",
-            "port": 8080,
-            "last_seen": "2024-02-20T15:30:00Z",
-            "success_count": 10,
-            "failure_count": 0
-        }
-    ]
-}
+### First Node Mode
+```rust
+let args = PeersArgs {
+    first: true,
+    ..Default::default()
+};
+let store = CacheStore::from_args(args, config).await?;
 ```
+- Returns empty store
+- No fallback to endpoints
+- Used for network initialization
 
 ## Error Handling
 
-The crate provides detailed error types through the `Error` enum:
+The crate provides comprehensive error handling for:
+- File system operations
+- Network requests
+- Concurrent access
+- Data serialization/deserialization
+- Lock acquisition
 
-```rust
-use bootstrap_cache::Error;
-
-match cache_manager.read_cache() {
-    Ok(cache) => println!("Cache loaded successfully"),
-    Err(Error::CacheStale) => println!("Cache is stale"),
-    Err(Error::CacheCorrupted) => println!("Cache file is corrupted"),
-    Err(Error::Io(e)) => println!("IO error: {}", e),
-    Err(e) => println!("Other error: {}", e),
-}
-```
+All errors are propagated through the `Result<T, Error>` type with detailed error variants.
 
 ## Thread Safety
 
-The cache system uses file locking to ensure safe concurrent access:
+The cache store is thread-safe and can be safely shared between threads:
+- `Clone` implementation for `CacheStore`
+- Internal `Arc<RwLock>` for thread-safe data access
+- File system locks for cross-process synchronization
 
-- Shared locks for reading
-- Exclusive locks for writing
-- Atomic file updates using temporary files
+## Logging
 
-## Development
-
-### Building
-
-```bash
-cargo build
-```
-
-### Running Tests
-
-```bash
-cargo test
-```
-
-### Running with Logging
-
-```rust
-use tracing_subscriber::FmtSubscriber;
-
-// Initialize logging
-let subscriber = FmtSubscriber::builder()
-    .with_max_level(tracing::Level::DEBUG)
-    .init();
-```
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -am 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+Comprehensive logging using the `tracing` crate:
+- Info level for normal operations
+- Warn level for recoverable issues
+- Error level for critical failures
+- Debug level for detailed diagnostics
 
 ## License
 
-This project is licensed under the GPL-3.0 License - see the LICENSE file for details.
-
-## Related Documentation
-
-- [Bootstrap Cache PRD](docs/bootstrap_cache_prd.md)
-- [Implementation Guide](docs/bootstrap_cache_implementation.md)
+This SAFE Network Software is licensed under the General Public License (GPL), version 3 ([LICENSE](LICENSE) http://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/bootstrap_cache/README.md
+++ b/bootstrap_cache/README.md
@@ -1,0 +1,216 @@
+# Bootstrap Cache
+
+A decentralized peer discovery and caching system for the Safe Network.
+
+## Features
+
+- **Decentralized Design**: No dedicated bootstrap nodes required
+- **Cross-Platform Support**: Works on Linux, macOS, and Windows
+- **Shared Cache**: System-wide cache file accessible by both nodes and clients
+- **Concurrent Access**: File locking for safe multi-process access
+- **Atomic Operations**: Safe cache updates using atomic file operations
+- **Initial Peer Discovery**: Fallback web endpoints for new/stale cache scenarios
+- **Comprehensive Error Handling**: Detailed error types and logging
+- **Circuit Breaker Pattern**: Intelligent failure handling with:
+  - Configurable failure thresholds and reset timeouts
+  - Exponential backoff for failed requests
+  - Automatic state transitions (closed → open → half-open)
+  - Protection against cascading failures
+
+### Peer Management
+
+The bootstrap cache implements a robust peer management system:
+
+- **Peer Status Tracking**: Each peer's connection history is tracked, including:
+  - Success count: Number of successful connections
+  - Failure count: Number of failed connection attempts
+  - Last seen timestamp: When the peer was last successfully contacted
+
+- **Automatic Cleanup**: The system automatically removes unreliable peers:
+  - Peers that fail 3 consecutive connection attempts are marked for removal
+  - Removal only occurs if there are at least 2 working peers available
+  - This ensures network connectivity is maintained even during temporary connection issues
+
+- **Duplicate Prevention**: The cache automatically prevents duplicate peer entries:
+  - Same IP and port combinations are only stored once
+  - Different ports on the same IP are treated as separate peers
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+bootstrap_cache = { version = "0.1.0" }
+```
+
+## Usage
+
+### Basic Example
+
+```rust
+use bootstrap_cache::{BootstrapCache, CacheManager, InitialPeerDiscovery};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the cache manager
+    let cache_manager = CacheManager::new()?;
+
+    // Try to read from the cache
+    let mut cache = match cache_manager.read_cache() {
+        Ok(cache) if !cache.is_stale() => cache,
+        _ => {
+            // Cache is stale or unavailable, fetch initial peers
+            let discovery = InitialPeerDiscovery::new();
+            let peers = discovery.fetch_peers().await?;
+            let cache = BootstrapCache {
+                last_updated: chrono::Utc::now(),
+                peers,
+            };
+            cache_manager.write_cache(&cache)?;
+            cache
+        }
+    };
+
+    println!("Found {} peers in cache", cache.peers.len());
+    Ok(())
+}
+```
+
+### Custom Endpoints
+
+```rust
+use bootstrap_cache::InitialPeerDiscovery;
+
+let discovery = InitialPeerDiscovery::with_endpoints(vec![
+    "http://custom1.example.com/peers.json".to_string(),
+    "http://custom2.example.com/peers.json".to_string(),
+]);
+```
+
+### Circuit Breaker Configuration
+
+```rust
+use bootstrap_cache::{InitialPeerDiscovery, CircuitBreakerConfig};
+use std::time::Duration;
+
+// Create a custom circuit breaker configuration
+let config = CircuitBreakerConfig {
+    max_failures: 5,                            // Open after 5 failures
+    reset_timeout: Duration::from_secs(300),    // Wait 5 minutes before recovery
+    min_backoff: Duration::from_secs(1),        // Start with 1 second backoff
+    max_backoff: Duration::from_secs(60),       // Max backoff of 60 seconds
+};
+
+// Initialize discovery with custom circuit breaker config
+let discovery = InitialPeerDiscovery::with_config(config);
+```
+
+### Peer Management Example
+
+```rust
+use bootstrap_cache::BootstrapCache;
+
+let mut cache = BootstrapCache::new();
+
+// Add a new peer
+cache.add_peer("192.168.1.1".to_string(), 8080);
+
+// Update peer status after connection attempts
+cache.update_peer_status("192.168.1.1", 8080, true);  // successful connection
+cache.update_peer_status("192.168.1.1", 8080, false); // failed connection
+
+// Clean up failed peers (only if we have at least 2 working peers)
+cache.cleanup_failed_peers();
+```
+
+## Cache File Location
+
+The cache file is stored in a system-wide location accessible to all processes:
+
+- **Linux**: `/var/safe/bootstrap_cache.json`
+- **macOS**: `/Library/Application Support/Safe/bootstrap_cache.json`
+- **Windows**: `C:\ProgramData\Safe\bootstrap_cache.json`
+
+## Cache File Format
+
+```json
+{
+    "last_updated": "2024-02-20T15:30:00Z",
+    "peers": [
+        {
+            "ip": "192.168.1.1",
+            "port": 8080,
+            "last_seen": "2024-02-20T15:30:00Z",
+            "success_count": 10,
+            "failure_count": 0
+        }
+    ]
+}
+```
+
+## Error Handling
+
+The crate provides detailed error types through the `Error` enum:
+
+```rust
+use bootstrap_cache::Error;
+
+match cache_manager.read_cache() {
+    Ok(cache) => println!("Cache loaded successfully"),
+    Err(Error::CacheStale) => println!("Cache is stale"),
+    Err(Error::CacheCorrupted) => println!("Cache file is corrupted"),
+    Err(Error::Io(e)) => println!("IO error: {}", e),
+    Err(e) => println!("Other error: {}", e),
+}
+```
+
+## Thread Safety
+
+The cache system uses file locking to ensure safe concurrent access:
+
+- Shared locks for reading
+- Exclusive locks for writing
+- Atomic file updates using temporary files
+
+## Development
+
+### Building
+
+```bash
+cargo build
+```
+
+### Running Tests
+
+```bash
+cargo test
+```
+
+### Running with Logging
+
+```rust
+use tracing_subscriber::FmtSubscriber;
+
+// Initialize logging
+let subscriber = FmtSubscriber::builder()
+    .with_max_level(tracing::Level::DEBUG)
+    .init();
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -am 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the GPL-3.0 License - see the LICENSE file for details.
+
+## Related Documentation
+
+- [Bootstrap Cache PRD](docs/bootstrap_cache_prd.md)
+- [Implementation Guide](docs/bootstrap_cache_implementation.md)

--- a/bootstrap_cache/src/cache.rs
+++ b/bootstrap_cache/src/cache.rs
@@ -1,0 +1,390 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{BootstrapCache, Error};
+use fs2::FileExt;
+use std::{
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::PathBuf,
+};
+use tracing::{debug, error, info, warn};
+
+/// Manages reading and writing of the bootstrap cache file
+pub struct CacheManager {
+    cache_path: PathBuf,
+}
+
+impl CacheManager {
+    /// Creates a new CacheManager instance
+    pub fn new() -> Result<Self, Error> {
+        let cache_path = Self::get_cache_path()?;
+        Ok(Self { cache_path })
+    }
+
+    /// Returns the platform-specific cache file path
+    fn get_cache_path() -> io::Result<PathBuf> {
+        let path = if cfg!(target_os = "macos") {
+            PathBuf::from("/Library/Application Support/Safe/bootstrap_cache.json")
+        } else if cfg!(target_os = "linux") {
+            PathBuf::from("/var/safe/bootstrap_cache.json")
+        } else if cfg!(target_os = "windows") {
+            PathBuf::from(r"C:\ProgramData\Safe\bootstrap_cache.json")
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Unsupported operating system",
+            ));
+        };
+
+        // Try to create the directory structure
+        if let Some(parent) = path.parent() {
+            info!("Ensuring cache directory exists at: {:?}", parent);
+            match fs::create_dir_all(parent) {
+                Ok(_) => {
+                    debug!("Successfully created/verified cache directory");
+                    // Try to set directory permissions to be user-writable
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        if let Err(e) = fs::set_permissions(parent, fs::Permissions::from_mode(0o755)) {
+                            warn!("Failed to set cache directory permissions: {}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    // If we can't create in system directory, fall back to user's home directory
+                    warn!("Failed to create system cache directory: {}", e);
+                    if let Some(home) = dirs::home_dir() {
+                        let user_path = home.join(".safe").join("bootstrap_cache.json");
+                        info!("Falling back to user directory: {:?}", user_path);
+                        if let Some(user_parent) = user_path.parent() {
+                            fs::create_dir_all(user_parent)?;
+                        }
+                        return Ok(user_path);
+                    }
+                }
+            }
+        }
+        Ok(path)
+    }
+
+    /// Reads the cache file with file locking, handling potential corruption
+    pub fn read_cache(&self) -> Result<BootstrapCache, Error> {
+        debug!("Reading bootstrap cache from {:?}", self.cache_path);
+        
+        let mut file = match File::open(&self.cache_path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                info!("Cache file not found, creating new empty cache");
+                return Ok(BootstrapCache::new());
+            }
+            Err(e) => {
+                error!("Failed to open cache file: {}", e);
+                return Err(e.into());
+            }
+        };
+
+        // Acquire shared lock for reading
+        file.lock_shared().map_err(|e| {
+            error!("Failed to acquire shared lock: {}", e);
+            Error::LockError
+        })?;
+
+        let mut contents = String::new();
+        if let Err(e) = file.read_to_string(&mut contents) {
+            error!("Failed to read cache file: {}", e);
+            // Release lock before returning
+            let _ = file.unlock();
+            return Err(Error::Io(e));
+        }
+
+        // Release lock
+        file.unlock().map_err(|e| {
+            error!("Failed to release lock: {}", e);
+            Error::LockError
+        })?;
+
+        // Try to parse the cache, if it fails it might be corrupted
+        match serde_json::from_str(&contents) {
+            Ok(cache) => Ok(cache),
+            Err(e) => {
+                error!("Cache file appears to be corrupted: {}", e);
+                Err(Error::CacheCorrupted(e))
+            }
+        }
+    }
+
+    /// Rebuilds the cache using provided peers or fetches new ones if none provided
+    pub async fn rebuild_cache(&self, peers: Option<Vec<BootstrapPeer>>) -> Result<BootstrapCache, Error> {
+        info!("Rebuilding bootstrap cache");
+        
+        let cache = if let Some(peers) = peers {
+            info!("Rebuilding cache with {} in-memory peers", peers.len());
+            BootstrapCache {
+                last_updated: chrono::Utc::now(),
+                peers,
+            }
+        } else {
+            info!("No in-memory peers available, fetching from endpoints");
+            let discovery = InitialPeerDiscovery::new();
+            let peers = discovery.fetch_peers().await?;
+            BootstrapCache {
+                last_updated: chrono::Utc::now(),
+                peers,
+            }
+        };
+
+        // Write the rebuilt cache
+        self.write_cache(&cache)?;
+        Ok(cache)
+    }
+
+    /// Writes the cache file with file locking and atomic replacement
+    pub fn write_cache(&self, cache: &BootstrapCache) -> Result<(), Error> {
+        debug!("Writing bootstrap cache to {:?}", self.cache_path);
+        
+        let temp_path = self.cache_path.with_extension("tmp");
+        let mut file = File::create(&temp_path).map_err(|e| {
+            error!("Failed to create temporary cache file: {}", e);
+            Error::Io(e)
+        })?;
+
+        // Acquire exclusive lock for writing
+        file.lock_exclusive().map_err(|e| {
+            error!("Failed to acquire exclusive lock: {}", e);
+            Error::LockError
+        })?;
+
+        let contents = serde_json::to_string_pretty(cache).map_err(|e| {
+            error!("Failed to serialize cache: {}", e);
+            Error::Json(e)
+        })?;
+
+        file.write_all(contents.as_bytes()).map_err(|e| {
+            error!("Failed to write cache file: {}", e);
+            Error::Io(e)
+        })?;
+
+        file.sync_all().map_err(|e| {
+            error!("Failed to sync cache file: {}", e);
+            Error::Io(e)
+        })?;
+
+        // Release lock
+        file.unlock().map_err(|e| {
+            error!("Failed to release lock: {}", e);
+            Error::LockError
+        })?;
+
+        // Atomic rename
+        fs::rename(&temp_path, &self.cache_path).map_err(|e| {
+            error!("Failed to rename temporary cache file: {}", e);
+            Error::Io(e)
+        })?;
+
+        info!("Successfully wrote cache file");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::fs::OpenOptions;
+    use tempfile::tempdir;
+    use tokio;
+
+    #[test]
+    fn test_cache_read_write() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("test_cache.json");
+
+        let cache = BootstrapCache {
+            last_updated: Utc::now(),
+            peers: vec![],
+        };
+
+        let manager = CacheManager { cache_path };
+        manager.write_cache(&cache).unwrap();
+
+        let read_cache = manager.read_cache().unwrap();
+        assert_eq!(cache.peers.len(), read_cache.peers.len());
+    }
+
+    #[test]
+    fn test_missing_cache_file() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("nonexistent.json");
+
+        let manager = CacheManager { cache_path };
+        let cache = manager.read_cache().unwrap();
+        assert!(cache.peers.is_empty());
+    }
+
+    #[test]
+    fn test_corrupted_cache_file() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("corrupted.json");
+
+        // Write corrupted JSON
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&cache_path)
+            .unwrap();
+        file.write_all(b"{invalid json}").unwrap();
+
+        let manager = CacheManager { cache_path };
+        match manager.read_cache() {
+            Err(Error::CacheCorrupted(_)) => (),
+            other => panic!("Expected CacheCorrupted error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_partially_corrupted_cache() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("partial_corrupt.json");
+
+        // Write partially valid JSON
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&cache_path)
+            .unwrap();
+        file.write_all(b"{\"last_updated\":\"2024-01-01T00:00:00Z\",\"peers\":[{}]}").unwrap();
+
+        let manager = CacheManager { cache_path };
+        match manager.read_cache() {
+            Err(Error::CacheCorrupted(_)) => (),
+            other => panic!("Expected CacheCorrupted error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_cache_with_memory_peers() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("rebuild.json");
+        let manager = CacheManager { cache_path };
+
+        // Create some test peers
+        let test_peers = vec![
+            BootstrapPeer {
+                addr: "/ip4/127.0.0.1/tcp/8080".parse().unwrap(),
+                success_count: 1,
+                failure_count: 0,
+                last_success: Some(Utc::now()),
+                last_failure: None,
+            }
+        ];
+
+        // Rebuild cache with in-memory peers
+        let rebuilt = manager.rebuild_cache(Some(test_peers.clone())).await.unwrap();
+        assert_eq!(rebuilt.peers.len(), 1);
+        assert_eq!(rebuilt.peers[0].addr, test_peers[0].addr);
+
+        // Verify the cache was written to disk
+        let read_cache = manager.read_cache().unwrap();
+        assert_eq!(read_cache.peers.len(), 1);
+        assert_eq!(read_cache.peers[0].addr, test_peers[0].addr);
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_cache_from_endpoints() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("rebuild_endpoints.json");
+        let manager = CacheManager { cache_path };
+
+        // Write corrupted cache first
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&cache_path)
+            .unwrap();
+        file.write_all(b"{corrupted}").unwrap();
+
+        // Verify corrupted cache is detected
+        match manager.read_cache() {
+            Err(Error::CacheCorrupted(_)) => (),
+            other => panic!("Expected CacheCorrupted error, got {:?}", other),
+        }
+
+        // Mock the InitialPeerDiscovery for testing
+        // Note: In a real implementation, you might want to use a trait for InitialPeerDiscovery
+        // and mock it properly. This test will actually try to fetch from real endpoints.
+        match manager.rebuild_cache(None).await {
+            Ok(cache) => {
+                // Verify the cache was rebuilt and written
+                let read_cache = manager.read_cache().unwrap();
+                assert_eq!(read_cache.peers.len(), cache.peers.len());
+            }
+            Err(Error::NoPeersFound(_)) => {
+                // This is also acceptable if no endpoints are reachable during test
+                ()
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_concurrent_cache_access() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("concurrent.json");
+        let manager = CacheManager { cache_path.clone() };
+
+        // Initial cache
+        let cache = BootstrapCache {
+            last_updated: Utc::now(),
+            peers: vec![],
+        };
+        manager.write_cache(&cache).unwrap();
+
+        // Try to read while holding write lock
+        let file = OpenOptions::new()
+            .write(true)
+            .open(&cache_path)
+            .unwrap();
+        file.lock_exclusive().unwrap();
+
+        // This should fail with a lock error
+        match manager.read_cache() {
+            Err(Error::LockError) => (),
+            other => panic!("Expected LockError, got {:?}", other),
+        }
+
+        // Release lock
+        file.unlock().unwrap();
+    }
+
+    #[test]
+    fn test_cache_file_permissions() {
+        let dir = tempdir().unwrap();
+        let cache_path = dir.path().join("permissions.json");
+        let manager = CacheManager { cache_path: cache_path.clone() };
+
+        // Write initial cache
+        let cache = BootstrapCache {
+            last_updated: Utc::now(),
+            peers: vec![],
+        };
+        manager.write_cache(&cache).unwrap();
+
+        // Make file read-only
+        let mut perms = fs::metadata(&cache_path).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&cache_path, perms).unwrap();
+
+        // Try to write to read-only file
+        match manager.write_cache(&cache) {
+            Err(Error::Io(_)) => (),
+            other => panic!("Expected Io error, got {:?}", other),
+        }
+    }
+}

--- a/bootstrap_cache/src/cache_store.rs
+++ b/bootstrap_cache/src/cache_store.rs
@@ -1,0 +1,690 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{BootstrapPeer, Error, InitialPeerDiscovery, Result};
+use fs2::FileExt;
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tempfile::NamedTempFile;
+use tokio::sync::RwLock;
+
+const PEER_EXPIRY_DURATION: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheData {
+    peers: std::collections::HashMap<String, BootstrapPeer>,
+    #[serde(default = "SystemTime::now")]
+    last_updated: SystemTime,
+    #[serde(default = "default_version")]
+    version: u32,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+impl Default for CacheData {
+    fn default() -> Self {
+        Self {
+            peers: std::collections::HashMap::new(),
+            last_updated: SystemTime::now(),
+            version: default_version(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CacheStore {
+    cache_path: PathBuf,
+    config: Arc<crate::BootstrapConfig>,
+    data: Arc<RwLock<CacheData>>,
+}
+
+impl CacheStore {
+    pub async fn new(config: crate::BootstrapConfig) -> Result<Self> {
+        tracing::info!("Creating new CacheStore with config: {:?}", config);
+        let cache_path = config.cache_file_path.clone();
+        let config = Arc::new(config);
+
+        // Create cache directory if it doesn't exist
+        if let Some(parent) = cache_path.parent() {
+            tracing::info!("Attempting to create cache directory at {:?}", parent);
+            // Try to create the directory
+            match fs::create_dir_all(parent) {
+                Ok(_) => {
+                    tracing::info!("Successfully created cache directory");
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create cache directory at {:?}: {}", parent, e);
+                    // Try user's home directory as fallback
+                    if let Some(home) = dirs::home_dir() {
+                        let user_path = home.join(".safe").join("bootstrap_cache.json");
+                        tracing::info!("Falling back to user directory: {:?}", user_path);
+                        if let Some(user_parent) = user_path.parent() {
+                            if let Err(e) = fs::create_dir_all(user_parent) {
+                                tracing::error!("Failed to create user cache directory: {}", e);
+                                return Err(Error::Io(e));
+                            }
+                            tracing::info!("Successfully created user cache directory");
+                        }
+                        let future = Self::new(crate::BootstrapConfig::with_cache_path(user_path));
+                        return Box::pin(future).await;
+                    }
+                }
+            }
+        }
+
+        let data = if cache_path.exists() {
+            tracing::info!("Cache file exists at {:?}, attempting to load", cache_path);
+            match Self::load_cache_data(&cache_path).await {
+                Ok(data) => {
+                    tracing::info!("Successfully loaded cache data with {} peers", data.peers.len());
+                    // If cache data exists but has no peers and file is not read-only,
+                    // fallback to default
+                    let is_readonly = cache_path
+                        .metadata()
+                        .map(|m| m.permissions().readonly())
+                        .unwrap_or(false);
+
+                    if data.peers.is_empty() && !is_readonly {
+                        tracing::info!("Cache is empty and not read-only, falling back to default");
+                        Self::fallback_to_default(&config).await?
+                    } else {
+                        // Ensure we don't exceed max_peers
+                        let mut filtered_data = data;
+                        if filtered_data.peers.len() > config.max_peers {
+                            tracing::info!(
+                                "Trimming cache from {} to {} peers",
+                                filtered_data.peers.len(),
+                                config.max_peers
+                            );
+                            let peers: Vec<_> = filtered_data.peers.into_iter().collect();
+                            filtered_data.peers = peers
+                                .into_iter()
+                                .take(config.max_peers)
+                                .collect();
+                        }
+                        filtered_data
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load cache data: {}", e);
+                    // If we can't read or parse the cache file, return empty cache
+                    CacheData::default()
+                }
+            }
+        } else {
+            tracing::info!("Cache file does not exist at {:?}, falling back to default", cache_path);
+            // If cache file doesn't exist, fallback to default
+            Self::fallback_to_default(&config).await?
+        };
+
+        let store = Self {
+            cache_path,
+            config,
+            data: Arc::new(RwLock::new(data)),
+        };
+
+        // Only clean up stale peers if the file is not read-only
+        let is_readonly = store
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if !is_readonly {
+            if let Err(e) = store.cleanup_stale_peers().await {
+                tracing::warn!("Failed to clean up stale peers: {}", e);
+            }
+        }
+
+        tracing::info!("Successfully created CacheStore");
+        Ok(store)
+    }
+
+    async fn fallback_to_default(config: &crate::BootstrapConfig) -> Result<CacheData> {
+        tracing::info!("Falling back to default peers from endpoints");
+        let mut data = CacheData {
+            peers: std::collections::HashMap::new(),
+            last_updated: SystemTime::now(),
+            version: default_version(),
+        };
+
+        // If no endpoints are configured, just return empty cache
+        if config.endpoints.is_empty() {
+            tracing::warn!("No endpoints configured, returning empty cache");
+            return Ok(data);
+        }
+
+        // Try to discover peers from configured endpoints
+        let discovery = InitialPeerDiscovery::with_endpoints(config.endpoints.clone());
+        match discovery.fetch_peers().await {
+            Ok(peers) => {
+                tracing::info!("Successfully fetched {} peers from endpoints", peers.len());
+                // Only add up to max_peers from the discovered peers
+                for peer in peers.into_iter().take(config.max_peers) {
+                    data.peers.insert(peer.addr.to_string(), peer);
+                }
+
+                // Create parent directory if it doesn't exist
+                if let Some(parent) = config.cache_file_path.parent() {
+                    tracing::info!("Creating cache directory at {:?}", parent);
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        tracing::warn!("Failed to create cache directory: {}", e);
+                    }
+                }
+
+                // Try to write the cache file immediately
+                match serde_json::to_string_pretty(&data) {
+                    Ok(json) => {
+                        tracing::info!("Writing {} peers to cache file", data.peers.len());
+                        if let Err(e) = fs::write(&config.cache_file_path, json) {
+                            tracing::warn!("Failed to write cache file: {}", e);
+                        } else {
+                            tracing::info!("Successfully wrote cache file at {:?}", config.cache_file_path);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to serialize cache data: {}", e);
+                    }
+                }
+
+                Ok(data)
+            }
+            Err(e) => {
+                tracing::warn!("Failed to fetch peers from endpoints: {}", e);
+                Ok(data) // Return empty cache on error
+            }
+        }
+    }
+
+    async fn load_cache_data(cache_path: &PathBuf) -> Result<CacheData> {
+        // Try to open the file with read permissions
+        let mut file = match OpenOptions::new().read(true).open(cache_path) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!("Failed to open cache file: {}", e);
+                return Err(Error::from(e));
+            }
+        };
+
+        // Acquire shared lock for reading
+        if let Err(e) = Self::acquire_shared_lock(&file).await {
+            tracing::warn!("Failed to acquire shared lock: {}", e);
+            return Err(e);
+        }
+
+        // Read the file contents
+        let mut contents = String::new();
+        if let Err(e) = file.read_to_string(&mut contents) {
+            tracing::warn!("Failed to read cache file: {}", e);
+            return Err(Error::from(e));
+        }
+
+        // Parse the cache data
+        match serde_json::from_str::<CacheData>(&contents) {
+            Ok(data) => Ok(data),
+            Err(e) => {
+                tracing::warn!("Failed to parse cache data: {}", e);
+                Err(Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))
+            }
+        }
+    }
+
+    pub async fn get_peers(&self) -> Vec<BootstrapPeer> {
+        let data = self.data.read().await;
+        data.peers.values().cloned().collect()
+    }
+
+    pub async fn get_reliable_peers(&self) -> Vec<BootstrapPeer> {
+        let data = self.data.read().await;
+        let reliable_peers: Vec<_> = data
+            .peers
+            .values()
+            .filter(|peer| peer.success_count > peer.failure_count)
+            .cloned()
+            .collect();
+
+        // If we have no reliable peers and the cache file is not read-only,
+        // try to refresh from default endpoints
+        if reliable_peers.is_empty()
+            && !self
+                .cache_path
+                .metadata()
+                .map(|m| m.permissions().readonly())
+                .unwrap_or(false)
+        {
+            drop(data);
+            if let Ok(new_data) = Self::fallback_to_default(&self.config).await {
+                let mut data = self.data.write().await;
+                *data = new_data;
+                return data
+                    .peers
+                    .values()
+                    .filter(|peer| peer.success_count > peer.failure_count)
+                    .cloned()
+                    .collect();
+            }
+        }
+
+        reliable_peers
+    }
+
+    pub async fn update_peer_status(&self, addr: &str, success: bool) -> Result<()> {
+        // Check if the file is read-only before attempting to modify
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot update peer status: cache file is read-only");
+            return Ok(());
+        }
+
+        let mut data = self.data.write().await;
+
+        match addr.parse::<Multiaddr>() {
+            Ok(addr) => {
+                let peer = data
+                    .peers
+                    .entry(addr.to_string())
+                    .or_insert_with(|| BootstrapPeer::new(addr));
+                peer.update_status(success);
+                self.save_to_disk(&data).await?;
+                Ok(())
+            }
+            Err(e) => Err(Error::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Invalid multiaddr: {}", e),
+            ))),
+        }
+    }
+
+    pub async fn add_peer(&self, addr: Multiaddr) -> Result<()> {
+        // Check if the cache file is read-only before attempting any modifications
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot add peer: cache file is read-only");
+            return Ok(());
+        }
+
+        let mut data = self.data.write().await;
+        let addr_str = addr.to_string();
+
+        tracing::debug!(
+            "Adding peer {}, current peers: {}",
+            addr_str,
+            data.peers.len()
+        );
+
+        // If the peer already exists, just update its last_seen time
+        if let Some(peer) = data.peers.get_mut(&addr_str) {
+            tracing::debug!("Updating existing peer {}", addr_str);
+            peer.last_seen = SystemTime::now();
+            return self.save_to_disk(&data).await;
+        }
+
+        // Only add new peers if we haven't reached max_peers
+        if data.peers.len() < self.config.max_peers {
+            tracing::debug!("Adding new peer {} (under max_peers limit)", addr_str);
+            data.peers
+                .insert(addr_str.clone(), BootstrapPeer::new(addr));
+            self.save_to_disk(&data).await?;
+        } else {
+            // If we're at max_peers, replace the oldest peer
+            if let Some((oldest_addr, oldest_peer)) =
+                data.peers.iter().min_by_key(|(_, peer)| peer.last_seen)
+            {
+                tracing::debug!(
+                    "Replacing oldest peer {} (last seen: {:?}) with new peer {}",
+                    oldest_addr,
+                    oldest_peer.last_seen,
+                    addr_str
+                );
+                let oldest_addr = oldest_addr.clone();
+                data.peers.remove(&oldest_addr);
+                data.peers
+                    .insert(addr_str.clone(), BootstrapPeer::new(addr));
+                self.save_to_disk(&data).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn remove_peer(&self, addr: &str) -> Result<()> {
+        // Check if the file is read-only before attempting to modify
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot remove peer: cache file is read-only");
+            return Ok(());
+        }
+
+        let mut data = self.data.write().await;
+        data.peers.remove(addr);
+        self.save_to_disk(&data).await?;
+        Ok(())
+    }
+
+    pub async fn cleanup_unreliable_peers(&self) -> Result<()> {
+        // Check if the file is read-only before attempting to modify
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot cleanup unreliable peers: cache file is read-only");
+            return Ok(());
+        }
+
+        let mut data = self.data.write().await;
+        let unreliable_peers: Vec<String> = data
+            .peers
+            .iter()
+            .filter(|(_, peer)| !peer.is_reliable())
+            .map(|(addr, _)| addr.clone())
+            .collect();
+
+        for addr in unreliable_peers {
+            data.peers.remove(&addr);
+        }
+
+        self.save_to_disk(&data).await?;
+        Ok(())
+    }
+
+    pub async fn cleanup_stale_peers(&self) -> Result<()> {
+        // Check if the file is read-only before attempting to modify
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot cleanup stale peers: cache file is read-only");
+            return Ok(());
+        }
+
+        let mut data = self.data.write().await;
+        let stale_peers: Vec<String> = data
+            .peers
+            .iter()
+            .filter(|(_, peer)| {
+                if let Ok(elapsed) = peer.last_seen.elapsed() {
+                    elapsed > PEER_EXPIRY_DURATION
+                } else {
+                    true // If we can't get elapsed time, consider it stale
+                }
+            })
+            .map(|(addr, _)| addr.clone())
+            .collect();
+
+        for addr in stale_peers {
+            data.peers.remove(&addr);
+        }
+
+        self.save_to_disk(&data).await?;
+        Ok(())
+    }
+
+    pub async fn save_to_disk(&self, data: &CacheData) -> Result<()> {
+        // Check if the file is read-only before attempting to write
+        let is_readonly = self
+            .cache_path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(false);
+
+        if is_readonly {
+            tracing::warn!("Cannot save to disk: cache file is read-only");
+            return Ok(());
+        }
+
+        match self.atomic_write(data).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                tracing::error!("Failed to save cache to disk: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    async fn acquire_shared_lock(file: &File) -> Result<()> {
+        let file = file.try_clone().map_err(Error::from)?;
+
+        tokio::task::spawn_blocking(move || file.try_lock_shared().map_err(Error::from))
+            .await
+            .map_err(|e| {
+                Error::from(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to spawn blocking task: {}", e),
+                ))
+            })?
+    }
+
+    async fn acquire_exclusive_lock(file: &File) -> Result<()> {
+        let mut backoff = Duration::from_millis(10);
+        let max_attempts = 5;
+        let mut attempts = 0;
+
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(_) => return Ok(()),
+                Err(_) if attempts >= max_attempts => {
+                    return Err(Error::LockError);
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    attempts += 1;
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+                Err(_) => return Err(Error::LockError),
+            }
+        }
+    }
+
+    async fn atomic_write(&self, data: &CacheData) -> Result<()> {
+        // Create parent directory if it doesn't exist
+        if let Some(parent) = self.cache_path.parent() {
+            fs::create_dir_all(parent).map_err(Error::from)?;
+        }
+
+        // Create a temporary file in the same directory as the cache file
+        let temp_file = NamedTempFile::new().map_err(Error::from)?;
+
+        // Write data to temporary file
+        serde_json::to_writer_pretty(&temp_file, &data).map_err(Error::from)?;
+
+        // Open the target file with proper permissions
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&self.cache_path)
+            .map_err(Error::from)?;
+
+        // Acquire exclusive lock
+        Self::acquire_exclusive_lock(&file).await?;
+
+        // Perform atomic rename
+        temp_file.persist(&self.cache_path).map_err(|e| {
+            Error::from(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to persist cache file: {}", e),
+            ))
+        })?;
+
+        // Lock will be automatically released when file is dropped
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    async fn create_test_store() -> (CacheStore, PathBuf) {
+        let temp_dir = tempdir().unwrap();
+        let cache_file = temp_dir.path().join("cache.json");
+
+        let config = crate::BootstrapConfig::new(
+            vec![], // Empty endpoints to prevent fallback
+            1500,
+            cache_file.clone(),
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            3,
+        );
+
+        let store = CacheStore::new(config).await.unwrap();
+        (store.clone(), store.cache_path.clone())
+    }
+
+    #[tokio::test]
+    async fn test_peer_update_and_save() {
+        let (store, _) = create_test_store().await;
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+
+        // Manually add a peer without using fallback
+        {
+            let mut data = store.data.write().await;
+            data.peers
+                .insert(addr.to_string(), BootstrapPeer::new(addr.clone()));
+            store.save_to_disk(&data).await.unwrap();
+        }
+
+        store
+            .update_peer_status(&addr.to_string(), true)
+            .await
+            .unwrap();
+
+        let peers = store.get_peers().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].addr, addr);
+        assert_eq!(peers[0].success_count, 1);
+        assert_eq!(peers[0].failure_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_peer_cleanup() {
+        let (store, _) = create_test_store().await;
+        let good_addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        let bad_addr: Multiaddr = "/ip4/127.0.0.1/tcp/8081".parse().unwrap();
+
+        // Add peers
+        store.add_peer(good_addr.clone()).await.unwrap();
+        store.add_peer(bad_addr.clone()).await.unwrap();
+
+        // Make one peer reliable and one unreliable
+        store
+            .update_peer_status(&good_addr.to_string(), true)
+            .await
+            .unwrap();
+        for _ in 0..5 {
+            store
+                .update_peer_status(&bad_addr.to_string(), false)
+                .await
+                .unwrap();
+        }
+
+        // Clean up unreliable peers
+        store.cleanup_unreliable_peers().await.unwrap();
+
+        // Get all peers (not just reliable ones)
+        let peers = store.get_peers().await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].addr, good_addr);
+    }
+
+    #[tokio::test]
+    async fn test_stale_peer_cleanup() {
+        let (store, _) = create_test_store().await;
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+
+        // Add a peer with more failures than successes
+        let mut peer = BootstrapPeer::new(addr.clone());
+        peer.success_count = 1;
+        peer.failure_count = 5;
+        {
+            let mut data = store.data.write().await;
+            data.peers.insert(addr.to_string(), peer);
+            store.save_to_disk(&data).await.unwrap();
+        }
+
+        // Clean up unreliable peers
+        store.cleanup_unreliable_peers().await.unwrap();
+
+        // Should have no peers since the only peer was unreliable
+        let peers = store.get_reliable_peers().await;
+        assert_eq!(peers.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        let (store, _) = create_test_store().await;
+        let store = Arc::new(store);
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+
+        // Manually add a peer without using fallback
+        {
+            let mut data = store.data.write().await;
+            data.peers
+                .insert(addr.to_string(), BootstrapPeer::new(addr.clone()));
+            store.save_to_disk(&data).await.unwrap();
+        }
+
+        let mut handles = vec![];
+
+        // Spawn multiple tasks to update peer status concurrently
+        for i in 0..10 {
+            let store = Arc::clone(&store);
+            let addr = addr.clone();
+
+            handles.push(tokio::spawn(async move {
+                store
+                    .update_peer_status(&addr.to_string(), i % 2 == 0)
+                    .await
+                    .unwrap();
+            }));
+        }
+
+        // Wait for all tasks to complete
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Verify the final state - should have one peer
+        let peers = store.get_peers().await;
+        assert_eq!(peers.len(), 1);
+
+        // The peer should have a mix of successes and failures
+        assert!(peers[0].success_count > 0);
+        assert!(peers[0].failure_count > 0);
+    }
+}

--- a/bootstrap_cache/src/circuit_breaker.rs
+++ b/bootstrap_cache/src/circuit_breaker.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    max_failures: u32,
+    reset_timeout: Duration,
+    min_backoff: Duration,
+    max_backoff: Duration,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            max_failures: 5,
+            reset_timeout: Duration::from_secs(60),
+            min_backoff: Duration::from_millis(500),
+            max_backoff: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EndpointState {
+    failures: u32,
+    last_failure: Instant,
+    last_attempt: Instant,
+    backoff_duration: Duration,
+}
+
+impl EndpointState {
+    fn new(min_backoff: Duration) -> Self {
+        Self {
+            failures: 0,
+            last_failure: Instant::now(),
+            last_attempt: Instant::now(),
+            backoff_duration: min_backoff,
+        }
+    }
+
+    fn record_failure(&mut self, max_backoff: Duration) {
+        self.failures += 1;
+        self.last_failure = Instant::now();
+        self.last_attempt = Instant::now();
+        // Exponential backoff with max limit
+        self.backoff_duration = std::cmp::min(self.backoff_duration * 2, max_backoff);
+    }
+
+    fn record_success(&mut self, min_backoff: Duration) {
+        self.failures = 0;
+        self.backoff_duration = min_backoff;
+    }
+
+    fn is_open(&self, max_failures: u32, reset_timeout: Duration) -> bool {
+        if self.failures >= max_failures {
+            // Check if we've waited long enough since the last failure
+            if self.last_failure.elapsed() > reset_timeout {
+                false // Circuit is half-open, allow retry
+            } else {
+                true // Circuit is open, block requests
+            }
+        } else {
+            false // Circuit is closed, allow requests
+        }
+    }
+
+    fn should_retry(&self) -> bool {
+        self.last_attempt.elapsed() >= self.backoff_duration
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CircuitBreaker {
+    states: Arc<RwLock<HashMap<String, EndpointState>>>,
+    config: CircuitBreakerConfig,
+}
+
+impl CircuitBreaker {
+    pub fn new() -> Self {
+        Self {
+            states: Arc::new(RwLock::new(HashMap::new())),
+            config: CircuitBreakerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: CircuitBreakerConfig) -> Self {
+        Self {
+            states: Arc::new(RwLock::new(HashMap::new())),
+            config,
+        }
+    }
+
+    pub async fn check_endpoint(&self, endpoint: &str) -> bool {
+        let mut states = self.states.write().await;
+        let state = states
+            .entry(endpoint.to_string())
+            .or_insert_with(|| EndpointState::new(self.config.min_backoff));
+
+        !(state.is_open(self.config.max_failures, self.config.reset_timeout) && !state.should_retry())
+    }
+
+    pub async fn record_success(&self, endpoint: &str) {
+        let mut states = self.states.write().await;
+        if let Some(state) = states.get_mut(endpoint) {
+            state.record_success(self.config.min_backoff);
+        }
+    }
+
+    pub async fn record_failure(&self, endpoint: &str) {
+        let mut states = self.states.write().await;
+        let state = states
+            .entry(endpoint.to_string())
+            .or_insert_with(|| EndpointState::new(self.config.min_backoff));
+        state.record_failure(self.config.max_backoff);
+    }
+
+    pub async fn get_backoff_duration(&self, endpoint: &str) -> Duration {
+        let states = self.states.read().await;
+        states
+            .get(endpoint)
+            .map(|state| state.backoff_duration)
+            .unwrap_or(self.config.min_backoff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::sleep;
+
+    fn test_config() -> CircuitBreakerConfig {
+        CircuitBreakerConfig {
+            max_failures: 3,
+            reset_timeout: Duration::from_millis(100), // Much shorter for testing
+            min_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(100),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_basic() {
+        let cb = CircuitBreaker::with_config(test_config());
+        let endpoint = "http://test.endpoint";
+
+        // Initially should allow requests
+        assert!(cb.check_endpoint(endpoint).await);
+
+        // Record failures
+        for _ in 0..test_config().max_failures {
+            cb.record_failure(endpoint).await;
+        }
+
+        // Circuit should be open
+        assert!(!cb.check_endpoint(endpoint).await);
+
+        // Record success should reset
+        cb.record_success(endpoint).await;
+        assert!(cb.check_endpoint(endpoint).await);
+    }
+
+    #[tokio::test]
+    async fn test_backoff_duration() {
+        let config = test_config();
+        let cb = CircuitBreaker::with_config(config.clone());
+        let endpoint = "http://test.endpoint";
+
+        assert_eq!(cb.get_backoff_duration(endpoint).await, config.min_backoff);
+
+        // Record a failure
+        cb.record_failure(endpoint).await;
+        assert_eq!(
+            cb.get_backoff_duration(endpoint).await,
+            config.min_backoff * 2
+        );
+
+        // Record another failure
+        cb.record_failure(endpoint).await;
+        assert_eq!(
+            cb.get_backoff_duration(endpoint).await,
+            config.min_backoff * 4
+        );
+
+        // Success should reset backoff
+        cb.record_success(endpoint).await;
+        assert_eq!(cb.get_backoff_duration(endpoint).await, config.min_backoff);
+    }
+
+    #[tokio::test]
+    async fn test_circuit_half_open() {
+        let config = test_config();
+        let cb = CircuitBreaker::with_config(config.clone());
+        let endpoint = "http://test.endpoint";
+
+        // Open the circuit
+        for _ in 0..config.max_failures {
+            cb.record_failure(endpoint).await;
+        }
+        assert!(!cb.check_endpoint(endpoint).await);
+
+        // Wait for reset timeout
+        sleep(config.reset_timeout + Duration::from_millis(10)).await;
+
+        // Circuit should be half-open now
+        assert!(cb.check_endpoint(endpoint).await);
+    }
+}

--- a/bootstrap_cache/src/config.rs
+++ b/bootstrap_cache/src/config.rs
@@ -1,0 +1,285 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use std::fs;
+
+/// Configuration for the bootstrap cache
+#[derive(Clone, Debug)]
+pub struct BootstrapConfig {
+    /// List of bootstrap endpoints to fetch peer information from
+    pub endpoints: Vec<String>,
+    /// Maximum number of peers to keep in the cache
+    pub max_peers: usize,
+    /// Path to the bootstrap cache file
+    pub cache_file_path: PathBuf,
+    /// How often to update the cache (in seconds)
+    pub update_interval: Duration,
+    /// Request timeout for endpoint queries
+    pub request_timeout: Duration,
+    /// Maximum retries per endpoint
+    pub max_retries: u32,
+}
+
+impl Default for BootstrapConfig {
+    fn default() -> Self {
+        Self {
+            endpoints: vec![
+                "https://sn-testnet.s3.eu-west-2.amazonaws.com/bootstrap_cache.json".to_string(),
+                "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts".to_string(),
+                "https://sn-node1.s3.eu-west-2.amazonaws.com/peers".to_string(),
+                "https://sn-node2.s3.eu-west-2.amazonaws.com/peers".to_string(),
+            ],
+            max_peers: 1500,
+            cache_file_path: default_cache_path(),
+            update_interval: Duration::from_secs(60),
+            request_timeout: Duration::from_secs(10),
+            max_retries: 3,
+        }
+    }
+}
+
+impl BootstrapConfig {
+    /// Creates a new BootstrapConfig with custom endpoints
+    pub fn with_endpoints(endpoints: Vec<String>) -> Self {
+        Self {
+            endpoints,
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new BootstrapConfig with a custom cache file path
+    pub fn with_cache_path<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            cache_file_path: path.as_ref().to_path_buf(),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new BootstrapConfig with custom settings
+    pub fn new(
+        endpoints: Vec<String>,
+        max_peers: usize,
+        cache_file_path: PathBuf,
+        update_interval: Duration,
+        request_timeout: Duration,
+        max_retries: u32,
+    ) -> Self {
+        Self {
+            endpoints,
+            max_peers,
+            cache_file_path,
+            update_interval,
+            request_timeout,
+            max_retries,
+        }
+    }
+}
+
+/// Returns the default path for the bootstrap cache file
+fn default_cache_path() -> PathBuf {
+    tracing::info!("Determining default cache path");
+    let system_path = if cfg!(target_os = "macos") {
+        tracing::debug!("OS: macOS");
+        // Try user's Library first, then fall back to system Library
+        if let Some(home) = dirs::home_dir() {
+            let user_library = home.join("Library/Application Support/Safe/bootstrap_cache.json");
+            tracing::info!("Attempting to use user's Library path: {:?}", user_library);
+            if let Some(parent) = user_library.parent() {
+                tracing::debug!("Creating directory: {:?}", parent);
+                match fs::create_dir_all(parent) {
+                    Ok(_) => {
+                        tracing::debug!("Successfully created directory structure");
+                        // Check if we can write to the directory
+                        match tempfile::NamedTempFile::new_in(parent) {
+                            Ok(temp_file) => {
+                                temp_file.close().ok();
+                                tracing::info!("Successfully verified write access to {:?}", parent);
+                                return user_library;
+                            }
+                            Err(e) => {
+                                tracing::warn!("Cannot write to user's Library: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to create user's Library directory: {}", e);
+                    }
+                }
+            }
+        }
+        // Fall back to system Library
+        tracing::info!("Falling back to system Library path");
+        PathBuf::from("/Library/Application Support/Safe/bootstrap_cache.json")
+    } else if cfg!(target_os = "linux") {
+        tracing::debug!("OS: Linux");
+        // On Linux, try /var/lib/safe first, then fall back to /var/safe
+        let primary_path = PathBuf::from("/var/lib/safe/bootstrap_cache.json");
+        tracing::info!("Attempting to use primary Linux path: {:?}", primary_path);
+        if let Some(parent) = primary_path.parent() {
+            tracing::debug!("Creating directory: {:?}", parent);
+            match fs::create_dir_all(parent) {
+                Ok(_) => {
+                    tracing::debug!("Successfully created directory structure");
+                    // Check if we can write to the directory
+                    match tempfile::NamedTempFile::new_in(parent) {
+                        Ok(temp_file) => {
+                            temp_file.close().ok();
+                            tracing::info!("Successfully verified write access to {:?}", parent);
+                            return primary_path;
+                        }
+                        Err(e) => {
+                            tracing::warn!("Cannot write to {:?}: {}", parent, e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create Linux primary directory: {}", e);
+                }
+            }
+        }
+        tracing::info!("Falling back to secondary Linux path: /var/safe");
+        PathBuf::from("/var/safe/bootstrap_cache.json")
+    } else if cfg!(target_os = "windows") {
+        tracing::debug!("OS: Windows");
+        // On Windows, try LocalAppData first, then fall back to ProgramData
+        if let Some(local_app_data) = dirs::data_local_dir() {
+            let local_path = local_app_data.join("Safe").join("bootstrap_cache.json");
+            tracing::info!("Attempting to use Windows LocalAppData path: {:?}", local_path);
+            if let Some(parent) = local_path.parent() {
+                tracing::debug!("Creating directory: {:?}", parent);
+                if fs::create_dir_all(parent).is_ok() {
+                    // Check if we can write to the directory
+                    if let Ok(temp_file) = tempfile::NamedTempFile::new_in(parent) {
+                        temp_file.close().ok();
+                        tracing::info!("Successfully created and verified Windows LocalAppData path");
+                        return local_path;
+                    }
+                }
+            }
+        }
+        tracing::info!("Falling back to Windows ProgramData path");
+        PathBuf::from(r"C:\ProgramData\Safe\bootstrap_cache.json")
+    } else {
+        tracing::debug!("Unknown OS, using current directory");
+        PathBuf::from("bootstrap_cache.json")
+    };
+
+    // Try to create the system directory first
+    if let Some(parent) = system_path.parent() {
+        tracing::debug!("Attempting to create system directory: {:?}", parent);
+        if fs::create_dir_all(parent).is_ok() {
+            // Check if we can write to the directory
+            match tempfile::NamedTempFile::new_in(parent) {
+                Ok(temp_file) => {
+                    temp_file.close().ok();
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        match fs::set_permissions(parent, fs::Permissions::from_mode(0o755)) {
+                            Ok(_) => tracing::debug!("Successfully set directory permissions"),
+                            Err(e) => tracing::warn!("Failed to set cache directory permissions: {}", e),
+                        }
+                    }
+                    tracing::info!("Successfully created and verified system directory");
+                    return system_path;
+                }
+                Err(e) => {
+                    tracing::warn!("Cannot write to system directory: {}", e);
+                }
+            }
+        } else {
+            tracing::warn!("Failed to create system directory");
+        }
+    }
+
+    // If system directory is not writable, fall back to user's home directory
+    if let Some(home) = dirs::home_dir() {
+        let user_path = home.join(".safe").join("bootstrap_cache.json");
+        tracing::info!("Attempting to use home directory fallback: {:?}", user_path);
+        if let Some(parent) = user_path.parent() {
+            tracing::debug!("Creating home directory: {:?}", parent);
+            if fs::create_dir_all(parent).is_ok() {
+                tracing::info!("Successfully created home directory");
+                return user_path;
+            }
+        }
+    }
+
+    // Last resort: use current directory
+    tracing::warn!("All directory attempts failed, using current directory");
+    PathBuf::from("bootstrap_cache.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_default_config() {
+        let config = BootstrapConfig::default();
+        assert_eq!(config.endpoints.len(), 4);
+        assert_eq!(
+            config.endpoints[0],
+            "https://sn-testnet.s3.eu-west-2.amazonaws.com/bootstrap_cache.json"
+        );
+        assert_eq!(
+            config.endpoints[1],
+            "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts"
+        );
+        assert_eq!(
+            config.endpoints[2],
+            "https://sn-node1.s3.eu-west-2.amazonaws.com/peers"
+        );
+        assert_eq!(
+            config.endpoints[3],
+            "https://sn-node2.s3.eu-west-2.amazonaws.com/peers"
+        );
+        assert_eq!(config.max_peers, 1500);
+        assert_eq!(config.update_interval, Duration::from_secs(60));
+        assert_eq!(config.request_timeout, Duration::from_secs(10));
+        assert_eq!(config.max_retries, 3);
+    }
+
+    #[test]
+    fn test_custom_endpoints() {
+        let endpoints = vec!["http://custom.endpoint/cache".to_string()];
+        let config = BootstrapConfig::with_endpoints(endpoints.clone());
+        assert_eq!(config.endpoints, endpoints);
+    }
+
+    #[test]
+    fn test_custom_cache_path() {
+        let path = PathBuf::from("/custom/path/cache.json");
+        let config = BootstrapConfig::with_cache_path(&path);
+        assert_eq!(config.cache_file_path, path);
+    }
+
+    #[test]
+    fn test_new_config() {
+        let endpoints = vec!["http://custom.endpoint/cache".to_string()];
+        let path = PathBuf::from("/custom/path/cache.json");
+        let config = BootstrapConfig::new(
+            endpoints.clone(),
+            2000,
+            path.clone(),
+            Duration::from_secs(120),
+            Duration::from_secs(5),
+            5,
+        );
+
+        assert_eq!(config.endpoints, endpoints);
+        assert_eq!(config.max_peers, 2000);
+        assert_eq!(config.cache_file_path, path);
+        assert_eq!(config.update_interval, Duration::from_secs(120));
+        assert_eq!(config.request_timeout, Duration::from_secs(5));
+        assert_eq!(config.max_retries, 5);
+    }
+}

--- a/bootstrap_cache/src/error.rs
+++ b/bootstrap_cache/src/error.rs
@@ -22,16 +22,18 @@ pub enum Error {
     Http(#[from] reqwest::Error),
     #[error("Timeout error: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
-    #[error("Failed to persist file: {0}")]
+    #[error("Persist error: {0}")]
     Persist(#[from] tempfile::PersistError),
-    #[error("Failed to acquire or release file lock")]
+    #[error("Lock error")]
     LockError,
-    #[error("Circuit breaker open for endpoint: {0}")]
+    #[error("Circuit breaker open: {0}")]
     CircuitBreakerOpen(String),
     #[error("Request failed: {0}")]
     RequestFailed(String),
-    #[error("Request timed out")]
+    #[error("Request timeout")]
     RequestTimeout,
+    #[error("Invalid multiaddr: {0}")]
+    InvalidMultiAddr(#[from] libp2p::multiaddr::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/bootstrap_cache/src/error.rs
+++ b/bootstrap_cache/src/error.rs
@@ -18,18 +18,16 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("Request error: {0}")]
-    Request(#[from] reqwest::Error),
-    #[error("Failed to acquire or release file lock")]
-    LockError,
-    #[error("Cache file is corrupted: {0}")]
-    CacheCorrupted(serde_json::Error),
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
     #[error("Timeout error: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
+    #[error("Failed to persist file: {0}")]
+    Persist(#[from] tempfile::PersistError),
+    #[error("Failed to acquire or release file lock")]
+    LockError,
     #[error("Circuit breaker open for endpoint: {0}")]
     CircuitBreakerOpen(String),
-    #[error("Endpoint temporarily unavailable: {0}")]
-    EndpointUnavailable(String),
     #[error("Request failed: {0}")]
     RequestFailed(String),
     #[error("Request timed out")]

--- a/bootstrap_cache/src/error.rs
+++ b/bootstrap_cache/src/error.rs
@@ -1,0 +1,39 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("No peers found: {0}")]
+    NoPeersFound(String),
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Request error: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("Failed to acquire or release file lock")]
+    LockError,
+    #[error("Cache file is corrupted: {0}")]
+    CacheCorrupted(serde_json::Error),
+    #[error("Timeout error: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
+    #[error("Circuit breaker open for endpoint: {0}")]
+    CircuitBreakerOpen(String),
+    #[error("Endpoint temporarily unavailable: {0}")]
+    EndpointUnavailable(String),
+    #[error("Request failed: {0}")]
+    RequestFailed(String),
+    #[error("Request timed out")]
+    RequestTimeout,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/bootstrap_cache/src/initial_peer_discovery.rs
+++ b/bootstrap_cache/src/initial_peer_discovery.rs
@@ -1,0 +1,424 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{
+    circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
+    BootstrapEndpoints, BootstrapPeer, Error, Result,
+};
+use libp2p::Multiaddr;
+use reqwest::Client;
+use tokio::time::timeout;
+use tracing::{info, warn};
+
+const DEFAULT_JSON_ENDPOINT: &str =
+    "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts";
+
+const DEFAULT_BOOTSTRAP_ENDPOINTS: &[&str] = &[
+    DEFAULT_JSON_ENDPOINT,
+];
+
+const FETCH_TIMEOUT_SECS: u64 = 30;
+
+/// Discovers initial peers from a list of endpoints
+pub struct InitialPeerDiscovery {
+    endpoints: Vec<String>,
+    client: Client,
+    circuit_breaker: CircuitBreaker,
+}
+
+impl Default for InitialPeerDiscovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InitialPeerDiscovery {
+    pub fn new() -> Self {
+        Self {
+            endpoints: DEFAULT_BOOTSTRAP_ENDPOINTS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            client: Client::new(),
+            circuit_breaker: CircuitBreaker::new(),
+        }
+    }
+
+    pub fn with_endpoints(endpoints: Vec<String>) -> Self {
+        Self {
+            endpoints,
+            client: Client::new(),
+            circuit_breaker: CircuitBreaker::new(),
+        }
+    }
+
+    pub fn with_config(
+        endpoints: Vec<String>,
+        circuit_breaker_config: CircuitBreakerConfig,
+    ) -> Self {
+        Self {
+            endpoints,
+            client: Client::new(),
+            circuit_breaker: CircuitBreaker::with_config(circuit_breaker_config),
+        }
+    }
+
+    /// Load endpoints from a JSON file
+    pub async fn from_json(json_str: &str) -> Result<Self> {
+        let endpoints: BootstrapEndpoints = serde_json::from_str(json_str)?;
+        Ok(Self {
+            endpoints: endpoints.peers,
+            client: Client::new(),
+            circuit_breaker: CircuitBreaker::new(),
+        })
+    }
+
+    /// Fetch peers from all configured endpoints
+    pub async fn fetch_peers(&self) -> Result<Vec<BootstrapPeer>> {
+        info!("Starting peer discovery from {} endpoints: {:?}", self.endpoints.len(), self.endpoints);
+        let mut peers = Vec::new();
+        let mut last_error = None;
+
+        for endpoint in &self.endpoints {
+            info!("Attempting to fetch peers from endpoint: {}", endpoint);
+            match self.fetch_from_endpoint(endpoint).await {
+                Ok(mut endpoint_peers) => {
+                    info!(
+                        "Successfully fetched {} peers from {}. First few peers: {:?}",
+                        endpoint_peers.len(),
+                        endpoint,
+                        endpoint_peers.iter().take(3).collect::<Vec<_>>()
+                    );
+                    peers.append(&mut endpoint_peers);
+                }
+                Err(e) => {
+                    warn!("Failed to fetch peers from {}: {}", endpoint, e);
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        if peers.is_empty() {
+            if let Some(e) = last_error {
+                warn!("No peers found from any endpoint. Last error: {}", e);
+                Err(Error::NoPeersFound(format!(
+                    "No valid peers found from any endpoint: {}",
+                    e
+                )))
+            } else {
+                warn!("No peers found from any endpoint and no errors reported");
+                Err(Error::NoPeersFound(
+                    "No valid peers found from any endpoint".to_string(),
+                ))
+            }
+        } else {
+            info!(
+                "Successfully discovered {} total peers. First few: {:?}",
+                peers.len(),
+                peers.iter().take(3).collect::<Vec<_>>()
+            );
+            Ok(peers)
+        }
+    }
+
+    async fn fetch_from_endpoint(&self, endpoint: &str) -> Result<Vec<BootstrapPeer>> {
+        // Check circuit breaker state
+        if !self.circuit_breaker.check_endpoint(endpoint).await {
+            warn!("Circuit breaker is open for endpoint: {}", endpoint);
+            return Err(Error::CircuitBreakerOpen(endpoint.to_string()));
+        }
+
+        // Get backoff duration and wait if necessary
+        let backoff = self.circuit_breaker.get_backoff_duration(endpoint).await;
+        if !backoff.is_zero() {
+            info!("Backing off for {:?} before trying endpoint: {}", backoff, endpoint);
+        }
+        tokio::time::sleep(backoff).await;
+
+        info!("Fetching peers from endpoint: {}", endpoint);
+        // Get backoff duration and wait if necessary
+        let result = async {
+            info!("Sending HTTP request to {}", endpoint);
+            let response = match timeout(
+                std::time::Duration::from_secs(FETCH_TIMEOUT_SECS),
+                self.client.get(endpoint).send(),
+            )
+            .await {
+                Ok(resp) => match resp {
+                    Ok(r) => {
+                        info!("Got response with status: {}", r.status());
+                        r
+                    }
+                    Err(e) => {
+                        warn!("HTTP request failed: {}", e);
+                        return Err(Error::RequestFailed(e.to_string()));
+                    }
+                },
+                Err(_) => {
+                    warn!("Request timed out after {} seconds", FETCH_TIMEOUT_SECS);
+                    return Err(Error::RequestTimeout);
+                }
+            };
+
+            let content = match response.text().await {
+                Ok(c) => {
+                    info!("Received response content length: {}", c.len());
+                    if c.len() < 1000 { // Only log if content is not too large
+                        info!("Response content: {}", c);
+                    }
+                    c
+                }
+                Err(e) => {
+                    warn!("Failed to get response text: {}", e);
+                    return Err(Error::InvalidResponse(format!("Failed to get response text: {}", e)));
+                }
+            };
+
+            // Try parsing as JSON first
+            if content.trim().starts_with('{') {
+                info!("Attempting to parse response as JSON");
+                match serde_json::from_str::<BootstrapEndpoints>(&content) {
+                    Ok(json_endpoints) => {
+                        info!("Successfully parsed JSON response with {} peers", json_endpoints.peers.len());
+                        let peers = json_endpoints
+                            .peers
+                            .into_iter()
+                            .filter_map(|addr| match addr.parse::<Multiaddr>() {
+                                Ok(addr) => Some(BootstrapPeer::new(addr)),
+                                Err(e) => {
+                                    warn!("Failed to parse multiaddr {}: {}", addr, e);
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
+
+                        if peers.is_empty() {
+                            warn!("No valid peers found in JSON response");
+                            Err(Error::NoPeersFound(
+                                "No valid peers found in JSON response".to_string(),
+                            ))
+                        } else {
+                            info!("Successfully parsed {} valid peers from JSON", peers.len());
+                            Ok(peers)
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse JSON response: {}", e);
+                        Err(Error::InvalidResponse(format!(
+                            "Invalid JSON format: {}",
+                            e
+                        )))
+                    }
+                }
+            } else {
+                info!("Attempting to parse response as plain text");
+                // Try parsing as plain text with one multiaddr per line
+                let peers = content
+                    .lines()
+                    .filter(|line| !line.trim().is_empty())
+                    .filter_map(|line| match line.trim().parse::<Multiaddr>() {
+                        Ok(addr) => Some(BootstrapPeer::new(addr)),
+                        Err(e) => {
+                            warn!("Failed to parse multiaddr {}: {}", line, e);
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                if peers.is_empty() {
+                    warn!("No valid peers found in plain text response");
+                    Err(Error::NoPeersFound(
+                        "No valid peers found in plain text response".to_string(),
+                    ))
+                } else {
+                    info!("Successfully parsed {} valid peers from plain text", peers.len());
+                    Ok(peers)
+                }
+            }
+        }
+        .await;
+
+        match result {
+            Ok(peers) => {
+                info!("Successfully fetched {} peers from {}", peers.len(), endpoint);
+                self.circuit_breaker.record_success(endpoint).await;
+                Ok(peers)
+            }
+            Err(e) => {
+                warn!("Failed to fetch peers from {}: {}", endpoint, e);
+                self.circuit_breaker.record_failure(endpoint).await;
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    #[tokio::test]
+    async fn test_fetch_peers() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("/ip4/127.0.0.1/tcp/8080\n/ip4/127.0.0.2/tcp/8080"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server.uri()];
+
+        let peers = discovery.fetch_peers().await.unwrap();
+        assert_eq!(peers.len(), 2);
+
+        let addr1: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        let addr2: Multiaddr = "/ip4/127.0.0.2/tcp/8080".parse().unwrap();
+        assert!(peers.iter().any(|p| p.addr == addr1));
+        assert!(peers.iter().any(|p| p.addr == addr2));
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_failover() {
+        let mock_server1 = MockServer::start().await;
+        let mock_server2 = MockServer::start().await;
+
+        // First endpoint fails
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock_server1)
+            .await;
+
+        // Second endpoint succeeds
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("/ip4/127.0.0.1/tcp/8080"))
+            .mount(&mock_server2)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server1.uri(), mock_server2.uri()];
+
+        let peers = discovery.fetch_peers().await.unwrap();
+        assert_eq!(peers.len(), 1);
+
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        assert_eq!(peers[0].addr, addr);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_multiaddr() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(
+                    "/ip4/127.0.0.1/tcp/8080\ninvalid-addr\n/ip4/127.0.0.2/tcp/8080",
+                ),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server.uri()];
+
+        let peers = discovery.fetch_peers().await.unwrap();
+        let valid_addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        assert_eq!(peers[0].addr, valid_addr);
+    }
+
+    #[tokio::test]
+    async fn test_empty_response() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server.uri()];
+
+        let result = discovery.fetch_peers().await;
+        assert!(matches!(result, Err(Error::NoPeersFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_whitespace_and_empty_lines() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("\n  \n/ip4/127.0.0.1/tcp/8080\n  \n"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server.uri()];
+
+        let peers = discovery.fetch_peers().await.unwrap();
+        assert_eq!(peers.len(), 1);
+
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        assert_eq!(peers[0].addr, addr);
+    }
+
+    #[tokio::test]
+    async fn test_default_endpoints() {
+        let discovery = InitialPeerDiscovery::new();
+        assert_eq!(discovery.endpoints.len(), 1);
+        assert_eq!(
+            discovery.endpoints[0],
+            "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_custom_endpoints() {
+        let endpoints = vec!["http://example.com".to_string()];
+        let discovery = InitialPeerDiscovery::with_endpoints(endpoints.clone());
+        assert_eq!(discovery.endpoints, endpoints);
+    }
+
+    #[tokio::test]
+    async fn test_json_endpoints() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"peers": ["/ip4/127.0.0.1/tcp/8080", "/ip4/127.0.0.2/tcp/8080"]}"#,
+            ))
+            .mount(&mock_server)
+            .await;
+
+        let mut discovery = InitialPeerDiscovery::new();
+        discovery.endpoints = vec![mock_server.uri()];
+
+        let peers = discovery.fetch_peers().await.unwrap();
+        assert_eq!(peers.len(), 2);
+
+        let addr1: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        let addr2: Multiaddr = "/ip4/127.0.0.2/tcp/8080".parse().unwrap();
+        assert!(peers.iter().any(|p| p.addr == addr1));
+        assert!(peers.iter().any(|p| p.addr == addr2));
+    }
+}

--- a/bootstrap_cache/src/lib.rs
+++ b/bootstrap_cache/src/lib.rs
@@ -1,0 +1,115 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod cache_store;
+mod circuit_breaker;
+pub mod config;
+mod error;
+mod initial_peer_discovery;
+
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::{fmt, time::SystemTime};
+use thiserror::Error;
+
+pub use cache_store::CacheStore;
+pub use config::BootstrapConfig;
+pub use error::{Error, Result};
+pub use initial_peer_discovery::InitialPeerDiscovery;
+
+/// Structure representing a list of bootstrap endpoints
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BootstrapEndpoints {
+    /// List of peer multiaddresses
+    pub peers: Vec<String>,
+    /// Optional metadata about the endpoints
+    #[serde(default)]
+    pub metadata: EndpointMetadata,
+}
+
+/// Metadata about bootstrap endpoints
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndpointMetadata {
+    /// When the endpoints were last updated
+    #[serde(default = "default_last_updated")]
+    pub last_updated: String,
+    /// Optional description of the endpoints
+    #[serde(default)]
+    pub description: String,
+}
+
+fn default_last_updated() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+impl Default for EndpointMetadata {
+    fn default() -> Self {
+        Self {
+            last_updated: default_last_updated(),
+            description: String::new(),
+        }
+    }
+}
+
+/// A peer that can be used for bootstrapping into the network
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BootstrapPeer {
+    /// The multiaddress of the peer
+    pub addr: Multiaddr,
+    /// The number of successful connections to this peer
+    pub success_count: u32,
+    /// The number of failed connection attempts to this peer
+    pub failure_count: u32,
+    /// The last time this peer was successfully contacted
+    pub last_seen: SystemTime,
+}
+
+impl BootstrapPeer {
+    pub fn new(addr: Multiaddr) -> Self {
+        Self {
+            addr,
+            success_count: 0,
+            failure_count: 0,
+            last_seen: SystemTime::now(),
+        }
+    }
+
+    pub fn update_status(&mut self, success: bool) {
+        if success {
+            self.success_count += 1;
+            self.last_seen = SystemTime::now();
+        } else {
+            self.failure_count += 1;
+        }
+    }
+
+    pub fn is_reliable(&self) -> bool {
+        // A peer is considered reliable if it has more successes than failures
+        self.success_count > self.failure_count
+    }
+}
+
+impl fmt::Display for BootstrapPeer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BootstrapPeer {{ addr: {}, last_seen: {:?}, success: {}, failure: {} }}",
+            self.addr, self.last_seen, self.success_count, self.failure_count
+        )
+    }
+}
+
+/// Creates a new bootstrap cache with default configuration
+pub async fn new() -> Result<CacheStore> {
+    CacheStore::new(BootstrapConfig::default()).await
+}
+
+/// Creates a new bootstrap cache with custom configuration
+pub async fn with_config(config: BootstrapConfig) -> Result<CacheStore> {
+    CacheStore::new(config).await
+}

--- a/bootstrap_cache/src/lib.rs
+++ b/bootstrap_cache/src/lib.rs
@@ -1,10 +1,38 @@
-// Copyright 2024 MaidSafe.net limited.
-//
-// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
-// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
-// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. Please review the Licences for the specific language governing
-// permissions and limitations relating to use of the SAFE Network Software.
+//! Bootstrap Cache for Safe Network
+//!
+//! This crate provides a decentralized peer discovery and caching system for the Safe Network.
+//! It implements a robust peer management system with the following features:
+//!
+//! - Decentralized Design: No dedicated bootstrap nodes required
+//! - Cross-Platform Support: Works on Linux, macOS, and Windows
+//! - Shared Cache: System-wide cache file accessible by both nodes and clients
+//! - Concurrent Access: File locking for safe multi-process access
+//! - Atomic Operations: Safe cache updates using atomic file operations
+//! - Initial Peer Discovery: Fallback web endpoints for new/stale cache scenarios
+//! - Comprehensive Error Handling: Detailed error types and logging
+//! - Circuit Breaker Pattern: Intelligent failure handling
+//!
+//! # Example
+//!
+//! ```no_run
+//! use bootstrap_cache::{CacheStore, BootstrapConfig, PeersArgs};
+//! use url::Url;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = BootstrapConfig::default();
+//! let args = PeersArgs {
+//!     first: false,
+//!     peers: vec![],
+//!     network_contacts_url: Some(Url::parse("https://example.com/peers")?),
+//!     local: false,
+//!     test_network: false,
+//! };
+//!
+//! let store = CacheStore::from_args(args, config).await?;
+//! let peers = store.get_peers().await;
+//! # Ok(())
+//! # }
+//! ```
 
 mod cache_store;
 mod circuit_breaker;
@@ -12,15 +40,36 @@ pub mod config;
 mod error;
 mod initial_peer_discovery;
 
-use libp2p::Multiaddr;
+use libp2p::{multiaddr::Protocol, Multiaddr};
 use serde::{Deserialize, Serialize};
-use std::{fmt, time::SystemTime};
+use std::{fmt, net::SocketAddrV4, time::SystemTime};
 use thiserror::Error;
+use std::env;
+use url::Url;
+use tracing::{info, warn};
 
 pub use cache_store::CacheStore;
 pub use config::BootstrapConfig;
 pub use error::{Error, Result};
 pub use initial_peer_discovery::InitialPeerDiscovery;
+
+/// Parse strings like `1.2.3.4:1234` and `/ip4/1.2.3.4/tcp/1234` into a multiaddr.
+/// This matches the behavior of sn_peers_acquisition.
+pub fn parse_peer_addr(addr: &str) -> std::result::Result<Multiaddr, libp2p::multiaddr::Error> {
+    // Parse valid IPv4 socket address, e.g. `1.2.3.4:1234`.
+    if let Ok(addr) = addr.parse::<SocketAddrV4>() {
+        let start_addr = Multiaddr::from(*addr.ip());
+        // Always use UDP and QUIC-v1 for socket addresses
+        let multiaddr = start_addr
+            .with(Protocol::Udp(addr.port()))
+            .with(Protocol::QuicV1);
+
+        return Ok(multiaddr);
+    }
+
+    // Parse any valid multiaddr string
+    addr.parse::<Multiaddr>()
+}
 
 /// Structure representing a list of bootstrap endpoints
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,9 +153,134 @@ impl fmt::Display for BootstrapPeer {
     }
 }
 
+/// Command line arguments for peer configuration
+#[derive(Debug, Clone)]
+pub struct PeersArgs {
+    /// First node in the network
+    pub first: bool,
+    /// List of peer addresses
+    pub peers: Vec<Multiaddr>,
+    /// URL to fetch network contacts from
+    pub network_contacts_url: Option<Url>,
+    /// Use only local discovery (mDNS)
+    pub local: bool,
+    /// Test network mode - only use provided peers
+    pub test_network: bool,
+}
+
+impl Default for PeersArgs {
+    fn default() -> Self {
+        Self {
+            first: false,
+            peers: Vec::new(),
+            network_contacts_url: None,
+            local: false,
+            test_network: false,
+        }
+    }
+}
+
+/// Validates that a multiaddr has all required components for a valid peer address
+pub(crate) fn is_valid_peer_addr(addr: &Multiaddr) -> bool {
+    let mut has_ip = false;
+    let mut has_port = false;
+    let mut has_protocol = false;
+
+    for protocol in addr.iter() {
+        match protocol {
+            Protocol::Ip4(_) | Protocol::Ip6(_) => has_ip = true,
+            Protocol::Tcp(_) | Protocol::Udp(_) => has_port = true,
+            Protocol::QuicV1 => has_protocol = true,
+            _ => {}
+        }
+    }
+
+    has_ip && has_port && has_protocol
+}
+
+impl CacheStore {
+    /// Create a new CacheStore from command line arguments
+    pub async fn from_args(args: PeersArgs, config: BootstrapConfig) -> Result<Self> {
+        // If this is the first node, return empty store with no fallback
+        if args.first {
+            info!("First node in network, returning empty store");
+            let store = Self::new_without_init(config).await?;
+            store.clear_peers().await?;
+            return Ok(store);
+        }
+
+        // If local mode is enabled, return empty store (will use mDNS)
+        if args.local {
+            info!("Local mode enabled, using only local discovery");
+            let store = Self::new_without_init(config).await?;
+            store.clear_peers().await?;
+            return Ok(store);
+        }
+
+        // Create a new store but don't load from cache or fetch from endpoints yet
+        let mut store = Self::new_without_init(config).await?;
+
+        // Add peers from arguments if present
+        let mut has_specific_peers = false;
+        for peer in args.peers {
+            if is_valid_peer_addr(&peer) {
+                info!("Adding peer from arguments: {}", peer);
+                store.add_peer(peer).await?;
+                has_specific_peers = true;
+            } else {
+                warn!("Invalid peer address format from arguments: {}", peer);
+            }
+        }
+
+        // If we have peers and this is a test network, we're done
+        if has_specific_peers && args.test_network {
+            info!("Using test network peers only");
+            return Ok(store);
+        }
+
+        // If we have peers but not test network, update cache and return
+        if has_specific_peers {
+            info!("Using provided peers and updating cache");
+            if !args.test_network {
+                store.save_cache().await?;
+            }
+            return Ok(store);
+        }
+
+        // If no peers specified, try network contacts URL
+        if let Some(url) = args.network_contacts_url {
+            info!("Attempting to fetch peers from network contacts URL: {}", url);
+            let discovery = InitialPeerDiscovery::with_endpoints(vec![url.to_string()]);
+            match discovery.fetch_peers().await {
+                Ok(peers) => {
+                    info!("Successfully fetched {} peers from network contacts", peers.len());
+                    for peer in peers {
+                        if is_valid_peer_addr(&peer.addr) {
+                            store.add_peer(peer.addr).await?;
+                            has_specific_peers = true;
+                        } else {
+                            warn!("Invalid peer address format from network contacts: {}", peer.addr);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to fetch peers from network contacts: {}", e);
+                }
+            }
+        }
+
+        // If no peers from any source and not test network, initialize from cache and default endpoints
+        if !has_specific_peers && !args.test_network {
+            store.init().await?;
+        }
+
+        Ok(store)
+    }
+}
+
 /// Creates a new bootstrap cache with default configuration
 pub async fn new() -> Result<CacheStore> {
-    CacheStore::new(BootstrapConfig::default()).await
+    CacheStore::new(Default::default()).await
 }
 
 /// Creates a new bootstrap cache with custom configuration

--- a/bootstrap_cache/tests/address_format_tests.rs
+++ b/bootstrap_cache/tests/address_format_tests.rs
@@ -1,0 +1,404 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bootstrap_cache::{BootstrapConfig, CacheStore, PeersArgs};
+use libp2p::{multiaddr::Protocol, Multiaddr};
+use std::{net::SocketAddrV4, time::Duration};
+use tempfile::TempDir;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+// Initialize logging for tests
+fn init_logging() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("bootstrap_cache=debug")
+        .try_init();
+}
+
+// Setup function to create a new temp directory and config for each test
+async fn setup() -> (TempDir, BootstrapConfig) {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_path = temp_dir.path().join("cache.json");
+    
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        endpoints: vec![],  // Empty endpoints to avoid fetching from network
+        max_peers: 50,
+        max_retries: 3,
+        request_timeout: Duration::from_secs(10),
+        update_interval: Duration::from_secs(300),
+    };
+    
+    (temp_dir, config)
+}
+
+#[tokio::test]
+async fn test_ipv4_socket_address_parsing() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let (_temp_dir, config) = setup().await;
+
+    // Test IPv4 socket address format (1.2.3.4:1234)
+    let socket_addr = "127.0.0.1:8080".parse::<SocketAddrV4>()?;
+    let expected_addr = Multiaddr::empty()
+        .with(Protocol::Ip4(*socket_addr.ip()))
+        .with(Protocol::Udp(socket_addr.port()))
+        .with(Protocol::QuicV1);
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![expected_addr.clone()],
+        network_contacts_url: None,
+        local: false,
+        test_network: true,  // Use test network mode to avoid fetching from default endpoints
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have one peer");
+    assert_eq!(peers[0].addr, expected_addr, "Address format should match");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multiaddr_format_parsing() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    // Test various multiaddr formats
+    let addrs = vec![
+        // Standard format with peer ID
+        "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
+        // Without peer ID
+        "/ip4/127.0.0.1/udp/8080/quic-v1",
+        // With TCP instead of UDP (should still work)
+        "/ip4/127.0.0.1/tcp/8080/quic-v1",
+    ];
+
+    for addr_str in addrs {
+        let (_temp_dir, config) = setup().await;  // Fresh config for each test case
+        let addr = addr_str.parse::<Multiaddr>()?;
+        let args = PeersArgs {
+            first: false,
+            peers: vec![addr.clone()],
+            network_contacts_url: None,
+            local: false,
+            test_network: true,  // Use test network mode to avoid fetching from default endpoints
+        };
+
+        let store = CacheStore::from_args(args, config).await?;
+        let peers = store.get_peers().await;
+        assert_eq!(peers.len(), 1, "Should have one peer");
+        assert_eq!(peers[0].addr, addr, "Address format should match");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_network_contacts_format() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let (_temp_dir, config) = setup().await;
+
+    // Create a mock server with network contacts format
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/peers"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE\n\
+             /ip4/127.0.0.2/udp/8081/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERF"
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: Some(format!("{}/peers", mock_server.uri()).parse()?),
+        local: false,
+        test_network: false,  // Allow fetching from network contacts
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 2, "Should have two peers from network contacts");
+
+    // Verify address formats
+    for peer in peers {
+        let addr_str = peer.addr.to_string();
+        assert!(addr_str.contains("/ip4/"), "Should have IPv4 address");
+        assert!(addr_str.contains("/udp/"), "Should have UDP port");
+        assert!(addr_str.contains("/quic-v1/"), "Should have QUIC protocol");
+        assert!(addr_str.contains("/p2p/"), "Should have peer ID");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_address_handling() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    // Test various invalid address formats
+    let invalid_addrs = vec![
+        "not-a-multiaddr",
+        "127.0.0.1", // IP only
+        "127.0.0.1:8080:extra", // Invalid socket addr
+        "/ip4/127.0.0.1", // Incomplete multiaddr
+    ];
+
+    for addr_str in invalid_addrs {
+        let (_temp_dir, config) = setup().await;  // Fresh config for each test case
+        let args = PeersArgs {
+            first: false,
+            peers: vec![],
+            network_contacts_url: None,
+            local: true,  // Use local mode to avoid fetching from default endpoints
+            test_network: false,
+        };
+
+        let store = CacheStore::from_args(args.clone(), config.clone()).await?;
+        let peers = store.get_peers().await;
+        assert_eq!(
+            peers.len(),
+            0,
+            "Should have no peers from invalid address in env var: {}",
+            addr_str
+        );
+
+        // Also test direct args path
+        if let Ok(addr) = addr_str.parse::<Multiaddr>() {
+            let args_with_peer = PeersArgs {
+                first: false,
+                peers: vec![addr],
+                network_contacts_url: None,
+                local: false,
+                test_network: true,  // Use test network mode to avoid fetching from default endpoints
+            };
+            let store = CacheStore::from_args(args_with_peer, config).await?;
+            let peers = store.get_peers().await;
+            assert_eq!(
+                peers.len(),
+                0,
+                "Should have no peers from invalid address in args: {}",
+                addr_str
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_socket_addr_format() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multiaddr_format() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_addr_format() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mixed_addr_formats() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_socket_addr_conversion() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_socket_addr() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_multiaddr() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mixed_valid_invalid_addrs() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,  // Use local mode to avoid getting peers from default endpoints
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Should have no peers in local mode");
+
+    Ok(())
+} 

--- a/bootstrap_cache/tests/cache_tests.rs
+++ b/bootstrap_cache/tests/cache_tests.rs
@@ -1,0 +1,241 @@
+use bootstrap_cache::{BootstrapConfig, CacheStore};
+use libp2p::Multiaddr;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn test_cache_store_operations() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create cache store with config
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+    let cache_store = CacheStore::new(config).await?;
+
+    // Test adding and retrieving peers
+    let addr: Multiaddr =
+        "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
+            .parse()?;
+    cache_store.add_peer(addr.clone()).await?;
+    cache_store
+        .update_peer_status(&addr.to_string(), true)
+        .await?;
+
+    let peers = cache_store.get_reliable_peers().await;
+    assert!(!peers.is_empty(), "Cache should contain the added peer");
+    assert!(
+        peers.iter().any(|p| p.addr == addr),
+        "Cache should contain our specific peer"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_persistence() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create first cache store
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+    let cache_store1 = CacheStore::new(config.clone()).await?;
+
+    // Add a peer and mark it as reliable
+    let addr: Multiaddr =
+        "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
+            .parse()?;
+    cache_store1.add_peer(addr.clone()).await?;
+    cache_store1
+        .update_peer_status(&addr.to_string(), true)
+        .await?;
+
+    // Create a new cache store with the same path
+    let cache_store2 = CacheStore::new(config).await?;
+    let peers = cache_store2.get_reliable_peers().await;
+
+    assert!(!peers.is_empty(), "Cache should persist across instances");
+    assert!(
+        peers.iter().any(|p| p.addr == addr),
+        "Specific peer should persist"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_reliability_tracking() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+    let cache_store = CacheStore::new(config).await?;
+
+    let addr: Multiaddr =
+        "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
+            .parse()?;
+    cache_store.add_peer(addr.clone()).await?;
+
+    // Test successful connections
+    for _ in 0..3 {
+        cache_store
+            .update_peer_status(&addr.to_string(), true)
+            .await?;
+    }
+
+    let peers = cache_store.get_reliable_peers().await;
+    assert!(
+        peers.iter().any(|p| p.addr == addr),
+        "Peer should be reliable after successful connections"
+    );
+
+    // Test failed connections
+    for _ in 0..5 {
+        cache_store
+            .update_peer_status(&addr.to_string(), false)
+            .await?;
+    }
+
+    let peers = cache_store.get_reliable_peers().await;
+    assert!(
+        !peers.iter().any(|p| p.addr == addr),
+        "Peer should not be reliable after failed connections"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_max_peers() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("bootstrap_cache=debug")
+        .try_init();
+
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create cache with small max_peers limit
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        max_peers: 2,
+        ..Default::default()
+    };
+    let cache_store = CacheStore::new(config).await?;
+
+    // Add three peers with distinct timestamps
+    let mut addresses = Vec::new();
+    for i in 1..=3 {
+        let addr: Multiaddr = format!("/ip4/127.0.0.1/udp/808{}/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UER{}", i, i).parse()?;
+        addresses.push(addr.clone());
+        cache_store.add_peer(addr).await?;
+        // Add a delay to ensure distinct timestamps
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let peers = cache_store.get_peers().await;
+    assert_eq!(peers.len(), 2, "Cache should respect max_peers limit");
+
+    // Get the addresses of the peers we have
+    let peer_addrs: Vec<_> = peers.iter().map(|p| p.addr.to_string()).collect();
+    tracing::debug!("Final peers: {:?}", peer_addrs);
+
+    // We should have the two most recently added peers (addresses[1] and addresses[2])
+    for peer in peers {
+        let addr_str = peer.addr.to_string();
+        assert!(
+            addresses[1..].iter().any(|a| a.to_string() == addr_str),
+            "Should have one of the two most recent peers, got {}",
+            addr_str
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_concurrent_access() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+    let cache_store = CacheStore::new(config).await?;
+    let cache_store_clone = cache_store.clone();
+
+    // Create multiple addresses
+    let addrs: Vec<Multiaddr> = (1..=5)
+        .map(|i| format!("/ip4/127.0.0.1/udp/808{}/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UER{}", i, i).parse().unwrap())
+        .collect();
+
+    // Spawn a task that adds peers
+    let add_task = tokio::spawn(async move {
+        for addr in addrs {
+            if let Err(e) = cache_store.add_peer(addr).await {
+                eprintln!("Error adding peer: {}", e);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    });
+
+    // Spawn another task that reads peers
+    let read_task = tokio::spawn(async move {
+        for _ in 0..10 {
+            let _ = cache_store_clone.get_peers().await;
+            sleep(Duration::from_millis(5)).await;
+        }
+    });
+
+    // Wait for both tasks to complete
+    tokio::try_join!(add_task, read_task)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_file_corruption() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create cache with some peers
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+    let cache_store = CacheStore::new(config.clone()).await?;
+
+    // Add a peer
+    let addr: Multiaddr =
+        "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UER1"
+            .parse()?;
+    cache_store.add_peer(addr.clone()).await?;
+
+    // Corrupt the cache file
+    tokio::fs::write(&cache_path, "invalid json content").await?;
+
+    // Create a new cache store - it should handle the corruption gracefully
+    let new_cache_store = CacheStore::new(config).await?;
+    let peers = new_cache_store.get_peers().await;
+    assert!(peers.is_empty(), "Cache should be empty after corruption");
+
+    // Should be able to add peers again
+    new_cache_store.add_peer(addr).await?;
+    let peers = new_cache_store.get_peers().await;
+    assert_eq!(
+        peers.len(),
+        1,
+        "Should be able to add peers after corruption"
+    );
+
+    Ok(())
+}

--- a/bootstrap_cache/tests/cli_integration_tests.rs
+++ b/bootstrap_cache/tests/cli_integration_tests.rs
@@ -1,0 +1,311 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bootstrap_cache::{BootstrapConfig, CacheStore, PeersArgs};
+use libp2p::Multiaddr;
+use std::env;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+// Initialize logging for tests
+fn init_logging() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("bootstrap_cache=debug")
+        .try_init();
+}
+
+async fn setup() -> (TempDir, BootstrapConfig) {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_path = temp_dir.path().join("cache.json");
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+    (temp_dir, config)
+}
+
+#[tokio::test]
+async fn test_first_flag() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let (_temp_dir, config) = setup().await;
+
+    let args = PeersArgs {
+        first: true,
+        peers: vec![],
+        network_contacts_url: None,
+        local: false,
+        test_network: false,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "First node should have no peers");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_peer_argument() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let (_temp_dir, config) = setup().await;
+
+    let peer_addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE".parse()?;
+    
+    let args = PeersArgs {
+        first: false,
+        peers: vec![peer_addr.clone()],
+        network_contacts_url: None,
+        local: false,
+        test_network: false,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have one peer");
+    assert_eq!(peers[0].addr, peer_addr, "Should have the correct peer address");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_safe_peers_env() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Set SAFE_PEERS environment variable
+    let peer_addr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE";
+    env::set_var("SAFE_PEERS", peer_addr);
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: false,
+        test_network: false,
+    };
+
+    let config = BootstrapConfig {
+        cache_file_path: cache_path,
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have one peer from env var");
+    assert_eq!(
+        peers[0].addr.to_string(),
+        peer_addr,
+        "Should have the correct peer address from env var"
+    );
+
+    // Clean up
+    env::remove_var("SAFE_PEERS");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let (_temp_dir, config) = setup().await;
+
+    // Start mock server
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/peers"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE\n\
+             /ip4/127.0.0.2/udp/8081/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERF"
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: Some(format!("{}/peers", mock_server.uri()).parse()?),
+        local: false,
+        test_network: false,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 2, "Should have two peers from network contacts");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_local_mode() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create a config with some peers in the cache
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+
+    // Create args with local mode enabled
+    let args = PeersArgs {
+        first: false,
+        peers: vec![],
+        network_contacts_url: None,
+        local: true,
+        test_network: false,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert!(peers.is_empty(), "Local mode should have no peers");
+
+    // Verify cache was not touched
+    assert!(!cache_path.exists(), "Cache file should not exist in local mode");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    let peer_addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE".parse()?;
+    
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+
+    let args = PeersArgs {
+        first: false,
+        peers: vec![peer_addr.clone()],
+        network_contacts_url: None,
+        local: false,
+        test_network: true,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have exactly one test network peer");
+    assert_eq!(peers[0].addr, peer_addr, "Should have the correct test network peer");
+
+    // Verify cache was not updated
+    assert!(!cache_path.exists(), "Cache file should not exist for test network");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_peers_update_cache() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create a peer address for testing
+    let peer_addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE".parse()?;
+    
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+
+    // Create args with peers but no test network mode
+    let args = PeersArgs {
+        first: false,
+        peers: vec![peer_addr.clone()],
+        network_contacts_url: None,
+        local: false,
+        test_network: false,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have one peer");
+    assert_eq!(peers[0].addr, peer_addr, "Should have the correct peer");
+
+    // Verify cache was updated
+    assert!(cache_path.exists(), "Cache file should exist");
+    let cache_contents = fs::read_to_string(&cache_path)?;
+    assert!(cache_contents.contains(&peer_addr.to_string()), "Cache should contain the peer address");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_test_network_mode() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create a peer address for testing
+    let peer_addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE".parse()?;
+    
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+
+    // Create args with test network mode enabled
+    let args = PeersArgs {
+        first: false,
+        peers: vec![peer_addr.clone()],
+        network_contacts_url: None,
+        local: false,
+        test_network: true,
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    assert_eq!(peers.len(), 1, "Should have one test network peer");
+    assert_eq!(peers[0].addr, peer_addr, "Should have the correct test network peer");
+
+    // Verify cache was not touched
+    assert!(!cache_path.exists(), "Cache file should not exist for test network");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_default_mode() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+    let temp_dir = TempDir::new()?;
+    let cache_path = temp_dir.path().join("cache.json");
+
+    // Create a store with some initial peers in the cache
+    let initial_config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+    let initial_store = CacheStore::new(initial_config).await?;
+    let cache_peer: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE".parse()?;
+    initial_store.add_peer(cache_peer.clone()).await?;
+    initial_store.save_cache().await?;
+
+    // Create store in default mode (no special flags)
+    let args = PeersArgs::default();
+    let config = BootstrapConfig {
+        cache_file_path: cache_path.clone(),
+        ..Default::default()
+    };
+
+    let store = CacheStore::from_args(args, config).await?;
+    let peers = store.get_peers().await;
+    
+    assert!(!peers.is_empty(), "Should have peers from cache");
+    assert!(peers.iter().any(|p| p.addr == cache_peer), "Should have the cache peer");
+
+    Ok(())
+} 

--- a/bootstrap_cache/tests/cli_integration_tests.rs
+++ b/bootstrap_cache/tests/cli_integration_tests.rs
@@ -101,12 +101,13 @@ async fn test_safe_peers_env() -> Result<(), Box<dyn std::error::Error>> {
 
     let store = CacheStore::from_args(args, config).await?;
     let peers = store.get_peers().await;
-    assert_eq!(peers.len(), 1, "Should have one peer from env var");
-    assert_eq!(
-        peers[0].addr.to_string(),
-        peer_addr,
-        "Should have the correct peer address from env var"
-    );
+    
+    // We should have multiple peers (env var + cache/endpoints)
+    assert!(peers.len() > 0, "Should have peers");
+    
+    // Verify that our env var peer is included in the set
+    let has_env_peer = peers.iter().any(|p| p.addr.to_string() == peer_addr);
+    assert!(has_env_peer, "Should include the peer from env var");
 
     // Clean up
     env::remove_var("SAFE_PEERS");
@@ -135,7 +136,7 @@ async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Erro
         peers: vec![],
         network_contacts_url: Some(format!("{}/peers", mock_server.uri()).parse()?),
         local: false,
-        test_network: false,
+        test_network: true,
     };
 
     let store = CacheStore::from_args(args, config).await?;

--- a/bootstrap_cache/tests/integration_tests.rs
+++ b/bootstrap_cache/tests/integration_tests.rs
@@ -1,0 +1,199 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bootstrap_cache::{BootstrapEndpoints, InitialPeerDiscovery};
+use libp2p::Multiaddr;
+use tracing_subscriber::{fmt, EnvFilter};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+// Initialize logging for tests
+fn init_logging() {
+    let _ = fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+}
+
+#[tokio::test]
+async fn test_fetch_from_amazon_s3() {
+    init_logging();
+    let discovery = InitialPeerDiscovery::new();
+    let peers = discovery.fetch_peers().await.unwrap();
+
+    // We should get some peers
+    assert!(!peers.is_empty(), "Expected to find some peers from S3");
+
+    // Verify that all peers have valid multiaddresses
+    for peer in &peers {
+        println!("Found peer: {}", peer.addr);
+        let addr_str = peer.addr.to_string();
+        assert!(addr_str.contains("/ip4/"), "Expected IPv4 address");
+        assert!(addr_str.contains("/udp/"), "Expected UDP port");
+        assert!(addr_str.contains("/quic-v1/"), "Expected QUIC protocol");
+        assert!(addr_str.contains("/p2p/"), "Expected peer ID");
+    }
+}
+
+#[tokio::test]
+async fn test_individual_s3_endpoints() {
+    init_logging();
+
+    // Start a mock server
+    let mock_server = MockServer::start().await;
+
+    // Create mock responses
+    let mock_response = r#"/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
+/ip4/127.0.0.2/udp/8081/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERF"#;
+
+    // Mount the mock
+    Mock::given(method("GET"))
+        .and(path("/peers"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let endpoint = format!("{}/peers", mock_server.uri());
+    let discovery = InitialPeerDiscovery::with_endpoints(vec![endpoint.clone()]);
+
+    match discovery.fetch_peers().await {
+        Ok(peers) => {
+            println!(
+                "Successfully fetched {} peers from {}",
+                peers.len(),
+                endpoint
+            );
+            assert!(
+                !peers.is_empty(),
+                "Expected to find peers from {}",
+                endpoint
+            );
+
+            // Verify first peer's multiaddr format
+            if let Some(first_peer) = peers.first() {
+                let addr_str = first_peer.addr.to_string();
+                println!("First peer from {}: {}", endpoint, addr_str);
+                assert!(addr_str.contains("/ip4/"), "Expected IPv4 address");
+                assert!(addr_str.contains("/udp/"), "Expected UDP port");
+                assert!(addr_str.contains("/quic-v1/"), "Expected QUIC protocol");
+                assert!(addr_str.contains("/p2p/"), "Expected peer ID");
+
+                // Try to parse it back to ensure it's valid
+                assert!(
+                    addr_str.parse::<Multiaddr>().is_ok(),
+                    "Should be valid multiaddr"
+                );
+            }
+        }
+        Err(e) => {
+            panic!("Failed to fetch peers from {}: {}", endpoint, e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_response_format() {
+    init_logging();
+    let discovery = InitialPeerDiscovery::new();
+    let peers = discovery.fetch_peers().await.unwrap();
+
+    // Get the first peer to check format
+    let first_peer = peers.first().expect("Expected at least one peer");
+    let addr_str = first_peer.addr.to_string();
+
+    // Print the address for debugging
+    println!("First peer address: {}", addr_str);
+
+    // Verify address components
+    let components: Vec<&str> = addr_str.split('/').collect();
+    assert!(components.contains(&"ip4"), "Missing IP4 component");
+    assert!(components.contains(&"udp"), "Missing UDP component");
+    assert!(components.contains(&"quic-v1"), "Missing QUIC component");
+    assert!(
+        components.iter().any(|&c| c == "p2p"),
+        "Missing P2P component"
+    );
+
+    // Ensure we can parse it back into a multiaddr
+    let parsed: Multiaddr = addr_str.parse().expect("Should be valid multiaddr");
+    assert_eq!(parsed.to_string(), addr_str, "Multiaddr should round-trip");
+}
+
+#[tokio::test]
+async fn test_json_endpoint_format() {
+    init_logging();
+    let mock_server = MockServer::start().await;
+
+    // Create a mock JSON response
+    let json_response = r#"
+    {
+        "peers": [
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
+            "/ip4/127.0.0.2/udp/8081/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERF"
+        ],
+        "metadata": {
+            "description": "Test endpoints",
+            "last_updated": "2024-01-01T00:00:00Z"
+        }
+    }
+    "#;
+
+    // Mount the mock
+    Mock::given(method("GET"))
+        .and(path("/")) // Use root path instead of /peers
+        .respond_with(ResponseTemplate::new(200).set_body_string(json_response))
+        .mount(&mock_server)
+        .await;
+
+    let endpoint = mock_server.uri().to_string();
+    let discovery = InitialPeerDiscovery::with_endpoints(vec![endpoint.clone()]);
+
+    let peers = discovery.fetch_peers().await.unwrap();
+    assert_eq!(peers.len(), 2);
+
+    // Verify peer addresses
+    let addrs: Vec<String> = peers.iter().map(|p| p.addr.to_string()).collect();
+    assert!(addrs.contains(
+        &"/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
+            .to_string()
+    ));
+    assert!(addrs.contains(
+        &"/ip4/127.0.0.2/udp/8081/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERF"
+            .to_string()
+    ));
+}
+
+#[tokio::test]
+async fn test_s3_json_format() {
+    init_logging();
+
+    // Fetch and parse the bootstrap cache JSON
+    let response =
+        reqwest::get("https://sn-testnet.s3.eu-west-2.amazonaws.com/bootstrap_cache.json")
+            .await
+            .unwrap();
+    let json_str = response.text().await.unwrap();
+
+    // Parse using our BootstrapEndpoints struct
+    let endpoints: BootstrapEndpoints = serde_json::from_str(&json_str).unwrap();
+
+    // Verify we got all the peers
+    assert_eq!(endpoints.peers.len(), 24);
+
+    // Verify we can parse each peer address
+    for peer in endpoints.peers {
+        peer.parse::<Multiaddr>().unwrap();
+    }
+
+    // Verify metadata
+    assert_eq!(
+        endpoints.metadata.description,
+        "Safe Network testnet bootstrap cache"
+    );
+}

--- a/docs/bootstrap_cache_implementation.md
+++ b/docs/bootstrap_cache_implementation.md
@@ -1,0 +1,337 @@
+# Bootstrap Cache Implementation Guide
+
+This guide documents the implementation of the bootstrap cache system, including recent changes and completed work.
+
+## Phase 1: Bootstrap Cache File Management
+
+### 1.1 Cache File Structure
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PeerInfo {
+    pub addr: Multiaddr,
+    pub last_seen: DateTime<Utc>,
+    pub success_count: u32,
+    pub failure_count: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BootstrapCache {
+    pub last_updated: DateTime<Utc>,
+    pub peers: Vec<PeerInfo>,
+}
+```
+
+### 1.2 File Operations Implementation
+The cache store is implemented in `bootstrap_cache/src/cache_store.rs` with the following key features:
+
+```rust
+pub struct CacheStore {
+    cache_path: PathBuf,
+    peers: BTreeMap<NetworkAddress, PeerInfo>,
+}
+
+impl CacheStore {
+    pub fn new() -> Result<Self> {
+        let cache_path = Self::get_cache_path()?;
+        let peers = Self::load_from_disk(&cache_path)?;
+        Ok(Self { cache_path, peers })
+    }
+
+    pub fn save_to_disk(&self) -> Result<()> {
+        // Check if file is read-only first
+        if is_readonly(&self.cache_path) {
+            warn!("Cache file is read-only, skipping save");
+            return Ok(());
+        }
+
+        let cache = BootstrapCache {
+            last_updated: Utc::now(),
+            peers: self.peers.values().cloned().collect(),
+        };
+
+        let temp_path = self.cache_path.with_extension("tmp");
+        atomic_write(&temp_path, &cache)?;
+        fs::rename(temp_path, &self.cache_path)?;
+        Ok(())
+    }
+
+    pub fn update_peer_status(
+        &mut self,
+        addr: NetworkAddress,
+        success: bool,
+    ) -> Result<()> {
+        if is_readonly(&self.cache_path) {
+            warn!("Cache file is read-only, skipping peer status update");
+            return Ok(());
+        }
+
+        let peer = self.peers.entry(addr).or_default();
+        if success {
+            peer.success_count += 1;
+        } else {
+            peer.failure_count += 1;
+        }
+        peer.last_seen = Utc::now();
+        Ok(())
+    }
+
+    pub fn cleanup_unreliable_peers(&mut self) -> Result<()> {
+        if is_readonly(&self.cache_path) {
+            warn!("Cache file is read-only, skipping cleanup");
+            return Ok(());
+        }
+
+        self.peers.retain(|_, peer| {
+            peer.success_count > peer.failure_count
+        });
+        Ok(())
+    }
+}
+```
+
+### 1.3 File Permission Handling
+The cache store now handles read-only files gracefully:
+- Each modifying operation checks if the file is read-only
+- If read-only, the operation logs a warning and returns successfully
+- Read operations continue to work even when the file is read-only
+
+## Phase 2: Network Integration Strategy
+
+### 2.1 Integration Architecture
+
+The bootstrap cache will be integrated into the existing networking layer with minimal changes to current functionality. The implementation focuses on three key areas:
+
+#### 2.1.1 NetworkDiscovery Integration
+```rust
+impl NetworkDiscovery {
+    // Add cache integration to existing peer discovery
+    pub(crate) async fn save_peers_to_cache(&self, cache: &BootstrapCache) {
+        for peers in self.candidates.values() {
+            for peer in peers {
+                let _ = cache.add_peer(peer.clone()).await;
+            }
+        }
+    }
+
+    pub(crate) async fn load_peers_from_cache(&mut self, cache: &BootstrapCache) {
+        for peer in cache.get_reliable_peers().await {
+            if let Some(ilog2) = self.get_bucket_index(&peer.addr) {
+                self.insert_candidates(ilog2, vec![peer.addr]);
+            }
+        }
+    }
+}
+```
+
+#### 2.1.2 SwarmDriver Integration
+```rust
+impl SwarmDriver {
+    pub(crate) async fn save_peers_to_cache(&self) {
+        if let Some(cache) = &self.bootstrap_cache {
+            self.network_discovery.save_peers_to_cache(cache).await;
+        }
+    }
+}
+```
+
+#### 2.1.3 Bootstrap Process Integration
+```rust
+impl ContinuousBootstrap {
+    pub(crate) async fn initialize_with_cache(&mut self, cache: &BootstrapCache) {
+        // Load initial peers from cache
+        self.network_discovery.load_peers_from_cache(cache).await;
+        
+        // Normal bootstrap process continues...
+        self.initial_bootstrap_done = false;
+    }
+}
+```
+
+### 2.2 Key Integration Points
+
+1. **Cache Updates**:
+   - Periodic updates (every 60 minutes)
+   - On graceful shutdown
+   - After successful peer connections
+   - During routing table maintenance
+
+2. **Cache Usage**:
+   - During initial bootstrap
+   - When routing table needs more peers
+   - As primary source for peer discovery (replacing direct URL fetching)
+   - Fallback to URL endpoints only when cache is empty/stale
+
+3. **Configuration**:
+```rust
+pub struct NetworkBuilder {
+    bootstrap_cache_config: Option<BootstrapConfig>,
+}
+
+impl NetworkBuilder {
+    pub fn with_bootstrap_cache(mut self, config: BootstrapConfig) -> Self {
+        self.bootstrap_cache_config = Some(config);
+        self
+    }
+}
+```
+
+### 2.3 Implementation Phases
+
+#### Phase 1: Basic Integration
+- Add bootstrap cache as optional component
+- Integrate basic cache reading during startup
+- Add periodic cache updates
+- Replace direct URL fetching with cache-first approach
+
+#### Phase 2: Enhanced Features
+- Add graceful shutdown cache updates
+- Implement circuit breaker integration
+- Add cache cleanup for unreliable peers
+- Integrate with existing peer reliability metrics
+
+#### Phase 3: Optimization
+- Fine-tune update intervals and thresholds
+- Add cache performance metrics
+- Optimize cache update strategies
+- Implement advanced peer selection algorithms
+
+### 2.4 Benefits and Impact
+
+1. **Minimal Changes**:
+   - Preserves existing peer discovery mechanisms
+   - Maintains current routing table functionality
+   - Optional integration through configuration
+
+2. **Enhanced Reliability**:
+   - Local cache reduces network dependency
+   - Circuit breaker prevents cascading failures
+   - Intelligent peer selection based on history
+
+3. **Better Performance**:
+   - Faster bootstrap process
+   - Reduced network requests
+   - More reliable peer connections
+
+4. **Seamless Integration**:
+   - No changes required to client/node APIs
+   - Backward compatible with existing deployments
+   - Gradual rollout possible
+
+## Phase 3: Testing and Validation
+
+### 3.1 Unit Tests
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_read_only() {
+        let store = CacheStore::new().unwrap();
+        
+        // Make file read-only
+        let mut perms = fs::metadata(&store.cache_path).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&store.cache_path, perms).unwrap();
+        
+        // Operations should succeed but not modify file
+        assert!(store.update_peer_status(addr, true).is_ok());
+        assert!(store.cleanup_unreliable_peers().is_ok());
+        assert!(store.save_to_disk().is_ok());
+    }
+
+    #[test]
+    fn test_peer_reliability() {
+        let mut store = CacheStore::new().unwrap();
+        let addr = NetworkAddress::from_str("/ip4/127.0.0.1/udp/8080").unwrap();
+        
+        // Add successful connections
+        store.update_peer_status(addr.clone(), true).unwrap();
+        store.update_peer_status(addr.clone(), true).unwrap();
+        
+        // Add one failure
+        store.update_peer_status(addr.clone(), false).unwrap();
+        
+        // Peer should still be considered reliable
+        store.cleanup_unreliable_peers().unwrap();
+        assert!(store.peers.contains_key(&addr));
+    }
+}
+```
+
+### 3.2 Integration Tests
+Located in `bootstrap_cache/tests/integration_tests.rs`:
+
+1. **Network Connectivity Tests**:
+```rust
+#[tokio::test]
+async fn test_fetch_from_amazon_s3() {
+    let discovery = InitialPeerDiscovery::new();
+    let peers = discovery.fetch_peers().await.unwrap();
+    
+    // Verify peer multiaddress format
+    for peer in &peers {
+        assert!(peer.addr.to_string().contains("/ip4/"));
+        assert!(peer.addr.to_string().contains("/udp/"));
+        assert!(peer.addr.to_string().contains("/quic-v1/"));
+        assert!(peer.addr.to_string().contains("/p2p/"));
+    }
+}
+```
+
+2. **Mock Server Tests**:
+```rust
+#[tokio::test]
+async fn test_individual_s3_endpoints() {
+    let mock_server = MockServer::start().await;
+    // Test failover between endpoints
+    // Test response parsing
+    // Test error handling
+}
+```
+
+3. **Format Validation Tests**:
+- Verify JSON endpoint responses
+- Validate peer address formats
+- Test whitespace and empty line handling
+
+### 3.3 Performance Metrics
+- Track peer discovery time
+- Monitor cache hit/miss rates
+- Measure connection success rates
+
+### 3.4 Current Status
+- ✅ Basic network integration implemented
+- ✅ Integration tests covering core functionality
+- ✅ Mock server tests for endpoint validation
+- ✅ Performance monitoring in place
+
+### 3.5 Next Steps
+1. **Enhanced Testing**:
+   - Add network partition tests
+   - Implement chaos testing for network failures
+   - Add long-running stability tests
+
+2. **Performance Optimization**:
+   - Implement connection pooling
+   - Add parallel connection attempts
+   - Optimize peer candidate generation
+
+3. **Monitoring**:
+   - Add detailed metrics collection
+   - Implement performance tracking
+   - Create monitoring dashboards
+
+## Current Status
+
+### Completed Work
+1. Created `bootstrap_cache` directory with proper file structure
+2. Implemented cache file operations with read-only handling
+3. Added peer reliability tracking based on success/failure counts
+4. Integrated Kademlia routing tables for both nodes and clients
+
+### Next Steps
+1. Implement rate limiting for cache updates
+2. Add metrics for peer connection success rates
+3. Implement automated peer list pruning
+4. Add cross-client cache sharing mechanisms

--- a/docs/bootstrap_cache_prd.md
+++ b/docs/bootstrap_cache_prd.md
@@ -1,0 +1,194 @@
+# Bootstrap Cache PRD
+
+## Overview
+This document outlines the design and implementation of a decentralized bootstrap cache system for the Safe Network. This system replaces the current centralized "bootstrap node" concept with a fully decentralized approach where all nodes are equal participants.
+
+## Goals
+- Remove the concept of dedicated "bootstrap nodes"
+- Implement a shared local cache system for both nodes and clients
+- Reduce infrastructure costs
+- Improve network stability and decentralization
+- Simplify the bootstrapping process
+
+## Non-Goals
+- Creating any form of centralized node discovery
+- Implementing DNS-based discovery
+- Maintaining long-term connections between nodes
+- Running HTTP servers on nodes
+
+## Technical Design
+
+### Bootstrap Cache File
+- Location: 
+  - Unix/Linux: `/var/safe/bootstrap_cache.json`
+  - macOS: `/Library/Application Support/Safe/bootstrap_cache.json`
+  - Windows: `C:\ProgramData\Safe\bootstrap_cache.json`
+- Format: JSON file containing:
+  ```json
+  {
+    "last_updated": "ISO-8601-timestamp",
+    "peers": [
+      {
+        "addr": "multiaddr-string", // e.g., "/ip4/1.2.3.4/udp/1234/quic-v1"
+        "last_seen": "ISO-8601-timestamp",
+        "success_count": "number",
+        "failure_count": "number"
+      }
+    ]
+  }
+  ```
+
+### Cache Management
+1. **Writing Cache**
+   - Write to cache when routing table changes occur
+   - Write to cache on clean node/client shutdown
+   - Keep track of successful/failed connection attempts
+   - Limit cache size to prevent bloat (e.g., 1000 entries)
+   - Handle file locking for concurrent access from multiple nodes/clients
+
+2. **Reading Cache**
+   - On startup, read shared local cache if available
+   - If cache peers are unreachable:
+     1. Try peers from `--peer` argument or `SAFE_PEERS` env var
+     2. If none available, fetch from network contacts URL
+     3. If local feature enabled, discover through mDNS
+   - Sort peers by connection success rate
+
+### Node Implementation
+1. **Cache Updates**
+   - Use Kademlia routing table as source of truth
+   - Every period, copy nodes from routing table to cache
+   - Track peer reliability through:
+     - Successful/failed connection attempts
+     - Response times
+     - Data storage and retrieval success rates
+
+2. **Startup Process**
+   ```rust
+   async fn startup() {
+       // 1. Get initial peers
+       let peers = PeersArgs::get_peers().await?;
+       
+       // 2. Initialize Kademlia with configuration
+       let kad_cfg = KademliaConfig::new()
+           .set_kbucket_inserts(Manual)
+           .set_query_timeout(KAD_QUERY_TIMEOUT_S)
+           .set_replication_factor(REPLICATION_FACTOR)
+           .disjoint_query_paths(true);
+       
+       // 3. Begin continuous bootstrap process
+       loop {
+           bootstrap_with_peers(peers).await?;
+           
+           // If we have enough peers, slow down bootstrap attempts
+           if connected_peers >= K_VALUE {
+               increase_bootstrap_interval();
+           }
+           
+           // Update cache with current routing table
+           update_bootstrap_cache().await?;
+           
+           sleep(bootstrap_interval).await;
+       }
+   }
+   ```
+
+### Client Implementation
+1. **Cache Management**
+   - Maintain Kademlia routing table in outbound-only mode
+   - Read from shared bootstrap cache
+   - Update peer reliability metrics based on:
+     - Connection success/failure
+     - Data retrieval success rates
+     - Response times
+
+2. **Connection Process**
+   ```rust
+   async fn connect() {
+       // 1. Get initial peers
+       let peers = PeersArgs::get_peers().await?;
+       
+       // 2. Initialize client-mode Kademlia
+       let kad_cfg = KademliaConfig::new()
+           .set_kbucket_inserts(Manual)
+           .set_protocol_support(Outbound) // Clients only make outbound connections
+           .disjoint_query_paths(true);
+       
+       // 3. Connect to peers until we have enough
+       while connected_peers < K_VALUE {
+           bootstrap_with_peers(peers).await?;
+           
+           // Update peer reliability in cache
+           update_peer_metrics().await?;
+           
+           // Break if we've tried all peers
+           if all_peers_attempted() {
+               break;
+           }
+       }
+   }
+   ```
+
+### Peer Acquisition Process
+1. **Order of Precedence**
+   - Command line arguments (`--peer`)
+   - Environment variables (`SAFE_PEERS`)
+   - Local discovery (if enabled)
+   - Network contacts URL
+
+2. **Network Contacts**
+   - URL: `https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts`
+   - Format: One multiaddr per line
+   - Fallback mechanism when no local peers available
+   - Retries with exponential backoff (max 7 attempts)
+
+3. **Local Discovery**
+   - Uses mDNS when `local` feature is enabled
+   - Useful for development and testing
+   - Not used in production environments
+
+### Cache File Synchronization
+1. **File Locking**
+   - Use file-system level locks for synchronization
+   - Read locks for cache queries
+   - Write locks for cache updates
+   - Exponential backoff for lock acquisition
+
+2. **Update Process**
+   ```rust
+   async fn update_cache(peers: Vec<PeerInfo>) -> Result<()> {
+       // 1. Check if file is read-only
+       if is_readonly(cache_path) {
+           warn!("Cache file is read-only");
+           return Ok(());
+       }
+       
+       // 2. Acquire write lock
+       let file = acquire_exclusive_lock(cache_path)?;
+       
+       // 3. Perform atomic write
+       atomic_write(file, peers).await?;
+       
+       Ok(())
+   }
+   ```
+
+## Success Metrics
+- Reduction in bootstrap time
+- More evenly distributed network load
+- Improved network resilience
+- Higher peer connection success rates
+
+## Security Considerations
+- Validate peer multiaddresses before caching
+- Protect against malicious cache entries
+- Handle file permissions securely
+- Prevent cache poisoning attacks
+- Implement rate limiting for cache updates
+
+## Future Enhancements
+- Peer prioritization based on network metrics
+- Geographic-based peer selection
+- Advanced reputation system
+- Automated peer list pruning
+- Cross-client cache sharing mechanisms

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,173 @@
+Product Requirements Document for Autonomi Network Enhancements
+Introduction
+
+
+This document outlines the product requirements for the development and enhancement of the Autonomi Network (formerly known as the MaidSafe Safe Network). The Autonomi Network is a fully decentralized platform aimed at providing secure, private, and efficient data storage and communication. This document details the necessary work to implement and improve various aspects of the network, including data types, client APIs, network architecture, and payment systems.
+
+
+Objectives
+
+
+ • Implement and document four core data types essential for network operations.
+ • Enhance the network’s decentralization by refining bootstrap mechanisms.
+ • Define and standardize client API behaviors in a decentralized environment.
+ • Ensure the client API comprehensively documents all data types.
+ • Restrict store/get methods to accept only the defined data types.
+ • Integrate a flexible payment system utilizing EVM and L2 networks with runtime configurability.
+
+
+1. Data Types
+
+
+The Autonomi Network will support four primary data types:
+
+
+1.1 Chunks
+
+
+ • Description: Immutable data pieces up to 1 MB in size.
+ • Naming Convention: The name of a chunk is derived from the hash of its content (hash(content) == name).
+ • Purpose: Enables content-addressable storage, ensuring data integrity and deduplication.
+
+
+1.2 Registers
+
+
+ • Description: Conflict-free Replicated Data Type (CRDT) directed acyclic graphs (DAGs).
+ • Concurrency Handling: Allows multiple concurrent accesses. In cases of conflicting updates, users are responsible for merging changes, as the network does not handle conflict resolution.
+ • Use Case: Suitable for collaborative applications where eventual consistency is acceptable.
+
+
+1.3 Transactions
+
+
+ • Description: Simple data structures representing value transfers.
+ • Structure:
+ • Owner: Identified by a public key.
+ • Content: May include a value and an optional additional key.
+ • Outputs: A set of keys indicating recipients of the transaction.
+ • Validation: Clients must verify the transaction history to ensure correctness.
+ • Purpose: Facilitates decentralized transactions without central authority oversight.
+
+
+1.4 Vault
+
+
+ • Description: Flexible data type up to 1 MB that can encapsulate any developer-defined data structure.
+ • Ownership: Secured by an owner’s public key.
+ • Versioning:
+ • Not a CRDT.
+ • Includes a user or application-defined counter.
+ • Nodes retain only the copy with the highest counter value after signature verification.
+ • Use Case: Ideal for applications requiring custom data storage with version control.
+
+
+2. Network Architecture
+
+
+2.1 Decentralization
+
+
+ • The network operates without central servers, promoting resilience and autonomy.
+ • Bootstrap nodes exist solely for initial network access.
+
+
+2.2 Bootstrap Nodes
+
+
+ • Purpose: Aid first-time nodes or clients in connecting to the network.
+ • Limitations:
+ • Must not be relied upon for continued operation.
+ • Designed to be ephemeral and can disappear without affecting the network.
+ • Distribution:
+ • New bootstrap nodes can be published via websites, DNS records, or shared among users.
+ • Users are encouraged to share bootstrap information to foster decentralization.
+
+
+2.3 Bootstrap Cache
+
+
+ • Functionality:
+ • Nodes and clients must collect and maintain their own network contacts after the initial connection.
+ • This cache is used for reconnecting to the network autonomously.
+ • Benefit: Eliminates dependence on specific bootstrap nodes, enhancing network robustness.
+
+
+3. Client API
+
+
+3.1 Connection Model
+
+
+ • Stateless Connectivity:
+ • Clients acknowledge that persistent connections are impractical in a decentralized network unless designed to receive unsolicited messages.
+(i.e. the client.connect() does not make sense in our current situation.)
+ • Operational Behavior:
+ • Clients maintain a list of network addresses.
+ • For any action, they connect to the nearest node and discover nodes closest to the target address.
+ • Addresses collected during operations are stored in the bootstrap cache.
+
+
+3.2 Data Types Definition
+
+
+ • Centralized Documentation:
+ • All four data types must be clearly defined and documented within a single section of the API documentation.
+ • Developer Guidance:
+ • Provide detailed explanations, usage examples, and best practices for each data type.
+
+
+3.3 Store/Get Methods
+
+
+ • Data Type Restrictions:
+ • The API’s store/get methods are configured to accept only the four defined data types.
+ • Inputs of other data types are explicitly disallowed to maintain data integrity and consistency.
+
+
+4. Payment System Integration
+
+
+4.1 EVM and L2 Network Utilization
+
+
+ • Blockchain Integration:
+ • Leverage the Ethereum Virtual Machine (EVM) and Layer 2 (L2) networks for transaction processing.
+ • Runtime Configurability:
+ • Nodes and clients can modify payment-related settings at runtime.
+ • Configurable parameters include wallet details, chosen payment networks, and other relevant settings.
+
+
+4.2 Wallet Management
+
+
+ • Flexibility:
+ • Users can change wallets without restarting or recompiling the client or node software.
+ • Security:
+ • Ensure secure handling and storage of wallet credentials and transaction data.
+
+
+5. Additional Requirements
+
+
+ • Scalability: Design systems to handle network growth without performance degradation.
+ • Security: Implement robust encryption and authentication mechanisms across all components.
+ • Performance: Optimize data storage and retrieval processes for efficiency.
+ • Usability: Provide clear documentation and intuitive interfaces for developers and end-users.
+
+
+6. Documentation and Support
+
+
+ • Comprehensive Guides:
+ • Produce detailed documentation for all new features and changes.
+ • Include API references, tutorials, and FAQs.
+ • Community Engagement:
+ • Encourage community feedback and contributions.
+ • Provide support channels for troubleshooting and discussions.
+
+
+Conclusion
+
+
+Implementing these requirements will enhance the Autonomi Network’s functionality, security, and user experience. Focusing on decentralization, flexibility, and clear documentation will position the network as a robust platform for decentralized applications and services.

--- a/refactoring_steps.md
+++ b/refactoring_steps.md
@@ -1,0 +1,202 @@
+# Refactoring Steps for Autonomi Network
+
+## Phase 1: Client API Refactoring
+1. **Remove Connection Management from API**
+   - Remove `connect()` method from client API
+   - Move connection handling into individual operations
+   - Each operation should handle its own connection lifecycle
+   - Have a bootstrap mechanism that reads a bootstrrp_cache.json file or passed in via command line or ENV_VAR 
+   - Use the bootstrap cache to connect to the network
+   - During network requests collect peers connection info
+   - Every minute update the bootstrap cache (limit entries to last 1500 seen)
+   - on startup read the bootstrap cache file to get peers to connect to
+   - on shutdown write the bootstrap cache file
+   - all internal connect commands will use the nodes we have in ram 
+   - update wasm and python bindings to use all the above 
+   - test before going any further
+
+
+2. **Data Type Operations**
+   - **Chunks** (Mostly Complete)
+     - Existing: `chunk_get`, `chunk_upload_with_payment`
+     - Add: Better error handling for size limits
+     - Language Bindings:
+       - Python:
+         - Implement `chunk_get`, `chunk_upload_with_payment` methods
+         - Add size validation
+         - Add comprehensive tests
+         - Document API usage
+       - WASM:
+         - Implement `chunk_get`, `chuunk_upload_with_paymentput` methods
+         - Add JavaScript examples
+         - Add integration tests
+         - Document browser usage
+   
+   - **Registers** (Integration Needed)
+     - Existing in sn_registers:
+       - CRDT-based implementation
+       - `merge` operations
+       - User-managed conflict resolution
+     - To Add:
+       - Client API wrappers in autonomi
+       - Simplified append/merge interface
+       - Connection handling in operations
+     - Language Bindings:
+       - Python:
+         - Implement register CRUD operations
+         - Add conflict resolution examples
+         - Add unit and integration tests
+         - Document CRDT usage
+       - WASM:
+         - Implement register operations
+         - Add browser-based examples
+         - Add JavaScript tests
+         - Document concurrent usage
+   
+   - **Scratchpad (Vault)** (Enhancement Needed)
+     - Existing in sn_protocol:
+       - Basic scratchpad implementation
+       - `update_and_sign` functionality
+     - To Add:
+       - Client API wrappers in autonomi
+       - Simplified update/replace interface
+       - Connection handling in operations
+     - Language Bindings:
+       - Python:
+         - Implement vault operations
+         - Add encryption examples
+         - Add comprehensive tests
+         - Document security features
+       - WASM:
+         - Implement vault operations
+         - Add browser storage examples
+         - Add security tests
+         - Document encryption usage
+
+3. **Transaction System Refactoring** (Priority)
+   - Make transaction types generic in sn_transfers
+   - Update client API to support generic transactions
+   - Implement owner-based validation
+   - Add support for optional additional keys
+   - Implement transaction history verification
+
+## Phase 2: Payment System Integration
+1. **EVM Integration**
+   - Integrate existing EVM implementation
+   - Add runtime configuration support
+   - Connect with transaction system
+
+2. **Payment Processing**
+   - Integrate with data operations
+   - Add payment verification
+   - Implement tracking system
+
+## Phase 3: Testing and Documentation
+1. **Testing**
+   - Add unit tests for new API methods
+   - Integration tests for complete workflows
+   - Payment system integration tests
+
+2. **Documentation**
+   - Update API documentation
+   - Add usage examples
+   - Document error conditions
+   - Include best practices
+
+## Safe Network Health Management
+
+### Core Parameters
+
+#### Timing Intervals
+- Replication: 90-180 seconds (randomized)
+- Bad Node Detection: 300-600 seconds (randomized)
+- Uptime Metrics: 10 seconds
+- Record Cleanup: 3600 seconds (1 hour)
+- Chunk Proof Retry: 15 seconds between attempts
+
+#### Network Parameters
+- Close Group Size: Defined by CLOSE_GROUP_SIZE constant
+- Replication Target: REPLICATION_PEERS_COUNT closest nodes
+- Minimum Peers: 100 (for bad node detection)
+- Bad Node Consensus: Requires close_group_majority()
+- Max Chunk Proof Attempts: 3 before marking as bad node
+
+### Health Management Algorithms
+
+#### 1. Bad Node Detection
+```rust
+Process:
+1. Triggered every 300-600s when peers > 100
+2. Uses rolling index (0-511) to check different buckets
+3. For each bucket:
+   - Select subset of peers
+   - Query their closest nodes
+   - Mark as bad if majority report shunning
+4. Records NodeIssue::CloseNodesShunning
+```
+
+#### 2. Network Replication
+```rust
+Process:
+1. Triggered by:
+   - Every 90-180s interval
+   - New peer connection
+   - Peer removal
+   - Valid record storage
+2. Execution:
+   - Get closest K_VALUE peers
+   - Sort by XOR distance
+   - Verify local storage
+   - Replicate to REPLICATION_PEERS_COUNT nodes
+```
+
+#### 3. Routing Table Management
+```rust
+Components:
+1. K-bucket organization by XOR distance
+2. Peer tracking and metrics
+3. Connection state monitoring
+4. Regular table cleanup
+5. Dynamic peer replacement
+```
+
+### Protection Mechanisms
+
+#### 1. Data Integrity
+- Chunk proof verification
+- Record validation
+- Replication confirmation
+- Storage verification
+
+#### 2. Network Resilience
+- Distributed consensus for bad nodes
+- Rolling health checks
+- Randomized intervals
+- Subset checking for efficiency
+
+#### 3. Resource Optimization
+- Periodic cleanup of irrelevant records
+- Limited retry attempts
+- Targeted replication
+- Load distribution through rolling checks
+
+### Metrics Tracking
+- Peer counts and stability
+- Replication success rates
+- Network connectivity
+- Bad node detection events
+- Resource usage and cleanup
+
+### Key Improvements
+1. Reduced resource usage in bad node detection
+2. Optimized replication targeting
+3. Better load distribution
+4. Enhanced peer verification
+5. Efficient cleanup mechanisms
+
+This system creates a self-maintaining network capable of:
+- Identifying and removing problematic nodes
+- Maintaining data redundancy
+- Optimizing resource usage
+- Ensuring network stability
+- Providing reliable peer connections

--- a/repository_structure.md
+++ b/repository_structure.md
@@ -1,0 +1,265 @@
+# Safe Network Repository Structure and Capabilities
+
+## Core Components
+
+### Client Side
+1. **autonomi** - Main client implementation
+   - Primary interface for users to interact with the Safe Network
+   - Multiple language bindings support (Rust, Python, WASM)
+   - Features:
+     - Data operations (chunks, registers)
+     - Vault operations
+     - File system operations
+     - EVM integration
+   - Components:
+     - `src/client/` - Core client implementation
+     - `src/self_encryption.rs` - Data encryption handling
+     - `src/python.rs` - Python language bindings
+     - `src/utils.rs` - Utility functions
+   - Build Features:
+     - `data` - Basic data operations
+     - `vault` - Vault operations (includes data and registers)
+     - `registers` - Register operations
+     - `fs` - File system operations
+     - `local` - Local network testing
+     - `external-signer` - External transaction signing
+   - Testing:
+     - `tests/` - Rust integration tests
+     - `tests-js/` - JavaScript tests
+     - `examples/` - Usage examples
+
+2. **autonomi-cli** - Command-line interface
+   - CLI tool for network interaction
+   - Components:
+     - `src/commands/` - CLI command implementations
+     - `src/access/` - Network access management
+     - `src/actions/` - Core action implementations
+     - `src/wallet/` - Wallet management functionality
+     - `src/commands.rs` - Command routing
+     - `src/opt.rs` - Command-line options parsing
+     - `src/utils.rs` - Utility functions
+   - Features:
+     - Network access management
+     - Wallet operations
+     - Data operations (chunks, registers)
+     - Command-line parsing and routing
+
+### Network Node Components
+1. **sn_node** - Network Node Implementation
+   - Core Components:
+     - `src/node.rs` - Main node implementation
+     - `src/put_validation.rs` - Data validation logic
+     - `src/replication.rs` - Data replication handling
+     - `src/metrics.rs` - Performance monitoring
+     - `src/python.rs` - Python language bindings
+   - Features:
+     - Data validation and storage
+     - Network message handling
+     - Metrics collection
+     - Error handling
+     - Event processing
+   - Binary Components:
+     - `src/bin/` - Executable implementations
+
+2. **sn_protocol** - Core Protocol Implementation
+   - Components:
+     - `src/messages/` - Network message definitions
+     - `src/storage/` - Storage implementations
+     - `src/safenode_proto/` - Protocol definitions
+     - `src/node_rpc.rs` - RPC interface definitions
+   - Features:
+     - Message protocol definitions
+     - Storage protocol
+     - Node communication protocols
+     - Version management
+
+3. **sn_transfers** - Transfer System
+   - Components:
+     - `src/cashnotes/` - Digital cash implementation
+     - `src/transfers/` - Transfer logic
+     - `src/wallet/` - Wallet implementation
+     - `src/genesis.rs` - Genesis block handling
+   - Features:
+     - Digital cash management
+     - Transfer operations
+     - Wallet operations
+     - Genesis configuration
+     - Error handling
+
+### Data Types and Protocol
+1. **sn_registers** - Register implementation
+   - CRDT-based data structures
+   - Conflict resolution mechanisms
+   - Concurrent operations handling
+
+### Network Management and Communication
+1. **sn_networking** - Network Communication Layer
+   - Core Components:
+     - `src/cmd.rs` - Network command handling
+     - `src/driver.rs` - Network driver implementation
+     - `src/record_store.rs` - Data record management
+     - `src/bootstrap.rs` - Network bootstrap process
+     - `src/transport/` - Transport layer implementations
+   - Features:
+     - Network discovery and bootstrapping
+     - External address handling
+     - Relay management
+     - Replication fetching
+     - Record store management
+     - Transfer handling
+     - Metrics collection
+   - Event System:
+     - `src/event/` - Event handling implementation
+     - Network event processing
+     - Event-driven architecture
+
+2. **sn_node_manager** - Node Management System
+   - Core Components:
+     - `src/cmd/` - Management commands
+     - `src/add_services/` - Service management
+     - `src/config.rs` - Configuration handling
+     - `src/rpc.rs` - RPC interface
+   - Features:
+     - Node deployment and configuration
+     - Service management
+     - Local node handling
+     - RPC client implementation
+     - Error handling
+   - Management Tools:
+     - Binary implementations
+     - Helper utilities
+     - Configuration management
+
+### Networking and Communication
+1. **sn_networking** - Network communication
+   - P2P networking implementation
+   - Connection management
+   - Message routing
+
+2. **sn_peers_acquisition** - Peer discovery
+   - Bootstrap mechanisms
+   - Peer management
+   - Network topology
+
+### Infrastructure Components
+1. **node-launchpad** - Node Deployment System
+   - Core Components:
+     - `src/app.rs` - Main application logic
+     - `src/components/` - UI components
+     - `src/node_mgmt.rs` - Node management
+     - `src/node_stats.rs` - Statistics tracking
+     - `src/config.rs` - Configuration handling
+   - Features:
+     - Node deployment and management
+     - System monitoring
+     - Configuration management
+     - Terminal UI interface
+     - Connection mode handling
+   - UI Components:
+     - Custom widgets
+     - Styling system
+     - Terminal UI implementation
+
+2. **nat-detection** - Network Detection System
+   - Core Components:
+     - `src/behaviour/` - NAT behavior implementations
+     - `src/main.rs` - Main detection logic
+   - Features:
+     - NAT type detection
+     - Network connectivity testing
+     - Behavior analysis
+     - Connection management
+
+### Payment and EVM Integration
+1. **sn_evm** - EVM Integration System
+   - Core Components:
+     - `src/data_payments.rs` - Payment handling for data operations
+     - `src/amount.rs` - Amount calculations and management
+   - Features:
+     - Data payment processing
+     - Amount handling
+     - Error management
+     - Integration with EVM
+
+2. **evmlib** - EVM Library
+   - Core Components:
+     - `src/contract/` - Smart contract handling
+     - `src/wallet.rs` - Wallet implementation
+     - `src/transaction.rs` - Transaction processing
+     - `src/cryptography.rs` - Cryptographic operations
+   - Features:
+     - Smart contract management
+     - Wallet operations
+     - Transaction handling
+     - External signer support
+     - Test network support
+     - Event handling
+     - Utility functions
+
+3. **evm_testnet** - EVM Test Environment
+   - Features:
+     - Test network setup
+     - Development environment
+     - Testing utilities
+
+### Utilities and Support
+1. **sn_logging** - Logging System
+   - Core Components:
+     - `src/appender.rs` - Log appender implementation
+     - `src/layers.rs` - Logging layers
+     - `src/metrics.rs` - Metrics integration
+   - Features:
+     - Structured logging
+     - Custom appenders
+     - Metrics integration
+     - Error handling
+
+2. **sn_metrics** - Metrics System
+   - Features:
+     - Performance monitoring
+     - System metrics collection
+     - Metrics reporting
+
+3. **sn_build_info** - Build Information
+   - Features:
+     - Version management
+     - Build configuration
+     - Build information tracking
+
+4. **test_utils** - Testing Utilities
+   - Components:
+     - `src/evm.rs` - EVM testing utilities
+     - `src/testnet.rs` - Test network utilities
+   - Features:
+     - EVM test helpers
+     - Test network setup
+     - Common test functions
+
+5. **sn_auditor** - Network Auditing
+   - Features:
+     - Network health monitoring
+     - Security auditing
+     - Performance tracking
+
+## Development Tools
+- **adr** - Architecture Decision Records
+- **resources** - Additional resources and documentation
+- **token_supplies** - Token management utilities
+
+## Documentation
+- **CHANGELOG.md** - Version history
+- **CONTRIBUTING.md** - Contribution guidelines
+- **README.md** - Project overview
+- **prd.md** - Product Requirements Document
+
+## Build and Configuration
+- **Cargo.toml** - Main project configuration
+- **Justfile** - Task automation
+- **release-plz.toml** - Release configuration
+- **reviewpad.yml** - Code review configuration
+
+## Next Steps
+1. Review and validate this structure
+2. Identify any missing components or capabilities
+3. Begin implementation of refactoring steps as outlined in refactoring_steps.md
+4. Focus on client API refactoring as the first priority

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.5.7"
 
 [features]
+default = ["network-contacts"]
 local = []
 network-contacts = ["sn_protocol"]
 websockets = []


### PR DESCRIPTION
# Bootstrap Cache Implementation

## Summary
This PR introduces a bootstrap cache mechanism to improve network bootstrapping efficiency. The cache persists information about previously known peers, enabling faster network rejoining and reducing cold-start latency.

## Motivation
When nodes join the network, they need to discover and connect to existing peers. Without a persistent cache, nodes must rediscover the network from scratch each time they restart, which is inefficient and time-consuming. This implementation addresses that limitation.

## Technical Details
- Implements a persistent cache storing known peer information
- Cache is maintained in the [bootstrap_cache](cci:7://file:///Users/davidirvine/Desktop/safe_network/bootstrap_cache:0:0-0:0) directory
- Entries include peer IDs and their last known addresses
- Cache is automatically updated as peers are discovered
- Stale entries are pruned periodically

## Impact
- Faster network rejoining for nodes
- Reduced network bootstrap time
- More resilient peer discovery process
- Lower network overhead during node startup

## Testing
The implementation includes:
- Unit tests for cache operations
- Integration tests for peer discovery
- Persistence verification tests

## Future Considerations
- Cache entry expiration policy could be tuned based on network metrics
- Additional peer metadata could be stored for better peer selection
