### PR TITLE
Node side RBS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
  "hex 0.4.3",
  "instant",
  "js-sys",
- "libp2p 0.54.1",
+ "libp2p",
  "pyo3",
  "rand 0.8.5",
  "rmp-serde",
@@ -4783,57 +4783,30 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libp2p"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681fb3f183edfbedd7a57d32ebe5dcdc0b9f94061185acf3c30249349cc6fc99"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "instant",
- "libp2p-allow-block-list 0.3.0",
- "libp2p-connection-limits 0.3.1",
- "libp2p-core 0.41.3",
- "libp2p-identify 0.44.2",
- "libp2p-identity",
- "libp2p-kad 0.45.3",
- "libp2p-metrics 0.14.1",
- "libp2p-swarm 0.44.2",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "bytes",
  "either",
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
- "libp2p-allow-block-list 0.4.0",
+ "libp2p-allow-block-list",
  "libp2p-autonat",
- "libp2p-connection-limits 0.4.0",
- "libp2p-core 0.42.0",
+ "libp2p-connection-limits",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify 0.45.0",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.46.2",
+ "libp2p-kad",
  "libp2p-mdns",
- "libp2p-metrics 0.15.0",
+ "libp2p-metrics",
  "libp2p-noise",
  "libp2p-quic",
  "libp2p-relay",
  "libp2p-request-response",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-websocket",
@@ -4847,33 +4820,19 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
-dependencies = [
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "libp2p-swarm 0.44.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
 ]
 
 [[package]]
 name = "libp2p-autonat"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4882,10 +4841,10 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-request-response",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -4898,61 +4857,19 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
-dependencies = [
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "libp2p-swarm 0.44.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.41.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink",
- "smallvec",
- "thiserror",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-core"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "either",
  "fnv",
@@ -4979,13 +4896,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -4995,8 +4911,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "asynchronous-codec",
  "base64 0.22.1",
@@ -5008,9 +4923,9 @@ dependencies = [
  "futures-ticker",
  "getrandom 0.2.15",
  "hex_fmt",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -5025,41 +4940,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d635ebea5ca0c3c3e77d414ae9b67eccf2a822be06091b9c1a0d13029a1e2f"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "libp2p-swarm 0.44.2",
- "lru",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-identify"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -5089,38 +4980,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.45.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc5767727d062c4eac74dd812c998f0e488008e82cce9c33b463d38423f9ad2"
-dependencies = [
- "arrayvec",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "instant",
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "libp2p-swarm 0.44.2",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "sha2 0.10.8",
- "smallvec",
- "thiserror",
- "tracing",
- "uint",
- "void",
-]
-
-[[package]]
-name = "libp2p-kad"
 version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -5130,9 +4991,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -5148,16 +5009,15 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "data-encoding",
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "socket2",
@@ -5168,34 +5028,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdac91ae4f291046a3b2660c039a2830c931f84df2ee227989af92f7692d3357"
-dependencies = [
- "futures",
- "instant",
- "libp2p-core 0.41.3",
- "libp2p-identify 0.44.2",
- "libp2p-identity",
- "libp2p-kad 0.45.3",
- "libp2p-swarm 0.44.2",
- "pin-project",
- "prometheus-client",
-]
-
-[[package]]
-name = "libp2p-metrics"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "futures",
- "libp2p-core 0.42.0",
- "libp2p-identify 0.45.0",
+ "libp2p-core",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.46.2",
+ "libp2p-kad",
  "libp2p-relay",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -5204,14 +5046,13 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "curve25519-dalek 4.1.3",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -5230,14 +5071,13 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
  "parking_lot",
@@ -5254,8 +5094,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10df23d7f5b5adcc129f4a69d6fbd05209e356ccf9e8f4eb10b2692b79c77247"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5263,9 +5102,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -5279,17 +5118,16 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "rand 0.8.5",
  "serde",
  "smallvec",
@@ -5300,38 +5138,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "lru",
- "multistream-select",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-swarm"
 version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
  "lru",
@@ -5349,8 +5164,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5361,14 +5175,13 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "socket2",
  "tokio",
@@ -5378,12 +5191,11 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring 0.17.8",
@@ -5397,14 +5209,13 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.42.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
  "void",
@@ -5413,13 +5224,12 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888b2ff2e5d8dcef97283daab35ad1043d18952b65e05279eecbe02af4c6e347"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "pin-project-lite",
@@ -5434,13 +5244,12 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf9b429dd07be52cd82c4c484b1694df4209210a7db3b9ffb00c7606e230c8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "bytes",
  "futures",
  "js-sys",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "parking_lot",
  "send_wrapper 0.6.0",
  "thiserror",
@@ -5452,12 +5261,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "thiserror",
  "tracing",
  "yamux 0.12.1",
@@ -5772,15 +5580,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -5791,7 +5598,7 @@ dependencies = [
  "clap-verbosity-flag",
  "color-eyre",
  "futures",
- "libp2p 0.54.1",
+ "libp2p",
  "sn_build_info",
  "sn_networking",
  "sn_protocol",
@@ -7108,8 +6915,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -7984,8 +7790,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=kad_0.46.2#15f0535f87256ff141963006af129cc2c839b472"
 dependencies = [
  "futures",
  "pin-project",
@@ -8496,7 +8301,7 @@ dependencies = [
  "colored",
  "dirs-next",
  "indicatif",
- "libp2p 0.54.1",
+ "libp2p",
  "libp2p-identity",
  "mockall 0.12.1",
  "nix 0.27.1",
@@ -8608,7 +8413,7 @@ dependencies = [
  "evmlib",
  "hex 0.4.3",
  "lazy_static",
- "libp2p 0.53.2",
+ "libp2p",
  "rand 0.8.5",
  "ring 0.17.8",
  "rmp-serde",
@@ -8681,7 +8486,7 @@ dependencies = [
  "hyper 0.14.30",
  "itertools 0.12.1",
  "lazy_static",
- "libp2p 0.54.1",
+ "libp2p",
  "libp2p-identity",
  "prometheus-client",
  "quickcheck",
@@ -8732,7 +8537,7 @@ dependencies = [
  "futures",
  "hex 0.4.3",
  "itertools 0.12.1",
- "libp2p 0.54.1",
+ "libp2p",
  "num-traits",
  "prometheus-client",
  "prost 0.9.0",
@@ -8778,7 +8583,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "hex 0.4.3",
- "libp2p 0.54.1",
+ "libp2p",
  "libp2p-identity",
  "sn_build_info",
  "sn_logging",
@@ -8801,7 +8606,7 @@ version = "0.5.7"
 dependencies = [
  "clap",
  "lazy_static",
- "libp2p 0.54.1",
+ "libp2p",
  "rand 0.8.5",
  "reqwest 0.12.7",
  "sn_protocol",
@@ -8824,7 +8629,7 @@ dependencies = [
  "exponential-backoff",
  "hex 0.4.3",
  "lazy_static",
- "libp2p 0.54.1",
+ "libp2p",
  "prost 0.9.0",
  "rmp-serde",
  "serde",
@@ -8865,7 +8670,7 @@ version = "0.4.3"
 dependencies = [
  "async-trait",
  "dirs-next",
- "libp2p 0.54.1",
+ "libp2p",
  "libp2p-identity",
  "mockall 0.11.4",
  "prost 0.9.0",
@@ -8899,7 +8704,7 @@ dependencies = [
  "fs2",
  "hex 0.4.3",
  "lazy_static",
- "libp2p 0.54.1",
+ "libp2p",
  "pprof",
  "rand 0.8.5",
  "rayon",
@@ -9243,7 +9048,7 @@ dependencies = [
  "color-eyre",
  "dirs-next",
  "evmlib",
- "libp2p 0.54.1",
+ "libp2p",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -36,7 +36,7 @@ curv = { version = "0.10.1", package = "sn_curv", default-features = false, feat
 eip2333 = { version = "0.2.1", package = "sn_bls_ckd" }
 const-hex = "1.12.0"
 hex = "~0.4.3"
-libp2p = "0.54.1"
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2" }
 rand = "0.8.5"
 rmp-serde = "1.1.1"
 self_encryption = "~0.30.0"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }
 futures = "~0.3.13"
-libp2p = { version = "0.54.1", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = [
     "tokio",
     "tcp",
     "noise",

--- a/sn_evm/Cargo.toml
+++ b/sn_evm/Cargo.toml
@@ -20,7 +20,7 @@ custom_debug = "~0.6.1"
 evmlib = { path = "../evmlib", version = "0.1.4" }
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
-libp2p = { version = "0.53", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = ["derive", "rc"] }

--- a/sn_networking/Cargo.toml
+++ b/sn_networking/Cargo.toml
@@ -22,7 +22,7 @@ loud = []
 
 [dependencies]
 lazy_static = "~1.4.0"
-libp2p = { version = "0.54.1", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = [
     "tokio",
     "dns",
     "kad",
@@ -98,7 +98,7 @@ crate-type = ["cdylib", "rlib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
-libp2p = { version = "0.54.1", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = [
     "tokio",
     "dns",
     "kad",

--- a/sn_networking/src/cmd.rs
+++ b/sn_networking/src/cmd.rs
@@ -17,7 +17,7 @@ use crate::{
 use libp2p::{
     kad::{
         store::{Error as StoreError, RecordStore},
-        Quorum, Record, RecordKey,
+        KBucketDistance as Distance, Quorum, Record, RecordKey,
     },
     Multiaddr, PeerId,
 };
@@ -136,6 +136,10 @@ pub enum LocalSwarmCmd {
     TriggerIntervalReplication,
     /// Triggers unrelevant record cleanup
     TriggerIrrelevantRecordCleanup,
+    /// Add a network density sample
+    AddNetworkDensitySample {
+        distance: Distance,
+    },
 }
 
 /// Commands to send to the Swarm
@@ -286,6 +290,9 @@ impl Debug for LocalSwarmCmd {
             }
             LocalSwarmCmd::TriggerIrrelevantRecordCleanup => {
                 write!(f, "LocalSwarmCmd::TriggerUnrelevantRecordCleanup")
+            }
+            LocalSwarmCmd::AddNetworkDensitySample { distance } => {
+                write!(f, "LocalSwarmCmd::AddNetworkDensitySample({distance:?})")
             }
         }
     }
@@ -867,6 +874,10 @@ impl SwarmDriver {
                     .kademlia
                     .store_mut()
                     .cleanup_irrelevant_records();
+            }
+            LocalSwarmCmd::AddNetworkDensitySample { distance } => {
+                cmd_string = "AddNetworkDensitySample";
+                self.network_density_samples.add(distance);
             }
         }
 

--- a/sn_networking/src/driver.rs
+++ b/sn_networking/src/driver.rs
@@ -13,6 +13,7 @@ use crate::{
     error::{NetworkError, Result},
     event::{NetworkEvent, NodeEvent},
     external_address::ExternalAddressManager,
+    fifo_register::FifoRegister,
     log_markers::Marker,
     multiaddr_pop_p2p,
     network_discovery::NetworkDiscovery,
@@ -736,6 +737,7 @@ impl NetworkBuilder {
             replication_targets: Default::default(),
             last_replication: None,
             last_connection_pruning_time: Instant::now(),
+            network_density_samples: FifoRegister::new(100),
         };
 
         let network = Network::new(
@@ -841,6 +843,8 @@ pub struct SwarmDriver {
     pub(crate) last_replication: Option<Instant>,
     /// when was the last outdated connection prunning undertaken.
     pub(crate) last_connection_pruning_time: Instant,
+    /// FIFO cache for the network density samples
+    pub(crate) network_density_samples: FifoRegister,
 }
 
 impl SwarmDriver {
@@ -925,7 +929,13 @@ impl SwarmDriver {
                         let closest_k_peers = self.get_closest_k_value_local_peers();
 
                         if let Some(distance) = self.get_responsbile_range_estimate(&closest_k_peers) {
-                            info!("Set responsible range to {distance}");
+                            let network_density = self.network_density_samples.get_median();
+                            let ilog2 = if let Some(distance) = network_density {
+                                distance.ilog2()
+                            } else {
+                                None
+                            };
+                            info!("Set responsible range to {distance}, current sampled network density is {ilog2:?}({network_density:?})");
                             // set any new distance to farthest record in the store
                             self.swarm.behaviour_mut().kademlia.store_mut().set_distance_range(distance);
                             // the distance range within the replication_fetcher shall be in sync as well

--- a/sn_networking/src/event/swarm.rs
+++ b/sn_networking/src/event/swarm.rs
@@ -612,7 +612,7 @@ impl SwarmDriver {
     // Optionally force remove all the connections for a provided peer.
     fn remove_outdated_connections(&mut self) {
         // To avoid this being called too frequenctly, only carry out prunning intervally.
-        if Instant::now() > self.last_connection_pruning_time + Duration::from_secs(30) {
+        if Instant::now() < self.last_connection_pruning_time + Duration::from_secs(30) {
             return;
         }
         self.last_connection_pruning_time = Instant::now();

--- a/sn_networking/src/fifo_register.rs
+++ b/sn_networking/src/fifo_register.rs
@@ -12,8 +12,9 @@ use std::collections::VecDeque;
 pub(crate) struct FifoRegister {
     queue: VecDeque<Distance>,
     max_length: usize,
+    #[allow(dead_code)]
     cached_median: Option<Distance>, // Cache for the median result
-    is_dirty: bool,                  // Flag indicating if cache is valid
+    is_dirty: bool, // Flag indicating if cache is valid
 }
 
 impl FifoRegister {
@@ -39,6 +40,7 @@ impl FifoRegister {
     }
 
     // Returns the median of the maximum values of the entries
+    #[allow(dead_code)]
     pub(crate) fn get_median(&mut self) -> Option<Distance> {
         if self.queue.is_empty() {
             return None; // No median if the queue is empty

--- a/sn_networking/src/fifo_register.rs
+++ b/sn_networking/src/fifo_register.rs
@@ -1,0 +1,62 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use libp2p::kad::KBucketDistance as Distance;
+use std::collections::VecDeque;
+
+pub(crate) struct FifoRegister {
+    queue: VecDeque<Distance>,
+    max_length: usize,
+    cached_median: Option<Distance>, // Cache for the median result
+    is_dirty: bool,                  // Flag indicating if cache is valid
+}
+
+impl FifoRegister {
+    // Creates a new FifoRegister with a specified maximum length
+    pub(crate) fn new(max_length: usize) -> Self {
+        FifoRegister {
+            queue: VecDeque::with_capacity(max_length),
+            max_length,
+            cached_median: None,
+            is_dirty: true,
+        }
+    }
+
+    // Adds an entry to the register, removing excess elements if over max_length
+    pub(crate) fn add(&mut self, entry: Distance) {
+        if self.queue.len() == self.max_length {
+            self.queue.pop_front(); // Remove the oldest element to maintain length
+        }
+        self.queue.push_back(entry);
+
+        // Mark the cache as invalid since the data has changed
+        self.is_dirty = true;
+    }
+
+    // Returns the median of the maximum values of the entries
+    pub(crate) fn get_median(&mut self) -> Option<Distance> {
+        if self.queue.is_empty() {
+            return None; // No median if the queue is empty
+        }
+
+        if !self.is_dirty {
+            return self.cached_median; // Return cached result if it's valid
+        }
+
+        let mut max_values: Vec<Distance> = self.queue.iter().copied().collect();
+
+        max_values.sort_unstable();
+
+        let len = max_values.len();
+        // Cache the result and mark the cache as valid
+        self.cached_median = Some(max_values[len / 2]);
+        self.is_dirty = false;
+
+        self.cached_median
+    }
+}

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -16,6 +16,7 @@ mod driver;
 mod error;
 mod event;
 mod external_address;
+mod fifo_register;
 mod log_markers;
 #[cfg(feature = "open-metrics")]
 mod metrics;
@@ -1026,6 +1027,10 @@ impl Network {
 
     pub fn trigger_irrelevant_record_cleanup(&self) {
         self.send_local_swarm_cmd(LocalSwarmCmd::TriggerIrrelevantRecordCleanup)
+    }
+
+    pub fn add_network_density_sample(&self, distance: KBucketDistance) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::AddNetworkDensitySample { distance })
     }
 
     /// Helper to send NetworkSwarmCmd

--- a/sn_networking/src/lib.rs
+++ b/sn_networking/src/lib.rs
@@ -87,10 +87,6 @@ use {
 /// The type of quote for a selected payee.
 pub type PayeeQuote = (PeerId, RewardsAddress, PaymentQuote);
 
-/// The count of peers that will be considered as close to a record target,
-/// that a replication of the record shall be sent/accepted to/by the peer.
-pub const REPLICATION_PEERS_COUNT: usize = CLOSE_GROUP_SIZE + 2;
-
 /// Majority of a given group (i.e. > 1/2).
 #[inline]
 pub const fn close_group_majority() -> usize {
@@ -263,6 +259,16 @@ impl Network {
     pub async fn get_closest_k_value_local_peers(&self) -> Result<Vec<PeerId>> {
         let (sender, receiver) = oneshot::channel();
         self.send_local_swarm_cmd(LocalSwarmCmd::GetClosestKLocalPeers { sender });
+
+        receiver
+            .await
+            .map_err(|_e| NetworkError::InternalMsgChannelDropped)
+    }
+
+    /// Returns the replicate candidates in range.
+    pub async fn get_replicate_candidates(&self, data_addr: NetworkAddress) -> Result<Vec<PeerId>> {
+        let (sender, receiver) = oneshot::channel();
+        self.send_local_swarm_cmd(LocalSwarmCmd::GetReplicateCandidates { data_addr, sender });
 
         receiver
             .await

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -130,7 +130,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn get_farthest_replication_distance_bucket(&self) -> Option<Distance> {
+    pub(crate) fn get_farthest_replication_distance(&self) -> Option<Distance> {
         match self {
             Self::Client(_store) => {
                 warn!("Calling get_distance_range at Client. This should not happen");

--- a/sn_networking/src/record_store_api.rs
+++ b/sn_networking/src/record_store_api.rs
@@ -10,7 +10,7 @@
 use crate::record_store::{ClientRecordStore, NodeRecordStore};
 use libp2p::kad::{
     store::{RecordStore, Result},
-    ProviderRecord, Record, RecordKey,
+    KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
 };
 use sn_evm::{AttoTokens, QuotingMetrics};
 use sn_protocol::{storage::RecordType, NetworkAddress};
@@ -130,7 +130,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn get_farthest_replication_distance_bucket(&self) -> Option<u32> {
+    pub(crate) fn get_farthest_replication_distance_bucket(&self) -> Option<Distance> {
         match self {
             Self::Client(_store) => {
                 warn!("Calling get_distance_range at Client. This should not happen");
@@ -140,7 +140,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn set_distance_range(&mut self, distance: u32) {
+    pub(crate) fn set_distance_range(&mut self, distance: Distance) {
         match self {
             Self::Client(_store) => {
                 warn!("Calling set_distance_range at Client. This should not happen");

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -42,7 +42,7 @@ file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
 itertools = "~0.12.1"
-libp2p = { version = "0.54.1", features = ["tokio", "dns", "kad", "macros"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["tokio", "dns", "kad", "macros"] }
 num-traits = "0.2"
 prometheus-client = { version = "0.22", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -71,6 +71,10 @@ const MIN_ACCEPTABLE_HEALTHY_SCORE: usize = 5000;
 /// in ms, expecting average StorageChallenge complete time to be around 250ms.
 const TIME_STEP: usize = 20;
 
+/// Interval to carryout network density sampling
+/// This is the max time it should take. Minimum interval at any node will be half this
+const NETWORK_DENSITY_SAMPLING_INTERVAL_MAX_S: u64 = 180;
+
 /// Helper to build and run a Node
 pub struct NodeBuilder {
     identity_keypair: Keypair,
@@ -272,7 +276,7 @@ impl Node {
             let _ = irrelevant_records_cleanup_interval.tick().await; // first tick completes immediately
 
             // use a random neighbour storage challenge ticker to ensure
-            // neighbour do not carryout challenges at the same time
+            // neighbours do not carryout challenges at the same time
             let storage_challenge_interval: u64 =
                 rng.gen_range(STORE_CHALLENGE_INTERVAL_MAX_S / 2..STORE_CHALLENGE_INTERVAL_MAX_S);
             let storage_challenge_interval_time = Duration::from_secs(storage_challenge_interval);
@@ -281,6 +285,22 @@ impl Node {
             let mut storage_challenge_interval =
                 tokio::time::interval(storage_challenge_interval_time);
             let _ = storage_challenge_interval.tick().await; // first tick completes immediately
+
+            // use a random network density sampling ticker to ensure
+            // neighbours do not carryout sampling at the same time
+            let network_density_sampling_interval: u64 = rng.gen_range(
+                NETWORK_DENSITY_SAMPLING_INTERVAL_MAX_S / 2
+                    ..NETWORK_DENSITY_SAMPLING_INTERVAL_MAX_S,
+            );
+            let network_density_sampling_interval_time =
+                Duration::from_secs(network_density_sampling_interval);
+            debug!(
+                "Network density sampling interval set to {network_density_sampling_interval:?}"
+            );
+
+            let mut network_density_sampling_interval =
+                tokio::time::interval(network_density_sampling_interval_time);
+            let _ = network_density_sampling_interval.tick().await; // first tick completes immediately
 
             loop {
                 let peers_connected = &peers_connected;
@@ -337,6 +357,16 @@ impl Node {
                         let _handle = spawn(async move {
                             Self::storage_challenge(network).await;
                             trace!("Periodic storage challenge took {:?}", start.elapsed());
+                        });
+                    }
+                    _ = network_density_sampling_interval.tick() => {
+                        let start = Instant::now();
+                        debug!("Periodic network density sampling triggered");
+                        let network = self.network().clone();
+
+                        let _handle = spawn(async move {
+                            Self::network_density_sampling(network).await;
+                            trace!("Periodic network density sampling took {:?}", start.elapsed());
                         });
                     }
                 }
@@ -818,6 +848,22 @@ impl Node {
             "Completed node StorageChallenge against neighbours in {:?}!",
             start.elapsed()
         );
+    }
+
+    async fn network_density_sampling(network: Network) {
+        for _ in 0..10 {
+            let target = NetworkAddress::from_peer(PeerId::random());
+            // Result is sorted and only return CLOSE_GROUP_SIZE entries
+            let peers = network.node_get_closest_peers(&target).await;
+            if let Ok(peers) = peers {
+                if peers.len() >= CLOSE_GROUP_SIZE {
+                    // Calculate the distance to the farthest.
+                    let distance =
+                        target.distance(&NetworkAddress::from_peer(peers[CLOSE_GROUP_SIZE - 1]));
+                    network.add_network_density_sample(distance);
+                }
+            }
+        }
     }
 }
 

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -360,14 +360,18 @@ impl Node {
                         });
                     }
                     _ = network_density_sampling_interval.tick() => {
-                        let start = Instant::now();
-                        debug!("Periodic network density sampling triggered");
-                        let network = self.network().clone();
+                        // The following shall be used by client only to support RBS.
+                        // Due to the concern of the extra resource usage that incurred.
+                        continue;
 
-                        let _handle = spawn(async move {
-                            Self::network_density_sampling(network).await;
-                            trace!("Periodic network density sampling took {:?}", start.elapsed());
-                        });
+                        // let start = Instant::now();
+                        // debug!("Periodic network density sampling triggered");
+                        // let network = self.network().clone();
+
+                        // let _handle = spawn(async move {
+                        //     Self::network_density_sampling(network).await;
+                        //     trace!("Periodic network density sampling took {:?}", start.elapsed());
+                        // });
                     }
                 }
             }
@@ -850,6 +854,7 @@ impl Node {
         );
     }
 
+    #[allow(dead_code)]
     async fn network_density_sampling(network: Network) {
         for _ in 0..10 {
             let target = NetworkAddress::from_peer(PeerId::random());

--- a/sn_node/src/node.rs
+++ b/sn_node/src/node.rs
@@ -73,7 +73,7 @@ const TIME_STEP: usize = 20;
 
 /// Interval to carryout network density sampling
 /// This is the max time it should take. Minimum interval at any node will be half this
-const NETWORK_DENSITY_SAMPLING_INTERVAL_MAX_S: u64 = 180;
+const NETWORK_DENSITY_SAMPLING_INTERVAL_MAX_S: u64 = 200;
 
 /// Helper to build and run a Node
 pub struct NodeBuilder {
@@ -863,6 +863,8 @@ impl Node {
                     network.add_network_density_sample(distance);
                 }
             }
+            // Sleep a short while to avoid causing a spike on resource usage.
+            std::thread::sleep(std::time::Duration::from_secs(10));
         }
     }
 }

--- a/sn_node_manager/Cargo.toml
+++ b/sn_node_manager/Cargo.toml
@@ -38,7 +38,7 @@ colored = "2.0.4"
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
 indicatif = { version = "0.17.5", features = ["tokio"] }
-libp2p = { version = "0.54.1", features = [] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 rand = "0.8.5"

--- a/sn_node_rpc_client/Cargo.toml
+++ b/sn_node_rpc_client/Cargo.toml
@@ -23,7 +23,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.2"
 hex = "~0.4.3"
-libp2p = { version = "0.54.1", features = ["kad"]}
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 sn_build_info = { path = "../sn_build_info", version = "0.1.19" }
 sn_logging = { path = "../sn_logging", version = "0.2.40" }

--- a/sn_peers_acquisition/Cargo.toml
+++ b/sn_peers_acquisition/Cargo.toml
@@ -18,7 +18,7 @@ websockets = []
 [dependencies]
 clap = { version = "4.2.1", features = ["derive", "env"] }
 lazy_static = "~1.4.0"
-libp2p = { version = "0.54.1", features = [] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = [] }
 rand = "0.8.5"
 reqwest = { version="0.12.2", default-features=false, features = ["rustls-tls"] }
 sn_protocol = { path = "../sn_protocol", version = "0.17.15", optional = true}

--- a/sn_protocol/Cargo.toml
+++ b/sn_protocol/Cargo.toml
@@ -23,7 +23,7 @@ custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
 lazy_static = "1.4.0"
-libp2p = { version = "0.54.1", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["identify", "kad"] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.133", features = [ "derive", "rc" ]}
 serde_json = "1.0"

--- a/sn_service_management/Cargo.toml
+++ b/sn_service_management/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.4.3"
 [dependencies]
 async-trait = "0.1"
 dirs-next = "2.0.0"
-libp2p = { version = "0.54.1", features = ["kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["kad"] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/sn_transfers/Cargo.toml
+++ b/sn_transfers/Cargo.toml
@@ -21,7 +21,7 @@ custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
-libp2p = { version = "0.54.1", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 secrecy = "0.8.0"

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -17,7 +17,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.2"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.1.4" }
-libp2p = { version = "0.54.1", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "kad_0.46.2", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Description

The network density can be calculated via sampling or equation approach.
For the performance consideration, the equation calculated network_density will be used by node for:
  * define responsible range
  * define replicate candidates
Meanwhile, the sampling calculated network_density can be used by client for:
  * define the range of candidates to quoting with and upload record to

This PR is mainly the node-side RBS support, which paves the way for RBS deployment entirely (which client to be involved as well) without requiring breaking change to the live network in furture.

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
