### PR TITLE
chore: update more `ant_releases` references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
@@ -1062,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "ant-releases"
 version = "0.3.1"
-source = "git+https://github.com/jacderida/ant-releases.git?branch=chore-rename_binaries#9747746fbef12b63c49cdb9dbb08ecd42b18794b"
+source = "git+https://github.com/jacderida/ant-releases.git?branch=chore-rename_binaries#464f306a4b609fa57cbb7533fd6fdb21dd0f81a6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8802,9 +8802,9 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/ant-node-manager/src/cmd/daemon.rs
+++ b/ant-node-manager/src/cmd/daemon.rs
@@ -12,7 +12,7 @@ use crate::{
     helpers::{download_and_extract_release, get_bin_version},
     print_banner, ServiceManager, VerbosityLevel,
 };
-use ant_releases::{ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
 use ant_service_management::{
     control::{ServiceControl, ServiceController},
     DaemonService, NodeRegistry,
@@ -44,7 +44,7 @@ pub async fn add(
     service_manager.create_service_user(service_user)?;
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
     let (daemon_src_bin_path, version) = if let Some(path) = src_path {
         let version = get_bin_version(&path)?;

--- a/ant-node-manager/src/cmd/local.rs
+++ b/ant-node-manager/src/cmd/local.rs
@@ -17,7 +17,7 @@ use crate::{
 use ant_evm::{EvmNetwork, RewardsAddress};
 use ant_logging::LogFormat;
 use ant_peers_acquisition::PeersArgs;
-use ant_releases::{ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
 use ant_service_management::{
     control::ServiceController, get_local_node_registry_path, NodeRegistry,
 };
@@ -58,7 +58,7 @@ pub async fn join(
     let local_node_reg_path = &get_local_node_registry_path()?;
     let mut local_node_registry = NodeRegistry::load(local_node_reg_path)?;
 
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
     let antnode_bin_path = get_bin_path(
         build,
@@ -183,7 +183,7 @@ pub async fn run(
     }
     info!("Launching local network");
 
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
     let antnode_bin_path = get_bin_path(
         build,

--- a/ant-node-manager/src/cmd/mod.rs
+++ b/ant-node-manager/src/cmd/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     helpers::{download_and_extract_release, get_bin_version},
     print_banner, VerbosityLevel,
 };
-use ant_releases::{ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
 use ant_service_management::UpgradeResult;
 use color_eyre::{eyre::eyre, Result};
 use colored::Colorize;
@@ -47,7 +47,7 @@ pub async fn download_and_get_upgrade_bin_path(
         return Ok((path, bin_version.parse()?));
     }
 
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
     if let Some(version) = version {
         debug!("Downloading provided version {version} of {release_type}");
         let (upgrade_bin_path, version) = download_and_extract_release(
@@ -136,7 +136,7 @@ pub async fn get_bin_path(
     path: Option<PathBuf>,
     release_type: ReleaseType,
     version: Option<String>,
-    release_repo: &dyn SafeReleaseRepoActions,
+    release_repo: &dyn AntReleaseRepoActions,
     verbosity: VerbosityLevel,
 ) -> Result<PathBuf> {
     if build {

--- a/ant-node-manager/src/cmd/nat_detection.rs
+++ b/ant-node-manager/src/cmd/nat_detection.rs
@@ -10,7 +10,7 @@ use crate::{
     config::get_node_registry_path, helpers::download_and_extract_release, VerbosityLevel,
 };
 use ant_peers_acquisition::get_peers_from_url;
-use ant_releases::{ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
 use ant_service_management::{NatDetectionStatus, NodeRegistry};
 use color_eyre::eyre::{bail, OptionExt, Result};
 use libp2p::Multiaddr;
@@ -59,7 +59,7 @@ pub async fn run_nat_detection(
     let nat_detection_path = if let Some(path) = path {
         path
     } else {
-        let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+        let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
         let (nat_detection_path, _) = download_and_extract_release(
             ReleaseType::NatDetection,

--- a/ant-node-manager/src/cmd/node.rs
+++ b/ant-node-manager/src/cmd/node.rs
@@ -21,7 +21,7 @@ use crate::{
 use ant_evm::{EvmNetwork, RewardsAddress};
 use ant_logging::LogFormat;
 use ant_peers_acquisition::PeersArgs;
-use ant_releases::{ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
 use ant_service_management::{
     control::{ServiceControl, ServiceController},
     rpc::RpcClient,
@@ -86,7 +86,7 @@ pub async fn add(
         config::get_service_log_dir_path(ReleaseType::AntNode, log_dir_path, service_user.clone())?;
 
     let mut node_registry = NodeRegistry::load(&config::get_node_registry_path()?)?;
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
     let (antnode_src_path, version) = if let Some(path) = src_path.clone() {
         let version = get_bin_version(&path)?;

--- a/ant-node-manager/src/helpers.rs
+++ b/ant-node-manager/src/helpers.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use ant_releases::{get_running_platform, ArchiveType, ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{get_running_platform, AntReleaseRepoActions, ArchiveType, ReleaseType};
 use ant_service_management::NodeServiceData;
 use color_eyre::{
     eyre::{bail, eyre},
@@ -49,7 +49,7 @@ pub async fn configure_winsw(dest_path: &Path, verbosity: VerbosityLevel) -> Res
         }
         debug!("Downloading WinSW to {dest_path:?}");
 
-        let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+        let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
         let mut pb = None;
         let callback = if verbosity != VerbosityLevel::Minimal {
@@ -120,7 +120,7 @@ pub async fn download_and_extract_release(
     release_type: ReleaseType,
     url: Option<String>,
     version: Option<String>,
-    release_repo: &dyn SafeReleaseRepoActions,
+    release_repo: &dyn AntReleaseRepoActions,
     verbosity: VerbosityLevel,
     download_dir_path: Option<PathBuf>,
 ) -> Result<(PathBuf, String)> {

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -5,7 +5,7 @@ use ant_node_manager::{
     add_services::config::PortRange, config::get_node_registry_path, VerbosityLevel,
 };
 use ant_peers_acquisition::PeersArgs;
-use ant_releases::{self, ReleaseType, SafeReleaseRepoActions};
+use ant_releases::{self, AntReleaseRepoActions, ReleaseType};
 use ant_service_management::NodeRegistry;
 use color_eyre::eyre::{eyre, Error};
 use color_eyre::Result;
@@ -305,7 +305,7 @@ struct NodeConfig {
 async fn run_nat_detection(action_sender: &UnboundedSender<Action>) {
     info!("Running nat detection....");
 
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
     let version = match release_repo
         .get_latest_version(&ReleaseType::NatDetection)
         .await


### PR DESCRIPTION
The `SafeReleaseRepoActions` type was renamed to `AntReleaseRepoActions` and the `ReleaseType::Autonomi` variant was changed to `ReleaseType::Ant`.
