### PR TITLE
fix: use correct crate for `ant-cli`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -156,7 +156,7 @@ package-bin bin version="":
       crate_dir_name="node-launchpad"
       ;;
     ant)
-      crate_dir_name="autonomi-cli"
+      crate_dir_name="ant-cli"
       ;;
     antnode)
       crate_dir_name="ant-node"


### PR DESCRIPTION
This was another reference that was missed.
