### PR TITLE
fix: use `ant_networking` for metrics prefix

### DIFF
--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -77,7 +77,7 @@ impl NetworkMetricsRecorder {
         let libp2p_metrics = Libp2pMetrics::new(&mut registries.standard_metrics);
         let sub_registry = registries
             .standard_metrics
-            .sub_registry_with_prefix("ant-networking");
+            .sub_registry_with_prefix("ant_networking");
 
         let records_stored = Gauge::default();
         sub_registry.register(

--- a/ant-node/src/metrics.rs
+++ b/ant-node/src/metrics.rs
@@ -71,7 +71,7 @@ impl NodeMetricsRecorder {
 
         let sub_registry = registries
             .standard_metrics
-            .sub_registry_with_prefix("sn_node");
+            .sub_registry_with_prefix("ant_node");
 
         let put_record_ok = Family::default();
         sub_registry.register(


### PR DESCRIPTION
The `ant-networking` prefix was incompatible with the new version of Telegraf because it doesn't allow hyphens in the metric name; however, in any case, this shouldn't have had the hyphen, and should actually have remained as `sn_networking`.

It was mistakenly renamed, because we wanted to keep the `sn_` prefix in the metric names so that we could change them more gradually. Now we've decided to just go with the `ant_` prefix, so we are also changing the `sn_node` prefix to `ant_node` as part of this commit.