### PR TITLE
chore: avoid access Distance private field of U256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
  "clap",
  "dirs-next",
  "futures",
- "libp2p 0.54.1",
+ "libp2p",
  "reqwest 0.12.9",
  "serde",
  "serde_json",
@@ -790,11 +790,12 @@ dependencies = [
 name = "ant-evm"
 version = "0.1.4"
 dependencies = [
+ "alloy",
  "custom_debug",
  "evmlib",
  "hex 0.4.3",
  "lazy_static",
- "libp2p 0.54.2",
+ "libp2p",
  "rand 0.8.5",
  "ring 0.17.8",
  "rmp-serde",
@@ -853,6 +854,7 @@ name = "ant-networking"
 version = "0.19.5"
 dependencies = [
  "aes-gcm-siv",
+ "alloy",
  "ant-bootstrap",
  "ant-build-info",
  "ant-evm",
@@ -872,7 +874,7 @@ dependencies = [
  "hyper 0.14.31",
  "itertools 0.12.1",
  "lazy_static",
- "libp2p 0.54.2",
+ "libp2p",
  "libp2p-identity",
  "prometheus-client",
  "quickcheck",
@@ -900,6 +902,7 @@ dependencies = [
 name = "ant-node"
 version = "0.112.6"
 dependencies = [
+ "alloy",
  "ant-bootstrap",
  "ant-build-info",
  "ant-evm",
@@ -926,7 +929,7 @@ dependencies = [
  "futures",
  "hex 0.4.3",
  "itertools 0.12.1",
- "libp2p 0.54.2",
+ "libp2p",
  "num-traits",
  "prometheus-client",
  "prost 0.9.0",
@@ -975,7 +978,7 @@ dependencies = [
  "colored",
  "dirs-next",
  "indicatif",
- "libp2p 0.54.2",
+ "libp2p",
  "libp2p-identity",
  "mockall 0.12.1",
  "nix 0.27.1",
@@ -1011,7 +1014,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "hex 0.4.3",
- "libp2p 0.54.2",
+ "libp2p",
  "libp2p-identity",
  "thiserror 1.0.69",
  "tokio",
@@ -1025,6 +1028,7 @@ dependencies = [
 name = "ant-protocol"
 version = "0.17.15"
 dependencies = [
+ "alloy",
  "ant-build-info",
  "ant-evm",
  "ant-registers",
@@ -1037,7 +1041,7 @@ dependencies = [
  "exponential-backoff",
  "hex 0.4.3",
  "lazy_static",
- "libp2p 0.54.2",
+ "libp2p",
  "prost 0.9.0",
  "rmp-serde",
  "serde",
@@ -1096,7 +1100,7 @@ dependencies = [
  "ant-protocol",
  "async-trait",
  "dirs-next",
- "libp2p 0.54.2",
+ "libp2p",
  "libp2p-identity",
  "mockall 0.11.4",
  "prost 0.9.0",
@@ -1401,18 +1405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,12 +1479,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic-write-file"
@@ -1576,7 +1562,7 @@ dependencies = [
  "hex 0.4.3",
  "instant",
  "js-sys",
- "libp2p 0.54.2",
+ "libp2p",
  "pyo3",
  "rand 0.8.5",
  "rmp-serde",
@@ -4433,25 +4419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.0",
- "slab",
- "tokio",
- "tokio-util 0.7.13",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,7 +4727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
- "async-channel 1.9.0",
+ "async-channel",
  "base64 0.13.1",
  "futures-lite 1.13.0",
  "http 0.2.12",
@@ -4812,7 +4779,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -4835,7 +4802,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -5122,18 +5088,16 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 1.2.0",
- "http-body-util",
- "hyper 1.5.1",
- "hyper-util",
+ "http 0.2.12",
+ "hyper 0.14.31",
  "log",
  "rand 0.8.5",
  "tokio",
@@ -5445,45 +5409,22 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
- "libp2p-allow-block-list 0.4.0",
- "libp2p-connection-limits 0.4.0",
- "libp2p-core 0.42.0",
- "libp2p-gossipsub 0.47.0",
- "libp2p-identity",
- "libp2p-kad 0.46.2",
- "libp2p-swarm 0.45.1",
- "multiaddr",
- "pin-project",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.54.2"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "libp2p-allow-block-list 0.4.2",
+ "libp2p-allow-block-list",
  "libp2p-autonat",
- "libp2p-connection-limits 0.4.1",
- "libp2p-core 0.42.1",
+ "libp2p-connection-limits",
+ "libp2p-core",
  "libp2p-dns",
- "libp2p-gossipsub 0.48.0",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.47.1",
+ "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
  "libp2p-quic",
  "libp2p-relay",
  "libp2p-request-response",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-websocket",
@@ -5491,8 +5432,8 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
- "rw-stream-sink 0.4.0 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
- "thiserror 2.0.4",
+ "rw-stream-sink",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5501,26 +5442,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
 ]
 
 [[package]]
-name = "libp2p-allow-block-list"
-version = "0.4.2"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "libp2p-core 0.42.1",
- "libp2p-identity",
- "libp2p-swarm 0.45.2",
-]
-
-[[package]]
 name = "libp2p-autonat"
-version = "0.13.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5529,16 +5461,17 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-request-response",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
+ "void",
  "web-time",
 ]
 
@@ -5548,20 +5481,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.4.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "libp2p-core 0.42.1",
- "libp2p-identity",
- "libp2p-swarm 0.45.2",
 ]
 
 [[package]]
@@ -5577,13 +5500,13 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "multihash",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
  "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
@@ -5594,40 +5517,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-core"
-version = "0.42.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select 0.13.0 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink 0.4.0 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
- "smallvec",
- "thiserror 2.0.4",
- "tracing",
- "unsigned-varint 0.8.0",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
 dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -5650,12 +5548,12 @@ dependencies = [
  "futures-ticker",
  "getrandom 0.2.15",
  "hex_fmt",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -5667,54 +5565,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-gossipsub"
-version = "0.48.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "async-channel 2.3.1",
- "asynchronous-codec",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "hex_fmt",
- "libp2p-core 0.42.1",
- "libp2p-identity",
- "libp2p-swarm 0.45.2",
- "prometheus-client",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
- "rand 0.8.5",
- "regex",
- "sha2 0.10.8",
- "smallvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-identify"
-version = "0.46.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "lru",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
+ "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
+ "void",
 ]
 
 [[package]]
@@ -5750,11 +5620,11 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -5767,63 +5637,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-kad"
-version = "0.47.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "arrayvec",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.42.1",
- "libp2p-identity",
- "libp2p-swarm 0.45.2",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
- "rand 0.8.5",
- "sha2 0.10.8",
- "smallvec",
- "thiserror 2.0.4",
- "tracing",
- "uint",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
 dependencies = [
  "data-encoding",
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "socket2",
  "tokio",
  "tracing",
+ "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
 version = "0.15.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
  "futures",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.47.1",
+ "libp2p-kad",
  "libp2p-relay",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -5831,14 +5677,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.45.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "curve25519-dalek 4.1.3",
  "futures",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -5848,7 +5695,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5856,14 +5703,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.2"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
  "parking_lot",
@@ -5872,15 +5720,16 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.19",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10df23d7f5b5adcc129f4a69d6fbd05209e356ccf9e8f4eb10b2692b79c77247"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5888,35 +5737,38 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "static_assertions",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
+ "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
 dependencies = [
  "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
+ "libp2p-swarm",
  "rand 0.8.5",
  "serde",
  "smallvec",
  "tracing",
+ "void",
  "web-time",
 ]
 
@@ -5930,38 +5782,18 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "lru",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.45.2"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
  "getrandom 0.2.15",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
  "lru",
- "multistream-select 0.13.0 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
+ "multistream-select",
  "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
+ "void",
  "wasm-bindgen-futures",
  "web-time",
 ]
@@ -5969,7 +5801,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5980,13 +5813,14 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "socket2",
  "tokio",
@@ -5996,50 +5830,54 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring 0.17.8",
  "rustls 0.23.19",
  "rustls-webpki 0.101.7",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "x509-parser",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
 dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.42.1",
- "libp2p-swarm 0.45.2",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
+ "void",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.44.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888b2ff2e5d8dcef97283daab35ad1043d18952b65e05279eecbe02af4c6e347"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "pin-project-lite",
- "rw-stream-sink 0.4.0 (git+https://github.com/maqi/rust-libp2p.git?branch=master)",
+ "rw-stream-sink",
  "soketto",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
  "url",
  "webpki-roots 0.25.4",
@@ -6047,16 +5885,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket-websys"
-version = "0.4.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cf9b429dd07be52cd82c4c484b1694df4209210a7db3b9ffb00c7606e230c8"
 dependencies = [
  "bytes",
  "futures",
  "js-sys",
- "libp2p-core 0.42.1",
+ "libp2p-core",
  "parking_lot",
  "send_wrapper 0.6.0",
- "thiserror 2.0.4",
+ "thiserror 1.0.69",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -6065,12 +5904,13 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.42.1",
- "thiserror 2.0.4",
+ "libp2p-core",
+ "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.4",
@@ -6402,19 +6242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "bytes",
- "futures",
- "pin-project",
- "smallvec",
- "tracing",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
 name = "nat-detection"
 version = "0.2.11"
 dependencies = [
@@ -6425,7 +6252,7 @@ dependencies = [
  "clap-verbosity-flag",
  "color-eyre",
  "futures",
- "libp2p 0.54.2",
+ "libp2p",
  "tokio",
  "tracing",
  "tracing-log 0.2.0",
@@ -7719,18 +7546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror 2.0.4",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8165,7 +7980,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
@@ -8595,16 +8410,6 @@ name = "rw-stream-sink"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/maqi/rust-libp2p.git?branch=master#d0590a7a71160dcf806d38813b74925d3217a98c"
 dependencies = [
  "futures",
  "pin-project",
@@ -9465,7 +9270,7 @@ dependencies = [
  "color-eyre",
  "dirs-next",
  "evmlib",
- "libp2p 0.54.2",
+ "libp2p",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -9808,7 +9613,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
@@ -9840,7 +9645,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -15,11 +15,12 @@ external-signer = ["evmlib/external-signer"]
 test-utils = []
 
 [dependencies]
+alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
 custom_debug = "~0.6.1"
 evmlib = { path = "../evmlib", version = "0.1.4" }
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["identify", "kad"] }
+libp2p = { version = "0.54.1", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 ring = "0.17.8"
 rmp-serde = "1.1.1"

--- a/ant-evm/src/data_payments.rs
+++ b/ant-evm/src/data_payments.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{AttoTokens, EvmError};
+use alloy::primitives::U256;
 use evmlib::common::TxHash;
 use evmlib::{
     common::{Address as RewardsAddress, QuoteHash},
@@ -14,6 +15,7 @@ use evmlib::{
 };
 use libp2p::{identity::PublicKey, PeerId};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 #[cfg(not(target_arch = "wasm32"))]
 pub use std::time::SystemTime;
 #[cfg(target_arch = "wasm32")]
@@ -43,9 +45,7 @@ impl ProofOfPayment {
 }
 
 /// Quoting metrics that got used to generate a quote, or to track peer's status.
-#[derive(
-    Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, custom_debug::Debug,
-)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct QuotingMetrics {
     /// the records stored
     pub close_records_stored: usize,
@@ -60,6 +60,15 @@ pub struct QuotingMetrics {
     pub network_density: Option<[u8; 32]>,
     /// estimated network size
     pub network_size: Option<u64>,
+}
+
+impl Debug for QuotingMetrics {
+    fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
+        let density_u256 = self.network_density.map(U256::from_be_bytes);
+
+        write!(formatter, "QuotingMetrics {{ close_records_stored: {}, max_records: {}, received_payment_count: {}, live_time: {}, network_density: {density_u256:?}, network_size: {:?} }}",
+            self.close_records_stored, self.max_records, self.received_payment_count, self.live_time, self.network_size)
+    }
 }
 
 impl QuotingMetrics {

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -20,6 +20,7 @@ upnp = ["libp2p/upnp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
+alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
 ant-evm = { path = "../ant-evm", version = "0.1.4" }
@@ -39,7 +40,7 @@ hyper = { version = "0.14", features = [
 ], optional = true }
 itertools = "~0.12.1"
 lazy_static = "~1.4.0"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = [
+libp2p = { version = "0.54.1", features = [
     "tokio",
     "dns",
     "kad",
@@ -95,7 +96,7 @@ crate-type = ["cdylib", "rlib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = [
+libp2p = { version = "0.54.1", features = [
     "tokio",
     "dns",
     "kad",

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -13,8 +13,10 @@ use crate::{
     log_markers::Marker,
     multiaddr_pop_p2p, GetRecordCfg, GetRecordError, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
 };
+use alloy::primitives::U256;
 use ant_evm::{AttoTokens, PaymentQuote, QuotingMetrics};
 use ant_protocol::{
+    convert_distance_to_u256,
     messages::{Cmd, Request, Response},
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintRecordKey,
@@ -1138,11 +1140,12 @@ impl SwarmDriver {
 }
 
 /// Returns the nodes that within the defined distance.
-fn get_peers_in_range(peers: &[PeerId], address: &NetworkAddress, range: Distance) -> Vec<PeerId> {
+fn get_peers_in_range(peers: &[PeerId], address: &NetworkAddress, range: U256) -> Vec<PeerId> {
     peers
         .iter()
         .filter_map(|peer_id| {
-            let distance = address.distance(&NetworkAddress::from_peer(*peer_id));
+            let distance =
+                convert_distance_to_u256(&address.distance(&NetworkAddress::from_peer(*peer_id)));
             if distance <= range {
                 Some(*peer_id)
             } else {

--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -16,8 +16,10 @@ use aes_gcm_siv::{
     aead::{Aead, KeyInit},
     Aes256GcmSiv, Key as AesKey, Nonce,
 };
+use alloy::primitives::U256;
 use ant_evm::{AttoTokens, QuotingMetrics};
 use ant_protocol::{
+    convert_distance_to_u256,
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintRecordKey,
 };
@@ -145,7 +147,7 @@ pub struct NodeRecordStore {
     /// Main records store remains unchanged for compatibility
     records: HashMap<Key, (NetworkAddress, RecordType)>,
     /// Additional index organizing records by distance
-    records_by_distance: BTreeMap<Distance, Key>,
+    records_by_distance: BTreeMap<U256, Key>,
     /// FIFO simple cache of records to reduce read times
     records_cache: RecordCache,
     /// Send network events to the node layer.
@@ -155,7 +157,7 @@ pub struct NodeRecordStore {
     /// ilog2 distance range of responsible records
     /// AKA: how many buckets of data do we consider "close"
     /// None means accept all records.
-    responsible_distance_range: Option<Distance>,
+    responsible_distance_range: Option<U256>,
     #[cfg(feature = "open-metrics")]
     /// Used to report the number of records held by the store to the metrics server.
     record_count_metric: Option<Gauge>,
@@ -374,9 +376,9 @@ impl NodeRecordStore {
         let local_address = NetworkAddress::from_peer(local_id);
 
         // Initialize records_by_distance
-        let mut records_by_distance: BTreeMap<Distance, Key> = BTreeMap::new();
+        let mut records_by_distance: BTreeMap<U256, Key> = BTreeMap::new();
         for (key, (addr, _record_type)) in records.iter() {
-            let distance = local_address.distance(addr);
+            let distance = convert_distance_to_u256(&local_address.distance(addr));
             let _ = records_by_distance.insert(distance, key.clone());
         }
 
@@ -413,7 +415,7 @@ impl NodeRecordStore {
     }
 
     /// Returns the current distance ilog2 (aka bucket) range of CLOSE_GROUP nodes.
-    pub fn get_responsible_distance_range(&self) -> Option<Distance> {
+    pub fn get_responsible_distance_range(&self) -> Option<U256> {
         self.responsible_distance_range
     }
 
@@ -615,13 +617,14 @@ impl NodeRecordStore {
     pub(crate) fn mark_as_stored(&mut self, key: Key, record_type: RecordType) {
         let addr = NetworkAddress::from_record_key(&key);
         let distance = self.local_address.distance(&addr);
+        let distance_u256 = convert_distance_to_u256(&distance);
 
         // Update main records store
         self.records
             .insert(key.clone(), (addr.clone(), record_type));
 
         // Update bucket index
-        let _ = self.records_by_distance.insert(distance, key.clone());
+        let _ = self.records_by_distance.insert(distance_u256, key.clone());
 
         // Update farthest record if needed (unchanged)
         if let Some((_farthest_record, farthest_record_distance)) = self.farthest_record.clone() {
@@ -751,7 +754,7 @@ impl NodeRecordStore {
             let relevant_records = self.get_records_within_distance_range(distance_range);
 
             // The `responsible_range` is the network density
-            quoting_metrics.network_density = Some(distance_range.0.into());
+            quoting_metrics.network_density = Some(distance_range.to_be_bytes());
 
             quoting_metrics.close_records_stored = relevant_records;
         } else {
@@ -777,7 +780,7 @@ impl NodeRecordStore {
     }
 
     /// Calculate how many records are stored within a distance range
-    pub fn get_records_within_distance_range(&self, range: Distance) -> usize {
+    pub fn get_records_within_distance_range(&self, range: U256) -> usize {
         let within_range = self
             .records_by_distance
             .range(..range)
@@ -790,7 +793,7 @@ impl NodeRecordStore {
     }
 
     /// Setup the distance range.
-    pub(crate) fn set_responsible_distance_range(&mut self, responsible_distance: Distance) {
+    pub(crate) fn set_responsible_distance_range(&mut self, responsible_distance: U256) {
         self.responsible_distance_range = Some(responsible_distance);
     }
 }
@@ -886,7 +889,7 @@ impl RecordStore for NodeRecordStore {
     fn remove(&mut self, k: &Key) {
         // Remove from main store
         if let Some((addr, _)) = self.records.remove(k) {
-            let distance = self.local_address.distance(&addr);
+            let distance = convert_distance_to_u256(&self.local_address.distance(&addr));
             let _ = self.records_by_distance.remove(&distance);
         }
 
@@ -1035,6 +1038,7 @@ mod tests {
 
     use ant_evm::utils::dummy_address;
     use ant_evm::{PaymentQuote, RewardsAddress};
+    use ant_protocol::convert_distance_to_u256;
     use ant_protocol::storage::{
         try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, Scratchpad,
     };
@@ -1677,7 +1681,7 @@ mod tests {
                 .wrap_err("Could not parse record store key")?,
         );
         // get the distance to this record from our local key
-        let distance = self_address.distance(&halfway_record_address);
+        let distance = convert_distance_to_u256(&self_address.distance(&halfway_record_address));
 
         // must be plus one bucket from the halfway record
         store.set_responsible_distance_range(distance);

--- a/ant-networking/src/record_store_api.rs
+++ b/ant-networking/src/record_store_api.rs
@@ -8,11 +8,12 @@
 #![allow(clippy::mutable_key_type)] // for the Bytes in NetworkAddress
 
 use crate::record_store::{ClientRecordStore, NodeRecordStore};
+use alloy::primitives::U256;
 use ant_evm::{AttoTokens, QuotingMetrics};
 use ant_protocol::{storage::RecordType, NetworkAddress};
 use libp2p::kad::{
     store::{RecordStore, Result},
-    KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
+    ProviderRecord, Record, RecordKey,
 };
 use std::{borrow::Cow, collections::HashMap};
 
@@ -134,7 +135,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn get_farthest_replication_distance(&self) -> Option<Distance> {
+    pub(crate) fn get_farthest_replication_distance(&self) -> Option<U256> {
         match self {
             Self::Client(_store) => {
                 warn!("Calling get_distance_range at Client. This should not happen");
@@ -144,7 +145,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn set_distance_range(&mut self, distance: Distance) {
+    pub(crate) fn set_distance_range(&mut self, distance: U256) {
         match self {
             Self::Client(_store) => {
                 warn!("Calling set_distance_range at Client. This should not happen");

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -43,7 +43,7 @@ colored = "2.0.4"
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
 indicatif = { version = "0.17.5", features = ["tokio"] }
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = [] }
+libp2p = { version = "0.54.1", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 rand = "0.8.5"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -27,7 +27,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.2"
 hex = "~0.4.3"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["kad"]}
+libp2p = { version = "0.54.1", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -26,6 +26,7 @@ otlp = ["ant-logging/otlp"]
 upnp = ["ant-networking/upnp"]
 
 [dependencies]
+alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
 ant-evm = { path = "../ant-evm", version = "0.1.4" }
@@ -49,7 +50,7 @@ file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
 itertools = "~0.12.1"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["tokio", "dns", "kad", "macros"] }
+libp2p = { version = "0.54.1", features = ["tokio", "dns", "kad", "macros"] }
 num-traits = "0.2"
 prometheus-client = { version = "0.22", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -12,12 +12,14 @@ use super::{
 #[cfg(feature = "open-metrics")]
 use crate::metrics::NodeMetricsRecorder;
 use crate::RunningNode;
+use alloy::primitives::U256;
 use ant_bootstrap::BootstrapCacheStore;
 use ant_evm::{AttoTokens, RewardsAddress};
 #[cfg(feature = "open-metrics")]
 use ant_networking::MetricsRegistries;
 use ant_networking::{Instant, Network, NetworkBuilder, NetworkEvent, NodeIssue, SwarmDriver};
 use ant_protocol::{
+    convert_distance_to_u256,
     error::Error as ProtocolError,
     messages::{ChunkProof, CmdResponse, Nonce, Query, QueryResponse, Request, Response},
     storage::RecordType,
@@ -25,11 +27,7 @@ use ant_protocol::{
 };
 use bytes::Bytes;
 use itertools::Itertools;
-use libp2p::{
-    identity::Keypair,
-    kad::{KBucketDistance as Distance, U256},
-    Multiaddr, PeerId,
-};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use num_traits::cast::ToPrimitive;
 use rand::{
     rngs::{OsRng, StdRng},
@@ -754,12 +752,12 @@ impl Node {
     ) -> Vec<(NetworkAddress, Vec<Multiaddr>)> {
         match (num_of_peers, range) {
             (_, Some(value)) => {
-                let distance = Distance(U256::from(value));
+                let distance = U256::from_be_bytes(value);
                 peer_addrs
                     .iter()
                     .filter_map(|(peer_id, multi_addrs)| {
                         let addr = NetworkAddress::from_peer(*peer_id);
-                        if target.distance(&addr) <= distance {
+                        if convert_distance_to_u256(&target.distance(&addr)) <= distance {
                             Some((addr, multi_addrs.clone()))
                         } else {
                             None
@@ -1160,12 +1158,12 @@ mod tests {
         );
 
         // Range shall be preferred, i.e. the result peers shall all within the range
-        let distance = Distance(U256::from(range_value));
+        let distance = U256::from_be_bytes(range_value);
         let expected_result: Vec<(NetworkAddress, Vec<Multiaddr>)> = local_peers
             .into_iter()
             .filter_map(|(peer_id, multi_addrs)| {
                 let addr = NetworkAddress::from_peer(peer_id);
-                if target.distance(&addr) <= distance {
+                if convert_distance_to_u256(&target.distance(&addr)) <= distance {
                     Some((addr, multi_addrs.clone()))
                 } else {
                     None

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 rpc=["tonic", "prost"]
 
 [dependencies]
+alloy = { version = "0.5.3", default-features = false, features = ["std", "reqwest-rustls-tls", "provider-anvil-node", "sol-types", "json", "signers", "contract", "signer-local", "network"] }
 ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
 ant-evm = { path = "../ant-evm", version = "0.1.4" }
 ant-registers = { path = "../ant-registers", version = "0.4.3" }
@@ -26,7 +27,7 @@ dirs-next = "~2.0.0"
 exponential-backoff = "2.0.0"
 hex = "~0.4.3"
 lazy_static = "1.4.0"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["identify", "kad"] }
+libp2p = { version = "0.54.1", features = ["identify", "kad"] }
 # # watch out updating this, protoc compiler needs to be installed on all build systems
 # # arm builds + musl are very problematic
 # prost and tonic are needed for the RPC server messages, not the underlying protocol

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -36,6 +36,7 @@ use self::storage::{ChunkAddress, RegisterAddress, TransactionAddress};
 /// Re-export of Bytes used throughout the protocol
 pub use bytes::Bytes;
 
+use alloy::primitives::U256;
 use libp2p::{
     kad::{KBucketDistance as Distance, KBucketKey as Key, RecordKey},
     multiaddr::Protocol,
@@ -45,6 +46,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     borrow::Cow,
     fmt::{self, Debug, Display, Formatter, Write},
+    str::FromStr,
 };
 use xor_name::XorName;
 
@@ -64,6 +66,18 @@ pub fn get_port_from_multiaddr(multi_addr: &Multiaddr) -> Option<u16> {
         }
     }
     None
+}
+
+// This conversion shall no longer be required once updated to the latest libp2p.
+// Which can has the direct access to the Distance private field of U256.
+pub fn convert_distance_to_u256(distance: &Distance) -> U256 {
+    let addr_str = format!("{distance:?}");
+    let numeric_part = addr_str
+        .trim_start_matches("Distance(")
+        .trim_end_matches(")")
+        .to_string();
+    let distance_value = U256::from_str(&numeric_part);
+    distance_value.unwrap_or(U256::ZERO)
 }
 
 /// This is the address in the network by which proximity/distance

--- a/ant-protocol/src/messages/query.rs
+++ b/ant-protocol/src/messages/query.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{messages::Nonce, NetworkAddress};
-use libp2p::kad::{KBucketDistance as Distance, U256};
+use alloy::primitives::U256;
 use serde::{Deserialize, Serialize};
 
 /// Data queries - retrieving data and inspecting their structure.
@@ -131,7 +131,7 @@ impl std::fmt::Display for Query {
                 range,
                 sign_result,
             } => {
-                let distance = range.as_ref().map(|value| Distance(U256::from(value)));
+                let distance = range.as_ref().map(|value| U256::from_be_slice(value));
                 write!(
                     f,
                     "Query::GetClosestPeers({key:?} {num_of_peers:?} {distance:?} {sign_result})"

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -15,7 +15,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.40" }
 ant-protocol = { path = "../ant-protocol", version = "0.17.15", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["kad"] }
+libp2p = { version = "0.54.1", features = ["kad"] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -42,7 +42,7 @@ curv = { version = "0.10.1", package = "sn_curv", default-features = false, feat
 eip2333 = { version = "0.2.1", package = "sn_bls_ckd" }
 futures = "0.3.30"
 hex = "~0.4.3"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master" }
+libp2p = "0.54.1"
 pyo3 = { version = "0.20", optional = true, features = ["extension-module", "abi3-py38"] }
 rand = "0.8.5"
 rmp-serde = "1.1.1"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }
 futures = "~0.3.13"
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = [
+libp2p = { version = "0.54.1", features = [
     "tokio",
     "tcp",
     "noise",

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.2"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.1.4" }
-libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "master", features = ["identify", "kad"] }
+libp2p = { version = "0.54.1", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Description

avoid access Distance private field of U256
also rolls back the libp2p dependency to the previous 0.54.1

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
