### PR TITLE
fix(cli): store relative file paths in archive instead of absolute wh…

### DIFF
--- a/autonomi/src/client/files/fs_public.rs
+++ b/autonomi/src/client/files/fs_public.rs
@@ -6,17 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::archive_public::{ArchiveAddr, PublicArchive};
+use super::fs::*;
 use crate::client::data::DataAddr;
 use crate::client::files::archive::Metadata;
+use crate::client::files::get_relative_file_path_from_abs_file_and_folder_path;
 use crate::client::utils::process_tasks_with_max_concurrency;
 use crate::client::Client;
 use ant_evm::EvmWallet;
 use ant_networking::target_arch::{Duration, SystemTime};
 use bytes::Bytes;
 use std::path::PathBuf;
-
-use super::archive_public::{ArchiveAddr, PublicArchive};
-use super::fs::*;
 
 impl Client {
     /// Download file from network to local file system
@@ -69,7 +69,7 @@ impl Client {
 
         // start upload of files in parallel
         let mut upload_tasks = Vec::new();
-        for entry in walkdir::WalkDir::new(dir_path) {
+        for entry in walkdir::WalkDir::new(dir_path.clone()) {
             let entry = entry?;
             if !entry.file_type().is_file() {
                 continue;
@@ -93,8 +93,10 @@ impl Client {
         );
         let mut archive = PublicArchive::new();
         for (path, metadata, maybe_file) in uploads.into_iter() {
+            let rel_path = get_relative_file_path_from_abs_file_and_folder_path(&path, &dir_path);
+
             match maybe_file {
-                Ok(file) => archive.add_file(path, file, metadata),
+                Ok(file) => archive.add_file(rel_path, file, metadata),
                 Err(err) => {
                     error!("Failed to upload file: {path:?}: {err:?}");
                     return Err(err);

--- a/autonomi/src/client/files/mod.rs
+++ b/autonomi/src/client/files/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "fs")]
+use std::path::{Path, PathBuf};
+
 pub mod archive;
 pub mod archive_public;
 #[cfg(feature = "fs")]
@@ -6,3 +9,32 @@ pub mod fs;
 #[cfg(feature = "fs")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
 pub mod fs_public;
+
+#[cfg(feature = "fs")]
+pub(crate) fn get_relative_file_path_from_abs_file_and_folder_path(
+    abs_file_pah: &Path,
+    abs_folder_path: &Path,
+) -> PathBuf {
+    // check if the dir is a file
+    let is_file = abs_folder_path.is_file();
+
+    // could also be the file name
+    let dir_name = PathBuf::from(
+        abs_folder_path
+            .file_name()
+            .expect("Failed to get file/dir name"),
+    );
+
+    if is_file {
+        dir_name
+    } else {
+        let folder_prefix = abs_folder_path
+            .parent()
+            .unwrap_or(Path::new(""))
+            .to_path_buf();
+        abs_file_pah
+            .strip_prefix(folder_prefix)
+            .expect("Could not strip prefix path")
+            .to_path_buf()
+    }
+}


### PR DESCRIPTION
Fixes not being able to choose the destination path when downloading files. The problem was that the paths in the uploaded archives were all absolute paths instead of relative paths to the parent of the root upload directory.