### PR TITLE
fixes to address connection errors and rise on adding peers into RT & extra disk writes

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -759,7 +759,6 @@ impl NetworkBuilder {
             quotes_history: Default::default(),
             replication_targets: Default::default(),
             last_replication: None,
-            last_connection_pruning_time: Instant::now(),
             network_density_samples: FifoRegister::new(100),
         };
 
@@ -867,8 +866,6 @@ pub struct SwarmDriver {
     /// when was the last replication event
     /// This allows us to throttle replication no matter how it is triggered
     pub(crate) last_replication: Option<Instant>,
-    /// when was the last outdated connection prunning undertaken.
-    pub(crate) last_connection_pruning_time: Instant,
     /// FIFO cache for the network density samples
     pub(crate) network_density_samples: FifoRegister,
 }

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -626,9 +626,12 @@ impl SwarmDriver {
     fn remove_bootstrap_from_full(&mut self, peer_id: PeerId) {
         let mut shall_removed = None;
 
+        let mut bucket_index = Some(0);
+
         if let Some(kbucket) = self.swarm.behaviour_mut().kademlia.kbucket(peer_id) {
             if kbucket.num_entries() >= K_VALUE.into() {
-                if let Some(peers) = self.bootstrap_peers.get(&kbucket.range().0.ilog2()) {
+                bucket_index = kbucket.range().0.ilog2();
+                if let Some(peers) = self.bootstrap_peers.get(&bucket_index) {
                     for peer_entry in kbucket.iter() {
                         if peers.contains(peer_entry.node.key.preimage()) {
                             shall_removed = Some(*peer_entry.node.key.preimage());
@@ -647,6 +650,13 @@ impl SwarmDriver {
                 .remove_peer(&to_be_removed_bootstrap);
             if let Some(removed_peer) = entry {
                 self.update_on_peer_removal(*removed_peer.node.key.preimage());
+            }
+
+            // With the switch to using bootstrap cache, workload is distributed already.
+            // to avoid peers keeps being replaced by each other,
+            // there shall be just one time of removal to be undertaken.
+            if let Some(peers) = self.bootstrap_peers.get_mut(&bucket_index) {
+                let _ = peers.remove(&peer_id);
             }
         }
     }

--- a/ant-networking/src/relay_manager.rs
+++ b/ant-networking/src/relay_manager.rs
@@ -47,12 +47,6 @@ impl RelayManager {
         }
     }
 
-    /// Should we keep this peer alive? Closing a connection to that peer would remove that server from the listen addr.
-    pub(crate) fn keep_alive_peer(&self, peer_id: &PeerId) -> bool {
-        self.connected_relays.contains_key(peer_id)
-            || self.waiting_for_reservation.contains_key(peer_id)
-    }
-
     /// Add a potential candidate to the list if it satisfies all the identify checks and also supports the relay server
     /// protocol.
     pub(crate) fn add_potential_candidates(


### PR DESCRIPTION
### Description
Contains following fixes:
* not to carry out connection pruning, this is no longer required due to the libp2p upgrades
* bootstrap node replacement only to be carried out once, as due to the switch to the bootstrap cache, workload is already distributed and could have peers `replacing each other`.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
