### PR TITLE
Only prune bootstrap once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "ant-build-info"
-version = "0.1.20-rc.1"
+version = "0.1.20-rc.2"
 dependencies = [
  "chrono",
  "tracing",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 dependencies = [
  "custom_debug",
  "evmlib",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ant-logging"
-version = "0.2.41-rc.1"
+version = "0.2.41-rc.2"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "ant-metrics"
-version = "0.1.21-rc.1"
+version = "0.1.21-rc.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ant-networking"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.11.4-rc.1"
+version = "0.11.4-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-rpc-client"
-version = "0.6.37-rc.1"
+version = "0.6.37-rc.2"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "ant-registers"
-version = "0.4.4-rc.1"
+version = "0.4.4-rc.2"
 dependencies = [
  "blsttc",
  "crdts",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.4.4-rc.1"
+version = "0.4.4-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ant-token-supplies"
-version = "0.1.59-rc.1"
+version = "0.1.59-rc.2"
 dependencies = [
  "dirs-next",
  "reqwest 0.11.27",
@@ -1591,7 +1591,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autonomi"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "nat-detection"
-version = "0.2.12-rc.1"
+version = "0.2.12-rc.2"
 dependencies = [
  "ant-build-info",
  "ant-networking",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -9321,7 +9321,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-utils"
-version = "0.4.12-rc.1"
+version = "0.4.12-rc.2"
 dependencies = [
  "bytes",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "ant-build-info"
-version = "0.1.19"
+version = "0.1.20-rc.1"
 dependencies = [
  "chrono",
  "tracing",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.1.5"
+version = "0.3.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 dependencies = [
  "custom_debug",
  "evmlib",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ant-logging"
-version = "0.2.40"
+version = "0.2.41-rc.1"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "ant-metrics"
-version = "0.1.20"
+version = "0.1.21-rc.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ant-networking"
-version = "0.19.5"
+version = "0.3.0-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.112.6"
+version = "0.3.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.11.3"
+version = "0.11.4-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-rpc-client"
-version = "0.6.36"
+version = "0.6.37-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "0.17.15"
+version = "0.3.0-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "ant-registers"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "blsttc",
  "crdts",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ant-token-supplies"
-version = "0.1.58"
+version = "0.1.59-rc.1"
 dependencies = [
  "dirs-next",
  "reqwest 0.11.27",
@@ -1591,7 +1591,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autonomi"
-version = "0.2.4"
+version = "0.3.0-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "nat-detection"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-networking",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.4.5"
+version = "0.5.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -9321,7 +9321,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-utils"
-version = "0.4.11"
+version = "0.4.12-rc.1"
 dependencies = [
  "bytes",
  "color-eyre",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,14 +7,14 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 
 [features]
 local = []
 
 [dependencies]
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,14 +7,14 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 
 [features]
 local = []
 
 [dependencies]
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-protocol = { version = "0.17.15", path = "../ant-protocol" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/Cargo.toml
+++ b/ant-build-info/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-build-info"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.20-rc.1"
+version = "0.1.20-rc.2"
 build = "build.rs"
 include = ["Cargo.toml", "src/**/*", "build.rs"]
 

--- a/ant-build-info/Cargo.toml
+++ b/ant-build-info/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-build-info"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.19"
+version = "0.1.20-rc.1"
 build = "build.rs"
 include = ["Cargo.toml", "src/**/*", "build.rs"]
 

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2024";
 pub const RELEASE_MONTH: &str = "12";
 pub const RELEASE_CYCLE: &str = "1";
-pub const RELEASE_CYCLE_COUNTER: &str = "1";
+pub const RELEASE_CYCLE_COUNTER: &str = "2";

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2024";
-pub const RELEASE_MONTH: &str = "11";
+pub const RELEASE_MONTH: &str = "12";
 pub const RELEASE_CYCLE: &str = "1";
-pub const RELEASE_CYCLE_COUNTER: &str = "6";
+pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -23,11 +23,11 @@ name = "files"
 harness = false
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
-autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = [
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
+autonomi = { path = "../autonomi", version = "0.3.0-rc.2", features = [
     "fs",
     "vault",
     "registers",
@@ -59,7 +59,7 @@ tracing = { version = "~0.1.26" }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = ["fs"]}
+autonomi = { path = "../autonomi", version = "0.3.0-rc.2", features = ["fs"]}
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.1.5"
+version = "0.3.0-rc.1"
 edition = "2021"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -23,11 +23,11 @@ name = "files"
 harness = false
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
-autonomi = { path = "../autonomi", version = "0.2.4", features = [
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = [
     "fs",
     "vault",
     "registers",
@@ -59,7 +59,7 @@ tracing = { version = "~0.1.26" }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.2.4", features = ["fs"]}
+autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = ["fs"]}
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -158,9 +158,18 @@ pub enum WalletCmd {
         /// Optional flag to not add a password.
         #[clap(long, action)]
         no_password: bool,
-        /// Optional hex-encoded private key.
-        #[clap(long)]
-        private_key: Option<String>,
+        /// Optional password to encrypt the wallet with.
+        #[clap(long, short)]
+        password: Option<String>,
+    },
+
+    /// Import an existing wallet.
+    Import {
+        /// Hex-encoded private key.
+        private_key: String,
+        /// Optional flag to not add a password.
+        #[clap(long, action)]
+        no_password: bool,
         /// Optional password to encrypt the wallet with.
         #[clap(long, short)]
         password: Option<String>,
@@ -208,9 +217,13 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
         SubCmd::Wallet { command } => match command {
             WalletCmd::Create {
                 no_password,
-                private_key,
                 password,
-            } => wallet::create(no_password, private_key, password),
+            } => wallet::create(no_password, password),
+            WalletCmd::Import {
+                private_key,
+                no_password,
+                password,
+            } => wallet::import(private_key, no_password, password),
             WalletCmd::Balance => Ok(wallet::balance().await?),
         },
     }

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -175,6 +175,9 @@ pub enum WalletCmd {
         password: Option<String>,
     },
 
+    /// Print the private key of a wallet.
+    Export,
+
     /// Check the balance of the wallet.
     Balance,
 }
@@ -224,7 +227,8 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 no_password,
                 password,
             } => wallet::import(private_key, no_password, password),
-            WalletCmd::Balance => Ok(wallet::balance().await?),
+            WalletCmd::Export => wallet::export(),
+            WalletCmd::Balance => wallet::balance().await,
         },
     }
 }

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -16,34 +16,10 @@ use prettytable::{Cell, Row, Table};
 
 const WALLET_PASSWORD_REQUIRED: bool = false;
 
-pub fn create(
-    no_password: bool,
-    private_key: Option<String>,
-    password: Option<String>,
-) -> Result<()> {
-    if no_password && password.is_some() {
-        return Err(eyre!(
-            "Only one of `--no-password` or `--password` may be specified"
-        ));
-    }
+pub fn create(no_password: bool, password: Option<String>) -> Result<()> {
+    let maybe_encryption_password = maybe_request_password(no_password, password)?;
 
-    // Set a password for encryption or not
-    let encryption_password: Option<String> = match (no_password, password) {
-        (true, _) => None,
-        (false, Some(pass)) => Some(pass.to_owned()),
-        (false, None) => request_password(WALLET_PASSWORD_REQUIRED),
-    };
-
-    let wallet_private_key = if let Some(private_key) = private_key {
-        // Validate imported key
-        Wallet::new_from_private_key(DUMMY_NETWORK, &private_key)
-            .map_err(|_| eyre!("Please provide a valid secret key in hex format"))?;
-
-        private_key
-    } else {
-        // Create a new key
-        Wallet::random_private_key()
-    };
+    let wallet_private_key = Wallet::random_private_key();
 
     let wallet_address = Wallet::new_from_private_key(DUMMY_NETWORK, &wallet_private_key)
         .expect("Infallible")
@@ -51,7 +27,32 @@ pub fn create(
         .to_string();
 
     // Save the private key file
-    let file_path = store_private_key(&wallet_private_key, encryption_password)?;
+    let file_path = store_private_key(&wallet_private_key, maybe_encryption_password)?;
+
+    println!("Wallet address: {wallet_address}");
+    println!("Stored wallet in: {file_path:?}");
+
+    Ok(())
+}
+
+pub fn import(
+    wallet_private_key: String,
+    no_password: bool,
+    password: Option<String>,
+) -> Result<()> {
+    // Validate imported key
+    Wallet::new_from_private_key(DUMMY_NETWORK, &wallet_private_key)
+        .map_err(|_| eyre!("Please provide a valid private key in hex format"))?;
+
+    let maybe_encryption_password = maybe_request_password(no_password, password)?;
+
+    let wallet_address = Wallet::new_from_private_key(DUMMY_NETWORK, &wallet_private_key)
+        .expect("Infallible")
+        .address()
+        .to_string();
+
+    // Save the private key file
+    let file_path = store_private_key(&wallet_private_key, maybe_encryption_password)?;
 
     println!("Wallet address: {wallet_address}");
     println!("Stored wallet in: {file_path:?}");
@@ -82,4 +83,21 @@ pub async fn balance() -> Result<()> {
     table.printstd();
 
     Ok(())
+}
+
+fn maybe_request_password(no_password: bool, password: Option<String>) -> Result<Option<String>> {
+    if no_password && password.is_some() {
+        return Err(eyre!(
+            "Only one of `--no-password` or `--password` may be specified"
+        ));
+    }
+
+    // Set a password for encryption or not
+    let maybe_password = match (no_password, password) {
+        (true, _) => None,
+        (false, Some(pass)) => Some(pass.to_owned()),
+        (false, None) => request_password(WALLET_PASSWORD_REQUIRED),
+    };
+
+    Ok(maybe_password)
 }

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::wallet::fs::{select_wallet, store_private_key};
+use crate::wallet::fs::{select_wallet, select_wallet_private_key, store_private_key};
 use crate::wallet::input::request_password;
 use crate::wallet::DUMMY_NETWORK;
 use autonomi::Wallet;
@@ -57,6 +57,20 @@ pub fn import(
 
     println!("Wallet address: {wallet_address}");
     println!("Stored wallet in: {file_path:?}");
+
+    Ok(())
+}
+
+pub fn export() -> Result<()> {
+    let wallet_private_key = select_wallet_private_key()?;
+
+    let wallet_address = Wallet::new_from_private_key(DUMMY_NETWORK, &wallet_private_key)
+        .expect("Infallible")
+        .address()
+        .to_string();
+
+    println!("Wallet address: {wallet_address}");
+    println!("Wallet private key: {wallet_private_key}");
 
     Ok(())
 }

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -37,7 +37,7 @@ pub fn create(no_password: bool, password: Option<String>) -> Result<()> {
 }
 
 pub fn import(
-    wallet_private_key: String,
+    mut wallet_private_key: String,
     no_password: bool,
     password: Option<String>,
 ) -> Result<()> {
@@ -51,6 +51,11 @@ pub fn import(
         .expect("Infallible")
         .address()
         .to_string();
+
+    // Prepend with 0x if it isn't already
+    if !wallet_private_key.starts_with("0x") {
+        wallet_private_key = format!("0x{wallet_private_key}");
+    }
 
     // Save the private key file
     let file_path = store_private_key(&wallet_private_key, maybe_encryption_password)?;

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -30,6 +30,7 @@ pub fn create(no_password: bool, password: Option<String>) -> Result<()> {
     let file_path = store_private_key(&wallet_private_key, maybe_encryption_password)?;
 
     println!("Wallet address: {wallet_address}");
+    println!("Wallet private key: {wallet_private_key}");
     println!("Stored wallet in: {file_path:?}");
 
     Ok(())

--- a/ant-cli/src/wallet/encryption.rs
+++ b/ant-cli/src/wallet/encryption.rs
@@ -123,11 +123,8 @@ pub fn decrypt_private_key(encrypted_data: &str, password: &str) -> Result<Strin
             ))
         })?;
 
-    let mut private_key_bytes = [0u8; 66];
-    private_key_bytes.copy_from_slice(&decrypted_data[0..66]);
-
     // Create secret key from decrypted byte
-    Ok(String::from_utf8(private_key_bytes.to_vec()).expect("not able to convert private key"))
+    Ok(String::from_utf8(decrypted_data.to_vec()).expect("not able to convert private key"))
 }
 
 #[cfg(test)]

--- a/ant-cli/src/wallet/fs.rs
+++ b/ant-cli/src/wallet/fs.rs
@@ -82,7 +82,10 @@ pub(crate) fn load_private_key(wallet_address: &str) -> Result<String, Error> {
     let encrypted_file_path =
         wallets_folder.join(format!("{wallet_address}{ENCRYPTED_PRIVATE_KEY_EXT}"));
 
-    let is_encrypted = encrypted_file_path.exists();
+    let is_plain = wallets_folder.join(&file_name).exists();
+
+    // Trick to favour the plain file in case they both exist
+    let is_encrypted = encrypted_file_path.exists() && !is_plain;
 
     if is_encrypted {
         file_name.push_str(ENCRYPTED_PRIVATE_KEY_EXT);

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 
 [features]
 local = ["evmlib/local"]
@@ -16,7 +16,7 @@ test-utils = []
 
 [dependencies]
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.2" }
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 
 [features]
 local = ["evmlib/local"]
@@ -16,7 +16,7 @@ test-utils = []
 
 [dependencies]
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.1.4" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
 hex = "~0.4.3"
 lazy_static = "~1.4.0"
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }

--- a/ant-logging/Cargo.toml
+++ b/ant-logging/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-logging"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.41-rc.1"
+version = "0.2.41-rc.2"
 
 [dependencies]
 chrono = "~0.4.19"

--- a/ant-logging/Cargo.toml
+++ b/ant-logging/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-logging"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.40"
+version = "0.2.41-rc.1"
 
 [dependencies]
 chrono = "~0.4.19"

--- a/ant-metrics/Cargo.toml
+++ b/ant-metrics/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-metrics"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.20"
+version = "0.1.21-rc.1"
 
 [[bin]]
 path = "src/main.rs"

--- a/ant-metrics/Cargo.toml
+++ b/ant-metrics/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-metrics"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.21-rc.1"
+version = "0.1.21-rc.2"
 
 [[bin]]
 path = "src/main.rs"

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-networking"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 
 [features]
 default = []
@@ -20,11 +20,11 @@ upnp = ["libp2p/upnp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
-ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.2" }
 async-trait = "0.1"
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.6.1"

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-networking"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.19.5"
+version = "0.3.0-rc.1"
 
 [features]
 default = []
@@ -20,11 +20,11 @@ upnp = ["libp2p/upnp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
-ant-registers = { path = "../ant-registers", version = "0.4.3" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
 async-trait = "0.1"
 bytes = { version = "1.0.1", features = ["serde"] }
 custom_debug = "~0.6.1"

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -627,9 +627,12 @@ impl SwarmDriver {
     fn remove_bootstrap_from_full(&mut self, peer_id: PeerId) {
         let mut shall_removed = None;
 
+        let mut bucket_index = Some(0);
+
         if let Some(kbucket) = self.swarm.behaviour_mut().kademlia.kbucket(peer_id) {
             if kbucket.num_entries() >= K_VALUE.into() {
-                if let Some(peers) = self.bootstrap_peers.get(&kbucket.range().0.ilog2()) {
+                bucket_index = kbucket.range().0.ilog2();
+                if let Some(peers) = self.bootstrap_peers.get(&bucket_index) {
                     for peer_entry in kbucket.iter() {
                         if peers.contains(peer_entry.node.key.preimage()) {
                             shall_removed = Some(*peer_entry.node.key.preimage());
@@ -648,6 +651,13 @@ impl SwarmDriver {
                 .remove_peer(&to_be_removed_bootstrap);
             if let Some(removed_peer) = entry {
                 self.update_on_peer_removal(*removed_peer.node.key.preimage());
+            }
+
+            // With the switch to using bootstrap cache, workload is distributed already.
+            // to avoid peers keeps being replaced by each other,
+            // there shall be just one time of removal to be undertaken.
+            if let Some(peers) = self.bootstrap_peers.get_mut(&bucket_index) {
+                let _ = peers.remove(&peer_id);
             }
         }
     }

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -1111,7 +1111,8 @@ impl Network {
             );
         }
 
-        let closest_peers = sort_peers_by_address(&closest_peers, key, CLOSE_GROUP_SIZE + 1)?;
+        let expanded_close_group = CLOSE_GROUP_SIZE + CLOSE_GROUP_SIZE / 2;
+        let closest_peers = sort_peers_by_address(&closest_peers, key, expanded_close_group)?;
         Ok(closest_peers.into_iter().cloned().collect())
     }
 

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.11.4-rc.1"
+version = "0.11.4-rc.2"
 
 [[bin]]
 name = "antctl"
@@ -30,13 +30,13 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
 ant-releases = { version = "0.4.0" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.2" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.11.3"
+version = "0.11.4-rc.1"
 
 [[bin]]
 name = "antctl"
@@ -30,13 +30,13 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
 ant-releases = { version = "0.4.0" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.3" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-rpc-client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.6.37-rc.1"
+version = "0.6.37-rc.2"
 
 [[bin]]
 name = "antnode_rpc_client"
@@ -17,11 +17,11 @@ path = "src/main.rs"
 nightly = []
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.3.0-rc.1" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.3.0-rc.2" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.2" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-rpc-client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.6.36"
+version = "0.6.37-rc.1"
 
 [[bin]]
 name = "antnode_rpc_client"
@@ -17,11 +17,11 @@ path = "src/main.rs"
 nightly = []
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.112.6" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.3" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.3.0-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,14 +26,14 @@ otlp = ["ant-logging/otlp"]
 upnp = ["ant-networking/upnp"]
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
-ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.2" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.2" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
@@ -83,10 +83,10 @@ walkdir = "~2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
-autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = ["registers"] }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.2" }
+autonomi = { path = "../autonomi", version = "0.3.0-rc.2", features = ["registers"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.112.6"
+version = "0.3.0-rc.1"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,14 +26,14 @@ otlp = ["ant-logging/otlp"]
 upnp = ["ant-networking/upnp"]
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-networking = { path = "../ant-networking", version = "0.19.5" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
-ant-registers = { path = "../ant-registers", version = "0.4.3" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.3" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.4.4-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
@@ -83,10 +83,10 @@ walkdir = "~2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "0.17.15", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.1.4" }
-autonomi = { path = "../autonomi", version = "0.2.4", features = ["registers"] }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
+autonomi = { path = "../autonomi", version = "0.3.0-rc.1", features = ["registers"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,16 +7,16 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 
 [features]
 default = []
 rpc = ["tonic", "prost"]
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.2" }
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.2"

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,16 +7,16 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.17.15"
+version = "0.3.0-rc.1"
 
 [features]
 default = []
 rpc = ["tonic", "prost"]
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-registers = { path = "../ant-registers", version = "0.4.3" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.2"

--- a/ant-registers/Cargo.toml
+++ b/ant-registers/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-registers"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 
 [features]
 test-utils = []

--- a/ant-registers/Cargo.toml
+++ b/ant-registers/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-registers"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.4-rc.1"
+version = "0.4.4-rc.2"
 
 [features]
 test-utils = []

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.4-rc.1"
+version = "0.4.4-rc.2"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features = ["rpc"] }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.54.1", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15", features = ["rpc"] }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.54.1", features = ["kad"] }

--- a/ant-token-supplies/Cargo.toml
+++ b/ant-token-supplies/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-token-supplies"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.58"
+version = "0.1.59-rc.1"
 
 
 [dependencies]

--- a/ant-token-supplies/Cargo.toml
+++ b/ant-token-supplies/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-token-supplies"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.59-rc.1"
+version = "0.1.59-rc.2"
 
 
 [dependencies]

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,11 +25,11 @@ registers = []
 vault = ["registers"]
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
-ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.2" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -60,7 +60,7 @@ xor_name = "5.0.0"
 
 [dev-dependencies]
 alloy = { version = "0.7.3", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
-ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.2" }
 eyre = "0.6.5"
 sha2 = "0.10.6"
 # Do not specify the version field. Release process expects even the local dev deps to be published.
@@ -72,7 +72,7 @@ wasm-bindgen-test = "0.3.43"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
-evmlib = { path = "../evmlib", version = "0.1.5-rc.1", features = ["wasm-bindgen"] }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.2", features = ["wasm-bindgen"] }
 # See https://github.com/sebcrozet/instant/blob/7bd13f51f5c930239fddc0476a837870fb239ed7/README.md#using-instant-for-a-wasm-platform-where-performancenow-is-not-available
 instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.70"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.2.4"
+version = "0.3.0-rc.1"
 edition = "2021"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,11 +25,11 @@ registers = []
 vault = ["registers"]
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-networking = { path = "../ant-networking", version = "0.19.5" }
-ant-protocol = { version = "0.17.15", path = "../ant-protocol" }
-ant-registers = { path = "../ant-registers", version = "0.4.3" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-registers = { path = "../ant-registers", version = "0.4.4-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -60,7 +60,7 @@ xor_name = "5.0.0"
 
 [dev-dependencies]
 alloy = { version = "0.7.3", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
-ant-logging = { path = "../ant-logging", version = "0.2.40" }
+ant-logging = { path = "../ant-logging", version = "0.2.41-rc.1" }
 eyre = "0.6.5"
 sha2 = "0.10.6"
 # Do not specify the version field. Release process expects even the local dev deps to be published.
@@ -72,7 +72,7 @@ wasm-bindgen-test = "0.3.43"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
-evmlib = { path = "../evmlib", version = "0.1.4", features = ["wasm-bindgen"] }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.1", features = ["wasm-bindgen"] }
 # See https://github.com/sebcrozet/instant/blob/7bd13f51f5c930239fddc0476a837870fb239ed7/README.md#using-instant-for-a-wasm-platform-where-performancenow-is-not-available
 instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.70"

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.2" }
 tokio = { version = "1.40", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.1.4" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
 tokio = { version = "1.40", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.4"
+version = "0.1.5-rc.1"
 
 [features]
 wasm-bindgen = ["alloy/wasm-bindgen"]

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.5-rc.1"
+version = "0.1.5-rc.2"
 
 [features]
 wasm-bindgen = ["alloy/wasm-bindgen"]

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "nat-detection"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.12-rc.1"
+version = "0.2.12-rc.2"
 
 [[bin]]
 name = "nat-detection"
@@ -17,9 +17,9 @@ path = "src/main.rs"
 nightly = []
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.2" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "nat-detection"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 
 [[bin]]
 name = "nat-detection"
@@ -17,9 +17,9 @@ path = "src/main.rs"
 nightly = []
 
 [dependencies]
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-networking = { path = "../ant-networking", version = "0.19.5" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-networking = { path = "../ant-networking", version = "0.3.0-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,13 +18,13 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
-ant-node-manager = { version = "0.11.4-rc.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.2" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.2" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.2" }
+ant-node-manager = { version = "0.11.4-rc.2", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.2" }
 ant-releases = { version = "0.4.0" }
-ant-service-management = { version = "0.4.4-rc.1", path = "../ant-service-management" }
+ant-service-management = { version = "0.4.4-rc.2", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.4.5"
+version = "0.5.0-rc.1"
 edition = "2021"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,13 +18,13 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0" }
-ant-build-info = { path = "../ant-build-info", version = "0.1.19" }
-ant-evm = { path = "../ant-evm", version = "0.1.4" }
-ant-node-manager = { version = "0.11.3", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "0.17.15" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.0-rc.1" }
+ant-build-info = { path = "../ant-build-info", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.5-rc.1" }
+ant-node-manager = { version = "0.11.4-rc.1", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "0.3.0-rc.1" }
 ant-releases = { version = "0.4.0" }
-ant-service-management = { version = "0.4.3", path = "../ant-service-management" }
+ant-service-management = { version = "0.4.4-rc.1", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -15,4 +15,4 @@
 release-year: 2024
 release-month: 12
 release-cycle: 1
-release-cycle-counter: 1
+release-cycle-counter: 2

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -13,6 +13,6 @@
 # Both of these numbers are used in the packaged version number, which is a collective version
 # number for all the released binaries.
 release-year: 2024
-release-month: 11
+release-month: 12
 release-cycle: 1
-release-cycle-counter: 6
+release-cycle-counter: 1

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "test-utils"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.4.12-rc.1"
+version = "0.4.12-rc.2"
 
 [dependencies]
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.2"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.2" }
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "test-utils"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.4.11"
+version = "0.4.12-rc.1"
 
 [dependencies]
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.2"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.1.4" }
+evmlib = { path = "../evmlib", version = "0.1.5-rc.1" }
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }


### PR DESCRIPTION
### Description

bootstrap node replacement only to be carried out once, as due to the switch to the bootstrap cache, workload is already distributed and could have peers replacing each other.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
