### PR TITLE
resolving client upload failures due to lack of quotes

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -135,7 +135,7 @@ const PERIODIC_KAD_BOOTSTRAP_INTERVAL_MAX_S: u64 = 21600;
 
 // Init during compilation, instead of runtime error that should never happen
 // Option<T>::expect will be stabilised as const in the future (https://github.com/rust-lang/rust/issues/67441)
-const REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(CLOSE_GROUP_SIZE) {
+const REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(CLOSE_GROUP_SIZE + 2) {
     Some(v) => v,
     None => panic!("CLOSE_GROUP_SIZE should not be zero"),
 };

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -387,6 +387,10 @@ impl Network {
             .await?;
         // Filter out results from the ignored peers.
         close_nodes.retain(|peer_id| !ignore_peers.contains(peer_id));
+        info!(
+            "For record {record_address:?} quoting {} nodes. ignore_peers is {ignore_peers:?}",
+            close_nodes.len()
+        );
 
         if close_nodes.is_empty() {
             error!("Can't get store_cost of {record_address:?}, as all close_nodes are ignored");


### PR DESCRIPTION
### Description

This PR contains two commits trying to resolve client upload failures due to lack of quotes:
* Carry out retries in case of fetched less quotes
* client shall expand `replication_factor` to get more closest_peers from the network query

### Related Issue

Fixes #<issue_number> (if applicable).

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
