### PR TITLE
chore: no longer carryout out bootstrap node replacement

### DIFF
--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -253,7 +253,10 @@ impl SwarmDriver {
                         // If we are not local, we care only for peers that we dialed and thus are reachable.
                         if self.local || has_dialed {
                             // A bad node cannot establish a connection with us. So we can add it to the RT directly.
-                            self.remove_bootstrap_from_full(peer_id);
+
+                            // With the new bootstrap cache, the workload is distributed,
+                            // hence no longer need to replace bootstrap nodes for workload share.
+                            // self.remove_bootstrap_from_full(peer_id);
 
                             // Avoid have `direct link format` addrs co-exists with `relay` addr
                             if has_relayed {
@@ -624,6 +627,7 @@ impl SwarmDriver {
     }
 
     // if target bucket is full, remove a bootstrap node if presents.
+    #[allow(dead_code)]
     fn remove_bootstrap_from_full(&mut self, peer_id: PeerId) {
         let mut shall_removed = None;
 


### PR DESCRIPTION
### Description

no longer carryout out bootstrap node replacement
With the new bootstrap cache, the workload is distributed,
hence no longer need to replace bootstrap nodes for workload 

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
