### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/ant-bootstrap/src/cache_store.rs
+++ b/ant-bootstrap/src/cache_store.rs
@@ -148,7 +148,7 @@ impl BootstrapCacheStore {
         &self.config
     }
 
-    /// Create a empty CacheStore with the given configuration
+    /// Create an empty CacheStore with the given configuration
     pub fn new(config: BootstrapCacheConfig) -> Result<Self> {
         info!("Creating new CacheStore with config: {:?}", config);
         let cache_path = config.cache_file_path.clone();
@@ -172,7 +172,7 @@ impl BootstrapCacheStore {
         Ok(store)
     }
 
-    /// Create a empty CacheStore from the given peers argument.
+    /// Create an empty CacheStore from the given peers argument.
     /// This also modifies the cfg if provided based on the PeersArgs.
     /// And also performs some actions based on the PeersArgs.
     ///

--- a/ant-bootstrap/src/contacts.rs
+++ b/ant-bootstrap/src/contacts.rs
@@ -28,7 +28,7 @@ const MAINNET_CONTACTS: &[&str] = &[
 const FETCH_TIMEOUT_SECS: u64 = 30;
 /// Maximum number of endpoints to fetch at a time
 const MAX_CONCURRENT_FETCHES: usize = 3;
-/// The max number of retries for a endpoint on failure.
+/// The max number of retries for an endpoint on failure.
 const MAX_RETRIES_ON_FETCH_FAILURE: usize = 3;
 
 /// Discovers initial peers from a list of endpoints
@@ -228,7 +228,7 @@ impl ContactsFetcher {
         Ok(bootstrap_addresses)
     }
 
-    /// Try to parse a response from a endpoint
+    /// Try to parse a response from an endpoint
     fn try_parse_response(response: &str, ignore_peer_id: bool) -> Result<Vec<Multiaddr>> {
         match serde_json::from_str::<CacheData>(response) {
             Ok(json_endpoints) => {

--- a/ant-protocol/src/storage/scratchpad.rs
+++ b/ant-protocol/src/storage/scratchpad.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use xor_name::XorName;
 
-/// Scratchpad, an mutable address for encrypted data
+/// Scratchpad, a mutable address for encrypted data
 #[derive(
     Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug, Serialize, Deserialize,
 )]

--- a/node-launchpad/src/error.rs
+++ b/node-launchpad/src/error.rs
@@ -13,7 +13,7 @@ use ratatui::{
 
 /// Error popup is a popup that is used to display error messages to the user.
 ///
-/// It accepts a title, a message and a error message.
+/// It accepts a title, a message and an error message.
 /// Handles key events to hide the popup (Enter and Esc keys).
 ///
 /// How to use:


### PR DESCRIPTION
This pull request corrects minor typographical errors in documentation and comments across several files. Specifically, the following changes were made:

- Replaced instances of "a empty" with "an empty" in comments and documentation in `cache_store.rs`.
- Corrected "a endpoint" to "an endpoint" in `contacts.rs` documentation.
- Fixed the use of "a error message" to "an error message" in `error.rs`.
- Minor adjustments to wording in `scratchpad.rs` for clarity.

These changes improve the clarity and correctness of the documentation.

#### Related Issue:
Fixes typos in documentation.

#### Type of Change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [x] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).
