### PR TITLE
feat: remove dial error print to stderr

### DIFF
--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -191,7 +191,6 @@ impl Client {
             for addr in peers {
                 if let Err(err) = network_clone.dial(addr.clone()).await {
                     error!("Failed to dial addr={addr} with err: {err:?}");
-                    eprintln!("addr={addr} Failed to dial: {err:?}");
                 };
             }
         });


### PR DESCRIPTION
### Description

User does not need to be aware of the errors that originate when dialing the peers. and Need not be displayed to the console. 


