### PR TITLE
fix: use smaller timeouts for circuit relay connections

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -671,6 +671,7 @@ impl NetworkBuilder {
                 circuit_src_rate_limiters: vec![], // No extra rate limiting for now
                 // We should at least be able to relay packets with chunks etc.
                 max_circuit_bytes: MAX_PACKET_SIZE as u64,
+                max_circuit_duration: CONNECTION_KEEP_ALIVE_TIMEOUT,
                 ..Default::default()
             };
             libp2p::relay::Behaviour::new(peer_id, relay_server_cfg)


### PR DESCRIPTION
This was originally PR #2568.

It was prematurely merged into an RC branch and that RC has since been abandoned.

We can release it in a new RC if it gets through a comparison.