### PR TITLE
chore: publish docs on merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,16 +3,14 @@ on:
   push:
     branches:
       - main
-      - data_further_refactor
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write
 
 jobs:
   deploy:
+    env:
+      GH_TOKEN: ${{ secrets.AUTONOMI_PAT }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/online-documentation/index.md
+++ b/docs/online-documentation/index.md
@@ -13,7 +13,7 @@ Autonomi is a decentralised data and communications platform designed to provide
   - [Data Types](guides/data_types.md) - Understanding the fundamental data structures
   - [Client Modes](guides/client_modes.md) - Different operational modes of the client
   - [Data Storage](guides/data_storage.md) - How data is stored and retrieved
-  - [Local Network Setup](guides/local_network.md) - Setting up a local development environmentv
+  - [Local Network Setup](guides/local_network.md) - Setting up a local development environment
 
 ### API References
 


### PR DESCRIPTION
We don't need to publish the documentation as part of the PR; it can be done after we merge.

The `GH_TOKEN` variable is also set to a personal access token that should have permission to push to the repository.

There is a small change in the documentation that removes a typo. It was used to test the process.