### PR TITLE
Small autonomi API changes for Dave

### DIFF
--- a/autonomi/src/client/data/public.rs
+++ b/autonomi/src/client/data/public.rs
@@ -177,7 +177,7 @@ impl Client {
     }
 
     // Upload chunks and retry failed uploads up to `RETRY_ATTEMPTS` times.
-    pub(crate) async fn upload_chunks_with_retries<'a>(
+    pub async fn upload_chunks_with_retries<'a>(
         &self,
         mut chunks: Vec<&'a Chunk>,
         receipt: &Receipt,

--- a/autonomi/src/client/vault/key.rs
+++ b/autonomi/src/client/vault/key.rs
@@ -39,6 +39,17 @@ pub fn derive_vault_key(evm_sk_hex: &str) -> Result<VaultSecretKey, VaultKeyErro
     Ok(vault_sk)
 }
 
+/// Derives the vault secret key from a signature hex string
+pub fn vault_key_from_signature_hex(signature_hex: &str) -> Result<VaultSecretKey, VaultKeyError> {
+    let signature_bytes = hex::decode(signature_hex)
+        .map_err(|e| VaultKeyError::FailedToGenerateVaultSecretKey(e.to_string()))?;
+
+    let blst_key = derive_secret_key_from_seed(&signature_bytes)?;
+    let vault_sk = blst_to_blsttc(&blst_key)?;
+
+    Ok(vault_sk)
+}
+
 /// Convert a blst secret key to a blsttc secret key and pray that endianness is the same
 pub(crate) fn blst_to_blsttc(sk: &BlstSecretKey) -> Result<bls::SecretKey, VaultKeyError> {
     let sk_bytes = sk.to_bytes();


### PR DESCRIPTION
- Changes the the `upload_chunks_with_retries` function visibility to `pub`.
- Adds a public `vault_key_from_signature_hex` function.