### PR TITLE
refactor(autonomi): deterministic archive

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -98,15 +98,14 @@ jobs:
           ls -l $ANT_DATA_PATH/client_first/logs
           mkdir $ANT_DATA_PATH/client
           ls -l $ANT_DATA_PATH
-          cp ./the-test-data.zip ./the-test-data_1.zip
-          ./target/release/ant --log-output-dest=data-dir file upload "./the-test-data_1.zip" > ./second_upload 2>&1
-          rg 'Total cost: 0 AttoTokens' ./second_upload -c --stats
+          ./target/release/ant --log-output-dest=data-dir file upload --public "./the-test-data.zip" > ./upload_output_second 2>&1
+          rg 'Total cost: 0 AttoTokens' ./upload_output_second -c --stats
         env:
           ANT_LOG: "all"
         timeout-minutes: 25
 
       - name: showing the second upload terminal output
-        run: cat second_upload
+        run: cat upload_output_second
         shell: bash
         if: always()
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -100,6 +100,7 @@ jobs:
           ls -l $ANT_DATA_PATH
           cp ./the-test-data.zip ./the-test-data_1.zip
           ./target/release/ant --log-output-dest=data-dir file upload "./the-test-data_1.zip" > ./second_upload 2>&1
+          rg 'Total cost: 0 AttoTokens' ./second_upload -c --stats
         env:
           ANT_LOG: "all"
         timeout-minutes: 25

--- a/autonomi/src/client/files/archive.rs
+++ b/autonomi/src/client/files/archive.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
@@ -36,8 +36,6 @@ pub enum RenameError {
 /// Metadata for a file in an archive. Time values are UNIX timestamps.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Metadata {
-    /// When the file was (last) uploaded to the network.
-    pub uploaded: u64,
     /// File creation time on local file system. See [`std::fs::Metadata::created`] for details per OS.
     pub created: u64,
     /// Last file modification time taken from local file system. See [`std::fs::Metadata::modified`] for details per OS.
@@ -67,7 +65,7 @@ impl Metadata {
 /// The data maps are stored within this structure instead of uploading them to the network, keeping the data private.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PrivateArchive {
-    map: HashMap<PathBuf, (DataMapChunk, Metadata)>,
+    map: BTreeMap<PathBuf, (DataMapChunk, Metadata)>,
 }
 
 impl PrivateArchive {
@@ -75,7 +73,7 @@ impl PrivateArchive {
     /// Note that this does not upload the archive to the network
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: BTreeMap::new(),
         }
     }
 
@@ -129,7 +127,7 @@ impl PrivateArchive {
     }
 
     /// Get the underlying map
-    pub fn map(&self) -> &HashMap<PathBuf, (DataMapChunk, Metadata)> {
+    pub fn map(&self) -> &BTreeMap<PathBuf, (DataMapChunk, Metadata)> {
         &self.map
     }
 

--- a/autonomi/src/client/files/archive.rs
+++ b/autonomi/src/client/files/archive.rs
@@ -55,7 +55,6 @@ impl Metadata {
             .as_secs();
 
         Self {
-            uploaded: now,
             created: now,
             modified: now,
             size,

--- a/autonomi/src/client/files/archive_public.rs
+++ b/autonomi/src/client/files/archive_public.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
@@ -34,7 +34,7 @@ pub type ArchiveAddr = XorName;
 /// to the network, of which the addresses are stored in this archive.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PublicArchive {
-    map: HashMap<PathBuf, (DataAddr, Metadata)>,
+    map: BTreeMap<PathBuf, (DataAddr, Metadata)>,
 }
 
 impl PublicArchive {
@@ -42,7 +42,7 @@ impl PublicArchive {
     /// Note that this does not upload the archive to the network
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: BTreeMap::new(),
         }
     }
 
@@ -92,7 +92,7 @@ impl PublicArchive {
     }
 
     /// Get the underlying map
-    pub fn map(&self) -> &HashMap<PathBuf, (DataAddr, Metadata)> {
+    pub fn map(&self) -> &BTreeMap<PathBuf, (DataAddr, Metadata)> {
         &self.map
     }
 

--- a/autonomi/src/client/files/fs_public.rs
+++ b/autonomi/src/client/files/fs_public.rs
@@ -194,7 +194,6 @@ pub(crate) fn metadata_from_entry(entry: &walkdir::DirEntry) -> Metadata {
                 entry.path().display()
             );
             return Metadata {
-                uploaded: 0,
                 created: 0,
                 modified: 0,
                 size: 0,
@@ -224,10 +223,6 @@ pub(crate) fn metadata_from_entry(entry: &walkdir::DirEntry) -> Metadata {
     let modified = unix_time("modified", fs_metadata.modified());
 
     Metadata {
-        uploaded: SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or(Duration::from_secs(0))
-            .as_secs(),
         created,
         modified,
         size: fs_metadata.len(),


### PR DESCRIPTION
This ensures the same bunch of files/directories will yield the same (serialized) archive (assuming the files haven't changed). Furthermore, this will mean that uploading the same files will not require uploading a new version of the archive (which would differ slightly from the old).