### PR TITLE
feat(ant-cli): show usage without arguments

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -233,7 +233,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
         None => {
             // If no subcommand is given, default to clap's error behaviour.
             Opt::command()
-                .error(ErrorKind::InvalidSubcommand, "No subcommand given")
+                .error(ErrorKind::MissingSubcommand, "Please provide a subcommand")
                 .exit();
         }
     }

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -12,7 +12,7 @@ mod vault;
 mod wallet;
 
 use crate::opt::Opt;
-use clap::Subcommand;
+use clap::{error::ErrorKind, CommandFactory as _, Subcommand};
 use color_eyre::Result;
 
 #[derive(Subcommand, Debug)]
@@ -230,6 +230,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             WalletCmd::Export => wallet::export(),
             WalletCmd::Balance => wallet::balance().await,
         },
-        None => Ok(()),
+        None => {
+            // If no subcommand is given, default to clap's error behaviour.
+            Opt::command()
+                .error(ErrorKind::InvalidSubcommand, "No subcommand given")
+                .exit();
+        }
     }
 }

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 #[command(disable_version_flag = true)]
 #[command(author, version, about, long_about = None)]
 pub(crate) struct Opt {
-    /// Available sub commands.
+    // Available subcommands. This is optional to allow `--version` to work without a subcommand.
     #[clap(subcommand)]
     pub command: Option<SubCmd>,
 


### PR DESCRIPTION
When no subcommand is passed, show the usage and error the CLI.

```console
zamaan@demo:~$ ant
Logging to directory: "$HOME/.local/share/autonomi/client/logs/log_2025-01-06_16-53-20"
error: Please provide a subcommand

Usage: ant-cli [OPTIONS] [COMMAND]

For more information, try '--help'.

zamaan@demo:~$ echo $?
2
```

```console
zamaan@demo:~$ ant --version
Autonomi Client v0.3.1
Network version: ant/0.3/1
Package version: 2024.12.1.6
Git info: feat-show-usage-on-no-arguments-cli / 463b7068d / 1980-01-01

zamaan@demo:~$ echo $?
0
```
