### PR TITLE
fix: shall only have Chunk and NonChunk for RecordType

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -662,9 +662,10 @@ impl SwarmDriver {
                     Ok(record_header) => {
                         match record_header.kind {
                             RecordKind::Chunk => RecordType::Chunk,
-                            RecordKind::Scratchpad => RecordType::Scratchpad,
-                            RecordKind::Pointer => RecordType::Pointer,
-                            RecordKind::GraphEntry | RecordKind::Register => {
+                            RecordKind::GraphEntry
+                            | RecordKind::Pointer
+                            | RecordKind::Register
+                            | RecordKind::Scratchpad => {
                                 let content_hash = XorName::from_content(&record.value);
                                 RecordType::NonChunk(content_hash)
                             }

--- a/ant-node/src/python.rs
+++ b/ant-node/src/python.rs
@@ -4,11 +4,7 @@
 use crate::{NodeBuilder, RunningNode};
 use ant_evm::{EvmNetwork, RewardsAddress};
 use ant_networking::PutRecordCfg;
-use ant_protocol::{
-    node::get_antnode_root_dir,
-    storage::{ChunkAddress, RecordType},
-    NetworkAddress,
-};
+use ant_protocol::{node::get_antnode_root_dir, storage::ChunkAddress, NetworkAddress};
 use const_hex::FromHex;
 use libp2p::{
     identity::{Keypair, PeerId},
@@ -239,7 +235,7 @@ impl AntNode {
         self_: PyRef<Self>,
         key: String,
         value: Vec<u8>,
-        record_type: String,
+        _data_type: String,
     ) -> PyResult<()> {
         let node_guard = self_
             .node
@@ -249,12 +245,6 @@ impl AntNode {
             .runtime
             .try_lock()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire runtime lock"))?;
-
-        let _record_type = match record_type.to_lowercase().as_str() {
-            "chunk" => RecordType::Chunk,
-            "scratchpad" => RecordType::Scratchpad,
-            _ => return Err(PyValueError::new_err("Invalid record type. Must be one of: 'chunk', 'register', 'scratchpad', 'transaction'")),
-        };
 
         match (&*node_guard, &*rt_guard) {
             (Some(node), Some(rt)) => {

--- a/ant-protocol/src/storage/header.rs
+++ b/ant-protocol/src/storage/header.rs
@@ -16,14 +16,11 @@ use std::fmt::Display;
 use xor_name::XorName;
 
 /// Indicates the type of the record content.
-/// Note for `Spend` and `Register`, using its content_hash (in `XorName` format)
-/// to indicate different content body.
+/// This is to be only used within the node instance to reflect different content version.
+/// Hence, only need to have two entries: Chunk and NonChunk.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub enum RecordType {
     Chunk,
-    Scratchpad,
-    Pointer,
-    GraphEntry,
     NonChunk(XorName),
 }
 


### PR DESCRIPTION
### Description

RecordType is only used within node instance to help with identify record content having different versions.
Hence only need to have entries of `Chunk` or `NonChunk`.


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
