### PR TITLE
Add evm network in client config

### DIFF
--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -82,6 +82,9 @@ pub struct ClientConfig {
     ///
     /// If not provided, the client will use the default bootstrap peers.
     pub peers: Option<Vec<Multiaddr>>,
+
+    /// EVM network to use for quotations and payments.
+    pub evm_network: EvmNetwork,
 }
 
 impl Default for ClientConfig {
@@ -92,6 +95,7 @@ impl Default for ClientConfig {
             #[cfg(not(feature = "local"))]
             local: false,
             peers: None,
+            evm_network: Default::default(),
         }
     }
 }
@@ -151,6 +155,7 @@ impl Client {
         Self::init_with_config(ClientConfig {
             local,
             peers: Some(peers),
+            evm_network: Default::default(),
         })
         .await
     }

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -78,8 +78,8 @@ impl CustomNetwork {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub enum Network {
-    #[default]
     ArbitrumOne,
+    #[default]
     ArbitrumSepolia,
     Custom(CustomNetwork),
 }


### PR DESCRIPTION
- Adds `evm_network` field to `ClientConfig`.
- Changes the default `EvmNetwork` to `EvmNetwork::ArbitrumSepolia`.