### PR TITLE
chore: refactor RecordKind, creating DataTypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libp2p",
+ "prometheus-client",
  "prost 0.9.0",
  "rand 0.8.5",
  "rmp-serde",

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -17,7 +17,7 @@ use ant_evm::{PaymentQuote, QuotingMetrics, U256};
 use ant_protocol::{
     convert_distance_to_u256,
     messages::{Cmd, Request, Response},
-    storage::{RecordHeader, RecordKind, ValidationType},
+    storage::{DataTypes, RecordHeader, RecordKind, ValidationType},
     NetworkAddress, PrettyPrintRecordKey,
 };
 use libp2p::{
@@ -661,19 +661,12 @@ impl SwarmDriver {
                 let record_type = match RecordHeader::from_record(&record) {
                     Ok(record_header) => {
                         match record_header.kind {
-                            RecordKind::Chunk => ValidationType::Chunk,
-                            RecordKind::GraphEntry
-                            | RecordKind::Pointer
-                            | RecordKind::Register
-                            | RecordKind::Scratchpad => {
+                            RecordKind::DataOnly(DataTypes::Chunk) => ValidationType::Chunk,
+                            RecordKind::DataOnly(_) => {
                                 let content_hash = XorName::from_content(&record.value);
                                 ValidationType::NonChunk(content_hash)
                             }
-                            RecordKind::ChunkWithPayment
-                            | RecordKind::RegisterWithPayment
-                            | RecordKind::PointerWithPayment
-                            | RecordKind::GraphEntryWithPayment
-                            | RecordKind::ScratchpadWithPayment => {
+                            RecordKind::DataWithPayment(_) => {
                                 error!("Record {record_key:?} with payment shall not be stored locally.");
                                 return Err(NetworkError::InCorrectRecordHeader);
                             }

--- a/ant-networking/src/event/kad.rs
+++ b/ant-networking/src/event/kad.rs
@@ -11,7 +11,7 @@ use crate::{
     GetRecordCfg, GetRecordError, NetworkError, Result, SwarmDriver, CLOSE_GROUP_SIZE,
 };
 use ant_protocol::{
-    storage::{try_serialize_record, GraphEntry, RecordKind},
+    storage::{try_serialize_record, DataTypes, GraphEntry, RecordKind},
     NetworkAddress, PrettyPrintRecordKey,
 };
 use itertools::Itertools;
@@ -415,7 +415,7 @@ impl SwarmDriver {
 
                         let bytes = try_serialize_record(
                             &accumulated_transactions,
-                            RecordKind::GraphEntry,
+                            RecordKind::DataOnly(DataTypes::GraphEntry),
                         )?;
 
                         let new_accumulated_record = Record {

--- a/ant-networking/src/graph.rs
+++ b/ant-networking/src/graph.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{driver::GetRecordCfg, Network, NetworkError, Result};
-use ant_protocol::storage::{GraphEntry, GraphEntryAddress};
+use ant_protocol::storage::{DataTypes, GraphEntry, GraphEntryAddress};
 use ant_protocol::{
     storage::{try_deserialize_record, RecordHeader, RecordKind, RetryStrategy},
     NetworkAddress, PrettyPrintRecordKey,
@@ -37,7 +37,7 @@ impl Network {
 
 pub fn get_graph_entry_from_record(record: &Record) -> Result<Vec<GraphEntry>> {
     let header = RecordHeader::from_record(record)?;
-    if let RecordKind::GraphEntry = header.kind {
+    if let RecordKind::DataOnly(DataTypes::GraphEntry) = header.kind {
         let transactions = try_deserialize_record::<Vec<GraphEntry>>(record)?;
         Ok(transactions)
     } else {
@@ -45,6 +45,8 @@ pub fn get_graph_entry_from_record(record: &Record) -> Result<Vec<GraphEntry>> {
             "RecordKind mismatch while trying to retrieve graph_entry from record {:?}",
             PrettyPrintRecordKey::from(&record.key)
         );
-        Err(NetworkError::RecordKindMismatch(RecordKind::GraphEntry))
+        Err(NetworkError::RecordKindMismatch(RecordKind::DataOnly(
+            DataTypes::GraphEntry,
+        )))
     }
 }

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -52,7 +52,7 @@ use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
     error::Error as ProtocolError,
     messages::{ChunkProof, Nonce, Query, QueryResponse, Request, Response},
-    storage::{Pointer, RetryStrategy, Scratchpad, ValidationType},
+    storage::{DataTypes, Pointer, RetryStrategy, Scratchpad, ValidationType},
     NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey, CLOSE_GROUP_SIZE,
 };
 use futures::future::select_all;
@@ -632,16 +632,11 @@ impl Network {
                 }
 
                 match kind {
-                    RecordKind::Chunk
-                    | RecordKind::ChunkWithPayment
-                    | RecordKind::GraphEntryWithPayment
-                    | RecordKind::RegisterWithPayment
-                    | RecordKind::PointerWithPayment
-                    | RecordKind::ScratchpadWithPayment => {
+                    RecordKind::DataOnly(DataTypes::Chunk) | RecordKind::DataWithPayment(_) => {
                         error!("Encountered a split record for {pretty_key:?} with unexpected RecordKind {kind:?}, skipping.");
                         continue;
                     }
-                    RecordKind::GraphEntry => {
+                    RecordKind::DataOnly(DataTypes::GraphEntry) => {
                         info!("For record {pretty_key:?}, we have a split record for a transaction attempt. Accumulating transactions");
 
                         match get_graph_entry_from_record(record) {
@@ -653,7 +648,7 @@ impl Network {
                             }
                         }
                     }
-                    RecordKind::Register => {
+                    RecordKind::DataOnly(DataTypes::Register) => {
                         info!("For record {pretty_key:?}, we have a split record for a register. Accumulating registers");
                         let Ok(register) = try_deserialize_record::<SignedRegister>(record) else {
                             error!(
@@ -675,7 +670,7 @@ impl Network {
                             }
                         }
                     }
-                    RecordKind::Pointer => {
+                    RecordKind::DataOnly(DataTypes::Pointer) => {
                         info!("For record {pretty_key:?}, we have a split record for a pointer. Selecting the one with the highest count");
                         let Ok(pointer) = try_deserialize_record::<Pointer>(record) else {
                             error!(
@@ -697,7 +692,7 @@ impl Network {
                         }
                         valid_pointer = Some(pointer);
                     }
-                    RecordKind::Scratchpad => {
+                    RecordKind::DataOnly(DataTypes::Scratchpad) => {
                         info!("For record {pretty_key:?}, we have a split record for a scratchpad. Selecting the one with the highest count");
                         let Ok(scratchpad) = try_deserialize_record::<Scratchpad>(record) else {
                             error!(
@@ -733,7 +728,7 @@ impl Network {
                 .collect::<Vec<GraphEntry>>();
             let record = Record {
                 key: key.clone(),
-                value: try_serialize_record(&accumulated_transactions, RecordKind::GraphEntry)
+                value: try_serialize_record(&accumulated_transactions, RecordKind::DataOnly(DataTypes::GraphEntry))
                     .map_err(|err| {
                         error!(
                             "Error while serializing the accumulated transactions for {pretty_key:?}: {err:?}"
@@ -754,14 +749,15 @@ impl Network {
                 acc
             });
 
-            let record_value = try_serialize_record(&signed_register, RecordKind::Register)
-                .map_err(|err| {
-                    error!(
+            let record_value =
+                try_serialize_record(&signed_register, RecordKind::DataOnly(DataTypes::Register))
+                    .map_err(|err| {
+                        error!(
                         "Error while serializing the merged register for {pretty_key:?}: {err:?}"
                     );
-                    NetworkError::from(err)
-                })?
-                .to_vec();
+                        NetworkError::from(err)
+                    })?
+                    .to_vec();
 
             let record = Record {
                 key: key.clone(),
@@ -772,12 +768,13 @@ impl Network {
             return Ok(Some(record));
         } else if let Some(pointer) = valid_pointer {
             info!("For record {pretty_key:?} task found a valid pointer, returning it.");
-            let record_value = try_serialize_record(&pointer, RecordKind::Pointer)
-                .map_err(|err| {
-                    error!("Error while serializing the pointer for {pretty_key:?}: {err:?}");
-                    NetworkError::from(err)
-                })?
-                .to_vec();
+            let record_value =
+                try_serialize_record(&pointer, RecordKind::DataOnly(DataTypes::Pointer))
+                    .map_err(|err| {
+                        error!("Error while serializing the pointer for {pretty_key:?}: {err:?}");
+                        NetworkError::from(err)
+                    })?
+                    .to_vec();
 
             let record = Record {
                 key: key.clone(),
@@ -788,12 +785,15 @@ impl Network {
             return Ok(Some(record));
         } else if let Some(scratchpad) = valid_scratchpad {
             info!("For record {pretty_key:?} task found a valid scratchpad, returning it.");
-            let record_value = try_serialize_record(&scratchpad, RecordKind::Scratchpad)
-                .map_err(|err| {
-                    error!("Error while serializing the scratchpad for {pretty_key:?}: {err:?}");
-                    NetworkError::from(err)
-                })?
-                .to_vec();
+            let record_value =
+                try_serialize_record(&scratchpad, RecordKind::DataOnly(DataTypes::Scratchpad))
+                    .map_err(|err| {
+                        error!(
+                            "Error while serializing the scratchpad for {pretty_key:?}: {err:?}"
+                        );
+                        NetworkError::from(err)
+                    })?
+                    .to_vec();
 
             let record = Record {
                 key: key.clone(),

--- a/ant-node/src/metrics.rs
+++ b/ant-node/src/metrics.rs
@@ -10,8 +10,9 @@ use crate::Marker;
 use ant_networking::time::Instant;
 #[cfg(feature = "open-metrics")]
 use ant_networking::MetricsRegistries;
+use ant_protocol::storage::DataTypes;
 use prometheus_client::{
-    encoding::{EncodeLabelSet, EncodeLabelValue},
+    encoding::EncodeLabelSet,
     metrics::{
         counter::Counter,
         family::Family,
@@ -47,14 +48,7 @@ pub(crate) struct NodeMetricsRecorder {
 
 #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
 struct PutRecordOk {
-    record_type: RecordType,
-}
-
-#[derive(EncodeLabelValue, Hash, Clone, Eq, PartialEq, Debug)]
-enum RecordType {
-    Chunk,
-    Register,
-    Spend,
+    record_type: DataTypes,
 }
 
 impl NodeMetricsRecorder {
@@ -157,7 +151,7 @@ impl NodeMetricsRecorder {
                 let _ = self
                     .put_record_ok
                     .get_or_create(&PutRecordOk {
-                        record_type: RecordType::Chunk,
+                        record_type: DataTypes::Chunk,
                     })
                     .inc();
             }
@@ -166,7 +160,7 @@ impl NodeMetricsRecorder {
                 let _ = self
                     .put_record_ok
                     .get_or_create(&PutRecordOk {
-                        record_type: RecordType::Register,
+                        record_type: DataTypes::Register,
                     })
                     .inc();
             }
@@ -175,7 +169,7 @@ impl NodeMetricsRecorder {
                 let _ = self
                     .put_record_ok
                     .get_or_create(&PutRecordOk {
-                        record_type: RecordType::Spend,
+                        record_type: DataTypes::GraphEntry,
                     })
                     .inc();
             }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -27,6 +27,7 @@ exponential-backoff = "2.0.0"
 hex = "~0.4.3"
 lazy_static = "1.4.0"
 libp2p = { version = "0.54.1", features = ["identify", "kad"] }
+prometheus-client = { version = "0.22" }
 prost = { version = "0.9", optional = true }
 rand = "0.8"
 rmp-serde = "1.1.1"

--- a/ant-protocol/src/storage/mod.rs
+++ b/ant-protocol/src/storage/mod.rs
@@ -23,7 +23,8 @@ pub use self::{
     chunks::Chunk,
     graph::GraphEntry,
     header::{
-        try_deserialize_record, try_serialize_record, RecordHeader, RecordKind, ValidationType,
+        try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind,
+        ValidationType,
     },
     scratchpad::Scratchpad,
 };

--- a/autonomi/src/client/data/public.rs
+++ b/autonomi/src/client/data/public.rs
@@ -17,7 +17,7 @@ use crate::{self_encryption::encrypt, Client};
 use ant_evm::{Amount, AttoTokens};
 use ant_networking::{GetRecordCfg, NetworkError};
 use ant_protocol::{
-    storage::{try_deserialize_record, Chunk, ChunkAddress, RecordHeader, RecordKind},
+    storage::{try_deserialize_record, Chunk, ChunkAddress, DataTypes, RecordHeader, RecordKind},
     NetworkAddress,
 };
 
@@ -129,7 +129,7 @@ impl Client {
             .inspect_err(|err| error!("Error fetching chunk: {err:?}"))?;
         let header = RecordHeader::from_record(&record)?;
 
-        if let RecordKind::Chunk = header.kind {
+        if let Ok(true) = RecordHeader::is_record_of_type_chunk(&record) {
             let chunk: Chunk = try_deserialize_record(&record)?;
             Ok(chunk)
         } else {
@@ -137,7 +137,7 @@ impl Client {
                 "Record kind mismatch: expected Chunk, got {:?}",
                 header.kind
             );
-            Err(NetworkError::RecordKindMismatch(RecordKind::Chunk).into())
+            Err(NetworkError::RecordKindMismatch(RecordKind::DataOnly(DataTypes::Chunk)).into())
         }
     }
 

--- a/autonomi/src/client/graph.rs
+++ b/autonomi/src/client/graph.rs
@@ -20,7 +20,7 @@ pub use bls::SecretKey;
 use ant_evm::{EvmWallet, EvmWalletError};
 use ant_networking::{GetRecordCfg, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::{
-    storage::{try_serialize_record, RecordKind, RetryStrategy},
+    storage::{try_serialize_record, DataTypes, RecordKind, RetryStrategy},
     NetworkAddress,
 };
 use libp2p::kad::{Quorum, Record};
@@ -89,9 +89,12 @@ impl Client {
         let payees = proof.payees();
         let record = Record {
             key: NetworkAddress::from_graph_entry_address(address).to_record_key(),
-            value: try_serialize_record(&(proof, &transaction), RecordKind::GraphEntryWithPayment)
-                .map_err(|_| GraphError::Serialization)?
-                .to_vec(),
+            value: try_serialize_record(
+                &(proof, &transaction),
+                RecordKind::DataWithPayment(DataTypes::GraphEntry),
+            )
+            .map_err(|_| GraphError::Serialization)?
+            .to_vec(),
             publisher: None,
             expires: None,
         };

--- a/autonomi/src/client/pointer.rs
+++ b/autonomi/src/client/pointer.rs
@@ -5,7 +5,9 @@ use tracing::{debug, error, trace};
 use ant_evm::{Amount, AttoTokens, EvmWallet, EvmWalletError};
 use ant_networking::{GetRecordCfg, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::{
-    storage::{try_serialize_record, Pointer, PointerAddress, RecordKind, RetryStrategy},
+    storage::{
+        try_serialize_record, DataTypes, Pointer, PointerAddress, RecordKind, RetryStrategy,
+    },
     NetworkAddress,
 };
 use bls::SecretKey;
@@ -80,9 +82,12 @@ impl Client {
 
         let record = Record {
             key: NetworkAddress::from_pointer_address(address).to_record_key(),
-            value: try_serialize_record(&(proof, &pointer), RecordKind::PointerWithPayment)
-                .map_err(|_| PointerError::Serialization)?
-                .to_vec(),
+            value: try_serialize_record(
+                &(proof, &pointer),
+                RecordKind::DataWithPayment(DataTypes::Pointer),
+            )
+            .map_err(|_| PointerError::Serialization)?
+            .to_vec(),
             publisher: None,
             expires: None,
         };

--- a/autonomi/src/client/registers.rs
+++ b/autonomi/src/client/registers.rs
@@ -19,7 +19,7 @@ pub use bls::SecretKey as RegisterSecretKey;
 use ant_evm::{Amount, AttoTokens, EvmWallet, EvmWalletError};
 use ant_networking::{GetRecordCfg, GetRecordError, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::{
-    storage::{try_deserialize_record, try_serialize_record, RecordKind, RetryStrategy},
+    storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordKind, RetryStrategy},
     NetworkAddress,
 };
 use ant_registers::Register as BaseRegister;
@@ -204,9 +204,12 @@ impl Client {
         // Prepare the record for network storage
         let record = Record {
             key: NetworkAddress::from_register_address(*register.address()).to_record_key(),
-            value: try_serialize_record(&signed_register, RecordKind::Register)
-                .map_err(|_| RegisterError::Serialization)?
-                .to_vec(),
+            value: try_serialize_record(
+                &signed_register,
+                RecordKind::DataOnly(DataTypes::Register),
+            )
+            .map_err(|_| RegisterError::Serialization)?
+            .to_vec(),
             publisher: None,
             expires: None,
         };
@@ -337,7 +340,7 @@ impl Client {
             key: NetworkAddress::from_register_address(*address).to_record_key(),
             value: try_serialize_record(
                 &(proof, &signed_register),
-                RecordKind::RegisterWithPayment,
+                RecordKind::DataWithPayment(DataTypes::Register),
             )
             .map_err(|_| RegisterError::Serialization)?
             .to_vec(),

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -11,7 +11,7 @@ use ant_evm::{EvmWallet, ProofOfPayment};
 use ant_networking::{GetRecordCfg, PutRecordCfg, VerificationKind};
 use ant_protocol::{
     messages::ChunkProof,
-    storage::{try_serialize_record, Chunk, RecordKind, RetryStrategy},
+    storage::{try_serialize_record, Chunk, DataTypes, RecordKind, RetryStrategy},
 };
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -110,7 +110,7 @@ impl Client {
 
         let key = chunk.network_address().to_record_key();
 
-        let record_kind = RecordKind::ChunkWithPayment;
+        let record_kind = RecordKind::DataWithPayment(DataTypes::Chunk);
         let record = Record {
             key: key.clone(),
             value: try_serialize_record(&(payment, chunk.clone()), record_kind)
@@ -133,9 +133,12 @@ impl Client {
                 is_register: false,
             };
 
-            let stored_on_node = try_serialize_record(&chunk, RecordKind::Chunk)
-                .map_err(|e| PutError::Serialization(format!("Failed to serialize chunk: {e:?}")))?
-                .to_vec();
+            let stored_on_node =
+                try_serialize_record(&chunk, RecordKind::DataOnly(DataTypes::Chunk))
+                    .map_err(|e| {
+                        PutError::Serialization(format!("Failed to serialize chunk: {e:?}"))
+                    })?
+                    .to_vec();
             let random_nonce = thread_rng().gen::<u64>();
             let expected_proof = ChunkProof::new(&stored_on_node, random_nonce);
 

--- a/autonomi/src/client/vault.rs
+++ b/autonomi/src/client/vault.rs
@@ -19,7 +19,7 @@ use crate::client::Client;
 use ant_evm::{Amount, AttoTokens};
 use ant_networking::{GetRecordCfg, GetRecordError, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::storage::{
-    try_serialize_record, RecordKind, RetryStrategy, Scratchpad, ScratchpadAddress,
+    try_serialize_record, DataTypes, RecordKind, RetryStrategy, Scratchpad, ScratchpadAddress,
 };
 use ant_protocol::Bytes;
 use ant_protocol::{storage::try_deserialize_record, NetworkAddress};
@@ -208,20 +208,23 @@ impl Client {
 
             Record {
                 key: scratch_key,
-                value: try_serialize_record(&(proof, scratch), RecordKind::ScratchpadWithPayment)
-                    .map_err(|_| {
-                        PutError::Serialization(
-                            "Failed to serialize scratchpad with payment".to_string(),
-                        )
-                    })?
-                    .to_vec(),
+                value: try_serialize_record(
+                    &(proof, scratch),
+                    RecordKind::DataWithPayment(DataTypes::Scratchpad),
+                )
+                .map_err(|_| {
+                    PutError::Serialization(
+                        "Failed to serialize scratchpad with payment".to_string(),
+                    )
+                })?
+                .to_vec(),
                 publisher: None,
                 expires: None,
             }
         } else {
             Record {
                 key: scratch_key,
-                value: try_serialize_record(&scratch, RecordKind::Scratchpad)
+                value: try_serialize_record(&scratch, RecordKind::DataOnly(DataTypes::Scratchpad))
                     .map_err(|_| {
                         PutError::Serialization("Failed to serialize scratchpad".to_string())
                     })?


### PR DESCRIPTION
### Description

refactor RecordKind, which is now based on a new enum of DataTypes.
DataTypes becomes the sole place to reflects all data types that natively supported by the autonomi network.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
