### PR TITLE
fix: add `evm_network` field to `ClientConfig`

### DIFF
--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -207,7 +207,7 @@ impl Client {
         Ok(Self {
             network,
             client_event_sender: Arc::new(None),
-            evm_network: Default::default(),
+            evm_network: config.evm_network,
         })
     }
 


### PR DESCRIPTION
The client didn't select the EVM network from the config, but still used the default