### PR TITLE
feat(client): try get evm network from env by default on client::init…

### DIFF
--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use autonomi::Client;
 use autonomi::Multiaddr;
-use autonomi::{get_evm_network_from_env, Client};
 use color_eyre::eyre::bail;
 use color_eyre::eyre::Result;
 use indicatif::ProgressBar;
@@ -23,9 +23,7 @@ pub async fn connect_to_network(peers: Vec<Multiaddr>) -> Result<Client> {
     progress_bar.set_message("Connecting to The Autonomi Network...");
 
     match Client::init_with_peers(peers).await {
-        Ok(mut client) => {
-            let evm_network = get_evm_network_from_env()?;
-            client.set_evm_network(evm_network);
+        Ok(client) => {
             info!("Connected to the Network");
             progress_bar.finish_with_message("Connected to the Network");
             Ok(client)

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -95,7 +95,7 @@ impl Default for ClientConfig {
             #[cfg(not(feature = "local"))]
             local: false,
             peers: None,
-            evm_network: Default::default(),
+            evm_network: EvmNetwork::try_from_env().unwrap_or_default(),
         }
     }
 }
@@ -155,7 +155,7 @@ impl Client {
         Self::init_with_config(ClientConfig {
             local,
             peers: Some(peers),
-            evm_network: Default::default(),
+            evm_network: EvmNetwork::try_from_env().unwrap_or_default(),
         })
         .await
     }
@@ -262,7 +262,7 @@ impl Client {
         Ok(Self {
             network,
             client_event_sender: Arc::new(None),
-            evm_network: Default::default(),
+            evm_network: EvmNetwork::try_from_env().unwrap_or_default(),
         })
     }
 
@@ -274,10 +274,6 @@ impl Client {
         debug!("All events to the clients are enabled");
 
         client_event_receiver
-    }
-
-    pub fn set_evm_network(&mut self, evm_network: EvmNetwork) {
-        self.evm_network = evm_network;
     }
 }
 

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::common::Address;
+use crate::utils::get_evm_network_from_env;
 use alloy::primitives::address;
 use alloy::transports::http::reqwest;
 use serde::{Deserialize, Serialize};
@@ -103,6 +104,12 @@ impl std::fmt::Display for Network {
 }
 
 impl Network {
+    pub fn try_from_env() -> Result<Self, utils::Error> {
+        get_evm_network_from_env().inspect_err(|err| {
+            warn!("Failed to select EVM network from ENV: {err}");
+        })
+    }
+
     pub fn new_custom(rpc_url: &str, payment_token_addr: &str, chunk_payments_addr: &str) -> Self {
         Self::Custom(CustomNetwork::new(
             rpc_url,

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 pub mod wallet;
 
 /// Timeout for transactions
-const TX_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const TX_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 
 static PUBLIC_ARBITRUM_ONE_HTTP_RPC_URL: LazyLock<reqwest::Url> = LazyLock::new(|| {
     "https://arb1.arbitrum.io/rpc"


### PR DESCRIPTION
Adjusts the default for `ClientConfig` to first try getting the EVM network from ENV before falling back to the default network option:

```rust
impl Default for ClientConfig {
    fn default() -> Self {
        Self {
            ...
            evm_network: EvmNetwork::try_from_env().unwrap_or_default(),
        }
    }
}
```
This makes it easier to create a client without manually having to specify the EVM network. This also fixes a problem in our tests where `Client::init_local` would select the default EVM network instead of the one specified in the ENV: "EVM_NETWORK=local".
