### PR TITLE
fix(metrics): avoid intialize un-necessary system resources

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -164,6 +164,22 @@ jobs:
         run: pgrep antnode | wc -l
         if: always()
 
+      - name: confirm opened FDs
+        shell: bash
+        timeout-minutes: 1
+        run: |
+          fd_cap="30"
+          pids=$(pgrep antnode)
+          for pid in $pids; do
+            fd_count=$(ls /proc/$pid/fd | wc -l)
+            echo "Process $pid - File Descriptors: $fd_count"
+            if (( $(echo "$fd_count > $fd_cap" | bc -l) )); then
+              echo "Process $pid holding FD exceeded threshold: $fd_cap"
+              exit 1
+            fi
+          done
+        if: always()
+
       - name: Stop the local network and upload logs
         if: always()
         uses: maidsafe/ant-local-testnet-action@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9201,17 +9201,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "rayon",
- "windows 0.52.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -10541,21 +10540,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
  "windows-core 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -10576,6 +10575,40 @@ checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
 dependencies = [
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/ant-logging/Cargo.toml
+++ b/ant-logging/Cargo.toml
@@ -19,7 +19,7 @@ opentelemetry-semantic-conventions = { version = "0.12.0", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"], optional = true }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
-sysinfo = { version = "0.30.8", default-features = false, optional = true }
+sysinfo = { version = "0.33.1", optional = true }
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", optional = true }
 tracing = { version = "~0.1.26" }

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -62,7 +62,7 @@ self_encryption = "~0.30.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sha2 = "0.10"
 strum = { version = "0.26.2", features = ["derive"] }
-sysinfo = { version = "0.30.8", default-features = false, optional = true }
+sysinfo = { version = "0.33.1", optional = true }
 thiserror = "1.0.23"
 tiny-keccak = { version = "~2.0.2", features = ["sha3"] }
 tokio = { version = "1.32.0", features = [

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -51,7 +51,7 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.7.0"
-sysinfo = "0.30.12"
+sysinfo = "0.33.1"
 thiserror = "1.0.23"
 tokio = { version = "1.26", features = ["full"] }
 tracing = { version = "~0.1.26" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -62,7 +62,7 @@ rayon = "1.8.0"
 self_encryption = "~0.30.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 strum = { version = "0.26.2", features = ["derive"] }
-sysinfo = { version = "0.30.8", default-features = false }
+sysinfo = "0.33.1"
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = [
     "io-util",

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -413,7 +413,7 @@ You can check your reward balance by running:
         }
     });
     let ctrl_tx_clone_cpu = ctrl_tx.clone();
-    // Monitor host CPU usage
+    // Monitor Host CPU usage
     tokio::spawn(async move {
         use rand::{thread_rng, Rng};
 
@@ -427,9 +427,10 @@ You can check your reward balance by running:
         const JITTER_MIN_S: u64 = 1;
         const JITTER_MAX_S: u64 = 15;
 
-        let mut sys = System::new_all();
-
         let mut high_cpu_count: u8 = 0;
+
+        let mut system = System::new();
+        system.refresh_cpu_usage();
 
         // Random initial delay between 1 and 5 minutes
         let initial_delay =
@@ -437,8 +438,10 @@ You can check your reward balance by running:
         tokio::time::sleep(initial_delay).await;
 
         loop {
-            sys.refresh_cpu();
-            let cpu_usage = sys.global_cpu_info().cpu_usage();
+            system.refresh_cpu_usage();
+
+            let cpu_usage = system.global_cpu_usage();
+            info!("Detected Host CPU usage is {cpu_usage:?}.");
 
             if cpu_usage > CPU_USAGE_THRESHOLD {
                 high_cpu_count += 1;
@@ -458,7 +461,6 @@ You can check your reward balance by running:
                 }
                 break;
             }
-
             // Add jitter to the interval
             let jitter = Duration::from_secs(thread_rng().gen_range(JITTER_MIN_S..=JITTER_MAX_S));
             tokio::time::sleep(CPU_CHECK_INTERVAL + jitter).await;

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0.20"
 service-manager = "0.7.0"
-sysinfo = "0.30.12"
+sysinfo = "0.33.1"
 thiserror = "1.0.23"
 tokio = { version = "1.32.0", features = ["time"] }
 tonic = { version = "0.6.2" }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = "1.0.107"
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }
-sysinfo = "0.30.12"
+sysinfo = "0.33.1"
 throbber-widgets-tui = "0.8.0"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-util = "0.7.9"


### PR DESCRIPTION
### Description

It turned out that new_all function opens FD for un-necessary system resources, which result in accumulated memory-usage issue.
Hence initialize with nothing and then refresh only related.

This PR also contains the CI test to confirm there is no extra and acculuated FDs to be held by the node process.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
