### PR TITLE
Avoid scan entire sys during cpu threshold check no sysinfo upgrade

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -164,6 +164,22 @@ jobs:
         run: pgrep antnode | wc -l
         if: always()
 
+      - name: confirm opened FDs
+        shell: bash
+        timeout-minutes: 1
+        run: |
+          fd_cap="30"
+          pids=$(pgrep antnode)
+          for pid in $pids; do
+            fd_count=$(ls /proc/$pid/fd | wc -l)
+            echo "Process $pid - File Descriptors: $fd_count"
+            if (( $(echo "$fd_count > $fd_cap" | bc -l) )); then
+              echo "Process $pid holding FD exceeded threshold: $fd_cap"
+              exit 1
+            fi
+          done
+        if: always()
+
       - name: Stop the local network and upload logs
         if: always()
         uses: maidsafe/ant-local-testnet-action@main

--- a/ant-logging/src/metrics.rs
+++ b/ant-logging/src/metrics.rs
@@ -44,7 +44,7 @@ struct ProcessMetrics {
 // Obtains the system metrics every UPDATE_INTERVAL and logs it.
 // The function should be spawned as a task and should be re-run if our main process is restarted.
 pub async fn init_metrics(pid: u32) {
-    let mut sys = System::new_all();
+    let mut sys = System::new();
     let mut networks = Networks::new_with_refreshed_list();
     let pid = Pid::from_u32(pid);
 

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -246,11 +246,12 @@ impl NetworkMetricsRecorder {
 
         let pid = Pid::from_u32(std::process::id());
         let process_refresh_kind = ProcessRefreshKind::everything().without_disk_usage();
-        let mut system = System::new_all();
+        let mut system = System::new();
         let physical_core_count = system.physical_core_count();
 
         tokio::spawn(async move {
             loop {
+                system.refresh_cpu();
                 system.refresh_process_specifics(pid, process_refresh_kind);
                 if let (Some(process), Some(core_count)) =
                     (system.process(pid), physical_core_count)

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -427,7 +427,7 @@ You can check your reward balance by running:
         const JITTER_MIN_S: u64 = 1;
         const JITTER_MAX_S: u64 = 15;
 
-        let mut sys = System::new_all();
+        let mut sys = System::new();
 
         let mut high_cpu_count: u8 = 0;
 


### PR DESCRIPTION
### Description

It turned out that new_all function opens FD for un-necessary system resources, which result in accumulated memory-usage issue.
Hence initialize with nothing and then refresh only related.

This PR also contains the CI test to confirm there is no extra and acculuated FDs to be held by the node process.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
