### PR TITLE
fix(external_address): limit some of the incoming error from...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2025-01-09
+
+## Network
+
+### Changed
+
+- Network discovery no longer queries the farthest full buckets. This significantly reduces the
+  number of messages as the network grows, resulting in fewer open connections and reduced resource
+  usage.
+
 ## 2024-12-21
 
 ### Network

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -594,19 +594,17 @@ impl NetworkBuilder {
         let kademlia = {
             match record_store_cfg {
                 Some(store_cfg) => {
+                    #[cfg(feature = "open-metrics")]
+                    let record_stored_metrics =
+                        metrics_recorder.as_ref().map(|r| r.records_stored.clone());
                     let node_record_store = NodeRecordStore::with_config(
                         peer_id,
                         store_cfg,
                         network_event_sender.clone(),
                         local_swarm_cmd_sender.clone(),
+                        #[cfg(feature = "open-metrics")]
+                        record_stored_metrics,
                     );
-                    #[cfg(feature = "open-metrics")]
-                    let mut node_record_store = node_record_store;
-                    #[cfg(feature = "open-metrics")]
-                    if let Some(metrics_recorder) = &metrics_recorder {
-                        node_record_store = node_record_store
-                            .set_record_count_metric(metrics_recorder.records_stored.clone());
-                    }
 
                     let store = UnifiedRecordStore::Node(node_record_store);
                     debug!("Using Kademlia with NodeRecordStore!");

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -55,6 +55,10 @@ impl SwarmDriver {
                 self.handle_kad_event(kad_event)?;
             }
             SwarmEvent::Behaviour(NodeEvent::RelayClient(event)) => {
+                #[cfg(feature = "open-metrics")]
+                if let Some(metrics_recorder) = &self.metrics_recorder {
+                    metrics_recorder.record(&(*event));
+                }
                 event_string = "relay_client_event";
 
                 info!(?event, "relay client event");

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -575,15 +575,19 @@ impl SwarmDriver {
                 // giving time for ConnectionEstablished to be hopefully processed.
                 // And since we don't do anything critical with this event, the order and time of processing is
                 // not critical.
-                if self.should_we_log_incoming_connection_error(connection_id, &send_back_addr) {
+                if self.is_incoming_connection_error_valid(connection_id, &send_back_addr) {
                     error!("IncomingConnectionError from local_addr:?{local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
+
+                    // This is best approximation that we can do to prevent harmless errors from affecting the external
+                    // address health.
+                    if let Some(external_addr_manager) = self.external_address_manager.as_mut() {
+                        external_addr_manager
+                            .on_incoming_connection_error(local_addr.clone(), &mut self.swarm);
+                    }
                 } else {
                     debug!("IncomingConnectionError from local_addr:?{local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
                 }
-                if let Some(external_addr_manager) = self.external_address_manager.as_mut() {
-                    external_addr_manager
-                        .on_incoming_connection_error(local_addr.clone(), &mut self.swarm);
-                }
+
                 let _ = self.live_connected_peers.remove(&connection_id);
                 self.record_connection_metrics();
             }
@@ -787,7 +791,7 @@ impl SwarmDriver {
     }
 
     // Do not log IncomingConnectionError if the ConnectionId is adjacent to an already established connection.
-    fn should_we_log_incoming_connection_error(&self, id: ConnectionId, addr: &Multiaddr) -> bool {
+    fn is_incoming_connection_error_valid(&self, id: ConnectionId, addr: &Multiaddr) -> bool {
         let Ok(id) = format!("{id}").parse::<usize>() else {
             return true;
         };

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -434,21 +434,27 @@ impl SwarmDriver {
                         // unless there are _specific_ errors (connection refused eg)
                         error!("Dial errors len : {:?}", errors.len());
                         let mut there_is_a_serious_issue = false;
+                        // Libp2p throws errors for all the listen addr (including private) of the remote peer even
+                        // though we try to dial just the global/public addr. This would mean that we get
+                        // MultiaddrNotSupported error for the private addr of the peer.
+                        //
+                        // Just a single MultiaddrNotSupported error is not a critical issue, but if all the listen
+                        // addrs of the peer are private, then it is a critical issue.
+                        let mut all_multiaddr_not_supported = true;
                         for (_addr, err) in errors {
-                            error!("OutgoingTransport error : {err:?}");
-
                             match err {
                                 TransportError::MultiaddrNotSupported(addr) => {
-                                    warn!("Multiaddr not supported : {addr:?}");
+                                    warn!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
                                     #[cfg(feature = "loud")]
                                     {
-                                        println!("Multiaddr not supported : {addr:?}");
+                                        warn!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
                                         println!("If this was your bootstrap peer, restart your node with a supported multiaddr");
                                     }
-                                    // if we can't dial a peer on a given address, we should remove it from the routing table
-                                    there_is_a_serious_issue = true
                                 }
                                 TransportError::Other(err) => {
+                                    error!("OutgoingConnectionError: Transport::Other {err:?}");
+
+                                    all_multiaddr_not_supported = false;
                                     let problematic_errors = [
                                         "ConnectionRefused",
                                         "HostUnreachable",
@@ -480,6 +486,10 @@ impl SwarmDriver {
                                     }
                                 }
                             }
+                        }
+                        if all_multiaddr_not_supported {
+                            warn!("All multiaddrs had MultiaddrNotSupported error for {failed_peer_id:?}. Marking it as a serious issue.");
+                            there_is_a_serious_issue = true;
                         }
                         there_is_a_serious_issue
                     }

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -8,6 +8,7 @@
 
 // Implementation to record `libp2p::upnp::Event` metrics
 mod bad_node;
+mod relay_client;
 pub mod service;
 #[cfg(feature = "upnp")]
 mod upnp;
@@ -39,6 +40,7 @@ pub(crate) struct NetworkMetricsRecorder {
     libp2p_metrics: Libp2pMetrics,
     #[cfg(feature = "upnp")]
     upnp_events: Family<upnp::UpnpEventLabels, Counter>,
+    relay_client_events: Family<relay_client::RelayClientEventLabels, Counter>,
 
     // metrics from ant-networking
     pub(crate) connected_peers: Gauge,
@@ -136,6 +138,13 @@ impl NetworkMetricsRecorder {
             upnp_events.clone(),
         );
 
+        let relay_client_events = Family::default();
+        sub_registry.register(
+            "relay_client_events",
+            "Events emitted by the relay client",
+            relay_client_events.clone(),
+        );
+
         let process_memory_used_mb = Gauge::<f64, AtomicU64>::default();
         sub_registry.register(
             "process_memory_used_mb",
@@ -211,6 +220,7 @@ impl NetworkMetricsRecorder {
             libp2p_metrics,
             #[cfg(feature = "upnp")]
             upnp_events,
+            relay_client_events,
 
             records_stored,
             estimated_network_size,

--- a/ant-networking/src/metrics/relay_client.rs
+++ b/ant-networking/src/metrics/relay_client.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct RelayClientEventLabels {
+    event: EventType,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+enum EventType {
+    ReservationReqAccepted,
+    OutboundCircuitEstablished,
+    InboundCircuitEstablished,
+}
+
+impl From<&libp2p::relay::client::Event> for EventType {
+    fn from(event: &libp2p::relay::client::Event) -> Self {
+        match event {
+            libp2p::relay::client::Event::ReservationReqAccepted { .. } => {
+                EventType::ReservationReqAccepted
+            }
+            libp2p::relay::client::Event::OutboundCircuitEstablished { .. } => {
+                EventType::OutboundCircuitEstablished
+            }
+            libp2p::relay::client::Event::InboundCircuitEstablished { .. } => {
+                EventType::InboundCircuitEstablished
+            }
+        }
+    }
+}
+
+impl super::Recorder<libp2p::relay::client::Event> for super::NetworkMetricsRecorder {
+    fn record(&self, event: &libp2p::relay::client::Event) {
+        self.relay_client_events
+            .get_or_create(&RelayClientEventLabels {
+                event: event.into(),
+            })
+            .inc();
+    }
+}


### PR DESCRIPTION
- fix(external_address): limit some of the incoming error from affecting the score

We should not consider all the incoming connection error while calculating the external address score. Some of these error are harmless, as we might have a connection established right before/after the error.

This does not prevent all such harmless error, but it is better than just considering every error as an issue.