### PR TITLE
chore: remove unallocated ip from mainnet contacts

### DIFF
--- a/ant-bootstrap/src/contacts.rs
+++ b/ant-bootstrap/src/contacts.rs
@@ -20,7 +20,6 @@ const MAINNET_CONTACTS: &[&str] = &[
     "http://159.223.246.45/bootstrap_cache.json",
     "http://139.59.201.153/bootstrap_cache.json",
     "http://139.59.200.27/bootstrap_cache.json",
-    "http://139.59.198.251/bootstrap_cache.json",
 ];
 
 /// The client fetch timeout


### PR DESCRIPTION
We have accidentally added this IP to the contacts for the production network, but it is not allocated.