### PR TITLE
fix(metric): not to refresh entire cpu un-necessarily and too often

### DIFF
--- a/ant-logging/src/metrics.rs
+++ b/ant-logging/src/metrics.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use sysinfo::{self, Networks, Pid, System};
 use tracing::{debug, error};
 
-const UPDATE_INTERVAL: Duration = Duration::from_secs(15);
+const UPDATE_INTERVAL: Duration = Duration::from_secs(60);
 const TO_MB: u64 = 1_000_000;
 
 // The following Metrics are collected and logged

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -28,7 +28,7 @@ use prometheus_client::{
 use sysinfo::{Pid, ProcessRefreshKind, System};
 use tokio::time::Duration;
 
-const UPDATE_INTERVAL: Duration = Duration::from_secs(15);
+const UPDATE_INTERVAL: Duration = Duration::from_secs(60);
 const TO_MB: u64 = 1_000_000;
 
 /// The shared recorders that are used to record metrics.
@@ -251,7 +251,6 @@ impl NetworkMetricsRecorder {
 
         tokio::spawn(async move {
             loop {
-                system.refresh_cpu();
                 system.refresh_process_specifics(pid, process_refresh_kind);
                 if let (Some(process), Some(core_count)) =
                     (system.process(pid), physical_core_count)


### PR DESCRIPTION
### Description

not to refresh entire cpu un-necessarily and reduce metrics collection frequency

as a further work of PR https://github.com/maidsafe/autonomi/pull/2639

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
