### PR TITLE
fix(networking): throw an error when no quotes could be fetched

### DIFF
--- a/ant-networking/src/error.rs
+++ b/ant-networking/src/error.rs
@@ -134,6 +134,9 @@ pub enum NetworkError {
     NoGraphEntryFoundInsideRecord(GraphEntryAddress),
 
     // ---------- Store Error
+    #[error("Not Enough Peers for Store Cost Request")]
+    NotEnoughPeersForStoreCostRequest,
+
     #[error("No Store Cost Responses")]
     NoStoreCostResponses,
 


### PR DESCRIPTION
Makes `get_store_quote_from_network` throw an error when no quotes could be fetched instead of returning an empty vec of quotes. As a returned empty vec means that the chunk address was already paid for.