### PR TITLE
Remove u256 conversion after libp2p upgrade

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -13,9 +13,8 @@ use crate::{
     log_markers::Marker,
     multiaddr_pop_p2p, GetRecordCfg, GetRecordError, MsgResponder, NetworkEvent, CLOSE_GROUP_SIZE,
 };
-use ant_evm::{PaymentQuote, QuotingMetrics, U256};
+use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
-    convert_distance_to_u256,
     messages::{Cmd, Request, Response},
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintRecordKey,
@@ -1139,13 +1138,11 @@ impl SwarmDriver {
 }
 
 /// Returns the nodes that within the defined distance.
-fn get_peers_in_range(peers: &[PeerId], address: &NetworkAddress, range: U256) -> Vec<PeerId> {
+fn get_peers_in_range(peers: &[PeerId], address: &NetworkAddress, range: Distance) -> Vec<PeerId> {
     peers
         .iter()
         .filter_map(|peer_id| {
-            let distance =
-                convert_distance_to_u256(&address.distance(&NetworkAddress::from_peer(*peer_id)));
-            if distance <= range {
+            if address.distance(&NetworkAddress::from_peer(*peer_id)) <= range {
                 Some(*peer_id)
             } else {
                 None

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -30,9 +30,8 @@ use crate::{
     metrics::service::run_metrics_server, metrics::NetworkMetricsRecorder, MetricsRegistries,
 };
 use ant_bootstrap::BootstrapCacheStore;
-use ant_evm::{PaymentQuote, U256};
+use ant_evm::PaymentQuote;
 use ant_protocol::{
-    convert_distance_to_u256,
     messages::{ChunkProof, Nonce, Request, Response},
     storage::{try_deserialize_record, RetryStrategy},
     version::{
@@ -49,7 +48,7 @@ use libp2p::mdns;
 use libp2p::{core::muxing::StreamMuxerBox, relay};
 use libp2p::{
     identity::Keypair,
-    kad::{self, QueryId, Quorum, Record, RecordKey, K_VALUE},
+    kad::{self, KBucketDistance as Distance, QueryId, Quorum, Record, RecordKey, K_VALUE, U256},
     multiaddr::Protocol,
     request_response::{self, Config as RequestResponseConfig, OutboundRequestId, ProtocolSupport},
     swarm::{
@@ -1000,9 +999,8 @@ impl SwarmDriver {
                         // Note: self is included
                         let self_addr = NetworkAddress::from_peer(self.self_peer_id);
                         let close_peers_distance = self_addr.distance(&NetworkAddress::from_peer(closest_k_peers[CLOSE_GROUP_SIZE + 1]));
-                        let close_peers_u256 = convert_distance_to_u256(&close_peers_distance);
 
-                        let distance = std::cmp::max(density_distance, close_peers_u256);
+                        let distance = std::cmp::max(Distance(density_distance), close_peers_distance);
 
                         // The sampling approach has severe impact to the node side performance
                         // Hence suggested to be only used by client side.
@@ -1021,7 +1019,7 @@ impl SwarmDriver {
                         //     self_addr.distance(&NetworkAddress::from_peer(closest_k_peers[CLOSE_GROUP_SIZE]))
                         // };
 
-                        info!("Set responsible range to {distance:?}({:?})", distance.log2());
+                        info!("Set responsible range to {distance:?}({:?})", distance.ilog2());
 
                         // set any new distance to farthest record in the store
                         self.swarm.behaviour_mut().kademlia.store_mut().set_distance_range(distance);

--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -16,9 +16,8 @@ use aes_gcm_siv::{
     aead::{Aead, KeyInit},
     Aes256GcmSiv, Key as AesKey, Nonce,
 };
-use ant_evm::{QuotingMetrics, U256};
+use ant_evm::QuotingMetrics;
 use ant_protocol::{
-    convert_distance_to_u256,
     storage::{RecordHeader, RecordKind, RecordType},
     NetworkAddress, PrettyPrintRecordKey,
 };
@@ -140,7 +139,7 @@ pub struct NodeRecordStore {
     /// Main records store remains unchanged for compatibility
     records: HashMap<Key, (NetworkAddress, RecordType)>,
     /// Additional index organizing records by distance
-    records_by_distance: BTreeMap<U256, Key>,
+    records_by_distance: BTreeMap<Distance, Key>,
     /// FIFO simple cache of records to reduce read times
     records_cache: RecordCache,
     /// Send network events to the node layer.
@@ -150,7 +149,7 @@ pub struct NodeRecordStore {
     /// ilog2 distance range of responsible records
     /// AKA: how many buckets of data do we consider "close"
     /// None means accept all records.
-    responsible_distance_range: Option<U256>,
+    responsible_distance_range: Option<Distance>,
     #[cfg(feature = "open-metrics")]
     /// Used to report the number of records held by the store to the metrics server.
     record_count_metric: Option<Gauge>,
@@ -369,9 +368,9 @@ impl NodeRecordStore {
         let local_address = NetworkAddress::from_peer(local_id);
 
         // Initialize records_by_distance
-        let mut records_by_distance: BTreeMap<U256, Key> = BTreeMap::new();
+        let mut records_by_distance: BTreeMap<Distance, Key> = BTreeMap::new();
         for (key, (addr, _record_type)) in records.iter() {
-            let distance = convert_distance_to_u256(&local_address.distance(addr));
+            let distance = local_address.distance(addr);
             let _ = records_by_distance.insert(distance, key.clone());
         }
 
@@ -408,7 +407,7 @@ impl NodeRecordStore {
     }
 
     /// Returns the current distance ilog2 (aka bucket) range of CLOSE_GROUP nodes.
-    pub fn get_responsible_distance_range(&self) -> Option<U256> {
+    pub fn get_responsible_distance_range(&self) -> Option<Distance> {
         self.responsible_distance_range
     }
 
@@ -610,14 +609,13 @@ impl NodeRecordStore {
     pub(crate) fn mark_as_stored(&mut self, key: Key, record_type: RecordType) {
         let addr = NetworkAddress::from_record_key(&key);
         let distance = self.local_address.distance(&addr);
-        let distance_u256 = convert_distance_to_u256(&distance);
 
         // Update main records store
         self.records
             .insert(key.clone(), (addr.clone(), record_type));
 
         // Update bucket index
-        let _ = self.records_by_distance.insert(distance_u256, key.clone());
+        let _ = self.records_by_distance.insert(distance, key.clone());
 
         // Update farthest record if needed (unchanged)
         if let Some((_farthest_record, farthest_record_distance)) = self.farthest_record.clone() {
@@ -748,7 +746,7 @@ impl NodeRecordStore {
             let relevant_records = self.get_records_within_distance_range(distance_range);
 
             // The `responsible_range` is the network density
-            quoting_metrics.network_density = Some(distance_range.to_be_bytes());
+            quoting_metrics.network_density = Some(distance_range.0.to_big_endian());
 
             quoting_metrics.close_records_stored = relevant_records;
         } else {
@@ -771,7 +769,7 @@ impl NodeRecordStore {
     }
 
     /// Calculate how many records are stored within a distance range
-    pub fn get_records_within_distance_range(&self, range: U256) -> usize {
+    pub fn get_records_within_distance_range(&self, range: Distance) -> usize {
         let within_range = self
             .records_by_distance
             .range(..range)
@@ -784,7 +782,7 @@ impl NodeRecordStore {
     }
 
     /// Setup the distance range.
-    pub(crate) fn set_responsible_distance_range(&mut self, responsible_distance: U256) {
+    pub(crate) fn set_responsible_distance_range(&mut self, responsible_distance: Distance) {
         self.responsible_distance_range = Some(responsible_distance);
     }
 }
@@ -880,7 +878,7 @@ impl RecordStore for NodeRecordStore {
     fn remove(&mut self, k: &Key) {
         // Remove from main store
         if let Some((addr, _)) = self.records.remove(k) {
-            let distance = convert_distance_to_u256(&self.local_address.distance(&addr));
+            let distance = self.local_address.distance(&addr);
             let _ = self.records_by_distance.remove(&distance);
         }
 
@@ -1003,7 +1001,6 @@ mod tests {
     use bls::SecretKey;
     use xor_name::XorName;
 
-    use ant_protocol::convert_distance_to_u256;
     use ant_protocol::storage::{
         try_deserialize_record, try_serialize_record, Chunk, ChunkAddress, Scratchpad,
     };
@@ -1572,7 +1569,7 @@ mod tests {
                 .wrap_err("Could not parse record store key")?,
         );
         // get the distance to this record from our local key
-        let distance = convert_distance_to_u256(&self_address.distance(&halfway_record_address));
+        let distance = self_address.distance(&halfway_record_address);
 
         // must be plus one bucket from the halfway record
         store.set_responsible_distance_range(distance);

--- a/ant-networking/src/record_store_api.rs
+++ b/ant-networking/src/record_store_api.rs
@@ -8,11 +8,11 @@
 #![allow(clippy::mutable_key_type)] // for the Bytes in NetworkAddress
 
 use crate::record_store::{ClientRecordStore, NodeRecordStore};
-use ant_evm::{QuotingMetrics, U256};
+use ant_evm::QuotingMetrics;
 use ant_protocol::{storage::RecordType, NetworkAddress};
 use libp2p::kad::{
     store::{RecordStore, Result},
-    ProviderRecord, Record, RecordKey,
+    KBucketDistance as Distance, ProviderRecord, Record, RecordKey,
 };
 use std::{borrow::Cow, collections::HashMap};
 
@@ -136,7 +136,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn get_farthest_replication_distance(&self) -> Option<U256> {
+    pub(crate) fn get_farthest_replication_distance(&self) -> Option<Distance> {
         match self {
             Self::Client(_store) => {
                 warn!("Calling get_distance_range at Client. This should not happen");
@@ -146,7 +146,7 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn set_distance_range(&mut self, distance: U256) {
+    pub(crate) fn set_distance_range(&mut self, distance: Distance) {
         match self {
             Self::Client(_store) => {
                 warn!("Calling set_distance_range at Client. This should not happen");

--- a/ant-networking/src/replication_fetcher.rs
+++ b/ant-networking/src/replication_fetcher.rs
@@ -9,10 +9,7 @@
 
 use crate::target_arch::spawn;
 use crate::{event::NetworkEvent, target_arch::Instant};
-use ant_evm::U256;
-use ant_protocol::{
-    convert_distance_to_u256, storage::RecordType, NetworkAddress, PrettyPrintRecordKey,
-};
+use ant_protocol::{storage::RecordType, NetworkAddress, PrettyPrintRecordKey};
 use libp2p::{
     kad::{KBucketDistance as Distance, RecordKey, K_VALUE},
     PeerId,
@@ -45,7 +42,7 @@ pub(crate) struct ReplicationFetcher {
     on_going_fetches: HashMap<(RecordKey, RecordType), (PeerId, ReplicationTimeout)>,
     event_sender: mpsc::Sender<NetworkEvent>,
     /// Distance range that the incoming key shall be fetched
-    distance_range: Option<U256>,
+    distance_range: Option<Distance>,
     /// Restrict fetch range to closer than this value
     /// used when the node is full, but we still have "close" data coming in
     /// that is _not_ closer than our farthest max record
@@ -66,7 +63,7 @@ impl ReplicationFetcher {
     }
 
     /// Set the distance range.
-    pub(crate) fn set_replication_distance_range(&mut self, distance_range: U256) {
+    pub(crate) fn set_replication_distance_range(&mut self, distance_range: Distance) {
         self.distance_range = Some(distance_range);
     }
 
@@ -139,8 +136,7 @@ impl ReplicationFetcher {
         // Filter out those out_of_range ones among the incoming_keys.
         if let Some(ref distance_range) = self.distance_range {
             new_incoming_keys.retain(|(addr, _record_type)| {
-                let is_in_range =
-                    convert_distance_to_u256(&self_address.distance(addr)) <= *distance_range;
+                let is_in_range = self_address.distance(addr) <= *distance_range;
                 if !is_in_range {
                     out_of_range_keys.push(addr.clone());
                 }
@@ -412,7 +408,7 @@ impl ReplicationFetcher {
 #[cfg(test)]
 mod tests {
     use super::{ReplicationFetcher, FETCH_TIMEOUT, MAX_PARALLEL_FETCH};
-    use ant_protocol::{convert_distance_to_u256, storage::RecordType, NetworkAddress};
+    use ant_protocol::{storage::RecordType, NetworkAddress};
     use eyre::Result;
     use libp2p::{kad::RecordKey, PeerId};
     use std::{collections::HashMap, time::Duration};
@@ -483,8 +479,7 @@ mod tests {
         // Set distance range
         let distance_target = NetworkAddress::from_peer(PeerId::random());
         let distance_range = self_address.distance(&distance_target);
-        let distance_256 = convert_distance_to_u256(&distance_range);
-        replication_fetcher.set_replication_distance_range(distance_256);
+        replication_fetcher.set_replication_distance_range(distance_range);
 
         let mut incoming_keys = Vec::new();
         let mut in_range_keys = 0;

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -36,14 +36,12 @@ use self::storage::{ChunkAddress, RegisterAddress, TransactionAddress};
 /// Re-export of Bytes used throughout the protocol
 pub use bytes::Bytes;
 
-use ant_evm::U256;
 use libp2p::{
     kad::{KBucketDistance as Distance, KBucketKey as Key, RecordKey},
     multiaddr::Protocol,
     Multiaddr, PeerId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::str::FromStr;
 use std::{
     borrow::Cow,
     fmt::{self, Debug, Display, Formatter, Write},
@@ -66,18 +64,6 @@ pub fn get_port_from_multiaddr(multi_addr: &Multiaddr) -> Option<u16> {
         }
     }
     None
-}
-
-// This conversion shall no longer be required once updated to the latest libp2p.
-// Which can has the direct access to the Distance private field of U256.
-pub fn convert_distance_to_u256(distance: &Distance) -> U256 {
-    let addr_str = format!("{distance:?}");
-    let numeric_part = addr_str
-        .trim_start_matches("Distance(")
-        .trim_end_matches(")")
-        .to_string();
-    let distance_value = U256::from_str(&numeric_part);
-    distance_value.unwrap_or(U256::ZERO)
 }
 
 /// This is the address in the network by which proximity/distance

--- a/ant-protocol/src/messages/query.rs
+++ b/ant-protocol/src/messages/query.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{messages::Nonce, NetworkAddress};
-use ant_evm::U256;
+use libp2p::kad::U256;
 use serde::{Deserialize, Serialize};
 
 /// Data queries - retrieving data and inspecting their structure.
@@ -131,7 +131,7 @@ impl std::fmt::Display for Query {
                 range,
                 sign_result,
             } => {
-                let distance = range.as_ref().map(|value| U256::from_be_slice(value));
+                let distance = range.as_ref().map(|value| U256::from_big_endian(value));
                 write!(
                     f,
                     "Query::GetClosestPeers({key:?} {num_of_peers:?} {distance:?} {sign_result})"


### PR DESCRIPTION
### Description

With the libp2p new release of 0.55.0, the previious private U256 is now public.
Hence we don't need to convert it via string any more.


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
