### PR TITLE
fix: get market price retry condition

### DIFF
--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -205,7 +205,7 @@ async fn get_market_price_with_rate_limiter_and_retries(
                 break Ok(amounts);
             }
             Err(err) => {
-                if err.to_string().contains("429") && retries < MAX_RETRIES {
+                if retries < MAX_RETRIES {
                     retries += 1;
                     interval_in_ms *= retries * 2;
                     error!("Error while fetching quote market price: {err:?}, retry #{retries}");


### PR DESCRIPTION
This was merged into `main`, but it could help with some errors that users are seeing, so it can go out with our next hotfix.
