### PR TITLE
feat: useable and tested scratchpads

### DIFF
--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -647,7 +647,7 @@ impl Network {
                         }
 
                         if let Some(old) = &valid_scratchpad {
-                            if old.count() >= scratchpad.count() {
+                            if old.counter() >= scratchpad.counter() {
                                 info!("Rejecting Scratchpad for {pretty_key} with lower count than the previous one");
                                 continue;
                             }

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -639,7 +639,7 @@ impl Network {
                             continue;
                         };
 
-                        if !scratchpad.is_valid() {
+                        if !scratchpad.verify() {
                             warn!(
                                 "Rejecting Scratchpad for {pretty_key} PUT with invalid signature"
                             );

--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -1296,12 +1296,8 @@ mod tests {
         // Create a scratchpad
         let unencrypted_scratchpad_data = Bytes::from_static(b"Test scratchpad data");
         let owner_sk = SecretKey::random();
-        let owner_pk = owner_sk.public_key();
 
-        let mut scratchpad = Scratchpad::new(owner_pk, 0);
-
-        let _next_version =
-            scratchpad.update_and_sign(unencrypted_scratchpad_data.clone(), &owner_sk);
+        let scratchpad = Scratchpad::new(&owner_sk, 0, &unencrypted_scratchpad_data, 0);
 
         let scratchpad_address = *scratchpad.address();
 

--- a/ant-node/src/error.rs
+++ b/ant-node/src/error.rs
@@ -12,6 +12,8 @@ use thiserror::Error;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
+const SCRATCHPAD_MAX_SIZE: usize = ant_protocol::storage::Scratchpad::MAX_SIZE;
+
 /// Internal error.
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
@@ -38,12 +40,13 @@ pub enum Error {
     #[error("The Record::key does not match with the key derived from Record::value")]
     RecordKeyMismatch,
 
-    // Scratchpad is old version
+    // ------------ Scratchpad Errors
     #[error("A newer version of this Scratchpad already exists")]
     IgnoringOutdatedScratchpadPut,
-    // Scratchpad is invalid
-    #[error("Scratchpad signature is invalid over the counter + content hash")]
+    #[error("Scratchpad signature is invalid")]
     InvalidScratchpadSignature,
+    #[error("Scratchpad too big: {0}, max size is {SCRATCHPAD_MAX_SIZE}")]
+    ScratchpadTooBig(usize),
 
     #[error("Invalid signature")]
     InvalidSignature,

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -467,9 +467,15 @@ impl Node {
         }
 
         // ensure data integrity
-        if !scratchpad.is_valid() {
+        if !scratchpad.verify() {
             warn!("Rejecting Scratchpad PUT with invalid signature");
             return Err(Error::InvalidScratchpadSignature);
+        }
+
+        // ensure the scratchpad is not too big
+        if scratchpad.is_too_big() {
+            warn!("Rejecting Scratchpad PUT with too big size");
+            return Err(Error::ScratchpadTooBig(scratchpad.size()));
         }
 
         info!(

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -447,7 +447,7 @@ impl Node {
     ) -> Result<()> {
         // owner PK is defined herein, so as long as record key and this match, we're good
         let addr = scratchpad.address();
-        let count = scratchpad.count();
+        let count = scratchpad.counter();
         debug!("Validating and storing scratchpad {addr:?} with count {count}");
 
         // check if the deserialized value's ScratchpadAddress matches the record's key
@@ -460,7 +460,7 @@ impl Node {
         // check if the Scratchpad is present locally that we don't have a newer version
         if let Some(local_pad) = self.network().get_local_record(&scratchpad_key).await? {
             let local_pad = try_deserialize_record::<Scratchpad>(&local_pad)?;
-            if local_pad.count() >= scratchpad.count() {
+            if local_pad.counter() >= scratchpad.counter() {
                 warn!("Rejecting Scratchpad PUT with counter less than or equal to the current counter");
                 return Err(Error::IgnoringOutdatedScratchpadPut);
             }

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -408,7 +408,10 @@ fn create_graph_entry_task(
 
             let mut retries = 1;
             loop {
-                match client.graph_entry_put(graph_entry.clone(), &wallet).await {
+                match client
+                    .graph_entry_put(graph_entry.clone(), (&wallet).into())
+                    .await
+                {
                     Ok((cost, addr)) => {
                         println!("Uploaded graph_entry to {addr:?} with cost of {cost:?} after a delay of: {delay:?}");
                         let net_addr = NetworkAddress::GraphEntryAddress(addr);

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -498,7 +498,7 @@ fn create_pointers_task(
                     PointerTarget::ChunkAddress(ChunkAddress::new(XorName(rand::random())));
                 loop {
                     match client
-                        .pointer_create(&owner, pointer_target.clone(), &wallet)
+                        .pointer_create(&owner, pointer_target.clone(), (&wallet).into())
                         .await
                     {
                         Ok((cost, addr)) => {

--- a/ant-protocol/src/storage/graph.rs
+++ b/ant-protocol/src/storage/graph.rs
@@ -28,6 +28,9 @@ pub struct GraphEntry {
 }
 
 impl GraphEntry {
+    /// Maximum size of a graph entry
+    pub const MAX_SIZE: usize = 1024;
+
     /// Create a new graph entry, signing it with the provided secret key.
     pub fn new(
         owner: PublicKey,
@@ -101,8 +104,29 @@ impl GraphEntry {
         Self::bytes_to_sign(&self.owner, &self.parents, &self.content, &self.outputs)
     }
 
+    /// Verify the signature of the graph entry
     pub fn verify(&self) -> bool {
         self.owner
             .verify(&self.signature, self.bytes_for_signature())
+    }
+
+    /// Size of the graph entry
+    pub fn size(&self) -> usize {
+        size_of::<GraphEntry>()
+            + self
+                .outputs
+                .iter()
+                .map(|(p, c)| p.to_bytes().len() + c.len())
+                .sum::<usize>()
+            + self
+                .parents
+                .iter()
+                .map(|p| p.to_bytes().len())
+                .sum::<usize>()
+    }
+
+    /// Returns true if the graph entry is too big
+    pub fn is_too_big(&self) -> bool {
+        self.size() > Self::MAX_SIZE
     }
 }

--- a/ant-protocol/src/storage/pointer.rs
+++ b/ant-protocol/src/storage/pointer.rs
@@ -132,6 +132,11 @@ impl Pointer {
         let bytes = self.bytes_for_signature();
         self.owner.verify(&self.signature, &bytes)
     }
+
+    /// Size of the pointer
+    pub fn size() -> usize {
+        size_of::<Pointer>()
+    }
 }
 
 #[cfg(test)]

--- a/ant-protocol/src/storage/pointer.rs
+++ b/ant-protocol/src/storage/pointer.rs
@@ -27,6 +27,8 @@ pub enum PointerError {
     SerializationError(String),
 }
 
+/// Pointer, a mutable address pointing to other data on the Network
+/// It is stored at the owner's public key and can only be updated by the owner
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Pointer {
     owner: PublicKey,

--- a/ant-protocol/src/storage/scratchpad.rs
+++ b/ant-protocol/src/storage/scratchpad.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use xor_name::XorName;
 
-/// Scratchpad, a mutable address for encrypted data
+/// Scratchpad, a mutable space for encrypted data on the Network
 #[derive(
     Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug, Serialize, Deserialize,
 )]
@@ -23,12 +23,12 @@ pub struct Scratchpad {
     /// Network address. Omitted when serialising and
     /// calculated from the `encrypted_data` when deserialising.
     address: ScratchpadAddress,
-    /// Data encoding: custom apps using scratchpad should use this so they can identify the type of data they are storing in the bytes
+    /// Data encoding: custom apps using scratchpad should use this so they can identify the type of data they are storing
     data_encoding: u64,
-    /// Contained data. This should be encrypted
+    /// Encrypted data stored in the scratchpad, it is encrypted automatically by the [`Scratchpad::new`] and [`Scratchpad::update_and_sign`] methods
     #[debug(skip)]
     encrypted_data: Bytes,
-    /// Monotonically increasing counter to track the number of times this has been updated.
+    /// Monotonically increasing counter to track the number of times this has been updated. When pushed to the network, the scratchpad with the highest counter is kept.
     counter: u64,
     /// Signature over the above fields
     signature: Signature,

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -71,12 +71,11 @@ impl Client {
 
         // pay for the graph entry
         let xor_name = address.xorname();
-        let graph_size_with_forks = size_of::<GraphEntry>() * 10;
         debug!("Paying for graph entry at address: {address:?}");
         let (payment_proofs, skipped_payments) = self
             .pay_for_content_addrs(
                 DataTypes::GraphEntry,
-                std::iter::once((*xor_name, graph_size_with_forks)),
+                std::iter::once((*xor_name, entry.size())),
                 payment_option,
             )
             .await
@@ -150,11 +149,10 @@ impl Client {
         trace!("Getting cost for GraphEntry of {key:?}");
         let address = GraphEntryAddress::from_owner(key);
         let xor = *address.xorname();
-        let graph_size_with_forks = size_of::<GraphEntry>() * 10;
         let store_quote = self
             .get_store_quotes(
                 DataTypes::GraphEntry,
-                std::iter::once((xor, graph_size_with_forks)),
+                std::iter::once((xor, GraphEntry::MAX_SIZE)),
             )
             .await?;
         let total_cost = AttoTokens::from_atto(

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -103,7 +103,7 @@ impl Client {
             // TODO: define Pointer default size for pricing
             .pay_for_content_addrs(
                 DataTypes::Pointer,
-                std::iter::once((xor_name, size_of::<Pointer>())),
+                std::iter::once((xor_name, Pointer::size())),
                 payment_option,
             )
             .await
@@ -275,10 +275,7 @@ impl Client {
         let address = PointerAddress::from_owner(key);
         let xor = *address.xorname();
         let store_quote = self
-            .get_store_quotes(
-                DataTypes::Pointer,
-                std::iter::once((xor, size_of::<Pointer>())),
-            )
+            .get_store_quotes(DataTypes::Pointer, std::iter::once((xor, Pointer::size())))
             .await?;
         let total_cost = AttoTokens::from_atto(
             store_quote

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -6,8 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client::{payment::PayError, quote::CostError, Client};
-use ant_evm::{Amount, AttoTokens, EvmWallet, EvmWalletError};
+use crate::client::{
+    payment::{PayError, PaymentOption},
+    quote::CostError,
+    Client,
+};
+use ant_evm::{Amount, AttoTokens, EvmWalletError};
 use ant_networking::{GetRecordCfg, GetRecordError, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::{
     storage::{
@@ -22,6 +26,7 @@ use tracing::{debug, error, trace};
 
 pub use ant_protocol::storage::{Pointer, PointerAddress, PointerTarget};
 
+/// Errors that can occur when dealing with Pointers
 #[derive(Debug, thiserror::Error)]
 pub enum PointerError {
     #[error("Cost error: {0}")]
@@ -83,11 +88,11 @@ impl Client {
         }
     }
 
-    /// Store a pointer on the network
+    /// Manually store a pointer on the network
     pub async fn pointer_put(
         &self,
         pointer: Pointer,
-        wallet: &EvmWallet,
+        payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PointerAddress), PointerError> {
         let address = pointer.network_address();
 
@@ -96,10 +101,10 @@ impl Client {
         debug!("Paying for pointer at address: {address:?}");
         let (payment_proofs, _skipped_payments) = self
             // TODO: define Pointer default size for pricing
-            .pay(
-                DataTypes::Pointer.get_index(),
-                std::iter::once((xor_name, 128)),
-                wallet,
+            .pay_for_content_addrs(
+                DataTypes::Pointer,
+                std::iter::once((xor_name, size_of::<Pointer>())),
+                payment_option,
             )
             .await
             .inspect_err(|err| {
@@ -174,7 +179,7 @@ impl Client {
         &self,
         owner: &SecretKey,
         target: PointerTarget,
-        wallet: &EvmWallet,
+        payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PointerAddress), PointerError> {
         let address = PointerAddress::from_owner(owner.public_key());
         let already_exists = match self.pointer_get(address).await {
@@ -193,7 +198,7 @@ impl Client {
         }
 
         let pointer = Pointer::new(owner, 0, target);
-        self.pointer_put(pointer, wallet).await
+        self.pointer_put(pointer, payment_option).await
     }
 
     /// Update an existing pointer to point to a new target on the network
@@ -269,9 +274,11 @@ impl Client {
 
         let address = PointerAddress::from_owner(key);
         let xor = *address.xorname();
-        // TODO: define default size of Pointer
         let store_quote = self
-            .get_store_quotes(DataTypes::Pointer.get_index(), std::iter::once((xor, 128)))
+            .get_store_quotes(
+                DataTypes::Pointer,
+                std::iter::once((xor, size_of::<Pointer>())),
+            )
             .await?;
         let total_cost = AttoTokens::from_atto(
             store_quote

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -6,10 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client::payment::PaymentOption;
-use crate::client::PutError;
+use crate::client::payment::{PayError, PaymentOption};
 use crate::{client::quote::CostError, Client};
-use ant_evm::{Amount, AttoTokens};
+use crate::{Amount, AttoTokens};
 use ant_networking::{GetRecordCfg, GetRecordError, NetworkError, PutRecordCfg, VerificationKind};
 use ant_protocol::storage::{try_serialize_record, RecordKind, RetryStrategy};
 use ant_protocol::{
@@ -19,18 +18,33 @@ use ant_protocol::{
 use libp2p::kad::{Quorum, Record};
 use std::collections::HashSet;
 
+pub use crate::Bytes;
 pub use ant_protocol::storage::{Scratchpad, ScratchpadAddress};
-pub use bls::{PublicKey, SecretKey};
+pub use bls::{PublicKey, SecretKey, Signature};
 
+/// Errors that can occur when dealing with Scratchpads
 #[derive(Debug, thiserror::Error)]
 pub enum ScratchpadError {
+    #[error("Payment failure occurred during scratchpad creation.")]
+    Pay(#[from] PayError),
     #[error("Scratchpad found at {0:?} was not a valid record.")]
     CouldNotDeserializeScratchPad(ScratchpadAddress),
     #[error("Network: {0}")]
     Network(#[from] NetworkError),
     #[error("Scratchpad not found")]
     Missing,
+    #[error("Serialization error")]
+    Serialization,
+    #[error("Scratchpad already exists at this address: {0:?}")]
+    ScratchpadAlreadyExists(ScratchpadAddress),
+    #[error("Scratchpad cannot be updated as it does not exist, please create it first or wait for it to be created")]
+    CannotUpdateNewScratchpad,
+    #[error("Scratchpad size is too big: {0} > {MAX_SCRATCHPAD_SIZE}")]
+    ScratchpadTooBig(usize),
 }
+
+/// Max Scratchpad size is 4MB including the metadata
+pub const MAX_SCRATCHPAD_SIZE: usize = 4 * 1024 * 1024;
 
 impl Client {
     /// Get Scratchpad from the Network
@@ -79,14 +93,14 @@ impl Client {
                     .map_err(|_| ScratchpadError::CouldNotDeserializeScratchPad(*address))?;
 
                 // take the latest versions
-                pads.sort_by_key(|s| s.count());
-                let max_version = pads.last().map(|p| p.count()).unwrap_or_else(|| {
+                pads.sort_by_key(|s| s.counter());
+                let max_version = pads.last().map(|p| p.counter()).unwrap_or_else(|| {
                     error!("Got empty scratchpad vector for {scratch_key:?}");
                     u64::MAX
                 });
                 let latest_pads: Vec<_> = pads
                     .into_iter()
-                    .filter(|s| s.count() == max_version)
+                    .filter(|s| s.counter() == max_version)
                     .collect();
 
                 // make sure we only have one of latest version
@@ -112,170 +126,209 @@ impl Client {
         Ok(pad)
     }
 
-    /// Returns the latest found version of the scratchpad for that secret key
-    /// If none is found, it creates a new one locally
-    /// Note that is does not upload that new scratchpad to the network, one would need to call [`Self::scratchpad_create`] to do so
-    /// Returns the scratchpad along with a boolean indicating if that scratchpad is new or not
-    pub async fn get_or_create_scratchpad(
-        &self,
-        public_key: &PublicKey,
-        content_type: u64,
-    ) -> Result<(Scratchpad, bool), PutError> {
-        let pad_res = self.scratchpad_get_from_public_key(public_key).await;
-        let mut is_new = true;
-
-        let scratch = if let Ok(existing_data) = pad_res {
-            info!("Scratchpad already exists, returning existing data");
-
-            info!(
-                "scratch already exists, is version {:?}",
-                existing_data.count()
-            );
-
-            is_new = false;
-
-            if existing_data.owner() != public_key {
-                return Err(PutError::ScratchpadBadOwner);
-            }
-
-            existing_data
-        } else {
-            trace!("new scratchpad creation");
-            Scratchpad::new(*public_key, content_type)
-        };
-
-        Ok((scratch, is_new))
-    }
-
-    /// Create a new scratchpad to the network
-    /// Returns the cost of the scratchpad and the address of the scratchpad
-    pub async fn scratchpad_create(
+    /// Manually store a scratchpad on the network
+    pub async fn scratchpad_put(
         &self,
         scratchpad: Scratchpad,
         payment_option: PaymentOption,
-    ) -> Result<(AttoTokens, ScratchpadAddress), PutError> {
-        let scratch_address = scratchpad.network_address();
-        let address = *scratchpad.address();
-        let scratch_key = scratch_address.to_record_key();
+    ) -> Result<(AttoTokens, ScratchpadAddress), ScratchpadError> {
+        let address = scratchpad.address();
 
         // pay for the scratchpad
-        let (receipt, _skipped_payments) = self
+        let xor_name = address.xorname();
+        let size = size_of::<Scratchpad>() + scratchpad.payload_size();
+        if size > MAX_SCRATCHPAD_SIZE {
+            return Err(ScratchpadError::ScratchpadTooBig(size));
+        }
+        debug!("Paying for scratchpad at address: {address:?}");
+        let (payment_proofs, _skipped_payments) = self
             .pay_for_content_addrs(
-                DataTypes::Scratchpad.get_index(),
-                std::iter::once((scratchpad.xorname(), scratchpad.payload_size())),
+                DataTypes::Scratchpad,
+                std::iter::once((xor_name, MAX_SCRATCHPAD_SIZE)),
                 payment_option,
             )
             .await
             .inspect_err(|err| {
-                error!("Failed to pay for new scratchpad at addr: {scratch_address:?} : {err}");
+                error!("Failed to pay for scratchpad at address: {address:?} : {err}")
             })?;
 
-        let (proof, price) = match receipt.values().next() {
-            Some(proof) => proof,
-            None => return Err(PutError::PaymentUnexpectedlyInvalid(scratch_address)),
+        // verify payment was successful
+        let (proof, price) = match payment_proofs.get(&xor_name) {
+            Some((proof, price)) => (Some(proof), price),
+            None => {
+                info!("Scratchpad at address: {address:?} was already paid for, update is free");
+                (None, &AttoTokens::zero())
+            }
         };
         let total_cost = *price;
 
-        let record = Record {
-            key: scratch_key,
-            value: try_serialize_record(
-                &(proof, scratchpad),
-                RecordKind::DataWithPayment(DataTypes::Scratchpad),
-            )
-            .map_err(|_| {
-                PutError::Serialization("Failed to serialize scratchpad with payment".to_string())
-            })?
-            .to_vec(),
-            publisher: None,
-            expires: None,
+        let net_addr = NetworkAddress::from_scratchpad_address(*address);
+        let (record, payees) = if let Some(proof) = proof {
+            let payees = Some(proof.payees());
+            let record = Record {
+                key: net_addr.to_record_key(),
+                value: try_serialize_record(
+                    &(proof, &scratchpad),
+                    RecordKind::DataWithPayment(DataTypes::Scratchpad),
+                )
+                .map_err(|_| ScratchpadError::Serialization)?
+                .to_vec(),
+                publisher: None,
+                expires: None,
+            };
+            (record, payees)
+        } else {
+            let record = Record {
+                key: net_addr.to_record_key(),
+                value: try_serialize_record(
+                    &scratchpad,
+                    RecordKind::DataOnly(DataTypes::Scratchpad),
+                )
+                .map_err(|_| ScratchpadError::Serialization)?
+                .to_vec(),
+                publisher: None,
+                expires: None,
+            };
+            (record, None)
+        };
+
+        let get_cfg = GetRecordCfg {
+            get_quorum: Quorum::Majority,
+            retry_strategy: Some(RetryStrategy::default()),
+            target_record: None,
+            expected_holders: Default::default(),
         };
 
         let put_cfg = PutRecordCfg {
-            put_quorum: Quorum::Majority,
-            retry_strategy: Some(RetryStrategy::Balanced),
-            use_put_record_to: None,
-            verification: Some((
-                VerificationKind::Crdt,
-                GetRecordCfg {
-                    get_quorum: Quorum::Majority,
-                    retry_strategy: None,
-                    target_record: None,
-                    expected_holders: HashSet::new(),
-                },
-            )),
+            put_quorum: Quorum::All,
+            retry_strategy: None,
+            verification: Some((VerificationKind::Crdt, get_cfg)),
+            use_put_record_to: payees,
         };
 
-        debug!("Put record - scratchpad at {scratch_address:?} to the network");
+        // store the scratchpad on the network
+        debug!("Storing scratchpad at address {address:?} to the network");
         self.network
             .put_record(record, &put_cfg)
             .await
             .inspect_err(|err| {
-                error!(
-                    "Failed to put scratchpad {scratch_address:?} to the network with err: {err:?}"
-                )
+                error!("Failed to put record - scratchpad {address:?} to the network: {err}")
             })?;
 
-        Ok((total_cost, address))
+        Ok((total_cost, *address))
+    }
+
+    /// Create a new scratchpad to the network
+    /// Make sure that the owner key is not already used for another scratchpad as each key is associated with one scratchpad
+    /// The data will be encrypted with the owner key before being stored on the network
+    /// The content type is used to identify the type of data stored in the scratchpad, the choice is up to the caller
+    /// Returns the cost and the address of the scratchpad
+    pub async fn scratchpad_create(
+        &self,
+        owner: &SecretKey,
+        content_type: u64,
+        initial_data: &Bytes,
+        payment_option: PaymentOption,
+    ) -> Result<(AttoTokens, ScratchpadAddress), ScratchpadError> {
+        let address = ScratchpadAddress::new(owner.public_key());
+        let already_exists = match self.scratchpad_get(&address).await {
+            Ok(_) => true,
+            Err(ScratchpadError::Network(NetworkError::GetRecordError(
+                GetRecordError::SplitRecord { .. },
+            ))) => true,
+            Err(ScratchpadError::Network(NetworkError::GetRecordError(
+                GetRecordError::RecordNotFound,
+            ))) => false,
+            Err(err) => return Err(err),
+        };
+
+        if already_exists {
+            return Err(ScratchpadError::ScratchpadAlreadyExists(address));
+        }
+
+        let counter = 0;
+        let scratchpad = Scratchpad::new(owner, content_type, initial_data, counter);
+        self.scratchpad_put(scratchpad, payment_option).await
     }
 
     /// Update an existing scratchpad to the network
     /// This operation is free but requires the scratchpad to be already created on the network
-    /// Only the latest version of the scratchpad is kept, make sure to update the scratchpad counter before calling this function
+    /// Only the latest version of the scratchpad is kept on the Network, previous versions will be overwritten and unrecoverable
     /// The method [`Scratchpad::update_and_sign`] should be used before calling this function to send the scratchpad to the network
-    pub async fn scratchpad_update(&self, scratchpad: Scratchpad) -> Result<(), PutError> {
-        let scratch_address = scratchpad.network_address();
-        let scratch_key = scratch_address.to_record_key();
-
-        let put_cfg = PutRecordCfg {
-            put_quorum: Quorum::Majority,
-            retry_strategy: Some(RetryStrategy::Balanced),
-            use_put_record_to: None,
-            verification: Some((
-                VerificationKind::Crdt,
-                GetRecordCfg {
-                    get_quorum: Quorum::Majority,
-                    retry_strategy: None,
-                    target_record: None,
-                    expected_holders: HashSet::new(),
-                },
-            )),
+    pub async fn scratchpad_update(
+        &self,
+        owner: &SecretKey,
+        content_type: u64,
+        data: &Bytes,
+    ) -> Result<(), ScratchpadError> {
+        let address = ScratchpadAddress::new(owner.public_key());
+        let current = match self.scratchpad_get(&address).await {
+            Ok(scratchpad) => Some(scratchpad),
+            Err(ScratchpadError::Network(NetworkError::GetRecordError(
+                GetRecordError::RecordNotFound,
+            ))) => None,
+            Err(ScratchpadError::Network(NetworkError::GetRecordError(
+                GetRecordError::SplitRecord { result_map },
+            ))) => result_map
+                .values()
+                .filter_map(|(record, _)| try_deserialize_record::<Scratchpad>(record).ok())
+                .max_by_key(|scratchpad: &Scratchpad| scratchpad.counter()),
+            Err(err) => {
+                return Err(err);
+            }
         };
 
+        let scratchpad = if let Some(p) = current {
+            let version = p.counter() + 1;
+            Scratchpad::new(owner, content_type, data, version)
+        } else {
+            warn!("Scratchpad at address {address:?} cannot be updated as it does not exist, please create it first or wait for it to be created");
+            return Err(ScratchpadError::CannotUpdateNewScratchpad);
+        };
+
+        // prepare the record to be stored
         let record = Record {
-            key: scratch_key,
+            key: NetworkAddress::from_scratchpad_address(address).to_record_key(),
             value: try_serialize_record(&scratchpad, RecordKind::DataOnly(DataTypes::Scratchpad))
-                .map_err(|_| PutError::Serialization("Failed to serialize scratchpad".to_string()))?
+                .map_err(|_| ScratchpadError::Serialization)?
                 .to_vec(),
             publisher: None,
             expires: None,
         };
+        let get_cfg = GetRecordCfg {
+            get_quorum: Quorum::Majority,
+            retry_strategy: Some(RetryStrategy::default()),
+            target_record: None,
+            expected_holders: Default::default(),
+        };
+        let put_cfg = PutRecordCfg {
+            put_quorum: Quorum::All,
+            retry_strategy: None,
+            verification: Some((VerificationKind::Crdt, get_cfg)),
+            use_put_record_to: None,
+        };
 
-        debug!("Put record - scratchpad at {scratch_address:?} to the network");
+        // store the scratchpad on the network
+        debug!("Updating scratchpad at address {address:?} to the network");
         self.network
             .put_record(record, &put_cfg)
             .await
             .inspect_err(|err| {
-                error!(
-                    "Failed to put scratchpad {scratch_address:?} to the network with err: {err:?}"
-                )
+                error!("Failed to update scratchpad at address {address:?} to the network: {err}")
             })?;
 
         Ok(())
     }
 
     /// Get the cost of creating a new Scratchpad
-    pub async fn scratchpad_cost(&self, owner: &SecretKey) -> Result<AttoTokens, CostError> {
+    pub async fn scratchpad_cost(&self, owner: &PublicKey) -> Result<AttoTokens, CostError> {
         info!("Getting cost for scratchpad");
-        let client_pk = owner.public_key();
-        let content_type = Default::default();
-        let scratch = Scratchpad::new(client_pk, content_type);
-        let scratch_xor = scratch.address().xorname();
+        let scratch_xor = ScratchpadAddress::new(*owner).xorname();
 
-        // TODO: define default size of Scratchpad
         let store_quote = self
             .get_store_quotes(
-                DataTypes::Scratchpad.get_index(),
-                std::iter::once((scratch_xor, 256)),
+                DataTypes::Scratchpad,
+                std::iter::once((scratch_xor, size_of::<Scratchpad>())),
             )
             .await?;
 

--- a/autonomi/src/client/external_signer.rs
+++ b/autonomi/src/client/external_signer.rs
@@ -1,3 +1,4 @@
+use crate::client::quote::DataTypes;
 use crate::client::PutError;
 use crate::self_encryption::encrypt;
 use crate::Client;
@@ -17,7 +18,7 @@ impl Client {
     /// Returns a cost map, data payments to be executed and a list of free (already paid for) chunks.
     pub async fn get_quotes_for_content_addresses(
         &self,
-        data_type: u32,
+        data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)> + Clone,
     ) -> Result<
         (

--- a/autonomi/src/client/high_level/data/private.rs
+++ b/autonomi/src/client/high_level/data/private.rs
@@ -77,11 +77,7 @@ impl Client {
             .collect();
         info!("Paying for {} addresses", xor_names.len());
         let (receipt, skipped_payments) = self
-            .pay_for_content_addrs(
-                DataTypes::Chunk.get_index(),
-                xor_names.into_iter(),
-                payment_option,
-            )
+            .pay_for_content_addrs(DataTypes::Chunk, xor_names.into_iter(), payment_option)
             .await
             .inspect_err(|err| error!("Error paying for data: {err:?}"))?;
 

--- a/autonomi/src/client/high_level/data/public.rs
+++ b/autonomi/src/client/high_level/data/public.rs
@@ -54,11 +54,7 @@ impl Client {
         // Pay for all chunks + data map chunk
         info!("Paying for {} addresses", xor_names.len());
         let (receipt, skipped_payments) = self
-            .pay_for_content_addrs(
-                DataTypes::Chunk.get_index(),
-                xor_names.into_iter(),
-                payment_option,
-            )
+            .pay_for_content_addrs(DataTypes::Chunk, xor_names.into_iter(), payment_option)
             .await
             .inspect_err(|err| error!("Error paying for data: {err:?}"))?;
 
@@ -127,7 +123,7 @@ impl Client {
         );
 
         let store_quote = self
-            .get_store_quotes(DataTypes::Chunk.get_index(), content_addrs.into_iter())
+            .get_store_quotes(DataTypes::Chunk, content_addrs.into_iter())
             .await
             .inspect_err(|err| error!("Error getting store quotes: {err:?}"))?;
 

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -1,4 +1,4 @@
-use crate::client::quote::StoreQuote;
+use crate::client::quote::{DataTypes, StoreQuote};
 use crate::Client;
 use ant_evm::{AttoTokens, EncodedPeerId, EvmWallet, EvmWalletError, ProofOfPayment};
 use std::collections::HashMap;
@@ -56,7 +56,9 @@ pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
 /// Payment options for data payments.
 #[derive(Clone)]
 pub enum PaymentOption {
+    /// Pay using an evm wallet
     Wallet(EvmWallet),
+    /// When data was already paid for, use the receipt
     Receipt(Receipt),
 }
 
@@ -81,7 +83,7 @@ impl From<Receipt> for PaymentOption {
 impl Client {
     pub(crate) async fn pay_for_content_addrs(
         &self,
-        data_type: u32,
+        data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)> + Clone,
         payment_option: PaymentOption,
     ) -> Result<(Receipt, AlreadyPaidAddressesCount), PayError> {
@@ -97,7 +99,7 @@ impl Client {
     /// Pay for the chunks and get the proof of payment.
     pub(crate) async fn pay(
         &self,
-        data_type: u32,
+        data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)> + Clone,
         wallet: &EvmWallet,
     ) -> Result<(Receipt, AlreadyPaidAddressesCount), PayError> {

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -16,6 +16,8 @@ use libp2p::PeerId;
 use std::collections::HashMap;
 use xor_name::XorName;
 
+pub use ant_protocol::storage::DataTypes;
+
 /// A quote for a single address
 pub struct QuoteForAddress(pub(crate) Vec<(PeerId, PaymentQuote, Amount)>);
 
@@ -72,14 +74,19 @@ pub enum CostError {
 impl Client {
     pub async fn get_store_quotes(
         &self,
-        data_type: u32,
+        data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)>,
     ) -> Result<StoreQuote, CostError> {
         // get all quotes from nodes
         let futures: Vec<_> = content_addrs
             .into_iter()
             .map(|(content_addr, data_size)| {
-                fetch_store_quote_with_retries(&self.network, content_addr, data_type, data_size)
+                fetch_store_quote_with_retries(
+                    &self.network,
+                    content_addr,
+                    data_type.get_index(),
+                    data_size,
+                )
             })
             .collect();
 

--- a/autonomi/src/python.rs
+++ b/autonomi/src/python.rs
@@ -187,12 +187,15 @@ impl Client {
         counter: u32,
         target: &PyPointerTarget,
         key: &PySecretKey,
-        wallet: &Wallet,
+        payment_option: &PaymentOption,
     ) -> PyResult<PyPointerAddress> {
         let rt = tokio::runtime::Runtime::new().expect("Could not start tokio runtime");
         let pointer = RustPointer::new(&key.inner, counter, target.inner.clone());
         let (_price, addr) = rt
-            .block_on(self.inner.pointer_put(pointer, &wallet.inner))
+            .block_on(
+                self.inner
+                    .pointer_put(pointer, payment_option.inner.clone()),
+            )
             .map_err(|e| PyValueError::new_err(format!("Failed to put pointer: {e}")))?;
         Ok(PyPointerAddress { inner: addr })
     }

--- a/autonomi/tests/graph.rs
+++ b/autonomi/tests/graph.rs
@@ -8,7 +8,10 @@
 
 use ant_logging::LogBuilder;
 use autonomi::{
-    client::graph::{GraphEntry, GraphError},
+    client::{
+        graph::{GraphEntry, GraphError},
+        payment::PaymentOption,
+    },
     Client,
 };
 use eyre::Result;
@@ -30,7 +33,10 @@ async fn graph_entry_put() -> Result<()> {
     println!("graph_entry cost: {cost}");
 
     // put the graph_entry
-    client.graph_entry_put(graph_entry.clone(), &wallet).await?;
+    let payment_option = PaymentOption::from(&wallet);
+    client
+        .graph_entry_put(graph_entry.clone(), payment_option)
+        .await?;
     println!("graph_entry put 1");
 
     // wait for the graph_entry to be replicated
@@ -44,7 +50,10 @@ async fn graph_entry_put() -> Result<()> {
     // try put another graph_entry with the same address
     let content2 = [1u8; 32];
     let graph_entry2 = GraphEntry::new(key.public_key(), vec![], content2, vec![], &key);
-    let res = client.graph_entry_put(graph_entry2.clone(), &wallet).await;
+    let payment_option = PaymentOption::from(&wallet);
+    let res = client
+        .graph_entry_put(graph_entry2.clone(), payment_option)
+        .await;
 
     assert!(matches!(
         res,

--- a/autonomi/tests/pointer.rs
+++ b/autonomi/tests/pointer.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ant_logging::LogBuilder;
+use autonomi::client::payment::PaymentOption;
 use autonomi::AttoTokens;
 use autonomi::{
     chunk::ChunkAddress,
@@ -35,7 +36,8 @@ async fn pointer_put_manual() -> Result<()> {
     println!("pointer cost: {cost}");
 
     // put the pointer
-    let (cost, addr) = client.pointer_put(pointer.clone(), &wallet).await?;
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client.pointer_put(pointer.clone(), payment_option).await?;
     assert_eq!(addr, pointer.address());
     println!("pointer put 1 cost: {cost}");
 
@@ -50,7 +52,8 @@ async fn pointer_put_manual() -> Result<()> {
     // try update pointer and make it point to itself
     let target2 = PointerTarget::PointerAddress(addr);
     let pointer2 = Pointer::new(&key, 1, target2);
-    let (cost, _) = client.pointer_put(pointer2.clone(), &wallet).await?;
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, _) = client.pointer_put(pointer2.clone(), payment_option).await?;
     assert_eq!(cost, AttoTokens::zero());
     println!("pointer put 2 cost: {cost}");
 
@@ -82,7 +85,10 @@ async fn pointer_put() -> Result<()> {
     println!("pointer cost: {cost}");
 
     // put the pointer
-    let (cost, addr) = client.pointer_create(&key, target.clone(), &wallet).await?;
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client
+        .pointer_create(&key, target.clone(), payment_option)
+        .await?;
     println!("pointer create cost: {cost}");
 
     // wait for the pointer to be replicated
@@ -96,7 +102,6 @@ async fn pointer_put() -> Result<()> {
     // try update pointer and make it point to itself
     let target2 = PointerTarget::PointerAddress(addr);
     client.pointer_update(&key, target2.clone()).await?;
-    println!("pointer update cost: {cost}");
 
     // wait for the pointer to be replicated
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;

--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -1,0 +1,192 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_logging::LogBuilder;
+use autonomi::client::payment::PaymentOption;
+use autonomi::scratchpad::ScratchpadError;
+use autonomi::AttoTokens;
+use autonomi::{
+    client::scratchpad::{Bytes, Scratchpad},
+    Client,
+};
+use eyre::Result;
+use test_utils::evm::get_funded_wallet;
+
+#[tokio::test]
+async fn scratchpad_put_manual() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("scratchpad", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let key = bls::SecretKey::random();
+    let public_key = key.public_key();
+    let content = Bytes::from("Massive Array of Internet Disks");
+    let scratchpad = Scratchpad::new(&key, 42, &content, 0);
+
+    // estimate the cost of the scratchpad
+    let cost = client.scratchpad_cost(&public_key).await?;
+    println!("scratchpad cost: {cost}");
+
+    // put the scratchpad
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client
+        .scratchpad_put(scratchpad.clone(), payment_option)
+        .await?;
+    assert_eq!(addr, *scratchpad.address());
+    println!("scratchpad put 1 cost: {cost}");
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is stored
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, scratchpad.clone());
+    println!("scratchpad got 1");
+
+    // check that the content is decrypted correctly
+    let got_content = got.decrypt_data(&key)?;
+    assert_eq!(got_content, content);
+
+    // try update scratchpad
+    let content2 = Bytes::from("Secure Access For Everyone");
+    let scratchpad2 = Scratchpad::new(&key, 42, &content2, 1);
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, _) = client
+        .scratchpad_put(scratchpad2.clone(), payment_option)
+        .await?;
+    assert_eq!(cost, AttoTokens::zero());
+    println!("scratchpad put 2 cost: {cost}");
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is updated
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, scratchpad2.clone());
+    println!("scratchpad got 2");
+
+    // check that the content is decrypted correctly
+    let got_content2 = got.decrypt_data(&key)?;
+    assert_eq!(got_content2, content2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn scratchpad_put() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("scratchpad", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let key = bls::SecretKey::random();
+    let public_key = key.public_key();
+    let content = Bytes::from("what's the meaning of life the universe and everything?");
+    let content_type = 42;
+
+    // estimate the cost of the scratchpad
+    let cost = client.scratchpad_cost(&public_key).await?;
+    println!("scratchpad cost: {cost}");
+
+    // put the scratchpad
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client
+        .scratchpad_create(&key, content_type, &content, payment_option)
+        .await?;
+    println!("scratchpad create cost: {cost}");
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is stored
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, Scratchpad::new(&key, content_type, &content, 0));
+    println!("scratchpad got 1");
+
+    // check that the content is decrypted correctly
+    let got_content = got.decrypt_data(&key)?;
+    assert_eq!(got_content, content);
+
+    // try update scratchpad
+    let content2 = Bytes::from("42");
+    client
+        .scratchpad_update(&key, content_type, &content2)
+        .await?;
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is updated
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, Scratchpad::new(&key, content_type, &content2, 1));
+    println!("scratchpad got 2");
+
+    // check that the content is decrypted correctly
+    let got_content2 = got.decrypt_data(&key)?;
+    assert_eq!(got_content2, content2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn scratchpad_errors() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("scratchpad", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let key = bls::SecretKey::random();
+    let content = Bytes::from("what's the meaning of life the universe and everything?");
+    let content_type = 42;
+
+    // try update scratchpad, it should fail as we haven't created it
+    let res = client.scratchpad_update(&key, content_type, &content).await;
+    assert!(matches!(
+        res,
+        Err(ScratchpadError::CannotUpdateNewScratchpad)
+    ));
+
+    // put the scratchpad normally
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client
+        .scratchpad_create(&key, content_type, &content, payment_option)
+        .await?;
+    println!("scratchpad create cost: {cost}");
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is stored
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, Scratchpad::new(&key, content_type, &content, 0));
+    println!("scratchpad got 1");
+
+    // try update scratchpad with same counter
+    let fork_content = Bytes::from("Fork");
+    let zero_again = 0;
+    let fork_scratch = Scratchpad::new(&key, content_type, &fork_content, zero_again);
+    let payment_option = PaymentOption::from(&wallet);
+    let res = client.scratchpad_put(fork_scratch, payment_option).await;
+    assert!(matches!(
+        res,
+        Err(ScratchpadError::ScratchpadAlreadyExists(_))
+    ));
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is stored
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, Scratchpad::new(&key, content_type, &content, 0));
+    println!("scratchpad got 1");
+
+    // check that the content is decrypted correctly and matches the original
+    let got_content = got.decrypt_data(&key)?;
+    assert_eq!(got_content, content);
+    Ok(())
+}

--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -110,7 +110,7 @@ async fn scratchpad_put() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.is_valid());
+    assert!(got.verify());
     println!("scratchpad got 1");
 
     // check that the content is decrypted correctly
@@ -132,7 +132,7 @@ async fn scratchpad_put() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content2.clone()));
     assert_eq!(got.counter(), 1);
-    assert!(got.is_valid());
+    assert!(got.verify());
     println!("scratchpad got 2");
 
     // check that the content is decrypted correctly
@@ -175,7 +175,7 @@ async fn scratchpad_errors() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.is_valid());
+    assert!(got.verify());
     println!("scratchpad got 1");
 
     // try create scratchpad at the same address
@@ -199,7 +199,7 @@ async fn scratchpad_errors() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.is_valid());
+    assert!(got.verify());
     println!("scratchpad got 1");
 
     // check that the content is decrypted correctly and matches the original

--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -106,7 +106,11 @@ async fn scratchpad_put() -> Result<()> {
 
     // check that the scratchpad is stored
     let got = client.scratchpad_get(&addr).await?;
-    assert_eq!(got, Scratchpad::new(&key, content_type, &content, 0));
+    assert_eq!(*got.owner(), public_key);
+    assert_eq!(got.data_encoding(), content_type);
+    assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
+    assert_eq!(got.counter(), 0);
+    assert!(got.is_valid());
     println!("scratchpad got 1");
 
     // check that the content is decrypted correctly
@@ -124,7 +128,11 @@ async fn scratchpad_put() -> Result<()> {
 
     // check that the scratchpad is updated
     let got = client.scratchpad_get(&addr).await?;
-    assert_eq!(got, Scratchpad::new(&key, content_type, &content2, 1));
+    assert_eq!(*got.owner(), public_key);
+    assert_eq!(got.data_encoding(), content_type);
+    assert_eq!(got.decrypt_data(&key), Ok(content2.clone()));
+    assert_eq!(got.counter(), 1);
+    assert!(got.is_valid());
     println!("scratchpad got 2");
 
     // check that the content is decrypted correctly


### PR DESCRIPTION
- Now scratchpad have their own module clearly separated from Vault and Vaults use the generic Scratchpad API.
- Exactly like Pointers, Scratchpads have a put/get/create/update API that allows for manual or user friendly use of the scratchpad.
- E2E tests for Scratchpad to prove they work as intended. They could serve as usage examples as well.
- GraphEntry, Pointer and Scratchpad use PaymentOption now, unifying the payment process