### PR TITLE
WIP: Initial Logging Reconfiguration

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -47,7 +47,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         env:
           ANT_LOG: "all"
         with:
@@ -71,7 +71,9 @@ jobs:
 
       - name: Start a client instance to compare memory usage
         shell: bash
-        run: ./target/release/ant --local file upload "./the-test-data.zip"
+        run: |
+          mkdir -p $CLIENT_DATA_PATH/logs
+          ./target/release/ant --local file upload "./the-test-data.zip" 2> $CLIENT_DATA_PATH/logs/ant.log
         env:
           ANT_LOG: "all"
         timeout-minutes: 5

--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Start a client instance to compare memory usage
         shell: bash
-        run: ./target/release/ant --log-output-dest=data-dir --local file upload "./the-test-data.zip"
+        run: ./target/release/ant --local file upload "./the-test-data.zip"
         env:
           ANT_LOG: "all"
         timeout-minutes: 5
@@ -205,13 +205,13 @@ jobs:
 
       # - name: Start a client to carry out download to output the logs
       #   shell: bash
-      #   run: target/release/safe --log-output-dest=data-dir files download --retry-strategy quick
+      #   run: target/release/safe files download --retry-strategy quick
 
       # - name: Start a client to simulate criterion upload
       #   shell: bash
       #   run: |
       #     ls -l target/release
-      #     target/release/safe --log-output-dest=data-dir files upload target/release/faucet --retry-strategy quick
+      #     target/release/safe files upload target/release/faucet --retry-strategy quick
 
       #########################
       ### Stop Network      ###

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Start a client instance to compare memory usage
         shell: bash
-        run: cargo run --bin ant --release -- --log-output-dest data-dir --local file upload the-test-data.zip
+        run: cargo run --bin ant --release -- --local file upload the-test-data.zip
         env:
           ANT_LOG: "all"
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: File upload
-        run: ./target/release/ant --log-output-dest=data-dir --local file upload --public "./the-test-data.zip" > ./upload_output 2>&1
+        run: ./target/release/ant --local file upload --public "./the-test-data.zip" > ./upload_output 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
@@ -98,7 +98,7 @@ jobs:
           ls -l $ANT_DATA_PATH/client_first/logs
           mkdir $ANT_DATA_PATH/client
           ls -l $ANT_DATA_PATH
-          ./target/release/ant --log-output-dest=data-dir --local file upload --public "./the-test-data.zip" > ./upload_output_second 2>&1
+          ./target/release/ant --local file upload --public "./the-test-data.zip" > ./upload_output_second 2>&1
           rg 'All chunks already exist on the network.' ./upload_output_second -c --stats
         env:
           ANT_LOG: "all"
@@ -150,7 +150,7 @@ jobs:
         if: always()
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
+        run: ./target/release/ant --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
         env:
           ANT_LOG: "v"
         timeout-minutes: 2

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -40,7 +40,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: start
           enable-evm-testnet: true
@@ -56,7 +56,10 @@ jobs:
         run: |
           mkdir -p $RESTART_TEST_NODE_DATA_PATH
           ./target/release/antnode \
-            --root-dir $RESTART_TEST_NODE_DATA_PATH --log-output-dest $RESTART_TEST_NODE_DATA_PATH --local --rewards-address "0x03B770D9cD32077cC0bF330c13C114a87643B124" &
+            --root-dir $RESTART_TEST_NODE_DATA_PATH \
+            --log-output-dest $RESTART_TEST_NODE_DATA_PATH \
+            --local \
+            --rewards-address "0x03B770D9cD32077cC0bF330c13C114a87643B124" &
           sleep 10
         env:
           ANT_LOG: "all"
@@ -70,19 +73,26 @@ jobs:
         shell: bash
 
       - name: File upload
-        run: ./target/release/ant --local file upload --public "./the-test-data.zip" > ./upload_output 2>&1
+        run: |
+          mkdir -p "${CLIENT_DATA_PATH}/logs"
+          ./target/release/ant \
+            --local \
+            file upload \
+            --public "./the-test-data.zip" \
+            > ./upload_output_second \
+            2> "${CLIENT_DATA_PATH}/logs/ant.log"
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
 
       - name: showing the upload terminal output
-        run: cat upload_output
+        run: cat upload_output_second
         shell: bash
         if: always()
 
       - name: parse address
         run: |
-          UPLOAD_ADDRESS=$(rg "At address: ([0-9a-f]*)" -o -r '$1' ./upload_output)
+          UPLOAD_ADDRESS=$(rg "At address: ([0-9a-f]*)" -o -r '$1' ./upload_output_second)
           echo "UPLOAD_ADDRESS=$UPLOAD_ADDRESS" >> $GITHUB_ENV
         shell: bash
 
@@ -90,14 +100,6 @@ jobs:
       # Note rg will throw an error directly in case of failed to find a matching pattern.
       - name: Start a different client to upload the same file
         run: |
-          pwd
-          ls -l $ANT_DATA_PATH
-          mv $CLIENT_DATA_PATH $ANT_DATA_PATH/client_first
-          ls -l $ANT_DATA_PATH
-          ls -l $ANT_DATA_PATH/client_first
-          ls -l $ANT_DATA_PATH/client_first/logs
-          mkdir $ANT_DATA_PATH/client
-          ls -l $ANT_DATA_PATH
           ./target/release/ant --local file upload --public "./the-test-data.zip" > ./upload_output_second 2>&1
           rg 'All chunks already exist on the network.' ./upload_output_second -c --stats
         env:
@@ -127,7 +129,9 @@ jobs:
       # Currently, there will be `Existing record found`, but NO `Existing record loaded`
       # Due to the failure on decryption (as different seed used)
       - name: Assert we've reloaded some chunks
-        run: rg "Existing record found" $RESTART_TEST_NODE_DATA_PATH
+        run: |
+          ls -al $RESTART_TEST_NODE_DATA_PATH
+          rg "Existing record found" $RESTART_TEST_NODE_DATA_PATH/antnode.log
 
       - name: Wait at least 1min for replication to happen # it is throttled to once/30s.
         run: sleep 60
@@ -180,7 +184,7 @@ jobs:
 
       - name: Stop the local network and upload logs
         if: always()
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: stop
           log_file_prefix: safe_test_logs_memcheck

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -236,13 +236,13 @@ jobs:
         shell: pwsh
 
       - name: Get file cost
-        run: ./target/release/ant --log-output-dest=data-dir --local file cost "./resources"
+        run: ./target/release/ant --local file cost "./resources"
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
 
       - name: File upload
-        run: ./target/release/ant --log-output-dest=data-dir --local file upload "./resources" > ./upload_output 2>&1
+        run: ./target/release/ant --local file upload "./resources" > ./upload_output 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
@@ -262,7 +262,7 @@ jobs:
         shell: pwsh
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
+        run: ./target/release/ant --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
         env:
           ANT_LOG: "v"
         timeout-minutes: 5
@@ -274,19 +274,19 @@ jobs:
         timeout-minutes: 2
 
       - name: file upload
-        run: ./target/release/ant --log-output-dest data-dir --local file upload random.txt
+        run: ./target/release/ant --local file upload random.txt
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
 
       - name: Estimate cost to create a vault
-        run: ./target/release/ant --log-output-dest data-dir --local vault cost
+        run: ./target/release/ant --local vault cost
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
 
       - name: create a vault with existing user data as above
-        run: ./target/release/ant --log-output-dest data-dir --local vault create
+        run: ./target/release/ant --local vault create
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
@@ -297,8 +297,8 @@ jobs:
           set -e
           for i in {1..50}; do
             dd if=/dev/urandom of=random_file_$i.bin bs=1M count=1 status=none
-            ./target/release/ant --log-output-dest data-dir --local file upload random_file_$i.bin --public
-            ./target/release/ant --log-output-dest data-dir --local file upload random_file_$i.bin
+            ./target/release/ant --local file upload random_file_$i.bin --public
+            ./target/release/ant --local file upload random_file_$i.bin
           done
         env:
           ANT_LOG: "v"
@@ -323,13 +323,13 @@ jobs:
         timeout-minutes: 25
 
       - name: sync the vault
-        run: ./target/release/ant --log-output-dest data-dir --local vault sync
+        run: ./target/release/ant --local vault sync
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
 
       - name: load the vault from network
-        run: ./target/release/ant --log-output-dest data-dir --local vault load
+        run: ./target/release/ant --local vault load
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
@@ -344,11 +344,11 @@ jobs:
           NUM_OF_PUBLIC_FILES_IN_VAULT=""
           NUM_OF_PRIVATE_FILES_IN_VAULT=""
 
-          ./target/release/ant --log-output-dest data-dir --local file list 2>&1 > file_list.txt
+          ./target/release/ant --local file list 2>&1 > file_list.txt
 
           NUM_OF_PUBLIC_FILES=`cat file_list.txt | grep "public" | grep -o '[0-9]\+'`
           NUM_OF_PRIVATE_FILES=`cat file_list.txt | grep "private" | grep -o '[0-9]\+'`
-          ./target/release/ant --log-output-dest data-dir --local vault load 2>&1 > vault_data.txt
+          ./target/release/ant --local vault load 2>&1 > vault_data.txt
 
           NUM_OF_PUBLIC_FILES_IN_VAULT=`cat vault_data.txt  | grep "public" | grep -o '[0-9]\+'`
           NUM_OF_PRIVATE_FILES_IN_VAULT=`cat vault_data.txt| grep "private" | grep -o '[0-9]\+'`
@@ -370,8 +370,8 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          ./target/release/ant --log-output-dest data-dir --local file list > file_list.txt 2>&1
-          ./target/release/ant --log-output-dest data-dir --local vault load > vault_data.txt 2>&1
+          ./target/release/ant --local file list > file_list.txt 2>&1
+          ./target/release/ant --local vault load > vault_data.txt 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
@@ -418,7 +418,7 @@ jobs:
         timeout-minutes: 2
 
       - name: load an existing vault from the network
-        run: ./target/release/ant --log-output-dest data-dir --local vault load
+        run: ./target/release/ant --local vault load
         env:
           ANT_LOG: "v"
         timeout-minutes: 2
@@ -436,12 +436,12 @@ jobs:
           # 1 GB
           python3 -c "with open('random_1GB.bin', 'wb') as f: f.write(bytearray([0xff] * 1000 * 1024 * 1024))"
 
-          ./target/release/ant --log-output-dest=data-dir --local file list
-          time ./target/release/ant --log-output-dest=data-dir --local file upload random_1MB.bin
-          time ./target/release/ant --log-output-dest=data-dir --local file upload random_10MB.bin
-          time ./target/release/ant --log-output-dest=data-dir --local file upload random_100MB.bin
-          time ./target/release/ant --log-output-dest=data-dir --local file upload random_1GB.bin
-          ./target/release/ant --log-output-dest=data-dir --local vault sync
+          ./target/release/ant --local file list
+          time ./target/release/ant --local file upload random_1MB.bin
+          time ./target/release/ant --local file upload random_10MB.bin
+          time ./target/release/ant --local file upload random_100MB.bin
+          time ./target/release/ant --local file upload random_1GB.bin
+          ./target/release/ant --local vault sync
           rm -rf random*.bin
           rm -rf ${{ matrix.ant_path }}/autonomi
         env:
@@ -853,8 +853,8 @@ jobs:
 
   #     - name: Create and fund a wallet first time
   #       run: |
-  #         ~/safe --log-output-dest=data-dir wallet create --no-password
-  #         ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 1>first.txt
+  #         ~/safe wallet create --no-password
+  #         ~/faucet send 100000000 $(~/safe wallet address | tail -n 1) | tail -n 1 1>first.txt
   #         echo "----------"
   #         cat first.txt
   #       env:
@@ -886,13 +886,13 @@ jobs:
   #       if: always()
 
   # - name: Create a new wallet
-  #   run: ~/safe --log-output-dest=data-dir wallet create --no-password
+  #   run: ~/safe wallet create --no-password
   #   env:
   #     ANT_LOG: "all"
   #   timeout-minutes: 5
 
   # - name: Attempt second faucet genesis disbursement
-  #   run: ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1)  > second.txt 2>&1 || true
+  #   run: ~/faucet send 100000000 $(~/safe wallet address | tail -n 1)  > second.txt 2>&1 || true
   #   env:
   #     ANT_LOG: "all"
   #   timeout-minutes: 5
@@ -922,8 +922,8 @@ jobs:
   #     rm -rf /home/runner/.local/share/autonomi/test_faucet
   #     rm -rf /home/runner/.local/share/autonomi/test_genesis
   #     rm -rf /home/runner/.local/share/autonomi/autonomi
-  #     ~/safe --log-output-dest=data-dir wallet create --no-password
-  #     if GENESIS_PK=a9925296499299fdbf4412509d342a92e015f5b996e9acd1d2ab7f2326e3ad05934326efdc345345a95e973ac1bb6637 GENESIS_SK=40f6bbc870355c68138ac70b450b6425af02b49874df3f141b7018378ceaac66 nohup ~/faucet --log-output-dest=data-dir send 100000000 $(~/safe --log-output-dest=data-dir wallet address | tail -n 1); then
+  #     ~/safe wallet create --no-password
+  #     if GENESIS_PK=a9925296499299fdbf4412509d342a92e015f5b996e9acd1d2ab7f2326e3ad05934326efdc345345a95e973ac1bb6637 GENESIS_SK=40f6bbc870355c68138ac70b450b6425af02b49874df3f141b7018378ceaac66 nohup ~/faucet send 100000000 $(~/safe wallet address | tail -n 1); then
   #       echo "Faucet with different genesis key not rejected!"
   #       exit 1
   #     else
@@ -1053,7 +1053,7 @@ jobs:
         shell: bash
 
       - name: File upload
-        run: ./target/release/ant --log-output-dest data-dir --local file upload "./test_data_1.tar.gz" > ./upload_output 2>&1
+        run: ./target/release/ant --local file upload "./test_data_1.tar.gz" > ./upload_output 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 15
@@ -1070,7 +1070,7 @@ jobs:
         shell: bash
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources > ./download_output 2>&1
+        run: ./target/release/ant --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources > ./download_output 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 5
@@ -1112,7 +1112,6 @@ jobs:
           platform: ubuntu-latest
           log_file_prefix: safe_test_logs_large_file_upload_no_ws
           build: true
-
   # replication_bench_with_heavy_upload:
   #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
   #   name: Replication bench with heavy upload
@@ -1198,15 +1197,15 @@ jobs:
 
   #     - name: Create and fund a wallet to pay for files storage
   #       run: |
-  #         ./target/release/safe --log-output-dest=data-dir wallet create --no-password
-  #         ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
-  #         ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
+  #         ./target/release/safe wallet create --no-password
+  #         ./target/release/faucet send 100000000 $(./target/release/safe wallet address | tail -n 1) | tail -n 1 > transfer_hex
+  #         ./target/release/safe wallet receive --file transfer_hex
   #       env:
   #         ANT_LOG: "all"
   #       timeout-minutes: 5
 
   #     - name: Start a client to upload first file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_1.tar.gz" --retry-strategy quick
+  #       run: ./target/release/safe files upload "./test_data_1.tar.gz" --retry-strategy quick
   #       env:
   #         ANT_LOG: "all"
   #       timeout-minutes: 5
@@ -1240,7 +1239,7 @@ jobs:
   #       timeout-minutes: 6
 
   #     - name: Use same client to upload second file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_2.tar.gz" --retry-strategy quick
+  #       run: ./target/release/safe files upload "./test_data_2.tar.gz" --retry-strategy quick
   #       env:
   #         ANT_LOG: "all"
   #       timeout-minutes: 10
@@ -1283,9 +1282,9 @@ jobs:
   #         ls -l $SAFE_DATA_PATH
   #         mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
   #         ls -l $CLIENT_DATA_PATH
-  #         ./target/release/safe --log-output-dest=data-dir wallet create --no-password
-  #         ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
-  #         ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
+  #         ./target/release/safe wallet create --no-password
+  #         ./target/release/faucet send 100000000 $(./target/release/safe wallet address | tail -n 1) | tail -n 1 > transfer_hex
+  #         ./target/release/safe wallet receive --file transfer_hex
   #       env:
   #         ANT_LOG: "all"
   #         SAFE_DATA_PATH: /home/runner/.local/share/autonomi
@@ -1293,7 +1292,7 @@ jobs:
   #       timeout-minutes: 25
 
   #     - name: Use second client to upload third file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_3.tar.gz" --retry-strategy quick
+  #       run: ./target/release/safe files upload "./test_data_3.tar.gz" --retry-strategy quick
   #       env:
   #         ANT_LOG: "all"
   #       timeout-minutes: 10
@@ -1329,3 +1328,4 @@ jobs:
   #         action: stop
   #         log_file_prefix: safe_test_logs_heavy_replicate_bench
   #         platform: ubuntu-latest
+

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -193,7 +193,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: start
           enable-evm-testnet: true
@@ -315,8 +315,8 @@ jobs:
               [System.IO.File]::WriteAllBytes($fileName, $byteArray)
 
               # Run autonomi commands
-              ./target/release/ant --log-output-dest data-dir --local file upload "random_file_$i.bin" --public
-              ./target/release/ant --log-output-dest data-dir --local file upload "random_file_$i.bin"
+              ./target/release/ant --local file upload "random_file_$i.bin" --public
+              ./target/release/ant --local file upload "random_file_$i.bin"
           }
         env:
           ANT_LOG: "v"
@@ -558,7 +558,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: start
           enable-evm-testnet: true
@@ -705,7 +705,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: start
           enable-evm-testnet: true
@@ -1014,7 +1014,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
+        uses: jacderida/ant-local-testnet-action@chore-enable_logging
         with:
           action: start
           enable-evm-testnet: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Run autonomi --tests
         run: cargo test --package autonomi --tests -- --nocapture
         env:
-          ANT_LOG: "v"
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
@@ -80,15 +79,11 @@ jobs:
         shell: pwsh
 
       - name: Get file cost
-        run: ./target/release/ant --log-output-dest=data-dir file cost "./resources"
-        env:
-          ANT_LOG: "v"
+        run: ./target/release/ant file cost "./resources"
         timeout-minutes: 15
 
       - name: File upload
-        run: ./target/release/ant --log-output-dest=data-dir file upload "./resources" > ./upload_output 2>&1
-        env:
-          ANT_LOG: "v"
+        run: ./target/release/ant file upload "./resources" > ./upload_output 2>&1
         timeout-minutes: 15
 
       - name: parse address (unix)
@@ -106,7 +101,7 @@ jobs:
         shell: pwsh
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest=data-dir file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
+        run: ./target/release/ant file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
         env:
           ANT_LOG: "v"
         timeout-minutes: 5

--- a/.github/workflows/nightly_wan.yml
+++ b/.github/workflows/nightly_wan.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Start a client to carry out chunk actions
         run: |
           set -e
-          cargo run --bin safe --release -- --log-output-dest=data-dir files upload "./resources" --retry-strategy quick
+          cargo run --bin safe --release -- files upload "./resources" --retry-strategy quick
         env:
           ANT_LOG: "all"
         timeout-minutes: 2

--- a/.github/workflows/nightly_wan_churn.yml
+++ b/.github/workflows/nightly_wan_churn.yml
@@ -78,7 +78,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Start a client to upload
-        run: cargo run --bin safe -- --log-output-dest=data-dir files upload "ubuntu-16.04.7-desktop-amd64.iso" --retry-strategy quick
+        run: cargo run --bin safe -- files upload "ubuntu-16.04.7-desktop-amd64.iso" --retry-strategy quick
         env:
           ANT_LOG: "all"
         timeout-minutes: 45
@@ -94,7 +94,7 @@ jobs:
           random-churn-count: 5
 
       - name: Start a client to download files
-        run: cargo run --bin safe --release -- --log-output-dest=data-dir files download --retry-strategy quick
+        run: cargo run --bin safe --release -- files download --retry-strategy quick
         env:
           ANT_LOG: "all"
         timeout-minutes: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "clap-verbosity-flag 3.0.2",
  "color-eyre",
  "const-hex",
  "crdts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "ant-protocol",
  "autonomi",
  "clap",
+ "clap-verbosity-flag 3.0.2",
  "color-eyre",
  "const-hex",
  "criterion",
@@ -2169,6 +2170,16 @@ name = "clap-verbosity-flag"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c77f67047557f62582784fd7482884697731b2932c7d37ced54bce2312e1e2"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
 dependencies = [
  "clap",
  "log",
@@ -5949,7 +5960,7 @@ dependencies = [
  "ant-networking",
  "ant-protocol",
  "clap",
- "clap-verbosity-flag",
+ "clap-verbosity-flag 2.2.3",
  "color-eyre",
  "futures",
  "libp2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,9 +865,6 @@ dependencies = [
  "color-eyre",
  "dirs-next",
  "file-rotate",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -877,7 +874,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
 ]
@@ -968,7 +964,7 @@ dependencies = [
  "libp2p",
  "num-traits",
  "prometheus-client",
- "prost 0.9.0",
+ "prost",
  "pyo3",
  "rand 0.8.5",
  "rayon",
@@ -983,10 +979,9 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.6.2",
+ "tonic",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "walkdir",
  "xor_name",
@@ -1018,7 +1013,7 @@ dependencies = [
  "mockall 0.12.1",
  "nix 0.27.1",
  "predicates 3.1.3",
- "prost 0.9.0",
+ "prost",
  "rand 0.8.5",
  "reqwest 0.12.12",
  "semver 1.0.24",
@@ -1028,7 +1023,7 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.6.2",
+ "tonic",
  "tracing",
  "users",
  "uuid",
@@ -1054,7 +1049,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.6.2",
+ "tonic",
  "tracing",
  "tracing-core",
 ]
@@ -1076,7 +1071,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "prometheus-client",
- "prost 0.9.0",
+ "prost",
  "rand 0.8.5",
  "rmp-serde",
  "serde",
@@ -1084,7 +1079,7 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "tiny-keccak",
- "tonic 0.6.2",
+ "tonic",
  "tonic-build",
  "tracing",
  "xor_name",
@@ -1123,7 +1118,7 @@ dependencies = [
  "libp2p",
  "libp2p-identity",
  "mockall 0.11.4",
- "prost 0.9.0",
+ "prost",
  "semver 1.0.24",
  "serde",
  "serde_json",
@@ -1131,7 +1126,7 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.6.2",
+ "tonic",
  "tonic-build",
  "tracing",
  "tracing-core",
@@ -1581,51 +1576,6 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "xor_name",
-]
-
-[[package]]
-name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -5725,12 +5675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5966,7 +5910,7 @@ dependencies = [
  "libp2p",
  "tokio",
  "tracing",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -6391,108 +6335,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float",
- "percent-encoding",
- "rand 0.8.5",
- "regex",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "3.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-multimap"
@@ -7054,17 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
+ "prost-derive",
 ]
 
 [[package]]
@@ -7080,7 +6916,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "regex",
  "tempfile",
@@ -7101,26 +6937,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -9005,8 +8828,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
@@ -9016,34 +8839,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -9172,17 +8967,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -9190,22 +8974,6 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -9235,7 +9003,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -9444,12 +9212,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "users"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "clap-verbosity-flag 3.0.2",
  "color-eyre",
  "colored",
  "dirs-next",

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -29,6 +29,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.45" }
 ant-protocol = { path = "../ant-protocol", version = "0.3.3" }
 autonomi = { path = "../autonomi", version = "0.3.5", features = [ "loud" ] }
 clap = { version = "4.2.1", features = ["derive"] }
+clap-verbosity-flag = "3.0.2"
 color-eyre = "0.6.3"
 const-hex = "1.13.1"
 dirs-next = "~2.0.0"

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -96,7 +96,7 @@ fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGua
         LevelFilter::Trace => Some(Level::TRACE),
     };
 
-    let targets = if let Some(level) = level {          
+    let targets = if let Some(level) = level {
         vec![
             ("ant_evm".to_string(), level),
             ("autonomi_cli".to_string(), level),

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -25,8 +25,9 @@ use clap::Parser;
 use color_eyre::Result;
 
 use ant_logging::metrics::init_metrics;
-use ant_logging::{LogBuilder, LogFormat, ReloadHandle, WorkerGuard};
+use ant_logging::{LogBuilder, LogFormat, LogOutputDest, ReloadHandle, WorkerGuard};
 use ant_protocol::version;
+use clap_verbosity_flag::log::LevelFilter;
 use opt::Opt;
 use tracing::Level;
 
@@ -86,19 +87,28 @@ async fn main() -> Result<()> {
 }
 
 fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
-    let logging_targets = vec![
-        ("ant_bootstrap".to_string(), Level::DEBUG),
-        ("ant_build_info".to_string(), Level::TRACE),
-        ("ant_evm".to_string(), Level::TRACE),
-        ("ant_networking".to_string(), Level::INFO),
-        ("autonomi_cli".to_string(), Level::TRACE),
-        ("autonomi".to_string(), Level::TRACE),
-        ("evmlib".to_string(), Level::TRACE),
-        ("ant_logging".to_string(), Level::TRACE),
-        ("ant_protocol".to_string(), Level::TRACE),
-    ];
-    let mut log_builder = LogBuilder::new(logging_targets);
-    log_builder.output_dest(opt.log_output_dest.clone());
+    let level = match opt.verbose.log_level_filter() {
+        LevelFilter::Off => None,
+        LevelFilter::Error => Some(Level::ERROR),
+        LevelFilter::Warn => Some(Level::WARN),
+        LevelFilter::Info => Some(Level::INFO),
+        LevelFilter::Debug => Some(Level::DEBUG),
+        LevelFilter::Trace => Some(Level::TRACE),
+    };
+
+    let targets = if let Some(level) = level {          
+        vec![
+            ("ant_evm".to_string(), level),
+            ("autonomi_cli".to_string(), level),
+            ("autonomi".to_string(), level),
+            ("evmlib".to_string(), level),
+        ]
+    } else {
+        vec![]
+    };
+
+    let mut log_builder = LogBuilder::new(targets);
+    log_builder.output_dest(LogOutputDest::Stderr);
     log_builder.format(opt.log_format.unwrap_or(LogFormat::Default));
     let guards = log_builder.initialize()?;
     Ok(guards)

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -10,6 +10,7 @@ use crate::commands::SubCmd;
 use ant_bootstrap::PeersArgs;
 use ant_logging::{LogFormat, LogOutputDest};
 use clap::Parser;
+use clap_verbosity_flag::{OffLevel, Verbosity};
 use color_eyre::Result;
 use std::time::Duration;
 
@@ -39,20 +40,6 @@ pub(crate) struct Opt {
     #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
     pub log_format: Option<LogFormat>,
 
-    /// Specify the logging output destination.
-    ///
-    /// Valid values are "stdout", "data-dir", or a custom path.
-    ///
-    /// `data-dir` is the default value.
-    ///
-    /// The data directory location is platform specific:
-    ///  - Linux: $HOME/.local/share/autonomi/client/logs
-    ///  - macOS: $HOME/Library/Application Support/autonomi/client/logs
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\client\logs
-    #[allow(rustdoc::invalid_html_tags)]
-    #[clap(long, value_parser = LogOutputDest::parse_from_str, verbatim_doc_comment, default_value = "data-dir")]
-    pub log_output_dest: LogOutputDest,
-
     /// Specify the network ID to use. This will allow you to run the CLI on a different network.
     ///
     /// By default, the network ID is set to 1, which represents the mainnet.
@@ -76,6 +63,9 @@ pub(crate) struct Opt {
     /// Print the network protocol version.
     #[clap(long)]
     pub protocol_version: bool,
+
+    #[clap(flatten)]
+    pub verbose: Verbosity<OffLevel>,
 
     /// Print version information.
     #[clap(long)]

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -8,7 +8,7 @@
 
 use crate::commands::SubCmd;
 use ant_bootstrap::PeersArgs;
-use ant_logging::{LogFormat, LogOutputDest};
+use ant_logging::LogFormat;
 use clap::Parser;
 use clap_verbosity_flag::{OffLevel, Verbosity};
 use color_eyre::Result;

--- a/ant-logging/Cargo.toml
+++ b/ant-logging/Cargo.toml
@@ -13,9 +13,6 @@ version = "0.2.45"
 chrono = "~0.4.19"
 dirs-next = "~2.0.0"
 file-rotate = "0.7.3"
-opentelemetry = { version = "0.20", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.13", optional = true }
-opentelemetry-semantic-conventions = { version = "0.12.0", optional = true }
 rand = { version = "~0.8.5", features = ["small_rng"], optional = true }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
@@ -25,7 +22,6 @@ tokio = { version = "1.32.0", optional = true }
 tracing = { version = "~0.1.26" }
 tracing-appender = "~0.2.0"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { version = "0.21", optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["json"] }
 
 [dev-dependencies]
@@ -33,15 +29,8 @@ color-eyre = "0.6.3"
 tracing-test = "0.2.4"
 
 [features]
-otlp = [
-    "opentelemetry",
-    "opentelemetry-otlp",
-    "opentelemetry-semantic-conventions",
-    "tracing-opentelemetry",
-    "rand/small_rng",
-]
-test-utils = []
 process-metrics = ["sysinfo", "tokio"]
+test-utils = []
 
 [lints]
 workspace = true

--- a/ant-logging/src/error.rs
+++ b/ant-logging/src/error.rs
@@ -18,10 +18,6 @@ pub enum Error {
     #[error(transparent)]
     ReloadError(#[from] tracing_subscriber::reload::Error),
 
-    #[cfg(feature = "otlp")]
-    #[error("OpenTelemetry Tracing error: {0}")]
-    OpenTelemetryTracing(#[from] opentelemetry::trace::TraceError),
-
     #[error("Could not configure logging: {0}")]
     LoggingConfiguration(String),
 }

--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -109,16 +109,6 @@ impl TracingLayers {
         print_updates_to_stdout: bool,
     ) -> Result<ReloadHandle> {
         let layer = match output_dest {
-            LogOutputDest::Stdout => {
-                if print_updates_to_stdout {
-                    println!("Logging to stdout");
-                }
-                tracing_fmt::layer()
-                    .with_ansi(false)
-                    .with_target(false)
-                    .event_format(LogFormatter)
-                    .boxed()
-            }
             LogOutputDest::Stderr => tracing_fmt::layer()
                 .with_ansi(false)
                 .with_target(false)

--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -173,56 +173,6 @@ impl TracingLayers {
 
         Ok(ReloadHandle(reload_handle))
     }
-
-    #[cfg(feature = "otlp")]
-    pub(crate) fn otlp_layer(
-        &mut self,
-        default_logging_targets: Vec<(String, Level)>,
-    ) -> Result<()> {
-        use opentelemetry::{
-            sdk::{trace, Resource},
-            KeyValue,
-        };
-        use opentelemetry_otlp::WithExportConfig;
-        use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
-        use rand::{distributions::Alphanumeric, thread_rng, Rng};
-
-        let service_name = std::env::var("OTLP_SERVICE_NAME").unwrap_or_else(|_| {
-            let random_node_name: String = thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(10)
-                .map(char::from)
-                .collect();
-            random_node_name
-        });
-        println!("The opentelemetry traces are logged under the name: {service_name}");
-
-        let tracer = opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_env())
-            .with_trace_config(trace::config().with_resource(Resource::new(vec![
-                KeyValue::new(SERVICE_NAME, service_name),
-                KeyValue::new(SERVICE_INSTANCE_ID, std::process::id().to_string()),
-            ])))
-            .install_batch(opentelemetry::runtime::Tokio)?;
-
-        let targets = match std::env::var("ANT_LOG_OTLP") {
-            Ok(sn_log_val) => {
-                println!("Using ANT_LOG_OTLP={sn_log_val}");
-                get_logging_targets(&sn_log_val)?
-            }
-            Err(_) => default_logging_targets,
-        };
-
-        let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
-            Box::new(Targets::new().with_targets(targets));
-        let otlp_layer = tracing_opentelemetry::layer()
-            .with_tracer(tracer)
-            .with_filter(target_filters)
-            .boxed();
-        self.layers.push(otlp_layer);
-        Ok(())
-    }
 }
 
 /// Parses the logging targets from the env variable (ANT_LOG). The crates should be given as a CSV, for e.g.,

--- a/ant-logging/src/lib.rs
+++ b/ant-logging/src/lib.rs
@@ -30,45 +30,13 @@ pub use tracing_core::Level;
 #[derive(Debug, Clone)]
 pub enum LogOutputDest {
     Stderr,
-    Stdout,
     Path(PathBuf),
-}
-
-impl LogOutputDest {
-    pub fn parse_from_str(val: &str) -> Result<Self> {
-        match val {
-            "stdout" => Ok(LogOutputDest::Stdout),
-            "data-dir" => {
-                // Get the current timestamp and format it to be human readable
-                let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
-
-                // Get the data directory path and append the timestamp to the log file name
-                let dir = match dirs_next::data_dir() {
-                    Some(dir) => dir
-                        .join("autonomi")
-                        .join("client")
-                        .join("logs")
-                        .join(format!("log_{timestamp}")),
-                    None => {
-                        return Err(Error::LoggingConfiguration(
-                            "could not obtain data directory path".to_string(),
-                        ))
-                    }
-                };
-                Ok(LogOutputDest::Path(dir))
-            }
-            // The path should be a directory, but we can't use something like `is_dir` to check
-            // because the path doesn't need to exist. We can create it for the user.
-            value => Ok(LogOutputDest::Path(PathBuf::from(value))),
-        }
-    }
 }
 
 impl std::fmt::Display for LogOutputDest {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             LogOutputDest::Stderr => write!(f, "stderr"),
-            LogOutputDest::Stdout => write!(f, "stdout"),
             LogOutputDest::Path(p) => write!(f, "{}", p.to_string_lossy()),
         }
     }
@@ -252,7 +220,7 @@ impl LogBuilder {
                     .join(format!("log_{timestamp}"));
                 LogOutputDest::Path(path)
             }
-            None => LogOutputDest::Stdout,
+            None => LogOutputDest::Stderr,
         };
 
         println!("Logging test at {test_file_name:?} to {output_dest:?}");

--- a/ant-logging/src/lib.rs
+++ b/ant-logging/src/lib.rs
@@ -134,17 +134,6 @@ impl LogBuilder {
             self.print_updates_to_stdout,
         )?;
 
-        #[cfg(feature = "otlp")]
-        {
-            match std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
-                Ok(_) => layers.otlp_layer(self.default_logging_targets)?,
-                Err(_) => println!(
-                "The OTLP feature is enabled but the OTEL_EXPORTER_OTLP_ENDPOINT variable is not \
-                set, so traces will not be submitted."
-            ),
-            }
-        }
-
         if tracing_subscriber::registry()
             .with(layers.layers)
             .try_init()

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -38,6 +38,7 @@ ant-releases = { version = "0.4.0" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.7" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
+clap-verbosity-flag = "3.0.2"
 colored = "2.0.4"
 color-eyre = "0.6.3"
 dirs-next = "2.0.0"

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -18,6 +18,7 @@ use ant_node_manager::{
     VerbosityLevel, DEFAULT_NODE_STARTUP_CONNECTION_TIMEOUT_S,
 };
 use clap::{Parser, Subcommand};
+use clap_verbosity_flag::{OffLevel, Verbosity};
 use color_eyre::{eyre::eyre, Result};
 use libp2p::Multiaddr;
 use std::{net::Ipv4Addr, path::PathBuf};
@@ -859,6 +860,8 @@ pub enum LocalSubCmd {
         /// Set to skip the network validation process
         #[clap(long)]
         skip_validation: bool,
+        #[clap(flatten)]
+        verbose: Verbosity<OffLevel>,
     },
     /// Get the status of the local nodes.
     #[clap(name = "status")]
@@ -1070,7 +1073,6 @@ async fn main() -> Result<()> {
                     rewards_address,
                     evm_network,
                     true,
-                    verbosity,
                 )
                 .await
             }
@@ -1089,7 +1091,8 @@ async fn main() -> Result<()> {
                 rpc_port,
                 rewards_address,
                 evm_network,
-                skip_validation: _,
+                skip_validation,
+                verbose,
             } => {
                 let evm_network = if let Some(evm_network) = evm_network {
                     Some(evm_network.try_into()?)
@@ -1110,7 +1113,8 @@ async fn main() -> Result<()> {
                     rpc_port,
                     rewards_address,
                     evm_network,
-                    true,
+                    skip_validation,
+                    verbose,
                     verbosity,
                 )
                 .await

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -49,9 +49,6 @@ pub(crate) struct Cmd {
     #[clap(long, conflicts_with = "debug")]
     trace: bool,
 
-    #[clap(short, long, action = clap::ArgAction::Count, default_value_t = 2)]
-    verbose: u8,
-
     /// Print version information.
     #[clap(long)]
     version: bool,
@@ -906,7 +903,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let verbosity = VerbosityLevel::from(args.verbose);
+    let verbosity = VerbosityLevel::Normal;
 
     let _log_handle = if args.debug || args.trace {
         let level = if args.debug {

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -19,7 +19,6 @@ extension-module = ["pyo3/extension-module"]
 loud = ["ant-networking/loud"] # loud mode: print important messages to console
 nightly = []
 open-metrics = ["ant-networking/open-metrics", "prometheus-client"]
-otlp = ["ant-logging/otlp"]
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.1.4" }
@@ -71,7 +70,6 @@ tokio-stream = { version = "~0.1.12" }
 tonic = { version = "0.6.2" }
 tracing = { version = "~0.1.26" }
 tracing-appender = "~0.2.0"
-tracing-opentelemetry = { version = "0.21", optional = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 walkdir = "~2.5.0"
 xor_name = "5.0.0"

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive"] }
+clap-verbosity-flag = "3.0.2"
 crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 chrono = "~0.4.19"
 color-eyre = "0.6.3"

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -563,7 +563,6 @@ fn init_logging(
     };
 
     if targets.is_empty() {
-        println!("Logging is not enabled");
         return Ok(("stderr".to_string(), None, None));
     }
 
@@ -590,11 +589,6 @@ fn init_logging(
 
         log_builder.initialize()?
     };
-
-    println!(
-        "Initialised logging. Logs will be output to {:?}",
-        output_dest
-    );
 
     Ok((
         output_dest.to_string(),

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -25,6 +25,7 @@ use ant_protocol::{
     version,
 };
 use clap::{command, Parser};
+use clap_verbosity_flag::{log::LevelFilter, OffLevel, Verbosity};
 use color_eyre::{eyre::eyre, Result};
 use const_hex::traits::FromHex;
 use libp2p::PeerId;
@@ -88,17 +89,18 @@ struct Opt {
 
     /// Specify the logging output destination.
     ///
-    /// Valid values are "stdout", "data-dir", or a custom path.
+    /// Using this argument will enable logging, which is not on by default.
     ///
-    /// `data-dir` is the default value.
+    /// Valid values are "stderr", "data-dir", or a custom path.
     ///
     /// The data directory location is platform specific:
+    ///
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>/logs
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>/logs
     ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>\logs
     #[expect(rustdoc::invalid_html_tags)]
-    #[clap(long, default_value_t = LogOutputDestArg::DataDir, value_parser = parse_log_output, verbatim_doc_comment)]
-    log_output_dest: LogOutputDestArg,
+    #[clap(long, value_parser = parse_log_output, verbatim_doc_comment)]
+    log_output_dest: Option<LogOutputDestArg>,
 
     /// Specify the logging format.
     ///
@@ -206,6 +208,9 @@ struct Opt {
     #[cfg(not(feature = "nightly"))]
     #[clap(long)]
     package_version: bool,
+
+    #[clap(flatten)]
+    pub verbose: Verbosity<OffLevel>,
 
     /// Print version information.
     #[clap(long)]
@@ -333,8 +338,13 @@ fn main() -> Result<()> {
         };
         #[cfg(feature = "open-metrics")]
         node_builder.metrics_server_port(metrics_server_port);
-        let restart_options =
-            run_node(node_builder, opt.rpc, &log_output_dest, log_reload_handle).await?;
+        let restart_options = run_node(
+            node_builder,
+            opt.rpc,
+            &log_output_dest,
+            log_reload_handle,
+        )
+        .await?;
 
         Ok::<_, eyre::Report>(restart_options)
     })?;
@@ -362,7 +372,7 @@ async fn run_node(
     node_builder: NodeBuilder,
     rpc: Option<SocketAddr>,
     log_output_dest: &str,
-    log_reload_handle: ReloadHandle,
+    log_reload_handle: Option<ReloadHandle>,
 ) -> Result<Option<(bool, PathBuf, u16)>> {
     let started_instant = std::time::Instant::now();
 
@@ -511,29 +521,68 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
     });
 }
 
-fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Option<WorkerGuard>)> {
-    let logging_targets = vec![
-        ("ant_bootstrap".to_string(), Level::INFO),
-        ("ant_build_info".to_string(), Level::DEBUG),
+fn init_logging(
+    opt: &Opt,
+    peer_id: PeerId,
+) -> Result<(String, Option<ReloadHandle>, Option<WorkerGuard>)> {
+    let level = match opt.verbose.log_level_filter() {
+        LevelFilter::Off => None,
+        LevelFilter::Error => Some(Level::ERROR),
+        LevelFilter::Warn => Some(Level::WARN),
+        LevelFilter::Info => Some(Level::INFO),
+        LevelFilter::Debug => Some(Level::DEBUG),
+        LevelFilter::Trace => Some(Level::TRACE),
+    };
+
+    let default_targets = vec![
         ("ant_evm".to_string(), Level::DEBUG),
         ("ant_logging".to_string(), Level::DEBUG),
-        ("ant_networking".to_string(), Level::INFO),
+        ("ant_networking".to_string(), Level::DEBUG),
         ("ant_node".to_string(), Level::DEBUG),
         ("ant_protocol".to_string(), Level::DEBUG),
         ("antnode".to_string(), Level::DEBUG),
     ];
 
+    // The use of `-v` flags will control the logging level, but we also want to enable logging if
+    // either the `--log-output-dest` argument has been used, or the ANT_LOG env var is set,
+    // but the `-v` flag has not been used. This is to ensure backward compatibility with existing
+    // deployments.
+    let targets = if let Some(level) = level {
+        vec![
+            ("ant_evm".to_string(), level),
+            ("ant_logging".to_string(), level),
+            ("ant_networking".to_string(), level),
+            ("ant_node".to_string(), level),
+            ("ant_protocol".to_string(), level),
+            ("ant_registers".to_string(), level),
+            ("antnode".to_string(), level),
+        ]
+    } else if opt.log_output_dest.is_some() || std::env::var("ANT_LOG").is_ok() {
+        // If `ANT_LOG` has been set, the default targets will be overridden, but the code to
+        // override is in the logging crate. If we didn't use the default targets, we would not
+        // reach the code in the logging crate because we would return early without logging
+        // enabled.
+        default_targets
+    } else {
+        vec![]
+    };
+
+    if targets.is_empty() {
+        return Ok(("stderr".to_string(), None, None));
+    }
+
     let output_dest = match &opt.log_output_dest {
-        LogOutputDestArg::Stderr => LogOutputDest::Stderr,
-        LogOutputDestArg::DataDir => {
+        Some(LogOutputDestArg::Stderr) => LogOutputDest::Stderr,
+        Some(LogOutputDestArg::DataDir) => {
             let path = get_antnode_root_dir(peer_id)?.join("logs");
             LogOutputDest::Path(path)
         }
-        LogOutputDestArg::Path(path) => LogOutputDest::Path(path.clone()),
+        Some(LogOutputDestArg::Path(path)) => LogOutputDest::Path(path.clone()),
+        None => LogOutputDest::Stderr,
     };
 
     let (reload_handle, log_appender_guard) = {
-        let mut log_builder = ant_logging::LogBuilder::new(logging_targets);
+        let mut log_builder = ant_logging::LogBuilder::new(targets);
         log_builder.output_dest(output_dest.clone());
         log_builder.format(opt.log_format.unwrap_or(LogFormat::Default));
         if let Some(files) = opt.max_log_files {
@@ -546,7 +595,11 @@ fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Opt
         log_builder.initialize()?
     };
 
-    Ok((output_dest.to_string(), reload_handle, log_appender_guard))
+    Ok((
+        output_dest.to_string(),
+        Some(reload_handle),
+        log_appender_guard,
+    ))
 }
 
 /// Starts a new process running the binary with the same args as

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -338,13 +338,8 @@ fn main() -> Result<()> {
         };
         #[cfg(feature = "open-metrics")]
         node_builder.metrics_server_port(metrics_server_port);
-        let restart_options = run_node(
-            node_builder,
-            opt.rpc,
-            &log_output_dest,
-            log_reload_handle,
-        )
-        .await?;
+        let restart_options =
+            run_node(node_builder, opt.rpc, &log_output_dest, log_reload_handle).await?;
 
         Ok::<_, eyre::Report>(restart_options)
     })?;
@@ -568,6 +563,7 @@ fn init_logging(
     };
 
     if targets.is_empty() {
+        println!("Logging is not enabled");
         return Ok(("stderr".to_string(), None, None));
     }
 
@@ -594,6 +590,11 @@ fn init_logging(
 
         log_builder.initialize()?
     };
+
+    println!(
+        "Initialised logging. Logs will be output to {:?}",
+        output_dest
+    );
 
     Ok((
         output_dest.to_string(),

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -44,7 +44,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 
 #[derive(Debug, Clone)]
 pub enum LogOutputDestArg {
-    Stdout,
+    Stderr,
     DataDir,
     Path(PathBuf),
 }
@@ -52,7 +52,7 @@ pub enum LogOutputDestArg {
 impl std::fmt::Display for LogOutputDestArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LogOutputDestArg::Stdout => write!(f, "stdout"),
+            LogOutputDestArg::Stderr => write!(f, "stderr"),
             LogOutputDestArg::DataDir => write!(f, "data-dir"),
             LogOutputDestArg::Path(path) => write!(f, "{}", path.display()),
         }
@@ -61,7 +61,7 @@ impl std::fmt::Display for LogOutputDestArg {
 
 pub fn parse_log_output(val: &str) -> Result<LogOutputDestArg> {
     match val {
-        "stdout" => Ok(LogOutputDestArg::Stdout),
+        "stderr" => Ok(LogOutputDestArg::Stderr),
         "data-dir" => Ok(LogOutputDestArg::DataDir),
         // The path should be a directory, but we can't use something like `is_dir` to check
         // because the path doesn't need to exist. We can create it for the user.
@@ -524,7 +524,7 @@ fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Opt
     ];
 
     let output_dest = match &opt.log_output_dest {
-        LogOutputDestArg::Stdout => LogOutputDest::Stdout,
+        LogOutputDestArg::Stderr => LogOutputDest::Stderr,
         LogOutputDestArg::DataDir => {
             let path = get_antnode_root_dir(peer_id)?.join("logs");
             LogOutputDest::Path(path)


### PR DESCRIPTION
- a4af60390 **feat: `ant` logs to stderr**

  BREAKING CHANGE: the `--log-output-dest` argument is removed. Logging to file is a bit strange for a
  short-lived program, so we now log to stderr. The user can redirect to file if they want to.

  Logging is off by default. It is switched on by using the `verbosity` argument in the standard `-v`
  to `-vvvvv` form. This increases the levels from `WARN` to `TRACE`.

  The default logging targets were changed to crates that seem a bit more relevant for using `ant`,
  and to remove particularly noisy crates, like `ant_bootstrap`. All the crates will log at the same
  level, as defined by the `verbosity` argument; previously the default logging targets used different
  levels for different crates, and those seemed a little arbitrary.

  The behaviour of `ANT_LOG` is retained, so the user can still get output for particular crates, or
  use the special `all` option to get trace-level logging for all crates.

- 65a8ead41 **chore: remove `otlp` feature**

  This was a vestige of our attempt to use OpenSearch, so we don't need it any more.

  The `opentelemetry` crate references have also been removed.

- dc60e17df **feat: switch off logging by default in `antnode`**

  Previously, `antnode` would log to file by default.

  Now logging will be enabled if:

  * The `ANT_LOG` variable has been used.
  * The `--log-output-dest` argument has been used.
  * The `-v` argument has been used.

  The verbosity argument can take different counts, e.g., `-vvv`, each count increasing the level of
  the logging from `ERROR` through to `TRACE`.

  The logs will go to `stderr` by default. If the user wants them to go to file, they can use the
  `--log-output-dest` argument and specify either the default `data-dir` or a custom path.

  This setup should be backwards compatible for anybody who has tooling setup to use
  `--log-output-dest`, but it will be a breaking change for users who are expecting logs to file by
  default.

- 243a030f1 **chore: remove the `verbosity` argument from `antctl`**

  This was an argument that was implemented in a clumsy manual way that was intended to vary the
  amount of output on the node manager. We will need to provide another `verbose` argument on the
  `local run` command to control the output of the logs for local networks.

  We still need to retain the use of it, but instead of setting it via a command line argument, it
  will just be set to `Normal`. The `node-launchpad` sets it to `Minimal` in the places where it needs
  the text output reduced.

- 162d66bd2 **feat: provide `verbosity` arg for `local run` cmd**

  This also provides the `-v` mechanism for varying the logging output for the local network. The
  value that is set here is passed to each of the node processes.

  The logging output destination is to file, otherwise on the terminal you would get a blizzard of
  output from all the node processes.