### PR TITLE
Registers on top of graph entry

### DIFF
--- a/ant-networking/src/graph.rs
+++ b/ant-networking/src/graph.rs
@@ -6,33 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{driver::GetRecordCfg, Network, NetworkError, Result};
-use ant_protocol::storage::{DataTypes, GraphEntry, GraphEntryAddress};
+use crate::{NetworkError, Result};
+use ant_protocol::storage::{DataTypes, GraphEntry};
 use ant_protocol::{
-    storage::{try_deserialize_record, RecordHeader, RecordKind, RetryStrategy},
-    NetworkAddress, PrettyPrintRecordKey,
+    storage::{try_deserialize_record, RecordHeader, RecordKind},
+    PrettyPrintRecordKey,
 };
-use libp2p::kad::{Quorum, Record};
-
-impl Network {
-    /// Gets GraphEntry at GraphEntryAddress from the Network.
-    pub async fn get_graph_entry(&self, address: GraphEntryAddress) -> Result<Vec<GraphEntry>> {
-        let key = NetworkAddress::from_graph_entry_address(address).to_record_key();
-        let get_cfg = GetRecordCfg {
-            get_quorum: Quorum::All,
-            retry_strategy: Some(RetryStrategy::Quick),
-            target_record: None,
-            expected_holders: Default::default(),
-        };
-        let record = self.get_record_from_network(key.clone(), &get_cfg).await?;
-        debug!(
-            "Got record from the network, {:?}",
-            PrettyPrintRecordKey::from(&record.key)
-        );
-
-        get_graph_entry_from_record(&record)
-    }
-}
+use libp2p::kad::Record;
 
 pub fn get_graph_entry_from_record(record: &Record) -> Result<Vec<GraphEntry>> {
     let header = RecordHeader::from_record(record)?;

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -624,7 +624,7 @@ impl Network {
                             continue;
                         };
 
-                        if !pointer.verify() {
+                        if !pointer.verify_signature() {
                             warn!("Rejecting Pointer for {pretty_key} PUT with invalid signature");
                             continue;
                         }
@@ -646,7 +646,7 @@ impl Network {
                             continue;
                         };
 
-                        if !scratchpad.verify() {
+                        if !scratchpad.verify_signature() {
                             warn!(
                                 "Rejecting Scratchpad for {pretty_key} PUT with invalid signature"
                             );

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -480,7 +480,7 @@ impl Node {
         }
 
         // ensure data integrity
-        if !scratchpad.verify() {
+        if !scratchpad.verify_signature() {
             warn!("Rejecting Scratchpad PUT with invalid signature");
             return Err(Error::InvalidScratchpadSignature);
         }
@@ -560,8 +560,10 @@ impl Node {
         }
 
         // verify the GraphEntries
-        let mut validated_entries: BTreeSet<GraphEntry> =
-            entries_for_key.into_iter().filter(|t| t.verify()).collect();
+        let mut validated_entries: BTreeSet<GraphEntry> = entries_for_key
+            .into_iter()
+            .filter(|t| t.verify_signature())
+            .collect();
 
         // skip if none are valid
         let addr = match validated_entries.first() {
@@ -785,7 +787,7 @@ impl Node {
         payment: Option<ProofOfPayment>,
     ) -> Result<()> {
         // Verify the pointer's signature
-        if !pointer.verify() {
+        if !pointer.verify_signature() {
             warn!("Pointer signature verification failed");
             return Err(Error::InvalidSignature);
         }

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -337,7 +337,8 @@ fn create_graph_entry_task(
                         Ok(graph_entry) => {
                             println!("Fetched graph_entry at {addr:?}");
 
-                            let Some((old_output, old_content)) = graph_entry.outputs.last() else {
+                            let Some((old_output, old_content)) = graph_entry.descendants.last()
+                            else {
                                 println!("Can't get output from the graph_entry of {addr:?}");
                                 error!("Can't get output from the graph_entry of {addr:?}");
                                 break;
@@ -351,13 +352,8 @@ fn create_graph_entry_task(
                             };
 
                             let parents = vec![graph_entry.owner];
-                            let graph_entry = GraphEntry::new(
-                                owner.public_key(),
-                                parents,
-                                *old_content,
-                                outputs,
-                                owner,
-                            );
+                            let graph_entry =
+                                GraphEntry::new(owner, parents, *old_content, outputs);
 
                             growing_history[index].push(graph_entry.address());
 
@@ -389,8 +385,7 @@ fn create_graph_entry_task(
                 let owner = SecretKey::random();
                 let content: [u8; 32] = rand::random();
                 let parents = vec![];
-                let graph_entry =
-                    GraphEntry::new(owner.public_key(), parents, content, outputs, &owner);
+                let graph_entry = GraphEntry::new(&owner, parents, content, outputs);
 
                 growing_history.push(vec![graph_entry.address()]);
                 let _ = owners.insert(owner.public_key(), owner);

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -53,11 +53,6 @@ impl Chunk {
         self.address.xorname()
     }
 
-    /// Returns size of contained value.
-    pub fn payload_size(&self) -> usize {
-        self.value.len()
-    }
-
     /// Returns size of this chunk after serialisation.
     pub fn serialised_size(&self) -> usize {
         self.value.len()

--- a/ant-protocol/src/storage/graph.rs
+++ b/ant-protocol/src/storage/graph.rs
@@ -17,34 +17,49 @@ pub use bls::{PublicKey, Signature};
 pub type GraphContent = [u8; 32];
 
 /// A generic GraphEntry on the Network
+/// Graph entries are stored at the owner's public key. Note that there can only be one graph entry per owner.
+/// Graph entries can be linked to other graph entries as parents or descendants.
+/// Applications are free to define the meaning of these links, those are not enforced by the protocol.
+/// The protocol only ensures that the graph entry is immutable once uploaded and that the signature is valid and matches the owner.
+/// For convenience it is advised to make use of BLS key derivation to create multiple graph entries from a single key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 pub struct GraphEntry {
+    /// The owner of the graph. Note that graph entries are stored at the owner's public key
     pub owner: PublicKey,
+    /// Other graph entries that this graph entry refers to as parents
     pub parents: Vec<PublicKey>,
+    /// The content of the graph entry
     pub content: GraphContent,
-    pub outputs: Vec<(PublicKey, GraphContent)>,
+    /// Other graph entries that this graph entry refers to as descendants/outputs along with some data associated to each one
+    pub descendants: Vec<(PublicKey, GraphContent)>,
     /// signs the above 4 fields with the owners key
     pub signature: Signature,
 }
 
 impl GraphEntry {
-    /// Maximum size of a graph entry
-    pub const MAX_SIZE: usize = 1024;
+    /// Maximum size of a graph entry: 100KB
+    pub const MAX_SIZE: usize = 100 * 1024;
 
     /// Create a new graph entry, signing it with the provided secret key.
     pub fn new(
-        owner: PublicKey,
+        owner: &SecretKey,
         parents: Vec<PublicKey>,
         content: GraphContent,
-        outputs: Vec<(PublicKey, GraphContent)>,
-        signing_key: &SecretKey,
+        descendants: Vec<(PublicKey, GraphContent)>,
     ) -> Self {
-        let signature = signing_key.sign(Self::bytes_to_sign(&owner, &parents, &content, &outputs));
+        let key = owner;
+        let owner = key.public_key();
+        let signature = key.sign(Self::bytes_to_sign(
+            &owner,
+            &parents,
+            &content,
+            &descendants,
+        ));
         Self {
             owner,
             parents,
             content,
-            outputs,
+            descendants,
             signature,
         }
     }
@@ -54,14 +69,14 @@ impl GraphEntry {
         owner: PublicKey,
         parents: Vec<PublicKey>,
         content: GraphContent,
-        outputs: Vec<(PublicKey, GraphContent)>,
+        descendants: Vec<(PublicKey, GraphContent)>,
         signature: Signature,
     ) -> Self {
         Self {
             owner,
             parents,
             content,
-            outputs,
+            descendants,
             signature,
         }
     }
@@ -71,7 +86,7 @@ impl GraphEntry {
         owner: &PublicKey,
         parents: &[PublicKey],
         content: &[u8],
-        outputs: &[(PublicKey, GraphContent)],
+        descendants: &[(PublicKey, GraphContent)],
     ) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&owner.to_bytes());
@@ -85,9 +100,9 @@ impl GraphEntry {
         );
         bytes.extend_from_slice("content".as_bytes());
         bytes.extend_from_slice(content);
-        bytes.extend_from_slice("outputs".as_bytes());
+        bytes.extend_from_slice("descendants".as_bytes());
         bytes.extend_from_slice(
-            &outputs
+            &descendants
                 .iter()
                 .flat_map(|(p, c)| [&p.to_bytes(), c.as_slice()].concat())
                 .collect::<Vec<_>>(),
@@ -101,11 +116,11 @@ impl GraphEntry {
 
     /// Get the bytes that the signature is calculated from.
     pub fn bytes_for_signature(&self) -> Vec<u8> {
-        Self::bytes_to_sign(&self.owner, &self.parents, &self.content, &self.outputs)
+        Self::bytes_to_sign(&self.owner, &self.parents, &self.content, &self.descendants)
     }
 
     /// Verify the signature of the graph entry
-    pub fn verify(&self) -> bool {
+    pub fn verify_signature(&self) -> bool {
         self.owner
             .verify(&self.signature, self.bytes_for_signature())
     }
@@ -114,7 +129,7 @@ impl GraphEntry {
     pub fn size(&self) -> usize {
         size_of::<GraphEntry>()
             + self
-                .outputs
+                .descendants
                 .iter()
                 .map(|(p, c)| p.to_bytes().len() + c.len())
                 .sum::<usize>()

--- a/ant-protocol/src/storage/mod.rs
+++ b/ant-protocol/src/storage/mod.rs
@@ -10,8 +10,7 @@ mod address;
 mod chunks;
 mod graph;
 mod header;
-pub mod pointer;
-pub use pointer::{Pointer, PointerTarget};
+mod pointer;
 mod scratchpad;
 
 use core::fmt;
@@ -21,11 +20,12 @@ use std::{num::NonZeroUsize, time::Duration};
 pub use self::{
     address::{ChunkAddress, GraphEntryAddress, PointerAddress, ScratchpadAddress},
     chunks::Chunk,
-    graph::GraphEntry,
+    graph::{GraphContent, GraphEntry},
     header::{
         try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind,
         ValidationType,
     },
+    pointer::{Pointer, PointerTarget},
     scratchpad::Scratchpad,
 };
 

--- a/ant-protocol/src/storage/scratchpad.rs
+++ b/ant-protocol/src/storage/scratchpad.rs
@@ -122,11 +122,11 @@ impl Scratchpad {
             self.counter,
         );
         self.signature = sk.sign(&bytes_to_sign);
-        debug_assert!(self.verify(), "Must be valid after being signed. This is a bug, please report it by opening an issue on our github");
+        debug_assert!(self.verify_signature(), "Must be valid after being signed. This is a bug, please report it by opening an issue on our github");
     }
 
     /// Verifies that the Scratchpad signature is valid
-    pub fn verify(&self) -> bool {
+    pub fn verify_signature(&self) -> bool {
         let signing_bytes = Self::bytes_for_signature(
             self.address,
             self.data_encoding,
@@ -201,13 +201,13 @@ mod tests {
         let sk = SecretKey::random();
         let raw_data = Bytes::from_static(b"data to be encrypted");
         let mut scratchpad = Scratchpad::new(&sk, 42, &raw_data, 0);
-        assert!(scratchpad.verify());
+        assert!(scratchpad.verify_signature());
         assert_eq!(scratchpad.counter(), 0);
         assert_ne!(scratchpad.encrypted_data(), &raw_data);
 
         let raw_data2 = Bytes::from_static(b"data to be encrypted v2");
         scratchpad.update(&raw_data2, &sk);
-        assert!(scratchpad.verify());
+        assert!(scratchpad.verify_signature());
         assert_eq!(scratchpad.counter(), 1);
         assert_ne!(scratchpad.encrypted_data(), &raw_data);
         assert_ne!(scratchpad.encrypted_data(), &raw_data2);

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -162,9 +162,9 @@ impl Client {
     }
 
     /// Get the cost to create a GraphEntry
-    pub async fn graph_entry_cost(&self, key: PublicKey) -> Result<AttoTokens, GraphError> {
+    pub async fn graph_entry_cost(&self, key: &PublicKey) -> Result<AttoTokens, CostError> {
         trace!("Getting cost for GraphEntry of {key:?}");
-        let address = GraphEntryAddress::from_owner(key);
+        let address = GraphEntryAddress::from_owner(*key);
         let xor = *address.xorname();
         let store_quote = self
             .get_store_quotes(

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -14,7 +14,9 @@ use crate::client::ClientEvent;
 use crate::client::UploadSummary;
 
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
+use ant_networking::get_graph_entry_from_record;
 use ant_networking::{GetRecordCfg, NetworkError, PutRecordCfg, VerificationKind};
+use ant_protocol::PrettyPrintRecordKey;
 use ant_protocol::{
     storage::{try_serialize_record, DataTypes, RecordKind, RetryStrategy},
     NetworkAddress,
@@ -22,9 +24,8 @@ use ant_protocol::{
 use bls::PublicKey;
 use libp2p::kad::{Quorum, Record};
 
-pub use ant_protocol::storage::GraphEntry;
-pub use ant_protocol::storage::GraphEntryAddress;
-pub use bls::SecretKey;
+pub use crate::SecretKey;
+pub use ant_protocol::storage::{GraphContent, GraphEntry, GraphEntryAddress};
 
 #[derive(Debug, thiserror::Error)]
 pub enum GraphError {
@@ -54,14 +55,30 @@ impl Client {
         &self,
         address: GraphEntryAddress,
     ) -> Result<GraphEntry, GraphError> {
-        let graph_entries = self.network.get_graph_entry(address).await?;
+        let key = NetworkAddress::from_graph_entry_address(address).to_record_key();
+        let get_cfg = GetRecordCfg {
+            get_quorum: Quorum::All,
+            retry_strategy: Some(RetryStrategy::Quick),
+            target_record: None,
+            expected_holders: Default::default(),
+        };
+        let record = self
+            .network
+            .get_record_from_network(key.clone(), &get_cfg)
+            .await?;
+        debug!(
+            "Got record from the network, {:?}",
+            PrettyPrintRecordKey::from(&record.key)
+        );
+
+        let graph_entries = get_graph_entry_from_record(&record)?;
         match &graph_entries[..] {
             [entry] => Ok(entry.clone()),
             multiple => Err(GraphError::Fork(multiple.to_vec())),
         }
     }
 
-    /// Puts a GraphEntry to the network.
+    /// Manually puts a GraphEntry to the network.
     pub async fn graph_entry_put(
         &self,
         entry: GraphEntry,

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -29,14 +29,14 @@ pub use ant_protocol::storage::{Pointer, PointerAddress, PointerTarget};
 /// Errors that can occur when dealing with Pointers
 #[derive(Debug, thiserror::Error)]
 pub enum PointerError {
-    #[error("Cost error: {0}")]
-    Cost(#[from] CostError),
     #[error("Network error")]
     Network(#[from] NetworkError),
     #[error("Serialization error")]
     Serialization,
     #[error("Pointer record corrupt: {0}")]
     Corrupt(String),
+    #[error("Pointer signature is invalid")]
+    BadSignature,
     #[error("Payment failure occurred during pointer creation.")]
     Pay(#[from] PayError),
     #[error("Failed to retrieve wallet payment")]
@@ -72,20 +72,30 @@ impl Client {
             ))
         })?;
 
-        if matches!(header.kind, RecordKind::DataOnly(DataTypes::Pointer)) {
-            let pointer: Pointer = try_deserialize_record(&record).map_err(|err| {
-                PointerError::Corrupt(format!(
-                    "Failed to parse record for pointer at {key:?}: {err:?}"
-                ))
-            })?;
-            Ok(pointer)
-        } else {
-            error!(
-                "Record kind mismatch: expected Pointer, got {:?}",
-                header.kind
+        let kind = header.kind;
+        if !matches!(kind, RecordKind::DataOnly(DataTypes::Pointer)) {
+            error!("Record kind mismatch: expected Pointer, got {kind:?}");
+            return Err(
+                NetworkError::RecordKindMismatch(RecordKind::DataOnly(DataTypes::Pointer)).into(),
             );
-            Err(NetworkError::RecordKindMismatch(RecordKind::DataOnly(DataTypes::Pointer)).into())
+        };
+
+        let pointer: Pointer = try_deserialize_record(&record).map_err(|err| {
+            PointerError::Corrupt(format!(
+                "Failed to parse record for pointer at {key:?}: {err:?}"
+            ))
+        })?;
+
+        Self::pointer_verify(&pointer)?;
+        Ok(pointer)
+    }
+
+    /// Verify a pointer
+    pub fn pointer_verify(pointer: &Pointer) -> Result<(), PointerError> {
+        if !pointer.verify_signature() {
+            return Err(PointerError::BadSignature);
         }
+        Ok(())
     }
 
     /// Manually store a pointer on the network
@@ -269,7 +279,7 @@ impl Client {
     }
 
     /// Calculate the cost of storing a pointer
-    pub async fn pointer_cost(&self, key: PublicKey) -> Result<AttoTokens, PointerError> {
+    pub async fn pointer_cost(&self, key: PublicKey) -> Result<AttoTokens, CostError> {
         trace!("Getting cost for pointer of {key:?}");
 
         let address = PointerAddress::from_owner(key);

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -124,12 +124,13 @@ impl Client {
             }
         };
 
+        Self::scratchpad_verify(&pad)?;
         Ok(pad)
     }
 
     /// Verify a scratchpad
     pub fn scratchpad_verify(scratchpad: &Scratchpad) -> Result<(), ScratchpadError> {
-        if !scratchpad.verify() {
+        if !scratchpad.verify_signature() {
             return Err(ScratchpadError::BadSignature);
         }
         if scratchpad.is_too_big() {

--- a/autonomi/src/client/high_level/mod.rs
+++ b/autonomi/src/client/high_level/mod.rs
@@ -8,4 +8,5 @@
 
 pub mod data;
 pub mod files;
+pub mod register;
 pub mod vault;

--- a/autonomi/src/client/high_level/mod.rs
+++ b/autonomi/src/client/high_level/mod.rs
@@ -19,7 +19,8 @@ pub mod vault;
 /// The underlying structure of registers is a graph, where each version is a new [`crate::GraphEntry`]
 /// Each entry is linked to the previous entry and to the next entry, like a doubly linked list
 /// For fast access to the current register value, a [`crate::Pointer`] to the last entry always keeps track of the latest version
-/// ```no_run
+///
+/// ```ignore
 /// chain of GraphEntry: [register root] <-> [value2] <-> [value3] <-> [latest value]
 ///                                                                      ^
 ///                                                                      |

--- a/autonomi/src/client/high_level/mod.rs
+++ b/autonomi/src/client/high_level/mod.rs
@@ -8,5 +8,21 @@
 
 pub mod data;
 pub mod files;
-pub mod register;
 pub mod vault;
+
+/// Registers are a mutable piece of data on the Network.
+/// They can be read by anyone and updated only by the register owner.
+/// Each entry is signed by the owner and all value history is kept on the Network.
+/// They can be accessed on the Network using the RegisterAddress which is effectively the hash of the owner's [`crate::PublicKey`].
+/// This means there can only be one Register per key.
+///
+/// The underlying structure of registers is a graph, where each version is a new [`crate::GraphEntry`]
+/// Each entry is linked to the previous entry and to the next entry, like a doubly linked list
+/// For fast access to the current register value, a [`crate::Pointer`] to the last entry always keeps track of the latest version
+/// ```no_run
+/// chain of GraphEntry: [register root] <-> [value2] <-> [value3] <-> [latest value]
+///                                                                      ^
+///                                                                      |
+/// a Pointer to the latest version:                      [pointer to head]
+/// ```
+pub mod register;

--- a/autonomi/src/client/high_level/register/history.rs
+++ b/autonomi/src/client/high_level/register/history.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_networking::{GetRecordError, NetworkError};
+
+use crate::client::data_types::graph::{GraphEntryAddress, GraphError};
+use crate::client::high_level::register::{
+    PublicKey, RegisterAddress, RegisterError, RegisterValue,
+};
+use crate::client::key_derivation::MainPubkey;
+use crate::client::Client;
+
+/// A handle to the register history
+pub struct RegisterHistory {
+    client: Client,
+    register_owner: PublicKey,
+    current: GraphEntryAddress,
+}
+
+impl RegisterHistory {
+    fn new(client: Client, register_owner: PublicKey, root: GraphEntryAddress) -> Self {
+        Self {
+            client,
+            register_owner,
+            current: root,
+        }
+    }
+
+    /// Fetch and go to the next register value from the history
+    /// Returns `Ok(None)` when we reached the end
+    pub async fn next(&mut self) -> Result<Option<RegisterValue>, RegisterError> {
+        let (entry, next_derivation) = match self
+            .client
+            .register_get_graph_entry_and_next_derivation_index(&self.current)
+            .await
+        {
+            Ok(res) => res,
+            Err(RegisterError::GraphError(GraphError::Network(NetworkError::GetRecordError(
+                GetRecordError::RecordNotFound,
+            )))) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let next_entry_pk: PublicKey = MainPubkey::from(self.register_owner)
+            .derive_key(&next_derivation)
+            .into();
+        self.current = GraphEntryAddress::from_owner(next_entry_pk);
+        Ok(Some(entry.content))
+    }
+
+    /// Get all the register values from the history
+    pub async fn collect(&mut self) -> Result<Vec<RegisterValue>, RegisterError> {
+        let mut values = Vec::new();
+        while let Some(value) = self.next().await? {
+            values.push(value);
+        }
+        Ok(values)
+    }
+}
+
+impl Client {
+    /// Get the register history, starting from the root to the latest entry
+    /// This returns a [`RegisterHistory`] that can be use to get the register values from the history
+    /// [`RegisterHistory::next`] can be used to get the values one by one
+    /// [`RegisterHistory::collect`] can be used to get all the register values from the history
+    pub fn register_history(&self, addr: &RegisterAddress) -> RegisterHistory {
+        let graph_entry_addr = addr.to_underlying_graph_root();
+        RegisterHistory::new(self.clone(), addr.owner, graph_entry_addr)
+    }
+}

--- a/autonomi/src/client/high_level/register/mod.rs
+++ b/autonomi/src/client/high_level/register/mod.rs
@@ -111,8 +111,7 @@ impl Client {
         &self,
         owner: &SecretKey,
         initial_value: RegisterValue,
-        graph_payment_option: PaymentOption,
-        pointer_payment_option: PaymentOption,
+        payment_option: PaymentOption,
     ) -> Result<(AttoTokens, RegisterAddress), RegisterError> {
         let main_key = MainSecretKey::new(owner.clone());
         let public_key = main_key.public_key();
@@ -131,14 +130,14 @@ impl Client {
 
         // put the first entry in the graph
         let (graph_cost, addr) = self
-            .graph_entry_put(root_entry, graph_payment_option)
+            .graph_entry_put(root_entry, payment_option.clone())
             .await?;
 
         // create a Pointer to the last entry
         let target = PointerTarget::GraphEntryAddress(addr);
         let pointer_key = self.register_head_pointer_sk(&main_key.into());
         let (pointer_cost, _pointer_addr) = self
-            .pointer_create(&pointer_key, target, pointer_payment_option)
+            .pointer_create(&pointer_key, target, payment_option.clone())
             .await?;
 
         let total_cost = graph_cost

--- a/autonomi/src/client/high_level/register/mod.rs
+++ b/autonomi/src/client/high_level/register/mod.rs
@@ -320,4 +320,34 @@ mod tests {
         let same_name = super::Client::register_key_from_name(&main_key, "register1");
         assert_eq!(same_name.public_key(), register_key.public_key());
     }
+
+    #[tokio::test]
+    async fn test_register_value_from_bytes() {
+        let value = super::Client::register_value_from_bytes(&[1, 2, 3]).unwrap();
+        assert_eq!(
+            value,
+            [
+                1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        );
+        let value = super::Client::register_value_from_bytes(&[
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32,
+        ])
+        .unwrap();
+        assert_eq!(
+            value,
+            [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32
+            ]
+        );
+        let err = super::Client::register_value_from_bytes(&[
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33,
+        ])
+        .unwrap_err();
+        assert!(matches!(err, super::RegisterError::InvalidRegisterValueLength(v) if v == 33));
+    }
 }

--- a/autonomi/src/client/high_level/register/mod.rs
+++ b/autonomi/src/client/high_level/register/mod.rs
@@ -1,0 +1,282 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::client::data_types::graph::{GraphContent, GraphEntry, GraphError};
+use crate::client::data_types::pointer::{PointerAddress, PointerError, PointerTarget};
+use crate::client::key_derivation::{DerivationIndex, MainPubkey, MainSecretKey};
+use crate::client::payment::PaymentOption;
+use crate::client::quote::CostError;
+use crate::client::Client;
+use crate::AttoTokens;
+use crate::{PublicKey, SecretKey};
+use ant_networking::{GetRecordError, NetworkError};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use xor_name::XorName;
+
+/// A Register is addressed at a [`RegisterAddress`] which is in fact the owner's [`PublicKey`].
+/// There can only be one register stored at [`PublicKey`].
+/// Any data stored in the register is stored as is, without encryption or modifications.
+/// Since the data is publicly accessible by anyone knowing the [`RegisterAddress`],
+/// it is up to the owner to encrypt the data uploaded to the register, if wanted.
+/// Only the owner can update the register with its [`SecretKey`].
+/// The [`SecretKey`] is the only piece of information an owner should keep to access to the register.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RegisterAddress {
+    pub owner: PublicKey,
+}
+
+impl RegisterAddress {
+    /// Create a new register address
+    pub fn new(owner: PublicKey) -> Self {
+        Self { owner }
+    }
+
+    /// Get the owner of the register
+    pub fn owner(&self) -> PublicKey {
+        self.owner
+    }
+}
+
+/// The value of a register: a 32 bytes array (same as [`GraphContent`])
+pub type RegisterValue = GraphContent;
+
+#[derive(Error, Debug)]
+pub enum RegisterError {
+    #[error("Underlying GraphError: {0}")]
+    GraphError(#[from] GraphError),
+    #[error("Underlying PointerError: {0}")]
+    PointerError(#[from] PointerError),
+    #[error("Invalid cost")]
+    InvalidCost,
+    #[error("Invalid head pointer, was expecting a GraphEntryAddress but got: {0:?}")]
+    InvalidHeadPointer(PointerTarget),
+    #[error("Forked register, this can happen if the register has been updated concurrently, you can solve this by updating the register again with a new value. Concurrent entries: {0:?}")]
+    Fork(Vec<[u8; 32]>),
+    #[error("Corrupt register: {0}")]
+    Corrupt(String),
+    #[error("Register cannot be updated as it does not exist, please create it first or wait for it to be created")]
+    CannotUpdateNewRegister,
+}
+
+/// Hard coded derivation index for the register head pointer
+/// Derive the register's main public key by it to get the pointer owner/address
+const REGISTER_HEAD_DERIVATION_INDEX: [u8; 32] = [0; 32];
+
+impl Client {
+    /// Create a new register key from a SecretKey and a name
+    /// This derives a new [`SecretKey`] from the owner's [`SecretKey`] using the name
+    /// Note that you will need to keep track of the names you used to create the register key
+    pub fn register_key_from_name(owner: &SecretKey, name: &str) -> SecretKey {
+        let main_key = MainSecretKey::new(owner.clone());
+        let derivation_index =
+            DerivationIndex::from_bytes(XorName::from_content(name.as_bytes()).0);
+        main_key.derive_key(&derivation_index).into()
+    }
+
+    /// Create a new register
+    pub async fn register_create(
+        &self,
+        owner: &SecretKey,
+        initial_value: RegisterValue,
+        graph_payment_option: PaymentOption,
+        pointer_payment_option: PaymentOption,
+    ) -> Result<(AttoTokens, RegisterAddress), RegisterError> {
+        let main_key = MainSecretKey::new(owner.clone());
+        let public_key = main_key.public_key();
+
+        // create the first entry and decide on the next key
+        let index = DerivationIndex::random(&mut rand::thread_rng());
+        let next_key = main_key.public_key().derive_key(&index);
+        let parents = vec![];
+        let descendants = vec![(next_key.into(), index.into_bytes())];
+        let root_entry = GraphEntry::new(
+            &main_key.clone().into(),
+            parents,
+            initial_value,
+            descendants,
+        );
+
+        // put the first entry in the graph
+        let (graph_cost, addr) = self
+            .graph_entry_put(root_entry, graph_payment_option)
+            .await?;
+
+        // create a Pointer to the last entry
+        let target = PointerTarget::GraphEntryAddress(addr);
+        let pointer_key = self.register_head_pointer_sk(&main_key.into());
+        let (pointer_cost, _pointer_addr) = self
+            .pointer_create(&pointer_key, target, pointer_payment_option)
+            .await?;
+
+        let total_cost = graph_cost
+            .checked_add(pointer_cost)
+            .ok_or(RegisterError::InvalidCost)?;
+        Ok((
+            total_cost,
+            RegisterAddress {
+                owner: public_key.into(),
+            },
+        ))
+    }
+
+    /// Update the value of a register
+    pub async fn register_update(
+        &self,
+        owner: &SecretKey,
+        new_value: RegisterValue,
+        payment_option: PaymentOption,
+    ) -> Result<AttoTokens, RegisterError> {
+        // get the pointer of the register head
+        let addr = RegisterAddress {
+            owner: owner.public_key(),
+        };
+        let pointer_addr = self.register_head_pointer_address(&addr);
+        debug!("Getting pointer of register head at {pointer_addr:?}");
+        let pointer = match self.pointer_get(pointer_addr).await {
+            Ok(pointer) => pointer,
+            Err(PointerError::Network(NetworkError::GetRecordError(
+                GetRecordError::RecordNotFound,
+            ))) => return Err(RegisterError::CannotUpdateNewRegister),
+            Err(err) => return Err(err.into()),
+        };
+        let graph_entry_addr = match pointer.target() {
+            PointerTarget::GraphEntryAddress(addr) => addr,
+            other => return Err(RegisterError::InvalidHeadPointer(other.clone())),
+        };
+
+        // get the next derivation index from the current head entry
+        debug!("Getting register head graph entry at {graph_entry_addr:?}");
+        let parent_entry = match self.graph_entry_get(*graph_entry_addr).await {
+            Ok(e) => e,
+            Err(GraphError::Fork(entries)) => {
+                warn!("Forked register, multiple entries found: {entries:?}, choosing the one with the smallest derivation index for the next entry");
+                let (entry_by_smallest_derivation, _) = entries
+                    .into_iter()
+                    .filter_map(|e| {
+                        e.descendants
+                            .iter()
+                            .map(|d| d.1)
+                            .min()
+                            .map(|derivation| (e, derivation))
+                    })
+                    .min_by(|a, b| a.1.cmp(&b.1))
+                    .ok_or(RegisterError::Corrupt(format!(
+                        "No descendants found for FORKED entry at {graph_entry_addr:?}"
+                    )))?;
+                entry_by_smallest_derivation
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let new_derivation =
+            parent_entry
+                .descendants
+                .iter()
+                .map(|d| d.1)
+                .min()
+                .ok_or(RegisterError::Corrupt(format!(
+                    "No descendants found for entry at {graph_entry_addr:?}"
+                )))?;
+
+        // create a new entry with the new value
+        let main_key = MainSecretKey::new(owner.clone());
+        let new_key = main_key.derive_key(&DerivationIndex::from_bytes(new_derivation));
+        let parents = vec![parent_entry.owner];
+        let next_derivation = DerivationIndex::random(&mut rand::thread_rng());
+        let next_pk = main_key.public_key().derive_key(&next_derivation);
+        let descendants = vec![(next_pk.into(), next_derivation.into_bytes())];
+        let new_entry = GraphEntry::new(&new_key.into(), parents, new_value, descendants);
+
+        // put the new entry in the graph
+        let (cost, new_graph_entry_addr) = self.graph_entry_put(new_entry, payment_option).await?;
+
+        // update the pointer to point to the new entry
+        let target = PointerTarget::GraphEntryAddress(new_graph_entry_addr);
+        let pointer_key = self.register_head_pointer_sk(&main_key.into());
+        self.pointer_update(&pointer_key, target).await?;
+
+        Ok(cost)
+    }
+
+    /// Get the current value of the register
+    pub async fn register_get(
+        &self,
+        addr: &RegisterAddress,
+    ) -> Result<RegisterValue, RegisterError> {
+        // get the pointer of the register head
+        let pointer_addr = self.register_head_pointer_address(addr);
+        debug!("Getting pointer of register head at {pointer_addr:?}");
+        let pointer = self.pointer_get(pointer_addr).await?;
+        let graph_entry_addr = match pointer.target() {
+            PointerTarget::GraphEntryAddress(addr) => addr,
+            other => return Err(RegisterError::InvalidHeadPointer(other.clone())),
+        };
+
+        // get the entry from the graph
+        debug!("Getting register head graph entry at {graph_entry_addr:?}");
+        let entry = match self.graph_entry_get(*graph_entry_addr).await {
+            Ok(entry) => entry,
+            Err(GraphError::Fork(entries)) => {
+                let values = entries.iter().map(|e| e.content).collect::<Vec<_>>();
+                return Err(RegisterError::Fork(values));
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        // get the content of the entry
+        let content = entry.content;
+        Ok(content)
+    }
+
+    /// Get the cost of a register operation.
+    /// Returns the cost of creation if it doesn't exist, else returns the cost of an update
+    pub async fn register_cost(&self, owner: &PublicKey) -> Result<AttoTokens, CostError> {
+        let pointer_pk = self.register_head_pointer_pk(&RegisterAddress { owner: *owner });
+        let scratchpad_cost = self.scratchpad_cost(owner);
+        let pointer_cost = self.pointer_cost(pointer_pk);
+        let (scratchpad_cost, pointer_cost) =
+            futures::future::join(scratchpad_cost, pointer_cost).await;
+        scratchpad_cost?
+            .checked_add(pointer_cost?)
+            .ok_or(CostError::InvalidCost)
+    }
+
+    /// Get the address of the register's head pointer
+    fn register_head_pointer_address(&self, addr: &RegisterAddress) -> PointerAddress {
+        let pk: MainPubkey = addr.owner.into();
+        let pointer_pk =
+            pk.derive_key(&DerivationIndex::from_bytes(REGISTER_HEAD_DERIVATION_INDEX));
+        PointerAddress::from_owner(pointer_pk.into())
+    }
+
+    /// Get the secret key of the register's head pointer
+    fn register_head_pointer_sk(&self, register_owner: &SecretKey) -> SecretKey {
+        let pointer_sk = MainSecretKey::new(register_owner.clone())
+            .derive_key(&DerivationIndex::from_bytes(REGISTER_HEAD_DERIVATION_INDEX));
+        pointer_sk.into()
+    }
+
+    /// Get the public key of the register's head pointer
+    fn register_head_pointer_pk(&self, addr: &RegisterAddress) -> PublicKey {
+        let pk: MainPubkey = addr.owner.into();
+        let pointer_pk =
+            pk.derive_key(&DerivationIndex::from_bytes(REGISTER_HEAD_DERIVATION_INDEX));
+        pointer_pk.into()
+    }
+}
+
+mod tests {
+    #[tokio::test]
+    async fn test_register_by_name() {
+        let main_key = bls::SecretKey::random();
+        let register_key = super::Client::register_key_from_name(&main_key, "register1");
+        assert_ne!(register_key.public_key(), main_key.public_key());
+        let same_name = super::Client::register_key_from_name(&main_key, "register1");
+        assert_eq!(same_name.public_key(), register_key.public_key());
+    }
+}

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -25,6 +25,7 @@ pub use data_types::scratchpad;
 mod high_level;
 pub use high_level::data;
 pub use high_level::files;
+pub use high_level::register;
 pub use high_level::vault;
 
 pub mod address;

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -69,6 +69,8 @@ pub enum CostError {
     Serialization(String),
     #[error("Market price error: {0:?}")]
     MarketPriceError(#[from] ant_evm::payment_vault::error::Error),
+    #[error("Received invalid cost")]
+    InvalidCost,
 }
 
 impl Client {

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -64,6 +64,7 @@ pub use client::data_types::scratchpad;
 // The high-level data types
 pub use client::data;
 pub use client::files;
+pub use client::register;
 pub use client::vault;
 
 // Re-exports of the evm types
@@ -84,9 +85,9 @@ pub use libp2p::Multiaddr;
 
 #[doc(inline)]
 pub use client::{
-    // Data types
+    // Native data types
     data_types::chunk::Chunk,
-    // Addresses for the data types
+    // Addresses for the native data types
     data_types::chunk::ChunkAddress,
     data_types::graph::GraphEntry,
     data_types::graph::GraphEntryAddress,

--- a/autonomi/tests/graph.rs
+++ b/autonomi/tests/graph.rs
@@ -31,7 +31,7 @@ async fn graph_entry_put() -> Result<()> {
     let graph_entry = GraphEntry::new(&key, vec![], content, vec![]);
 
     // estimate the cost of the graph_entry
-    let cost = client.graph_entry_cost(key.public_key()).await?;
+    let cost = client.graph_entry_cost(&key.public_key()).await?;
     println!("graph_entry cost: {cost}");
 
     // put the graph_entry

--- a/autonomi/tests/graph.rs
+++ b/autonomi/tests/graph.rs
@@ -15,9 +15,11 @@ use autonomi::{
     Client,
 };
 use eyre::Result;
+use serial_test::serial;
 use test_utils::evm::get_funded_wallet;
 
 #[tokio::test]
+#[serial]
 async fn graph_entry_put() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("graph_entry", false);
 
@@ -26,7 +28,7 @@ async fn graph_entry_put() -> Result<()> {
 
     let key = bls::SecretKey::random();
     let content = [0u8; 32];
-    let graph_entry = GraphEntry::new(key.public_key(), vec![], content, vec![], &key);
+    let graph_entry = GraphEntry::new(&key, vec![], content, vec![]);
 
     // estimate the cost of the graph_entry
     let cost = client.graph_entry_cost(key.public_key()).await?;
@@ -49,7 +51,7 @@ async fn graph_entry_put() -> Result<()> {
 
     // try put another graph_entry with the same address
     let content2 = [1u8; 32];
-    let graph_entry2 = GraphEntry::new(key.public_key(), vec![], content2, vec![], &key);
+    let graph_entry2 = GraphEntry::new(&key, vec![], content2, vec![]);
     let payment_option = PaymentOption::from(&wallet);
     let res = client
         .graph_entry_put(graph_entry2.clone(), payment_option)
@@ -60,5 +62,22 @@ async fn graph_entry_put() -> Result<()> {
         Err(GraphError::AlreadyExists(address))
         if address == graph_entry2.address()
     ));
+
+    // try to put a graph entry linking to the first graph entry
+    let key3 = bls::SecretKey::random();
+    let graph_entry3 = GraphEntry::new(&key3, vec![graph_entry.owner], content2, vec![]);
+    let payment_option = PaymentOption::from(&wallet);
+    client
+        .graph_entry_put(graph_entry3.clone(), payment_option)
+        .await?;
+
+    // wait for the graph_entry to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the graph_entry is stored
+    let txs = client.graph_entry_get(graph_entry3.address()).await?;
+    assert_eq!(txs, graph_entry3.clone());
+    println!("graph_entry got 2");
+
     Ok(())
 }

--- a/autonomi/tests/pointer.rs
+++ b/autonomi/tests/pointer.rs
@@ -15,10 +15,12 @@ use autonomi::{
     Client,
 };
 use eyre::Result;
+use serial_test::serial;
 use test_utils::evm::get_funded_wallet;
 use xor_name::XorName;
 
 #[tokio::test]
+#[serial]
 async fn pointer_put_manual() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("pointer", false);
 
@@ -69,6 +71,7 @@ async fn pointer_put_manual() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn pointer_put() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("pointer", false);
 

--- a/autonomi/tests/registers.rs
+++ b/autonomi/tests/registers.rs
@@ -1,0 +1,129 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_logging::LogBuilder;
+use autonomi::{
+    client::{
+        payment::PaymentOption,
+        register::{RegisterAddress, RegisterValue},
+    },
+    graph::GraphError,
+    register::RegisterError,
+    Client,
+};
+use eyre::Result;
+use serial_test::serial;
+use test_utils::evm::get_funded_wallet;
+
+#[tokio::test]
+#[serial]
+async fn registers_usage() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("registers", false);
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let main_key = bls::SecretKey::random();
+
+    let register_key = Client::register_key_from_name(&main_key, "register1");
+    let mut content: RegisterValue = [0; 32];
+    content[..13].copy_from_slice(b"Hello, World!");
+    let cost = client.register_cost(&register_key.public_key()).await?;
+    println!("register cost: {cost}");
+
+    // create the register
+    let (cost, addr) = client
+        .register_create(
+            &register_key,
+            content,
+            PaymentOption::from(&wallet),
+            PaymentOption::from(&wallet),
+        )
+        .await?;
+    println!("register created: {cost} {addr:?}");
+    assert_eq!(addr, RegisterAddress::new(register_key.public_key()));
+
+    // wait for the register to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // get the register
+    let value = client.register_get(&addr).await?;
+    assert_eq!(value, content);
+
+    // update the register
+    let mut new_content: RegisterValue = [0; 32];
+    new_content[..26].copy_from_slice(b"any 32 bytes of fresh data");
+    let cost = client
+        .register_update(&register_key, new_content, PaymentOption::from(&wallet))
+        .await?;
+    println!("register updated: {cost}");
+
+    // wait for the register to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // get the register again
+    let value = client.register_get(&addr).await?;
+    assert_eq!(value, new_content);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn registers_errors() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("registers2", false);
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let main_key = bls::SecretKey::random();
+
+    let register_key = Client::register_key_from_name(&main_key, "register1");
+    let mut content: RegisterValue = [0; 32];
+    content[..13].copy_from_slice(b"Hello, World!");
+    let cost = client.register_cost(&register_key.public_key()).await?;
+    println!("register cost: {cost}");
+
+    // try to update non existing register
+    let res = client
+        .register_update(&register_key, content, PaymentOption::from(&wallet))
+        .await;
+    println!("register update without creating should fail: {res:?}");
+    assert!(matches!(
+        res.unwrap_err(),
+        RegisterError::CannotUpdateNewRegister
+    ));
+
+    // create the register
+    let (cost, addr) = client
+        .register_create(
+            &register_key,
+            content,
+            PaymentOption::from(&wallet),
+            PaymentOption::from(&wallet),
+        )
+        .await?;
+    println!("register created: {cost} {addr:?}");
+    assert_eq!(addr, RegisterAddress::new(register_key.public_key()));
+
+    // wait for the register to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // try to create the register again
+    let res = client
+        .register_create(
+            &register_key,
+            content,
+            PaymentOption::from(&wallet),
+            PaymentOption::from(&wallet),
+        )
+        .await;
+    println!("register create second time should fail: {res:?}");
+    assert!(matches!(
+        res.unwrap_err(),
+        RegisterError::GraphError(GraphError::AlreadyExists(_))
+    ));
+
+    Ok(())
+}

--- a/autonomi/tests/registers.rs
+++ b/autonomi/tests/registers.rs
@@ -32,12 +32,7 @@ async fn registers_usage() -> Result<()> {
 
     // create the register
     let (cost, addr) = client
-        .register_create(
-            &register_key,
-            content,
-            PaymentOption::from(&wallet),
-            PaymentOption::from(&wallet),
-        )
+        .register_create(&register_key, content, PaymentOption::from(&wallet))
         .await?;
     println!("register created: {cost} {addr:?}");
     assert_eq!(addr, RegisterAddress::new(register_key.public_key()));
@@ -91,12 +86,7 @@ async fn registers_errors() -> Result<()> {
 
     // create the register
     let (cost, addr) = client
-        .register_create(
-            &register_key,
-            content,
-            PaymentOption::from(&wallet),
-            PaymentOption::from(&wallet),
-        )
+        .register_create(&register_key, content, PaymentOption::from(&wallet))
         .await?;
     println!("register created: {cost} {addr:?}");
     assert_eq!(addr, RegisterAddress::new(register_key.public_key()));
@@ -106,12 +96,7 @@ async fn registers_errors() -> Result<()> {
 
     // try to create the register again
     let res = client
-        .register_create(
-            &register_key,
-            content,
-            PaymentOption::from(&wallet),
-            PaymentOption::from(&wallet),
-        )
+        .register_create(&register_key, content, PaymentOption::from(&wallet))
         .await;
     println!("register create second time should fail: {res:?}");
     assert!(matches!(
@@ -131,12 +116,7 @@ async fn test_register_history() -> Result<()> {
     let register_key = Client::register_key_from_name(&main_key, "history_test");
     let content1 = Client::register_value_from_bytes(b"Massive")?;
     let (_cost, addr) = client
-        .register_create(
-            &register_key,
-            content1,
-            PaymentOption::from(&wallet),
-            PaymentOption::from(&wallet),
-        )
+        .register_create(&register_key, content1, PaymentOption::from(&wallet))
         .await?;
 
     // let the network replicate the register

--- a/autonomi/tests/registers.rs
+++ b/autonomi/tests/registers.rs
@@ -8,10 +8,7 @@
 
 use ant_logging::LogBuilder;
 use autonomi::{
-    client::{
-        payment::PaymentOption,
-        register::{RegisterAddress, RegisterValue},
-    },
+    client::{payment::PaymentOption, register::RegisterAddress},
     graph::GraphError,
     register::RegisterError,
     Client,
@@ -29,8 +26,7 @@ async fn registers_usage() -> Result<()> {
     let main_key = bls::SecretKey::random();
 
     let register_key = Client::register_key_from_name(&main_key, "register1");
-    let mut content: RegisterValue = [0; 32];
-    content[..13].copy_from_slice(b"Hello, World!");
+    let content = Client::register_value_from_bytes(b"Hello, World!")?;
     let cost = client.register_cost(&register_key.public_key()).await?;
     println!("register cost: {cost}");
 
@@ -54,8 +50,7 @@ async fn registers_usage() -> Result<()> {
     assert_eq!(value, content);
 
     // update the register
-    let mut new_content: RegisterValue = [0; 32];
-    new_content[..26].copy_from_slice(b"any 32 bytes of fresh data");
+    let new_content = Client::register_value_from_bytes(b"any 32 bytes of fresh data")?;
     let cost = client
         .register_update(&register_key, new_content, PaymentOption::from(&wallet))
         .await?;
@@ -80,8 +75,7 @@ async fn registers_errors() -> Result<()> {
     let main_key = bls::SecretKey::random();
 
     let register_key = Client::register_key_from_name(&main_key, "register1");
-    let mut content: RegisterValue = [0; 32];
-    content[..13].copy_from_slice(b"Hello, World!");
+    let content = Client::register_value_from_bytes(b"Hello, World!")?;
     let cost = client.register_cost(&register_key.public_key()).await?;
     println!("register cost: {cost}");
 
@@ -124,6 +118,67 @@ async fn registers_errors() -> Result<()> {
         res.unwrap_err(),
         RegisterError::GraphError(GraphError::AlreadyExists(_))
     ));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_register_history() -> Result<()> {
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let main_key = bls::SecretKey::random();
+    let register_key = Client::register_key_from_name(&main_key, "history_test");
+    let content1 = Client::register_value_from_bytes(b"Massive")?;
+    let (_cost, addr) = client
+        .register_create(
+            &register_key,
+            content1,
+            PaymentOption::from(&wallet),
+            PaymentOption::from(&wallet),
+        )
+        .await?;
+
+    // let the network replicate the register
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    let mut history = client.register_history(&addr);
+    let first = history.next().await?;
+    assert_eq!(first, Some(content1));
+    let second = history.next().await?;
+    assert_eq!(second, None);
+
+    let content2 = Client::register_value_from_bytes(b"Array")?;
+    client
+        .register_update(&register_key, content2, PaymentOption::from(&wallet))
+        .await?;
+
+    // let the network replicate the updates
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    let all = client.register_history(&addr).collect().await?;
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0], content1);
+    assert_eq!(all[1], content2);
+
+    let content3 = Client::register_value_from_bytes(b"Internet")?;
+    client
+        .register_update(&register_key, content3, PaymentOption::from(&wallet))
+        .await?;
+    let content4 = Client::register_value_from_bytes(b"Disk")?;
+    client
+        .register_update(&register_key, content4, PaymentOption::from(&wallet))
+        .await?;
+
+    // let the network replicate the updates
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    let all = client.register_history(&addr).collect().await?;
+    assert_eq!(all.len(), 4);
+    assert_eq!(all[0], content1);
+    assert_eq!(all[1], content2);
+    assert_eq!(all[2], content3);
+    assert_eq!(all[3], content4);
 
     Ok(())
 }

--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -113,7 +113,7 @@ async fn scratchpad_put() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.verify());
+    assert!(got.verify_signature());
     println!("scratchpad got 1");
 
     // check that the content is decrypted correctly
@@ -135,7 +135,7 @@ async fn scratchpad_put() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content2.clone()));
     assert_eq!(got.counter(), 1);
-    assert!(got.verify());
+    assert!(got.verify_signature());
     println!("scratchpad got 2");
 
     // check that the content is decrypted correctly
@@ -179,7 +179,7 @@ async fn scratchpad_errors() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.verify());
+    assert!(got.verify_signature());
     println!("scratchpad got 1");
 
     // try create scratchpad at the same address
@@ -203,7 +203,7 @@ async fn scratchpad_errors() -> Result<()> {
     assert_eq!(got.data_encoding(), content_type);
     assert_eq!(got.decrypt_data(&key), Ok(content.clone()));
     assert_eq!(got.counter(), 0);
-    assert!(got.verify());
+    assert!(got.verify_signature());
     println!("scratchpad got 1");
 
     // check that the content is decrypted correctly and matches the original


### PR DESCRIPTION
By popular demand, `Registers` are back, but this time built on top of `GraphEntry`. Which:
- removes the update limitation (previously limited to 1024 updates)
- simplifies the underlying structure
- register value is a 32 bytes entry
- underlying structure looks like a doubly linked list so history traversal is simpler
- comes with a default way to access history in the API (although users can also manually access it through the underlying graph)
- pay for each update, although pretty cheap

How they work:
```
Pointer to register Head:                              [points to here]
                                                                    |
                                                                    V
GraphEntries: [register root] <-> [value2] <-> [value3] <-> [latest value]
```

> Usage examples in `autonomi/tests/registers.rs`

CLI integration coming soon! 

cc: @happybeing hope you like them!