### PR TITLE
chore: use hide listen addresses

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -513,7 +513,8 @@ impl NetworkBuilder {
             let cfg = libp2p::identify::Config::new(identify_protocol_str, self.keypair.public())
                 .with_agent_version(agent_version)
                 // Enlength the identify interval from default 5 mins to 1 hour.
-                .with_interval(RESEND_IDENTIFY_INVERVAL);
+                .with_interval(RESEND_IDENTIFY_INVERVAL)
+                .with_hide_listen_addrs(true);
             libp2p::identify::Behaviour::new(cfg)
         };
 

--- a/ant-networking/src/record_store_api.rs
+++ b/ant-networking/src/record_store_api.rs
@@ -23,7 +23,6 @@ pub enum UnifiedRecordStore {
     Client(ClientRecordStore),
     Node(NodeRecordStore),
 }
-
 impl RecordStore for UnifiedRecordStore {
     type RecordsIter<'a> = std::vec::IntoIter<Cow<'a, Record>>;
     type ProvidedIter<'a> = std::vec::IntoIter<Cow<'a, ProviderRecord>>;


### PR DESCRIPTION
With hide listen addresses, only our external addresses are shared.

In some contexts, this could prevent unnecessary dialling errors.