### PR TITLE
fix: not enough quotes by increasing sample size

### DIFF
--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -412,7 +412,7 @@ impl Network {
 
         // consider data to be already paid for if 1/2 of the close nodes already have it
         let mut peer_already_have_it = 0;
-        let enough_peers_already_have_it = close_nodes.len() / 2;
+        let enough_peers_already_have_it = CLOSE_GROUP_SIZE / 2 + 1;
 
         let mut peers_returned_error = 0;
 
@@ -1082,7 +1082,7 @@ impl Network {
             );
         }
 
-        let expanded_close_group = CLOSE_GROUP_SIZE + CLOSE_GROUP_SIZE / 2;
+        let expanded_close_group = CLOSE_GROUP_SIZE * 2;
         let closest_peers = sort_peers_by_address(&closest_peers, key, expanded_close_group)?;
         Ok(closest_peers.into_iter().cloned().collect())
     }

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -226,7 +226,8 @@ impl Network {
         &self,
         key: &NetworkAddress,
     ) -> Result<Vec<PeerId>> {
-        self.get_all_close_peers_in_range_or_close_group(key, true)
+        let expanded_close_group = CLOSE_GROUP_SIZE * 2;
+        self.get_all_close_peers_in_range(key, true, expanded_close_group)
             .await
     }
 
@@ -234,7 +235,8 @@ impl Network {
     ///
     /// Includes our node's `PeerId` while calculating the closest peers.
     pub async fn node_get_closest_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
-        self.get_all_close_peers_in_range_or_close_group(key, false)
+        let expanded_close_group = CLOSE_GROUP_SIZE * 2 + 4; // Add a small margin
+        self.get_all_close_peers_in_range(key, false, expanded_close_group)
             .await
     }
 
@@ -1038,10 +1040,11 @@ impl Network {
     /// If `client` is false, then include `self` among the `closest_peers`
     ///
     /// If less than CLOSE_GROUP_SIZE peers are found, it will return all the peers.
-    pub async fn get_all_close_peers_in_range_or_close_group(
+    pub async fn get_all_close_peers_in_range(
         &self,
         key: &NetworkAddress,
         client: bool,
+        peers_amount: usize,
     ) -> Result<Vec<PeerId>> {
         let pretty_key = PrettyPrintKBucketKey(key.as_kbucket_key());
         debug!("Getting the all closest peers in range of {pretty_key:?}");
@@ -1082,8 +1085,7 @@ impl Network {
             );
         }
 
-        let expanded_close_group = CLOSE_GROUP_SIZE * 2;
-        let closest_peers = sort_peers_by_address(&closest_peers, key, expanded_close_group)?;
+        let closest_peers = sort_peers_by_address(&closest_peers, key, peers_amount)?;
         Ok(closest_peers.into_iter().cloned().collect())
     }
 

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -651,20 +651,19 @@ impl Node {
         }
 
         // verify the claimed payees are indeed within range.
-        let closest_peers_to_address = self
-            .network()
-            .client_get_all_close_peers_in_range_or_close_group(address)
-            .await?;
+        let closest_peers_to_address = self.network().node_get_closest_peers(address).await?;
         let payees_out_of_range: Vec<PeerId> = payment
             .payees()
             .into_iter()
-            .filter(|peer_id| {
-                peer_id != &self_peer_id && !closest_peers_to_address.contains(peer_id)
-            })
+            .filter(|peer_id| !closest_peers_to_address.contains(peer_id))
             .collect();
         if !payees_out_of_range.is_empty() {
             warn!("Payment quote has out-of-range payees for record {pretty_key}");
             warn!("Payees out of range: {payees_out_of_range:?}");
+            debug!(
+                "Amount of closest peers found: {}",
+                closest_peers_to_address.len()
+            );
             return Err(Error::InvalidRequest(format!(
                 "Payment quote has out-of-range payees for record {pretty_key}"
             )));

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -21,6 +21,7 @@ use ant_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use libp2p::kad::{Record, RecordKey};
+use libp2p::PeerId;
 use xor_name::XorName;
 
 impl Node {
@@ -623,8 +624,9 @@ impl Node {
         let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
         debug!("Validating record payment for {pretty_key}");
 
-        // check if the quote is valid
         let self_peer_id = self.network().peer_id();
+
+        // check if the quote is valid
         if !payment.verify_for(self_peer_id) {
             warn!("Payment is not valid for record {pretty_key}");
             return Err(Error::InvalidRequest(format!(
@@ -648,14 +650,23 @@ impl Node {
             )));
         }
 
-        // verify the claimed payees are all known to us within the certain range.
-        let closest_k_peers = self.network().get_closest_k_value_local_peers().await?;
-        let mut payees = payment.payees();
-        payees.retain(|peer_id| !closest_k_peers.contains(peer_id));
-        if !payees.is_empty() {
+        // verify the claimed payees are indeed within range.
+        let closest_peers_to_address = self
+            .network()
+            .client_get_all_close_peers_in_range_or_close_group(address)
+            .await?;
+        let payees_out_of_range: Vec<PeerId> = payment
+            .payees()
+            .into_iter()
+            .filter(|peer_id| {
+                peer_id != &self_peer_id && !closest_peers_to_address.contains(peer_id)
+            })
+            .collect();
+        if !payees_out_of_range.is_empty() {
             warn!("Payment quote has out-of-range payees for record {pretty_key}");
+            warn!("Payees out of range: {payees_out_of_range:?}");
             return Err(Error::InvalidRequest(format!(
-                "Payment quote has out-of-range payees {payees:?}"
+                "Payment quote has out-of-range payees for record {pretty_key}"
             )));
         }
 


### PR DESCRIPTION
- Increases quote fetch sample size from 7 to 10.
- Widens the amount of nodes close enough to consider as valid payees in the node check.