### PR TITLE
feat: manual chunk API and test, improved config for client

### DIFF
--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -7,16 +7,20 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::network::NetworkPeers;
-use autonomi::client::config::ClientOperationConfig;
+use autonomi::client::config::ClientOperatingStrategy;
 use autonomi::{get_evm_network, Client, ClientConfig};
 use color_eyre::eyre::bail;
 use color_eyre::eyre::Result;
 use indicatif::ProgressBar;
 use std::time::Duration;
 
-pub async fn connect_to_network(
+pub async fn connect_to_network(peers: NetworkPeers) -> Result<Client> {
+    connect_to_network_with_config(peers, Default::default()).await
+}
+
+pub async fn connect_to_network_with_config(
     peers: NetworkPeers,
-    client_operation_config: ClientOperationConfig,
+    operation_config: ClientOperatingStrategy,
 ) -> Result<Client> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.enable_steady_tick(Duration::from_millis(120));
@@ -40,7 +44,7 @@ pub async fn connect_to_network(
         local,
         peers: peers_opt,
         evm_network,
-        operation_config: client_operation_config,
+        strategy: operation_config,
     };
 
     let res = Client::init_with_config(config).await;

--- a/ant-cli/src/actions/download.rs
+++ b/ant-cli/src/actions/download.rs
@@ -20,7 +20,7 @@ use color_eyre::{
 };
 use std::path::PathBuf;
 
-pub async fn download(addr: &str, dest_path: &str, client: &mut Client) -> Result<()> {
+pub async fn download(addr: &str, dest_path: &str, client: &Client) -> Result<()> {
     let public_address = str_to_addr(addr).ok();
     let private_address = crate::user_data::get_local_private_archive_access(addr)
         .inspect_err(|e| error!("Failed to get private archive access: {e}"))
@@ -40,7 +40,7 @@ async fn download_private(
     addr: &str,
     private_address: PrivateArchiveAccess,
     dest_path: &str,
-    client: &mut Client,
+    client: &Client,
 ) -> Result<()> {
     let archive = client
         .archive_get(private_address)
@@ -86,7 +86,7 @@ async fn download_public(
     addr: &str,
     address: ArchiveAddr,
     dest_path: &str,
-    client: &mut Client,
+    client: &Client,
 ) -> Result<()> {
     let archive = client
         .archive_get_public(address)

--- a/ant-cli/src/actions/mod.rs
+++ b/ant-cli/src/actions/mod.rs
@@ -10,6 +10,6 @@ mod connect;
 mod download;
 mod progress_bar;
 
-pub use connect::connect_to_network;
+pub use connect::{connect_to_network, connect_to_network_with_config};
 pub use download::download;
 pub use progress_bar::get_progress_bar;

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -71,6 +71,11 @@ pub enum FileCmd {
         addr: String,
         /// The destination file path.
         dest_file: String,
+        /// Experimental: Optionally specify the quorum for the download (makes sure that we have n copies for each chunks).
+        ///
+        /// Possible values are: "one", "majority", "all", n (where n is a number greater than 0)
+        #[arg(short, long)]
+        quorum: Option<ResponseQuorum>,
     },
 
     /// List previous uploads
@@ -203,9 +208,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 public,
                 quorum,
             } => file::upload(&file, public, peers.await?, quorum).await,
-            FileCmd::Download { addr, dest_file } => {
-                file::download(&addr, &dest_file, peers.await?).await
-            }
+            FileCmd::Download {
+                addr,
+                dest_file,
+                quorum,
+            } => file::download(&addr, &dest_file, peers.await?, quorum).await,
             FileCmd::List => file::list(),
         },
         Some(SubCmd::Register { command }) => match command {

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -58,6 +58,11 @@ pub enum FileCmd {
         /// Upload the file as public. Everyone can see public data on the Network.
         #[arg(short, long)]
         public: bool,
+        /// Experimental: Optionally specify the quorum for the verification of the upload.
+        ///
+        /// Possible values are: "one", "majority", "all", n (where n is a number greater than 0)
+        #[arg(short, long)]
+        quorum: Option<ResponseQuorum>,
     },
 
     /// Download a file from the given address.
@@ -66,8 +71,6 @@ pub enum FileCmd {
         addr: String,
         /// The destination file path.
         dest_file: String,
-        /// Optionally specify the quorum for the verification of the download.
-        read_quorum: Option<ResponseQuorum>,
     },
 
     /// List previous uploads
@@ -195,12 +198,14 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
     match cmd {
         Some(SubCmd::File { command }) => match command {
             FileCmd::Cost { file } => file::cost(&file, peers.await?).await,
-            FileCmd::Upload { file, public } => file::upload(&file, public, peers.await?).await,
-            FileCmd::Download {
-                addr,
-                dest_file,
-                read_quorum,
-            } => file::download(&addr, &dest_file, peers.await?, read_quorum).await,
+            FileCmd::Upload {
+                file,
+                public,
+                quorum,
+            } => file::upload(&file, public, peers.await?, quorum).await,
+            FileCmd::Download { addr, dest_file } => {
+                file::download(&addr, &dest_file, peers.await?).await
+            }
             FileCmd::List => file::list(),
         },
         Some(SubCmd::Register { command }) => match command {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -117,8 +117,17 @@ pub async fn upload(
     Ok(())
 }
 
-pub async fn download(addr: &str, dest_path: &str, peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers).await?;
+pub async fn download(
+    addr: &str,
+    dest_path: &str,
+    peers: NetworkPeers,
+    quorum: Option<ResponseQuorum>,
+) -> Result<()> {
+    let mut config = ClientOperatingStrategy::new();
+    if let Some(quorum) = quorum {
+        config.chunks.get_quorum = quorum;
+    }
+    let client = crate::actions::connect_to_network_with_config(peers, config).await?;
     crate::actions::download(addr, dest_path, &client).await
 }
 

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -10,7 +10,7 @@ use crate::network::NetworkPeers;
 use crate::utils::collect_upload_summary;
 use crate::wallet::load_wallet;
 use autonomi::client::address::addr_to_str;
-use autonomi::client::config::ClientOperationConfig;
+use autonomi::ClientOperatingStrategy;
 use autonomi::ResponseQuorum;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
@@ -18,7 +18,7 @@ use color_eyre::Section;
 use std::path::PathBuf;
 
 pub async fn cost(file: &str, peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
 
     println!("Getting upload cost...");
     info!("Calculating cost for file: {file}");
@@ -33,8 +33,17 @@ pub async fn cost(file: &str, peers: NetworkPeers) -> Result<()> {
     Ok(())
 }
 
-pub async fn upload(file: &str, public: bool, peers: NetworkPeers) -> Result<()> {
-    let mut client = crate::actions::connect_to_network(peers, Default::default()).await?;
+pub async fn upload(
+    file: &str,
+    public: bool,
+    peers: NetworkPeers,
+    optional_verification_quorum: Option<ResponseQuorum>,
+) -> Result<()> {
+    let mut config = ClientOperatingStrategy::new();
+    if let Some(verification_quorum) = optional_verification_quorum {
+        config.chunks.verification_quorum = verification_quorum;
+    }
+    let mut client = crate::actions::connect_to_network_with_config(peers, config).await?;
 
     let wallet = load_wallet(client.evm_network())?;
     let event_receiver = client.enable_client_events();
@@ -108,19 +117,9 @@ pub async fn upload(file: &str, public: bool, peers: NetworkPeers) -> Result<()>
     Ok(())
 }
 
-pub async fn download(
-    addr: &str,
-    dest_path: &str,
-    peers: NetworkPeers,
-    read_quorum: Option<ResponseQuorum>,
-) -> Result<()> {
-    let mut client_operation_config = ClientOperationConfig::default();
-    if let Some(read_quorum) = read_quorum {
-        client_operation_config.set_read_quorum(read_quorum);
-    }
-    let mut client = crate::actions::connect_to_network(peers, client_operation_config).await?;
-
-    crate::actions::download(addr, dest_path, &mut client).await
+pub async fn download(addr: &str, dest_path: &str, peers: NetworkPeers) -> Result<()> {
+    let client = crate::actions::connect_to_network(peers).await?;
+    crate::actions::download(addr, dest_path, &client).await
 }
 
 pub fn list() -> Result<()> {

--- a/ant-cli/src/commands/register.rs
+++ b/ant-cli/src/commands/register.rs
@@ -40,7 +40,7 @@ pub fn generate_key(overwrite: bool) -> Result<()> {
 pub async fn cost(name: &str, peers: NetworkPeers) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let key_for_name = Client::register_key_from_name(&main_registers_key, name);
 
     let cost = client
@@ -55,7 +55,7 @@ pub async fn cost(name: &str, peers: NetworkPeers) -> Result<()> {
 pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let wallet = load_wallet(client.evm_network())?;
     let register_key = Client::register_key_from_name(&main_registers_key, name);
 
@@ -84,7 +84,7 @@ pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> 
 pub async fn edit(address: String, name: bool, value: &str, peers: NetworkPeers) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let wallet = load_wallet(client.evm_network())?;
     let value_bytes = Client::register_value_from_bytes(value.as_bytes())?;
 
@@ -121,7 +121,7 @@ pub async fn edit(address: String, name: bool, value: &str, peers: NetworkPeers)
 }
 
 pub async fn get(address: String, name: bool, peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
 
     let addr = if name {
         let name_str = address.clone();

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::Result;
 use color_eyre::Section;
 
 pub async fn cost(peers: NetworkPeers, expected_max_size: u64) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let vault_sk = crate::keys::get_vault_secret_key()?;
 
     println!("Getting cost to create a new vault...");
@@ -28,7 +28,7 @@ pub async fn cost(peers: NetworkPeers, expected_max_size: u64) -> Result<()> {
 }
 
 pub async fn create(peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let wallet = load_wallet(client.evm_network())?;
     let vault_sk = crate::keys::get_vault_secret_key()?;
 
@@ -57,7 +57,7 @@ pub async fn create(peers: NetworkPeers) -> Result<()> {
 }
 
 pub async fn sync(force: bool, peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let vault_sk = crate::keys::get_vault_secret_key()?;
     let wallet = load_wallet(client.evm_network())?;
 
@@ -93,7 +93,7 @@ pub async fn sync(force: bool, peers: NetworkPeers) -> Result<()> {
 }
 
 pub async fn load(peers: NetworkPeers) -> Result<()> {
-    let client = crate::actions::connect_to_network(peers, Default::default()).await?;
+    let client = crate::actions::connect_to_network(peers).await?;
     let vault_sk = crate::keys::get_vault_secret_key()?;
 
     println!("Retrieving vault from network...");

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -25,6 +25,9 @@ pub struct Chunk {
 }
 
 impl Chunk {
+    /// The maximum size of a chunk is 1MB
+    pub const MAX_SIZE: usize = 1024 * 1024;
+
     /// Creates a new instance of `Chunk`.
     pub fn new(value: Bytes) -> Self {
         Self {

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -25,8 +25,8 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// The maximum size of a chunk is 1MB
-    pub const MAX_SIZE: usize = 1024 * 1024;
+    /// The default maximum size of a chunk is 1MB
+    pub const DEFAULT_MAX_SIZE: usize = 1024 * 1024;
 
     /// Creates a new instance of `Chunk`.
     pub fn new(value: Bytes) -> Self {

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -7,13 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ant_evm::EvmNetwork;
-use ant_networking::{ResponseQuorum, RetryStrategy};
-use libp2p::Multiaddr;
+use ant_networking::{GetRecordCfg, PutRecordCfg, VerificationKind};
+use ant_protocol::messages::ChunkProof;
+use libp2p::{kad::Record, Multiaddr, PeerId};
+use rand::{thread_rng, Rng};
+use std::{collections::HashSet, num::NonZero};
 
-/// Configuration for [`crate::Client::init_with_config`].
-///
-/// Use [`ClientConfig::set_client_operation_config`] to set configure how the client performs operations
-/// on the network.
+pub use ant_networking::{ResponseQuorum, RetryStrategy};
+
+/// Configuration for the [`crate::Client`] which can be provided through: [`crate::Client::init_with_config`].
 #[derive(Debug, Clone, Default)]
 pub struct ClientConfig {
     /// Whether we're expected to connect to a local network.
@@ -27,30 +29,8 @@ pub struct ClientConfig {
     /// EVM network to use for quotations and payments.
     pub evm_network: EvmNetwork,
 
-    /// Configuration for operations on the client.
-    ///
-    /// This will be shared across all clones of the client and cannot be changed after initialization.
-    pub operation_config: ClientOperationConfig,
-}
-
-/// Configurations for operations on the client.
-///
-/// Default values are used for each type of data, but you can override them here.
-#[derive(Debug, Clone, Default)]
-pub struct ClientOperationConfig {
-    /// The retry strategy to use if we fail to store a piece of data. Every write will also verify that the data
-    /// is stored on the network by fetching it back.
-    ///
-    /// Use the `verification_quorum` and `verification_retry_strategy` to configure the verification operation.
-    pub(crate) write_retry_strategy: Option<RetryStrategy>,
-    /// The number of records to wait for before considering the read after write operation successful.
-    pub(crate) verification_quorum: Option<ResponseQuorum>,
-    /// The retry strategy to use if the read after write operation fails.
-    pub(crate) verification_retry_strategy: Option<RetryStrategy>,
-    /// The number of records to wait for before considering the read operation successful.
-    pub(crate) read_quorum: Option<ResponseQuorum>,
-    /// The retry strategy to use if the read operation fails.
-    pub(crate) read_retry_strategy: Option<RetryStrategy>,
+    /// Strategy for data operations by the client.
+    pub strategy: ClientOperatingStrategy,
 }
 
 impl ClientConfig {
@@ -59,46 +39,154 @@ impl ClientConfig {
             local: true,
             peers,
             evm_network: EvmNetwork::new(true).unwrap_or_default(),
-            operation_config: Default::default(),
+            strategy: Default::default(),
         }
-    }
-
-    pub fn set_client_operation_config(&mut self, operation_config: ClientOperationConfig) {
-        self.operation_config = operation_config;
     }
 }
 
-impl ClientOperationConfig {
-    /// Set the retry strategy for the data write operations. Every write will also verify that the data
-    /// is stored on the network by fetching it back.
-    ///
-    /// Use the `set_verification_quorum` and `set_verification_retry_strategy` to configure the verification
-    /// operation.
-    pub fn set_write_retry_strategy(&mut self, strategy: RetryStrategy) {
-        self.write_retry_strategy = Some(strategy);
+/// Strategy configuration for data operations by the client.
+///
+/// Default values are used for each type of data, but you can override them here.
+#[derive(Debug, Clone)]
+pub struct ClientOperatingStrategy {
+    pub chunks: Strategy,
+    pub graph_entry: Strategy,
+    pub pointer: Strategy,
+    pub scratchpad: Strategy,
+}
+
+impl ClientOperatingStrategy {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// The default configuration for the client.
+///
+/// It is optimized for faster chunk put and get, benefiting from the chunk content addressed property.
+/// Other data types are optimized for fast verification, and resilience in case of forks, which are impossible for chunks.
+impl Default for ClientOperatingStrategy {
+    fn default() -> Self {
+        let two = NonZero::new(2).expect("2 is non 0");
+        Self {
+            chunks: Strategy {
+                put_quorum: ResponseQuorum::N(two),
+                put_retry: RetryStrategy::Balanced,
+                verification_quorum: ResponseQuorum::N(two),
+                verification_retry: RetryStrategy::Balanced,
+                get_quorum: ResponseQuorum::One, // chunks are content addressed so one is enough as there is no fork possible
+                get_retry: RetryStrategy::Balanced,
+                verification_kind: VerificationKind::Network, // it is recommended to use [`Strategy::chunk_put_cfg`] for chunks to benefit from the chunk proof
+            },
+            graph_entry: Strategy {
+                put_quorum: ResponseQuorum::All,
+                put_retry: RetryStrategy::Balanced,
+                verification_quorum: ResponseQuorum::Majority,
+                verification_retry: RetryStrategy::Quick, // verification should be quick
+                get_quorum: ResponseQuorum::Majority,     // majority to catch possible forks
+                get_retry: RetryStrategy::Balanced,
+                verification_kind: VerificationKind::Crdt, // forks are possible
+            },
+            pointer: Strategy {
+                put_quorum: ResponseQuorum::All,
+                put_retry: RetryStrategy::Balanced,
+                verification_quorum: ResponseQuorum::Majority,
+                verification_retry: RetryStrategy::Quick, // verification should be quick
+                get_quorum: ResponseQuorum::Majority, // majority to catch possible differences in versions
+                get_retry: RetryStrategy::Balanced,
+                verification_kind: VerificationKind::Crdt, // forks are possible
+            },
+            scratchpad: Strategy {
+                put_quorum: ResponseQuorum::All,
+                put_retry: RetryStrategy::Balanced,
+                verification_quorum: ResponseQuorum::Majority,
+                verification_retry: RetryStrategy::Quick, // verification should be quick
+                get_quorum: ResponseQuorum::Majority, // majority to catch possible differences in versions
+                get_retry: RetryStrategy::Balanced,
+                verification_kind: VerificationKind::Crdt, // forks are possible
+            },
+        }
+    }
+}
+
+/// The strategy to adopt when puting and getting data from the network
+///
+/// Puts are followed by a verification using get, to ensure the data is stored correctly. This verification can be configured separately from the regular gets.
+#[derive(Debug, Clone)]
+pub struct Strategy {
+    /// The number of responses to wait for before considering the put operation successful
+    pub put_quorum: ResponseQuorum,
+    /// The retry strategy to use if we fail to store a piece of data
+    pub put_retry: RetryStrategy,
+    /// The number of responses to wait for before considering the verification to be successful
+    pub verification_quorum: ResponseQuorum,
+    /// The retry strategy for verification
+    pub verification_retry: RetryStrategy,
+    /// The number of responses to wait for before considering the get operation successful
+    pub get_quorum: ResponseQuorum,
+    /// The retry strategy to use if the get operation fails
+    pub get_retry: RetryStrategy,
+    /// Verification kind
+    pub(crate) verification_kind: VerificationKind,
+}
+
+impl Strategy {
+    /// Get config for getting a record
+    pub(crate) fn get_cfg(&self) -> GetRecordCfg {
+        GetRecordCfg {
+            get_quorum: self.get_quorum,
+            retry_strategy: self.get_retry,
+            target_record: None,
+            expected_holders: HashSet::new(),
+        }
     }
 
-    /// Set the quorum for the data verification operations. This is the number of records to wait for before
-    /// considering the read after write operation successful.
-    pub fn set_verification_quorum(&mut self, quorum: ResponseQuorum) {
-        self.verification_quorum = Some(quorum);
+    /// Get config for verifying the existance of a record
+    pub(crate) fn verification_cfg(&self) -> GetRecordCfg {
+        GetRecordCfg {
+            get_quorum: self.verification_quorum,
+            retry_strategy: self.verification_retry,
+            target_record: None,
+            expected_holders: HashSet::new(),
+        }
     }
 
-    /// Set the retry strategy for the data verification operation. This is the retry strategy to use if the read
-    /// after write operation fails.
-    pub fn set_verification_retry_strategy(&mut self, strategy: RetryStrategy) {
-        self.verification_retry_strategy = Some(strategy);
+    /// Put config for storing a record
+    pub(crate) fn put_cfg(&self, put_to: Option<Vec<PeerId>>) -> PutRecordCfg {
+        PutRecordCfg {
+            put_quorum: self.put_quorum,
+            retry_strategy: self.put_retry,
+            use_put_record_to: put_to,
+            verification: Some((self.verification_kind.clone(), self.verification_cfg())),
+        }
     }
 
-    /// Set the quorum for the set read operations. This is the number of records to wait for before considering
-    /// the read operation successful.
-    pub fn set_read_quorum(&mut self, quorum: ResponseQuorum) {
-        self.read_quorum = Some(quorum);
+    /// Put config for storing a Chunk, more strict and requires a chunk proof of storage
+    pub(crate) fn chunk_put_cfg(&self, expected: Record, put_to: Vec<PeerId>) -> PutRecordCfg {
+        let random_nonce = thread_rng().gen::<u64>();
+        let expected_proof = ChunkProof::new(&expected.value, random_nonce);
+
+        PutRecordCfg {
+            put_quorum: self.put_quorum,
+            retry_strategy: self.put_retry,
+            use_put_record_to: Some(put_to),
+            verification: Some((
+                VerificationKind::ChunkProof {
+                    expected_proof,
+                    nonce: random_nonce,
+                },
+                self.verification_cfg_specific(expected),
+            )),
+        }
     }
 
-    /// Set the retry strategy for the data read operation. This is the retry strategy to use if the read
-    /// operation fails.
-    pub fn set_read_retry_strategy(&mut self, strategy: RetryStrategy) {
-        self.read_retry_strategy = Some(strategy);
+    /// Get config for verifying the existance and value of a record
+    pub(crate) fn verification_cfg_specific(&self, expected: Record) -> GetRecordCfg {
+        GetRecordCfg {
+            get_quorum: self.verification_quorum,
+            retry_strategy: self.verification_retry,
+            target_record: Some(expected),
+            expected_holders: HashSet::new(),
+        }
     }
 }

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -75,34 +75,34 @@ impl Default for ClientOperatingStrategy {
                 verification_quorum: ResponseQuorum::N(two),
                 verification_retry: RetryStrategy::Balanced,
                 get_quorum: ResponseQuorum::One, // chunks are content addressed so one is enough as there is no fork possible
-                get_retry: RetryStrategy::Balanced,
+                get_retry: RetryStrategy::Quick,
                 verification_kind: VerificationKind::Network, // it is recommended to use [`Strategy::chunk_put_cfg`] for chunks to benefit from the chunk proof
             },
             graph_entry: Strategy {
-                put_quorum: ResponseQuorum::All,
+                put_quorum: ResponseQuorum::Majority,
                 put_retry: RetryStrategy::Balanced,
                 verification_quorum: ResponseQuorum::Majority,
                 verification_retry: RetryStrategy::Quick, // verification should be quick
                 get_quorum: ResponseQuorum::N(two), // forks are rare but possible, balance between resilience and speed
-                get_retry: RetryStrategy::Balanced,
+                get_retry: RetryStrategy::Quick,
                 verification_kind: VerificationKind::Crdt, // forks are possible
             },
             pointer: Strategy {
-                put_quorum: ResponseQuorum::All,
+                put_quorum: ResponseQuorum::Majority,
                 put_retry: RetryStrategy::Balanced,
                 verification_quorum: ResponseQuorum::Majority,
                 verification_retry: RetryStrategy::Quick, // verification should be quick
                 get_quorum: ResponseQuorum::Majority, // majority to catch possible differences in versions
-                get_retry: RetryStrategy::Balanced,
+                get_retry: RetryStrategy::Quick,
                 verification_kind: VerificationKind::Crdt, // forks are possible
             },
             scratchpad: Strategy {
-                put_quorum: ResponseQuorum::All,
+                put_quorum: ResponseQuorum::Majority,
                 put_retry: RetryStrategy::Balanced,
                 verification_quorum: ResponseQuorum::Majority,
                 verification_retry: RetryStrategy::Quick, // verification should be quick
                 get_quorum: ResponseQuorum::Majority, // majority to catch possible differences in versions
-                get_retry: RetryStrategy::Balanced,
+                get_retry: RetryStrategy::Quick,
                 verification_kind: VerificationKind::Crdt, // forks are possible
             },
         }

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -83,7 +83,7 @@ impl Default for ClientOperatingStrategy {
                 put_retry: RetryStrategy::Balanced,
                 verification_quorum: ResponseQuorum::Majority,
                 verification_retry: RetryStrategy::Quick, // verification should be quick
-                get_quorum: ResponseQuorum::Majority,     // majority to catch possible forks
+                get_quorum: ResponseQuorum::N(two), // forks are rare but possible, balance between resilience and speed
                 get_retry: RetryStrategy::Balanced,
                 verification_kind: VerificationKind::Crdt, // forks are possible
             },

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -242,7 +242,10 @@ impl Client {
 
         let xor = *addr.xorname();
         let store_quote = self
-            .get_store_quotes(DataTypes::Chunk, std::iter::once((xor, Chunk::MAX_SIZE)))
+            .get_store_quotes(
+                DataTypes::Chunk,
+                std::iter::once((xor, Chunk::DEFAULT_MAX_SIZE)),
+            )
             .await?;
         let total_cost = AttoTokens::from_atto(
             store_quote

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -1,10 +1,12 @@
 use crate::client::quote::{DataTypes, StoreQuote};
 use crate::Client;
-use ant_evm::{AttoTokens, EncodedPeerId, EvmWallet, EvmWalletError, ProofOfPayment};
+use ant_evm::{EncodedPeerId, EvmWallet, EvmWalletError, ProofOfPayment};
 use std::collections::HashMap;
 use xor_name::XorName;
 
 use super::quote::CostError;
+
+pub use crate::{AttoTokens, Amount};
 
 /// Contains the proof of payments for each XOR address and the amount paid
 pub type Receipt = HashMap<XorName, (ProofOfPayment, AttoTokens)>;

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -6,7 +6,7 @@ use xor_name::XorName;
 
 use super::quote::CostError;
 
-pub use crate::{AttoTokens, Amount};
+pub use crate::{Amount, AttoTokens};
 
 /// Contains the proof of payments for each XOR address and the amount paid
 pub type Receipt = HashMap<XorName, (ProofOfPayment, AttoTokens)>;

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -90,7 +90,7 @@ pub use libp2p::Multiaddr;
 pub use client::{
     // Client Configs
     config::ClientConfig,
-    config::ClientOperationConfig,
+    config::ClientOperatingStrategy,
 
     // Native data types
     data_types::chunk::Chunk,

--- a/autonomi/tests/chunk.rs
+++ b/autonomi/tests/chunk.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 MaidSafe.net limited.
+// Copyright 2025 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/autonomi/tests/chunk.rs
+++ b/autonomi/tests/chunk.rs
@@ -1,0 +1,45 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_logging::LogBuilder;
+use autonomi::client::payment::PaymentOption;
+use autonomi::{client::chunk::Chunk, Bytes, Client};
+use eyre::Result;
+use serial_test::serial;
+use test_utils::evm::get_funded_wallet;
+
+#[tokio::test]
+#[serial]
+async fn chunk_put_manual() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("chunk", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let chunk = Chunk::new(Bytes::from("Hello, world!"));
+
+    // estimate the cost of the chunk
+    let cost = client.chunk_cost(chunk.address()).await?;
+    println!("chunk cost: {cost}");
+
+    // put the chunk
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client.chunk_put(&chunk, payment_option).await?;
+    assert_eq!(addr, *chunk.address());
+    println!("chunk put 1 cost: {cost}");
+
+    // wait for the chunk to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the chunk is stored
+    let got = client.chunk_get(addr).await?;
+    assert_eq!(got, chunk.clone());
+    println!("chunk got 1");
+
+    Ok(())
+}

--- a/autonomi/tests/vault.rs
+++ b/autonomi/tests/vault.rs
@@ -53,6 +53,7 @@ async fn vault_expand() -> Result<()> {
     println!("1KB Vault update cost: {cost}");
 
     let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    println!("1KB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, original_content);
 
@@ -67,8 +68,10 @@ async fn vault_expand() -> Result<()> {
         )
         .await?;
     assert_eq!(cost, AttoTokens::zero());
+    println!("2KB Vault update cost: {cost}");
 
     let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    println!("2KB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, update_content_2_kb);
 
@@ -83,11 +86,13 @@ async fn vault_expand() -> Result<()> {
         )
         .await?;
     assert_eq!(cost, AttoTokens::from_u64(6));
+    println!("10MB Vault update cost: {cost}");
 
     // Short break is required to avoid client choked by the last query round
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    println!("10MB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, update_content_10_mb);
 


### PR DESCRIPTION
- Adds a manual chunk API so all autonomi data types have a `put`/`get`/`cost` suite with the same API and the same behaviour. 
- The docs for `chunk_put` encourages the users to use the higher level `data_put` instead so users don't use the lower level manual chunk API accidentally. 
- Improve config