### PR TITLE
feat(optimization): optimize dir upload and rpc calls

### DIFF
--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -219,7 +219,7 @@ impl Client {
 
         let total_cost = self
             .process_upload_results(uploads, receipt, skipped_payments_amount)
-            .await;
+            .await?;
 
         Ok((total_cost, private_archive))
     }

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -18,11 +18,15 @@ use super::archive_private::{PrivateArchive, PrivateArchiveAccess};
 use super::{get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE};
 use super::{DownloadError, UploadError};
 
-use crate::client::Client;
+use crate::client::payment::PaymentOption;
 use crate::client::{data_types::chunk::DataMapChunk, utils::process_tasks_with_max_concurrency};
-use crate::{AttoTokens, Wallet};
+use crate::{AttoTokens, Client, Wallet};
+use crate::client::PutError;
+use crate::self_encryption::encrypt;
+use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
+use xor_name::XorName;
 
 impl Client {
     /// Download a private file from network to local file system
@@ -65,53 +69,161 @@ impl Client {
         info!("Uploading directory as private: {dir_path:?}");
         let start = tokio::time::Instant::now();
 
-        // start upload of file in parallel
-        let mut upload_tasks = Vec::new();
-        for entry in walkdir::WalkDir::new(dir_path.clone()) {
+        let mut encryption_tasks = vec![];
+
+        for entry in walkdir::WalkDir::new(&dir_path) {
             let entry = entry?;
-            if !entry.file_type().is_file() {
+
+            if entry.file_type().is_dir() {
                 continue;
             }
 
-            let metadata = super::fs_public::metadata_from_entry(&entry);
-            let path = entry.path().to_path_buf();
-            upload_tasks.push(async move {
-                let res = self.file_upload(path.clone(), wallet).await;
-                (path, metadata, res)
+            let dir_path = dir_path.clone();
+
+            encryption_tasks.push(async move {
+                let file_path = entry.path().to_path_buf();
+
+                info!("Encrypting file: {file_path:?}..");
+                #[cfg(feature = "loud")]
+                println!("Encrypting file: {file_path:?}..");
+
+                let data = tokio::fs::read(&file_path)
+                    .await
+                    .map_err(|err| format!("Could not read file {file_path:?}: {err:?}"))?;
+                let data = Bytes::from(data);
+
+                if data.len() < 3 {
+                    let err_msg =
+                        format!("Skipping file {file_path:?}, as it is smaller than 3 bytes");
+                    return Err(err_msg);
+                }
+
+                let now = ant_networking::time::Instant::now();
+
+                let (data_map_chunk, chunks) = encrypt(data).map_err(|err| err.to_string())?;
+
+                debug!("Encryption of {file_path:?} took: {:.2?}", now.elapsed());
+
+                let xor_names: Vec<_> = chunks
+                    .iter()
+                    .map(|chunk| (*chunk.name(), chunk.serialised_size()))
+                    .collect();
+
+                let metadata = super::fs_public::metadata_from_entry(&entry);
+
+                let relative_path =
+                    get_relative_file_path_from_abs_file_and_folder_path(&file_path, &dir_path);
+
+                Ok((
+                    file_path.to_string_lossy().to_string(),
+                    xor_names,
+                    chunks,
+                    (relative_path, DataMapChunk::from(data_map_chunk), metadata),
+                ))
             });
         }
 
-        // wait for all files to be uploaded
-        let uploads =
-            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
-        info!(
-            "Upload of {} files completed in {:?}",
-            uploads.len(),
-            start.elapsed()
-        );
-        let mut archive = PrivateArchive::new();
-        let mut total_cost = AttoTokens::zero();
-        for (path, metadata, maybe_file) in uploads.into_iter() {
-            let rel_path = get_relative_file_path_from_abs_file_and_folder_path(&path, &dir_path);
+        let mut combined_xor_names: Vec<(XorName, usize)> = vec![];
+        let mut combined_chunks: Vec<(String, Vec<Chunk>)> = vec![];
+        let mut private_archive = PrivateArchive::new();
 
-            match maybe_file {
-                Ok((cost, file)) => {
-                    archive.add_file(rel_path, file, metadata);
-                    total_cost = total_cost.checked_add(cost).unwrap_or_else(|| {
-                        error!("Total cost overflowed: {total_cost:?} + {cost:?}");
-                        total_cost
-                    });
+        let encryption_results =
+            process_tasks_with_max_concurrency(encryption_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+
+        for encryption_result in encryption_results {
+            match encryption_result {
+                Ok((file_path, xor_names, chunked_file, file_data)) => {
+                    info!("Successfully encrypted file: {file_path:?}");
+                    #[cfg(feature = "loud")]
+                    println!("Successfully encrypted file: {file_path:?}");
+
+                    combined_xor_names.extend(xor_names);
+                    combined_chunks.push((file_path, chunked_file));
+                    let (relative_path, data_map_chunk, file_metadata) = file_data;
+                    private_archive.add_file(relative_path, data_map_chunk, file_metadata);
                 }
-                Err(err) => {
-                    error!("Failed to upload file: {path:?}: {err:?}");
-                    return Err(err);
+                Err(err_msg) => {
+                    error!("Error during file encryption: {err_msg}");
                 }
             }
         }
 
+        info!("Paying for {} chunks..", combined_xor_names.len());
         #[cfg(feature = "loud")]
-        println!("Upload completed in {:?}", start.elapsed());
-        Ok((total_cost, archive))
+        println!("Paying for {} chunks..", combined_xor_names.len());
+
+        let (receipt, skipped_payments_amount) = self
+            .pay_for_content_addrs(
+                DataTypes::Chunk,
+                combined_xor_names.into_iter(),
+                wallet.into(),
+            )
+            .await
+            .inspect_err(|err| error!("Error paying for data: {err:?}"))
+            .map_err(PutError::from)?;
+
+        info!("{skipped_payments_amount} chunks were free");
+
+        let files_to_upload_amount = combined_chunks.len();
+
+        let mut upload_tasks = vec![];
+
+        for (name, chunks) in combined_chunks {
+            let receipt_clone = receipt.clone();
+
+            upload_tasks.push(async move {
+                info!("Uploading file: {name} ({} chunks)..", chunks.len());
+                #[cfg(feature = "loud")]
+                println!("Uploading file: {name} ({} chunks)..", chunks.len());
+
+                // todo: handle failed uploads
+                let mut failed_uploads = self
+                    .upload_chunks_with_retries(chunks.iter().collect(), &receipt_clone)
+                    .await;
+
+                let chunks_uploaded = chunks.len() - failed_uploads.len();
+
+                // Return the last chunk upload error
+                if let Some(last_chunk_fail) = failed_uploads.pop() {
+                    error!(
+                        "Error uploading chunk ({:?}): {:?}",
+                        last_chunk_fail.0.address(),
+                        last_chunk_fail.1
+                    );
+
+                    (name, Err(UploadError::from(last_chunk_fail.1)))
+                } else {
+                    info!("Successfully uploaded {name} ({} chunks)", chunks.len());
+                    #[cfg(feature = "loud")]
+                    println!("Successfully uploaded {name} ({} chunks)", chunks.len());
+
+                    (name, Ok(chunks_uploaded))
+                }
+            });
+        }
+
+        let uploads =
+            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+
+        info!(
+            "Upload of {} files completed in {:?}",
+            files_to_upload_amount,
+            start.elapsed()
+        );
+
+        #[cfg(feature = "loud")]
+        println!(
+            "Upload of {} files completed in {:?}",
+            files_to_upload_amount,
+            start.elapsed()
+        );
+
+        let total_cost = AttoTokens::from(0);
+
+        self.process_upload_results(uploads, receipt, skipped_payments_amount)
+            .await;
+
+        Ok((total_cost, private_archive))
     }
 
     /// Same as [`Client::dir_upload`] but also uploads the archive (privately) to the network.

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -133,7 +133,7 @@ impl Client {
 
     /// Upload a private file to the network.
     /// Reads file, splits into chunks, uploads chunks, uploads datamap, returns [`DataMapChunk`] (pointing to the datamap)
-    async fn file_upload(
+    pub async fn file_upload(
         &self,
         path: PathBuf,
         wallet: &Wallet,

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -18,11 +18,10 @@ use super::archive_private::{PrivateArchive, PrivateArchiveAccess};
 use super::{get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE};
 use super::{DownloadError, UploadError};
 
-use crate::client::payment::PaymentOption;
-use crate::client::{data_types::chunk::DataMapChunk, utils::process_tasks_with_max_concurrency};
-use crate::{AttoTokens, Client, Wallet};
 use crate::client::PutError;
+use crate::client::{data_types::chunk::DataMapChunk, utils::process_tasks_with_max_concurrency};
 use crate::self_encryption::encrypt;
+use crate::{AttoTokens, Client, Wallet};
 use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
@@ -106,7 +105,7 @@ impl Client {
 
                 let xor_names: Vec<_> = chunks
                     .iter()
-                    .map(|chunk| (*chunk.name(), chunk.serialised_size()))
+                    .map(|chunk| (*chunk.name(), chunk.size()))
                     .collect();
 
                 let metadata = super::fs_public::metadata_from_entry(&entry);
@@ -218,9 +217,8 @@ impl Client {
             start.elapsed()
         );
 
-        let total_cost = AttoTokens::from(0);
-
-        self.process_upload_results(uploads, receipt, skipped_payments_amount)
+        let total_cost = self
+            .process_upload_results(uploads, receipt, skipped_payments_amount)
             .await;
 
         Ok((total_cost, private_archive))

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -11,12 +11,15 @@ use super::{DownloadError, FileCostError, Metadata, UploadError};
 use crate::client::high_level::files::{
     get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE,
 };
-use crate::client::Client;
 use crate::client::{high_level::data::DataAddr, utils::process_tasks_with_max_concurrency};
+use crate::client::{Client, PutError};
+use crate::self_encryption::encrypt;
 use crate::{Amount, AttoTokens, Wallet};
 use ant_networking::time::{Duration, SystemTime};
+use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
+use xor_name::XorName;
 
 impl Client {
     /// Download file from network to local file system
@@ -67,53 +70,173 @@ impl Client {
         info!("Uploading directory: {dir_path:?}");
         let start = tokio::time::Instant::now();
 
-        // start upload of files in parallel
-        let mut upload_tasks = Vec::new();
-        for entry in walkdir::WalkDir::new(dir_path.clone()) {
+        let mut encryption_tasks = vec![];
+
+        for entry in walkdir::WalkDir::new(&dir_path) {
             let entry = entry?;
-            if !entry.file_type().is_file() {
+
+            if entry.file_type().is_dir() {
                 continue;
             }
 
-            let metadata = metadata_from_entry(&entry);
-            let path = entry.path().to_path_buf();
-            upload_tasks.push(async move {
-                let res = self.file_upload_public(path.clone(), wallet).await;
-                (path, metadata, res)
+            let dir_path = dir_path.clone();
+
+            encryption_tasks.push(async move {
+                let file_path = entry.path().to_path_buf();
+
+                info!("Encrypting file: {file_path:?}..");
+                #[cfg(feature = "loud")]
+                println!("Encrypting file: {file_path:?}..");
+
+                let data = tokio::fs::read(&file_path)
+                    .await
+                    .map_err(|err| format!("Could not read file {file_path:?}: {err:?}"))?;
+                let data = Bytes::from(data);
+
+                if data.len() < 3 {
+                    let err_msg =
+                        format!("Skipping file {file_path:?}, as it is smaller than 3 bytes");
+                    return Err(err_msg);
+                }
+
+                let now = ant_networking::time::Instant::now();
+
+                let (data_map_chunk, mut chunks) = encrypt(data).map_err(|err| err.to_string())?;
+
+                debug!("Encryption of {file_path:?} took: {:.2?}", now.elapsed());
+
+                let data_address = *data_map_chunk.name();
+
+                chunks.push(data_map_chunk);
+
+                let xor_names: Vec<_> = chunks
+                    .iter()
+                    .map(|chunk| (*chunk.name(), chunk.serialised_size()))
+                    .collect();
+
+                let metadata = metadata_from_entry(&entry);
+
+                let relative_path =
+                    get_relative_file_path_from_abs_file_and_folder_path(&file_path, &dir_path);
+
+                Ok((
+                    file_path.to_string_lossy().to_string(),
+                    xor_names,
+                    chunks,
+                    (relative_path, data_address, metadata),
+                ))
             });
         }
 
-        // wait for all files to be uploaded
-        let uploads =
-            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
-        info!(
-            "Upload of {} files completed in {:?}",
-            uploads.len(),
-            start.elapsed()
-        );
-        let mut archive = PublicArchive::new();
-        let mut total_cost = AttoTokens::zero();
-        for (path, metadata, maybe_file) in uploads.into_iter() {
-            let rel_path = get_relative_file_path_from_abs_file_and_folder_path(&path, &dir_path);
+        let mut combined_xor_names: Vec<(XorName, usize)> = vec![];
+        let mut combined_chunks: Vec<((String, XorName), Vec<Chunk>)> = vec![];
+        let mut public_archive = PublicArchive::new();
 
-            match maybe_file {
-                Ok((cost, file)) => {
-                    archive.add_file(rel_path, file, metadata);
-                    total_cost = total_cost.checked_add(cost).unwrap_or_else(|| {
-                        error!("Total cost overflowed: {total_cost:?} + {cost:?}");
-                        total_cost
-                    });
+        let encryption_results =
+            process_tasks_with_max_concurrency(encryption_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+
+        for encryption_result in encryption_results {
+            match encryption_result {
+                Ok((file_path, xor_names, chunks, file_data)) => {
+                    info!("Successfully encrypted file: {file_path:?}");
+                    #[cfg(feature = "loud")]
+                    println!("Successfully encrypted file: {file_path:?}");
+
+                    combined_xor_names.extend(xor_names);
+                    let (relative_path, data_address, file_metadata) = file_data;
+                    combined_chunks.push(((file_path, data_address), chunks));
+                    public_archive.add_file(relative_path, data_address, file_metadata);
                 }
-                Err(err) => {
-                    error!("Failed to upload file: {path:?}: {err:?}");
-                    return Err(err);
+                Err(err_msg) => {
+                    error!("Error during file encryption: {err_msg}");
                 }
             }
         }
 
+        info!("Paying for {} chunks..", combined_xor_names.len());
         #[cfg(feature = "loud")]
-        println!("Upload completed in {:?}", start.elapsed());
-        Ok((total_cost, archive))
+        println!("Paying for {} chunks..", combined_xor_names.len());
+
+        let (receipt, skipped_payments_amount) = self
+            .pay_for_content_addrs(
+                DataTypes::Chunk,
+                combined_xor_names.into_iter(),
+                wallet.into(),
+            )
+            .await
+            .inspect_err(|err| error!("Error paying for data: {err:?}"))
+            .map_err(PutError::from)?;
+
+        info!("{skipped_payments_amount} chunks were free");
+
+        let files_to_upload_amount = combined_chunks.len();
+
+        let mut upload_tasks = vec![];
+
+        for ((name, data_address), chunks) in combined_chunks {
+            let receipt_clone = receipt.clone();
+
+            upload_tasks.push(async move {
+                info!("Uploading file: {name} ({} chunks)..", chunks.len());
+                #[cfg(feature = "loud")]
+                println!("Uploading file: {name} ({} chunks)..", chunks.len());
+
+                // todo: handle failed uploads
+                let mut failed_uploads = self
+                    .upload_chunks_with_retries(chunks.iter().collect(), &receipt_clone)
+                    .await;
+
+                let chunks_uploaded = chunks.len() - failed_uploads.len();
+
+                // Return the last chunk upload error
+                if let Some(last_chunk_fail) = failed_uploads.pop() {
+                    error!(
+                        "Error uploading chunk ({:?}): {:?}",
+                        last_chunk_fail.0.address(),
+                        last_chunk_fail.1
+                    );
+
+                    (name, Err(UploadError::from(last_chunk_fail.1)))
+                } else {
+                    info!(
+                        "Successfully uploaded {name} ({} chunks) to: {}",
+                        chunks.len(),
+                        hex::encode(data_address.0)
+                    );
+                    #[cfg(feature = "loud")]
+                    println!(
+                        "Successfully uploaded {name} ({} chunks) to: {}",
+                        chunks.len(),
+                        hex::encode(data_address.0)
+                    );
+
+                    (name, Ok(chunks_uploaded))
+                }
+            });
+        }
+
+        let uploads =
+            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+
+        info!(
+            "Upload of {} files completed in {:?}",
+            files_to_upload_amount,
+            start.elapsed()
+        );
+
+        #[cfg(feature = "loud")]
+        println!(
+            "Upload of {} files completed in {:?}",
+            files_to_upload_amount,
+            start.elapsed()
+        );
+
+        let total_cost = AttoTokens::from(0);
+
+        self.process_upload_results(uploads, receipt, skipped_payments_amount)
+            .await;
+
+        Ok((total_cost, public_archive))
     }
 
     /// Same as [`Client::dir_upload_public`] but also uploads the archive to the network.
@@ -135,7 +258,7 @@ impl Client {
 
     /// Upload a file to the network.
     /// Reads file, splits into chunks, uploads chunks, uploads datamap, returns DataAddr (pointing to the datamap)
-    async fn file_upload_public(
+    pub async fn file_upload_public(
         &self,
         path: PathBuf,
         wallet: &Wallet,

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -233,7 +233,7 @@ impl Client {
 
         let total_cost = self
             .process_upload_results(uploads, receipt, skipped_payments_amount)
-            .await;
+            .await?;
 
         Ok((total_cost, public_archive))
     }

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -111,7 +111,7 @@ impl Client {
 
                 let xor_names: Vec<_> = chunks
                     .iter()
-                    .map(|chunk| (*chunk.name(), chunk.serialised_size()))
+                    .map(|chunk| (*chunk.name(), chunk.size()))
                     .collect();
 
                 let metadata = metadata_from_entry(&entry);
@@ -231,9 +231,8 @@ impl Client {
             start.elapsed()
         );
 
-        let total_cost = AttoTokens::from(0);
-
-        self.process_upload_results(uploads, receipt, skipped_payments_amount)
+        let total_cost = self
+            .process_upload_results(uploads, receipt, skipped_payments_amount)
             .await;
 
         Ok((total_cost, public_archive))

--- a/autonomi/src/client/high_level/files/fs_shared.rs
+++ b/autonomi/src/client/high_level/files/fs_shared.rs
@@ -1,0 +1,46 @@
+use crate::client::payment::Receipt;
+use crate::client::{ClientEvent, UploadSummary};
+use crate::files::UploadError;
+use crate::Client;
+use ant_evm::Amount;
+
+impl Client {
+    pub(crate) async fn process_upload_results(
+        &self,
+        uploads: Vec<(String, Result<usize, UploadError>)>,
+        receipt: Receipt,
+        skipped_payments_amount: usize,
+    ) {
+        let mut total_chunks_uploaded = 0;
+
+        for (name, result) in uploads {
+            match result {
+                Ok(chunks_uploaded) => {
+                    total_chunks_uploaded += chunks_uploaded;
+                }
+                Err(err) => {
+                    error!("Error uploading file {name}: {err:?}");
+                    #[cfg(feature = "loud")]
+                    println!("Error uploading file {name}: {err:?}");
+                }
+            }
+        }
+
+        // Reporting
+        if let Some(channel) = self.client_event_sender.as_ref() {
+            let tokens_spent = receipt
+                .values()
+                .map(|(_, cost)| cost.as_atto())
+                .sum::<Amount>();
+
+            let summary = UploadSummary {
+                records_paid: total_chunks_uploaded.saturating_sub(skipped_payments_amount),
+                records_already_paid: skipped_payments_amount,
+                tokens_spent,
+            };
+            if let Err(err) = channel.send(ClientEvent::UploadComplete(summary)).await {
+                error!("Failed to send client event: {err:?}");
+            }
+        }
+    }
+}

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -12,6 +12,7 @@ pub mod archive_private;
 pub mod archive_public;
 pub mod fs_private;
 pub mod fs_public;
+mod fs_shared;
 
 pub use archive_private::PrivateArchive;
 pub use archive_public::PublicArchive;

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -19,6 +19,11 @@ use xor_name::XorName;
 
 pub use ant_protocol::storage::DataTypes;
 
+// todo: limit depends per RPC endpoint. We should make this configurable
+// todo: test the limit for the Arbitrum One / Sepolia public RPC endpoint
+// Max limit of the Anvil RPC endpoint
+const GET_MARKET_PRICE_BATCH_LIMIT: usize = 2000;
+
 /// A quote for a single address
 pub struct QuoteForAddress(pub(crate) Vec<(PeerId, PaymentQuote, Amount)>);
 
@@ -80,7 +85,6 @@ impl Client {
         data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)>,
     ) -> Result<StoreQuote, CostError> {
-        // get all quotes from nodes
         let futures: Vec<_> = content_addrs
             .into_iter()
             .map(|(content_addr, data_size)| {
@@ -96,81 +100,79 @@ impl Client {
         let raw_quotes_per_addr =
             process_tasks_with_max_concurrency(futures, *FILE_UPLOAD_BATCH_SIZE).await;
 
-        // choose the quotes to pay for each address
         let mut quotes_to_pay_per_addr = HashMap::new();
+        let mut all_quoting_metrics = Vec::new();
+        let mut content_addr_map = HashMap::new();
 
         for result in raw_quotes_per_addr {
             let (content_addr, mut raw_quotes) = result?;
             debug!(
-                "fetched market price for content_addr: {content_addr}, with {} quotes.",
+                "fetched raw quotes for content_addr: {content_addr}, with {} quotes.",
                 raw_quotes.len()
             );
 
-            // FIXME: find better way to deal with paid content addrs and feedback to the user
-            // assume that content addr is already paid for and uploaded
             if raw_quotes.is_empty() {
                 debug!("content_addr: {content_addr} is already paid for. No need to fetch market price.");
                 continue;
             }
 
             let target_addr = NetworkAddress::from_chunk_address(ChunkAddress::new(content_addr));
-            // With the expand of quoting candidates,
-            // we shall get CLOSE_GROUP_SIZE closest into further procedure.
             raw_quotes.sort_by_key(|(peer_id, _)| {
                 NetworkAddress::from_peer(*peer_id).distance(&target_addr)
             });
 
-            // ask smart contract for the market price
             let quoting_metrics: Vec<QuotingMetrics> = raw_quotes
-                .clone()
                 .iter()
                 .take(CLOSE_GROUP_SIZE)
                 .map(|(_, q)| q.quoting_metrics.clone())
                 .collect();
 
-            let all_prices = get_market_price(&self.evm_network, quoting_metrics.clone()).await?;
+            content_addr_map.insert(content_addr, raw_quotes);
+            all_quoting_metrics.extend(quoting_metrics);
+        }
 
-            debug!("market prices: {all_prices:?}");
+        let mut all_prices = Vec::new();
+        for chunk in all_quoting_metrics.chunks(GET_MARKET_PRICE_BATCH_LIMIT) {
+            let batch_prices = get_market_price(&self.evm_network, chunk.to_vec()).await?;
+            all_prices.extend(batch_prices);
+        }
+        debug!("market prices: {all_prices:?}");
 
-            let mut prices: Vec<(PeerId, PaymentQuote, Amount)> = all_prices
+        let mut price_index = 0;
+        for (content_addr, raw_quotes) in content_addr_map {
+            let mut prices: Vec<(PeerId, PaymentQuote, Amount)> = raw_quotes
                 .into_iter()
-                .zip(raw_quotes.into_iter())
-                .map(|(price, (peer, quote))| (peer, quote, price))
+                .take(CLOSE_GROUP_SIZE)
+                .map(|(peer, quote)| {
+                    let price = all_prices[price_index];
+                    price_index += 1;
+                    (peer, quote, price)
+                })
                 .collect();
 
-            // sort by price
             prices.sort_by_key(|(_, _, price)| *price);
 
-            // we need at least 5 valid quotes to pay for the data
             const MINIMUM_QUOTES_TO_PAY: usize = 5;
-            match &prices[..] {
-                [first, second, third, fourth, fifth, ..] => {
-                    let (p1, q1, _) = first;
-                    let (p2, q2, _) = second;
+            if prices.len() >= MINIMUM_QUOTES_TO_PAY {
+                let (p1, q1, _) = &prices[0];
+                let (p2, q2, _) = &prices[1];
 
-                    // don't pay for the cheapest 2 quotes but include them
-                    let first = (*p1, q1.clone(), Amount::ZERO);
-                    let second = (*p2, q2.clone(), Amount::ZERO);
-
-                    // pay for the rest
-                    quotes_to_pay_per_addr.insert(
-                        content_addr,
-                        QuoteForAddress(vec![
-                            first,
-                            second,
-                            third.clone(),
-                            fourth.clone(),
-                            fifth.clone(),
-                        ]),
-                    );
-                }
-                _ => {
-                    return Err(CostError::NotEnoughNodeQuotes(
-                        content_addr,
-                        prices.len(),
-                        MINIMUM_QUOTES_TO_PAY,
-                    ));
-                }
+                quotes_to_pay_per_addr.insert(
+                    content_addr,
+                    QuoteForAddress(vec![
+                        (*p1, q1.clone(), Amount::ZERO),
+                        (*p2, q2.clone(), Amount::ZERO),
+                        prices[2].clone(),
+                        prices[3].clone(),
+                        prices[4].clone(),
+                    ]),
+                );
+            } else {
+                return Err(CostError::NotEnoughNodeQuotes(
+                    content_addr,
+                    prices.len(),
+                    MINIMUM_QUOTES_TO_PAY,
+                ));
             }
         }
 


### PR DESCRIPTION
Merge after a successful testnet!

- Batches payment of all files in a directory (saves gas fees & RPC calls).
- Fetches quotes for all files in one go (also stops `get_market_price` RPC calls being made in parallel, which was being a pain for the free rate limit).
- Batches `get_market_price` requests (massively reduces amount of RPC calls when needing to fetch a large amount of quotes).