### PR TITLE
feat(node): only cache client_put records and prune outdated ones

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -127,6 +127,7 @@ pub enum LocalSwarmCmd {
     /// Put record to the local RecordStore
     PutLocalRecord {
         record: Record,
+        is_client_put: bool,
     },
     /// Remove a local record from the RecordStore
     /// Typically because the write failed
@@ -237,10 +238,13 @@ pub enum NetworkSwarmCmd {
 impl Debug for LocalSwarmCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LocalSwarmCmd::PutLocalRecord { record } => {
+            LocalSwarmCmd::PutLocalRecord {
+                record,
+                is_client_put,
+            } => {
                 write!(
                     f,
-                    "LocalSwarmCmd::PutLocalRecord {{ key: {:?} }}",
+                    "LocalSwarmCmd::PutLocalRecord {{ key: {:?}, is_client_put: {is_client_put:?} }}",
                     PrettyPrintRecordKey::from(&record.key)
                 )
             }
@@ -708,7 +712,10 @@ impl SwarmDriver {
                 let _ = sender.send(record);
             }
 
-            LocalSwarmCmd::PutLocalRecord { record } => {
+            LocalSwarmCmd::PutLocalRecord {
+                record,
+                is_client_put,
+            } => {
                 cmd_string = "PutLocalRecord";
                 let key = record.key.clone();
                 let record_key = PrettyPrintRecordKey::from(&key);
@@ -738,7 +745,7 @@ impl SwarmDriver {
                     .behaviour_mut()
                     .kademlia
                     .store_mut()
-                    .put_verified(record, record_type.clone());
+                    .put_verified(record, record_type.clone(), is_client_put);
 
                 match result {
                     Ok(_) => {

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -887,13 +887,16 @@ impl Network {
 
     /// Put `Record` to the local RecordStore
     /// Must be called after the validations are performed on the Record
-    pub fn put_local_record(&self, record: Record) {
+    pub fn put_local_record(&self, record: Record, is_client_put: bool) {
         debug!(
             "Writing Record locally, for {:?} - length {:?}",
             PrettyPrintRecordKey::from(&record.key),
             record.value.len()
         );
-        self.send_local_swarm_cmd(LocalSwarmCmd::PutLocalRecord { record })
+        self.send_local_swarm_cmd(LocalSwarmCmd::PutLocalRecord {
+            record,
+            is_client_put,
+        })
     }
 
     /// Returns true if a RecordKey is present locally in the RecordStore

--- a/ant-networking/src/record_store_api.rs
+++ b/ant-networking/src/record_store_api.rs
@@ -121,13 +121,14 @@ impl UnifiedRecordStore {
         &mut self,
         r: Record,
         record_type: ValidationType,
+        is_client_put: bool,
     ) -> libp2p::kad::store::Result<()> {
         match self {
             Self::Client(_) => {
                 error!("Calling put_verified at Client. This should not happen");
                 Ok(())
             }
-            Self::Node(store) => store.put_verified(r, record_type),
+            Self::Node(store) => store.put_verified(r, record_type, is_client_put),
         }
     }
 


### PR DESCRIPTION
### Description

Reduce memory usage by only cache client_put records and prune outdated ones.
As most of time, the cache-hit only happens during the ChunkProof validation that being carried out by client after upload.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
