### PR TITLE
feat(register): add hex support for register operations

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -105,6 +105,9 @@ pub enum RegisterCmd {
         name: String,
         /// The value to store in the register.
         value: String,
+        /// Treat the value as a hex string and convert it to binary before storing
+        #[arg(long)]
+        hex: bool,
     },
 
     /// Edit an existing register.
@@ -119,6 +122,9 @@ pub enum RegisterCmd {
         address: String,
         /// The new value to store in the register.
         value: String,
+        /// Treat the value as a hex string and convert it to binary before storing
+        #[arg(long)]
+        hex: bool,
     },
 
     /// Get the value of a register.
@@ -130,6 +136,9 @@ pub enum RegisterCmd {
         /// The address of the register
         /// With the name option on the address will be used as a name
         address: String,
+        /// Display the value as a hex string instead of raw bytes
+        #[arg(long)]
+        hex: bool,
     },
 
     /// Show the history of values for a register.
@@ -141,6 +150,9 @@ pub enum RegisterCmd {
         /// The address of the register
         /// With the name option on the address will be used as a name
         address: String,
+        /// Display the values as hex strings instead of raw bytes
+        #[arg(long)]
+        hex: bool,
     },
 
     /// List previous registers
@@ -229,17 +241,20 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
         Some(SubCmd::Register { command }) => match command {
             RegisterCmd::GenerateKey { overwrite } => register::generate_key(overwrite),
             RegisterCmd::Cost { name } => register::cost(&name, peers.await?).await,
-            RegisterCmd::Create { name, value } => {
-                register::create(&name, &value, peers.await?).await
+            RegisterCmd::Create { name, value, hex } => {
+                register::create(&name, &value, hex, peers.await?).await
             }
             RegisterCmd::Edit {
                 address,
                 name,
                 value,
-            } => register::edit(address, name, &value, peers.await?).await,
-            RegisterCmd::Get { address, name } => register::get(address, name, peers.await?).await,
-            RegisterCmd::History { address, name } => {
-                register::history(address, name, peers.await?).await
+                hex,
+            } => register::edit(address, name, &value, hex, peers.await?).await,
+            RegisterCmd::Get { address, name, hex } => {
+                register::get(address, name, hex, peers.await?).await
+            }
+            RegisterCmd::History { address, name, hex } => {
+                register::history(address, name, hex, peers.await?).await
             }
             RegisterCmd::List => register::list(),
         },

--- a/ant-cli/src/commands/register.rs
+++ b/ant-cli/src/commands/register.rs
@@ -17,7 +17,6 @@ use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use color_eyre::Section;
-use hex;
 
 pub fn generate_key(overwrite: bool) -> Result<()> {
     // check if the key already exists
@@ -181,8 +180,8 @@ pub async fn get(address: String, name: bool, hex: bool, peers: NetworkPeers) ->
     info!("Register found at: {address}");
 
     if hex {
-        let hex_value = hex::encode(&value_bytes);
-        println!("With hex value: [{}]", hex_value);
+        let hex_value = hex::encode(value_bytes);
+        println!("With hex value: [{hex_value}]");
         info!("With hex value: [{hex_value}]");
     } else {
         let value = String::from_utf8_lossy(&value_bytes);
@@ -241,8 +240,8 @@ pub async fn history(address: String, name: bool, hex: bool, peers: NetworkPeers
 
     for value in values {
         if hex {
-            let hex_value = hex::encode(&value);
-            println!("[{}]", hex_value);
+            let hex_value = hex::encode(value);
+            println!("[{hex_value}]");
         } else {
             let value_str = String::from_utf8_lossy(&value[..]);
             println!("[{value_str}]");

--- a/ant-cli/src/commands/register.rs
+++ b/ant-cli/src/commands/register.rs
@@ -17,6 +17,7 @@ use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use color_eyre::Section;
+use hex;
 
 pub fn generate_key(overwrite: bool) -> Result<()> {
     // check if the key already exists
@@ -52,7 +53,7 @@ pub async fn cost(name: &str, peers: NetworkPeers) -> Result<()> {
     Ok(())
 }
 
-pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> {
+pub async fn create(name: &str, value: &str, hex: bool, peers: NetworkPeers) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
     let client = crate::actions::connect_to_network(peers).await?;
@@ -61,7 +62,16 @@ pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> 
 
     println!("Creating register with name: {name}");
     info!("Creating register with name: {name}");
-    let content = Client::register_value_from_bytes(value.as_bytes())?;
+
+    let value_bytes = if hex {
+        hex::decode(value.trim_start_matches("0x"))
+            .wrap_err("Failed to decode hex value")
+            .with_suggestion(|| "Make sure the value is a valid hex string")?
+    } else {
+        value.as_bytes().to_vec()
+    };
+    let content = Client::register_value_from_bytes(&value_bytes)?;
+
     let (cost, address) = client
         .register_create(&register_key, content, wallet.into())
         .await
@@ -69,7 +79,11 @@ pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> 
 
     println!("✅ Register created at address: {address}");
     println!("With name: {name}");
-    println!("And initial value: [{value}]");
+    if hex {
+        println!("And initial hex value: [{}]", hex::encode(&value_bytes));
+    } else {
+        println!("And initial value: [{value}]");
+    }
     info!("Register created at address: {address} with name: {name}");
     println!("Total cost: {cost} AttoTokens");
 
@@ -81,12 +95,26 @@ pub async fn create(name: &str, value: &str, peers: NetworkPeers) -> Result<()> 
     Ok(())
 }
 
-pub async fn edit(address: String, name: bool, value: &str, peers: NetworkPeers) -> Result<()> {
+pub async fn edit(
+    address: String,
+    name: bool,
+    value: &str,
+    hex: bool,
+    peers: NetworkPeers,
+) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
     let client = crate::actions::connect_to_network(peers).await?;
     let wallet = load_wallet(client.evm_network())?;
-    let value_bytes = Client::register_value_from_bytes(value.as_bytes())?;
+
+    let value_bytes = if hex {
+        hex::decode(value.trim_start_matches("0x"))
+            .wrap_err("Failed to decode hex value")
+            .with_suggestion(|| "Make sure the value is a valid hex string")?
+    } else {
+        value.as_bytes().to_vec()
+    };
+    let value_bytes = Client::register_value_from_bytes(&value_bytes)?;
 
     let register_key = if name {
         let name_str = address.clone();
@@ -120,7 +148,7 @@ pub async fn edit(address: String, name: bool, value: &str, peers: NetworkPeers)
     Ok(())
 }
 
-pub async fn get(address: String, name: bool, peers: NetworkPeers) -> Result<()> {
+pub async fn get(address: String, name: bool, hex: bool, peers: NetworkPeers) -> Result<()> {
     let client = crate::actions::connect_to_network(peers).await?;
 
     let addr = if name {
@@ -151,9 +179,16 @@ pub async fn get(address: String, name: bool, peers: NetworkPeers) -> Result<()>
 
     println!("✅ Register found at: {address}");
     info!("Register found at: {address}");
-    let value = String::from_utf8_lossy(&value_bytes);
-    println!("With value: [{value}]");
-    info!("With value: [{value}]");
+
+    if hex {
+        let hex_value = hex::encode(&value_bytes);
+        println!("With hex value: [{}]", hex_value);
+        info!("With hex value: [{hex_value}]");
+    } else {
+        let value = String::from_utf8_lossy(&value_bytes);
+        println!("With value: [{value}]");
+        info!("With value: [{value}]");
+    }
 
     Ok(())
 }
@@ -168,7 +203,7 @@ pub fn list() -> Result<()> {
     Ok(())
 }
 
-pub async fn history(address: String, name: bool, peers: NetworkPeers) -> Result<()> {
+pub async fn history(address: String, name: bool, hex: bool, peers: NetworkPeers) -> Result<()> {
     let client = crate::actions::connect_to_network(peers).await?;
 
     let addr = if name {
@@ -205,8 +240,13 @@ pub async fn history(address: String, name: bool, peers: NetworkPeers) -> Result
         .wrap_err(format!("Error getting register history at: {address}"))?;
 
     for value in values {
-        let value_str = String::from_utf8_lossy(&value[..]);
-        println!("[{value_str}]");
+        if hex {
+            let hex_value = hex::encode(&value);
+            println!("[{}]", hex_value);
+        } else {
+            let value_str = String::from_utf8_lossy(&value[..]);
+            println!("[{value_str}]");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
### Description

This change adds hex encoding/decoding functionality to the register commands in what appears to be a CLI tool. Here are the key changes:

1. Added a new `--hex` flag option to three register commands:
   - `Create`
   - `Edit`
   - `Get`

2. When creating or editing a register:
   - If `--hex` is used, the input value is treated as a hex string (with optional "0x" prefix)
   - The hex string is decoded to bytes before being stored
   - If `--hex` is not used, the value is stored as raw bytes (previous behavior)

3. When getting a register's value:
   - If `--hex` is used, the value is displayed as a hex string
   - If `--hex` is not used, the value is displayed as a UTF-8 string (previous behavior)

4. Added error handling for hex decoding with helpful error messages when invalid hex strings are provided.

5. Added the `hex` crate as a dependency for handling hex encoding/decoding.

This change allows users to work with binary data in a more convenient hexadecimal format when interacting with registers through the CLI.

### Why am I suggesting this

Registers are likely to be used to store references to other hashes which are output in hex with the ant cli.

My discussion on the forum:

https://forum.autonomi.community/t/understanding-registers/41208

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [x] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
