### PR TITLE
Attempts to reduce client upload failing rate during upscale test

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -1024,6 +1024,8 @@ impl SwarmDriver {
 
             if is_new_issue {
                 issue_vec.push((issue, Instant::now()));
+            } else {
+                return;
             }
 
             // Only consider candidate as a bad node when:

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -1039,9 +1039,12 @@ impl SwarmDriver {
                     // If it is a connection issue, we don't need to consider it as a bad node
                     if matches!(issue, NodeIssue::ConnectionIssue) {
                         is_connection_issue = true;
-                    } else {
-                        *is_bad = true;
                     }
+                    // TODO: disable black_list currently.
+                    //       re-enable once got more statistics from large scaled network
+                    // else {
+                    //     *is_bad = true;
+                    // }
                     new_bad_behaviour = Some(issue.clone());
                     info!("Peer {peer_id:?} accumulated {issue_counts} times of issue {issue:?}. Consider it as a bad node now.");
                     // Once a bad behaviour detected, no point to continue

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -195,7 +195,14 @@ impl Debug for NetworkEvent {
                 write!(f, "NetworkEvent::TerminateNode({reason:?})")
             }
             NetworkEvent::FailedToFetchHolders(bad_nodes) => {
-                write!(f, "NetworkEvent::FailedToFetchHolders({bad_nodes:?})")
+                let pretty_log: Vec<_> = bad_nodes
+                    .iter()
+                    .map(|(peer_id, record_key)| {
+                        let pretty_key = PrettyPrintRecordKey::from(record_key);
+                        (peer_id, pretty_key)
+                    })
+                    .collect();
+                write!(f, "NetworkEvent::FailedToFetchHolders({pretty_log:?})")
             }
             NetworkEvent::QuoteVerification { quotes } => {
                 write!(

--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -851,7 +851,7 @@ impl RecordStore for NodeRecordStore {
         let cached_record = self.records_cache.get(k);
         // first return from FIFO cache if existing there
         if let Some((record, _timestamp)) = cached_record {
-            return Some(Cow::Borrowed(record));
+            return Some(Cow::Owned(record.clone()));
         }
 
         if !self.records.contains_key(k) {

--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -1733,8 +1733,11 @@ mod tests {
 
         // Add records up to cache size
         cache.push_back(record1.key.clone(), record1.clone());
+        sleep(Duration::from_millis(1)).await;
         cache.push_back(record2.key.clone(), record2.clone());
+        sleep(Duration::from_millis(1)).await;
         cache.push_back(record3.key.clone(), record3.clone());
+        sleep(Duration::from_millis(1)).await;
 
         // Verify all records are present
         assert!(cache.get(&record1.key).is_some());

--- a/ant-networking/src/replication_fetcher.rs
+++ b/ant-networking/src/replication_fetcher.rs
@@ -14,14 +14,14 @@ use ant_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
 };
 use libp2p::{
-    kad::{KBucketDistance as Distance, RecordKey, K_VALUE},
+    kad::{KBucketDistance as Distance, RecordKey},
     PeerId,
 };
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet, VecDeque};
 use tokio::{sync::mpsc, time::Duration};
 
 // Max parallel fetches that can be undertaken at the same time.
-const MAX_PARALLEL_FETCH: usize = K_VALUE.get();
+const MAX_PARALLEL_FETCH: usize = 5;
 
 // The duration after which a peer will be considered failed to fetch data from,
 // if no response got from that peer.

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -531,10 +531,17 @@ impl Node {
             NetworkEvent::FailedToFetchHolders(bad_nodes) => {
                 event_header = "FailedToFetchHolders";
                 let network = self.network().clone();
+                let pretty_log: Vec<_> = bad_nodes
+                    .iter()
+                    .map(|(peer_id, record_key)| {
+                        let pretty_key = PrettyPrintRecordKey::from(record_key);
+                        (peer_id, pretty_key)
+                    })
+                    .collect();
                 // Note: this log will be checked in CI, and expecting `not appear`.
                 //       any change to the keyword `failed to fetch` shall incur
                 //       correspondent CI script change as well.
-                debug!("Received notification from replication_fetcher, notifying {bad_nodes:?} failed to fetch replication copies from.");
+                debug!("Received notification from replication_fetcher, notifying {pretty_log:?} failed to fetch replication copies from.");
                 let _handle = spawn(async move {
                     for (peer_id, record_key) in bad_nodes {
                         // Obsoleted fetch request (due to flooded in fresh replicates) could result

--- a/ant-node/src/replication.rs
+++ b/ant-node/src/replication.rs
@@ -8,11 +8,10 @@
 
 use crate::{error::Result, node::Node};
 use ant_evm::ProofOfPayment;
-use ant_networking::{GetRecordCfg, Network, ResponseQuorum};
-use ant_protocol::storage::DataTypes;
+use ant_networking::Network;
 use ant_protocol::{
     messages::{Query, QueryResponse, Request, Response},
-    storage::ValidationType,
+    storage::{DataTypes, ValidationType},
     NetworkAddress, PrettyPrintRecordKey,
 };
 use libp2p::{
@@ -69,22 +68,8 @@ impl Node {
                 let record = if let Some(record_content) = record_opt {
                     Record::new(key, record_content.to_vec())
                 } else {
-                    debug!(
-                        "Can not fetch record {pretty_key:?} from node {holder:?}, fetching from the network"
-                    );
-                    let get_cfg = GetRecordCfg {
-                        get_quorum: ResponseQuorum::One,
-                        retry_strategy: Default::default(),
-                        target_record: None,
-                        expected_holders: Default::default(),
-                    };
-                    match node.network().get_record_from_network(key, &get_cfg).await {
-                        Ok(record) => record,
-                        Err(err) => {
-                            error!("During replication fetch of {pretty_key:?}, failed in re-attempt of get from network {err:?}");
-                            return;
-                        }
-                    }
+                    debug!("Can not fetch record {pretty_key:?} from node {holder:?}");
+                    return;
                 };
 
                 debug!(


### PR DESCRIPTION
### Description

This PR contains following attempts (fixes) trying to reduce the client upload failing rate during the upscale test:
* avoid dead-lock on record_store cache access
* not fetch from network when replicate fetch failed
* lower parallel replication fetches
* issues comes in too quick shall not trigger extra action
* disable balck_list

This shall also help with reduce `open connection`, `large amount of identifies` and couple of other resource consuming issues.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
