### PR TITLE
improvement of relay related metrics; remove relay clients if we have no more connections

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -626,15 +626,8 @@ impl SwarmDriver {
                 sender,
             } => {
                 cmd_string = "GetLocalQuotingMetrics";
-                let (
-                    _index,
-                    _total_peers,
-                    peers_in_non_full_buckets,
-                    num_of_full_buckets,
-                    _kbucket_table_stats,
-                ) = self.kbuckets_status();
-                let estimated_network_size =
-                    Self::estimate_network_size(peers_in_non_full_buckets, num_of_full_buckets);
+                let kbucket_status = self.get_kbuckets_status();
+                self.update_on_kbucket_status(&kbucket_status);
                 let (quoting_metrics, is_already_stored) = match self
                     .swarm
                     .behaviour_mut()
@@ -644,7 +637,7 @@ impl SwarmDriver {
                         &key,
                         data_type,
                         data_size,
-                        Some(estimated_network_size as u64),
+                        Some(kbucket_status.estimated_network_size as u64),
                     ) {
                     Ok(res) => res,
                     Err(err) => {

--- a/ant-networking/src/event/identify.rs
+++ b/ant-networking/src/event/identify.rs
@@ -88,7 +88,7 @@ impl SwarmDriver {
                 .collect(),
         };
 
-        let is_relayed_peer = is_a_relayed_peer(&addrs);
+        let is_relayed_peer = is_a_relayed_peer(addrs.iter());
 
         let is_bootstrap_peer = self
             .bootstrap_peers

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -395,7 +395,7 @@ impl SwarmDriver {
                 .estimated_network_size
                 .set(estimated_network_size as i64);
 
-            let _ = metrics_recorder.percentage_of_relay_peers.set(
+            let _ = metrics_recorder.relay_peers_percentage.set(
                 (status.relay_peers_in_non_full_buckets as f64
                     / status.peers_in_non_full_buckets as f64)
                     * 100.0,

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -52,9 +52,10 @@ pub(crate) struct KBucketStatus {
 impl KBucketStatus {
     pub(crate) fn log(&self) {
         info!(
-            "kBucketTable has {:?} kbuckets {:?} peers, {:?}, estimated network size: {:?}",
+            "kBucketTable has {:?} kbuckets {:?} peers ({} relay peers), {:?}, estimated network size: {:?}",
             self.total_buckets,
             self.total_peers,
+            self.total_relay_peers,
             self.kbucket_table_stats,
             self.estimated_network_size
         );
@@ -286,6 +287,7 @@ impl SwarmDriver {
 
         self.send_event(NetworkEvent::PeerAdded(added_peer, self.peers_in_rt));
 
+        #[cfg(feature = "open-metrics")]
         if self.metrics_recorder.is_some() {
             self.check_for_change_in_our_close_group();
         }

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -387,14 +387,6 @@ impl SwarmDriver {
                 .relay_peers_in_routing_table
                 .set(status.total_relay_peers as i64);
 
-            let _ = metrics_recorder
-                .peers_in_non_full_buckets
-                .set(status.peers_in_non_full_buckets as i64);
-
-            let _ = metrics_recorder
-                .relay_peers_in_non_full_buckets
-                .set(status.relay_peers_in_non_full_buckets as i64);
-
             let estimated_network_size = Self::estimate_network_size(
                 status.peers_in_non_full_buckets,
                 status.num_of_full_buckets,
@@ -403,9 +395,11 @@ impl SwarmDriver {
                 .estimated_network_size
                 .set(estimated_network_size as i64);
 
-            let _ = metrics_recorder
-                .percentage_of_relay_peers
-                .set((status.total_relay_peers as f64 / status.total_peers as f64) * 100.0);
+            let _ = metrics_recorder.percentage_of_relay_peers.set(
+                (status.relay_peers_in_non_full_buckets as f64
+                    / status.peers_in_non_full_buckets as f64)
+                    * 100.0,
+            );
         }
     }
 

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -43,7 +43,7 @@ pub(crate) struct NetworkMetricsRecorder {
     pub(crate) connected_peers: Gauge,
     pub(crate) connected_relay_clients: Gauge,
     pub(crate) estimated_network_size: Gauge,
-    pub(crate) percentage_of_relay_peers: Gauge<f64, AtomicU64>,
+    pub(crate) relay_peers_percentage: Gauge<f64, AtomicU64>,
     pub(crate) open_connections: Gauge,
     pub(crate) peers_in_routing_table: Gauge,
     pub(crate) relay_peers_in_routing_table: Gauge,
@@ -115,11 +115,11 @@ impl NetworkMetricsRecorder {
             "The estimated number of nodes in the network calculated by the peers in our RT",
             estimated_network_size.clone(),
         );
-        let percentage_of_relay_peers = Gauge::<f64, AtomicU64>::default();
+        let relay_peers_percentage = Gauge::<f64, AtomicU64>::default();
         sub_registry.register(
-            "percentage_of_relay_peers",
+            "relay_peers_percentage",
             "The percentage of relay peers in our routing table",
-            percentage_of_relay_peers.clone(),
+            relay_peers_percentage.clone(),
         );
         let open_connections = Gauge::default();
         sub_registry.register(
@@ -246,7 +246,7 @@ impl NetworkMetricsRecorder {
 
             records_stored,
             estimated_network_size,
-            percentage_of_relay_peers,
+            relay_peers_percentage,
             connected_peers,
             connected_relay_clients,
             open_connections,

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -41,6 +41,7 @@ pub(crate) struct NetworkMetricsRecorder {
 
     // metrics from ant-networking
     pub(crate) connected_peers: Gauge,
+    pub(crate) connected_relay_clients: Gauge,
     pub(crate) estimated_network_size: Gauge,
     pub(crate) percentage_of_relay_peers: Gauge<f64, AtomicU64>,
     pub(crate) open_connections: Gauge,
@@ -102,6 +103,12 @@ impl NetworkMetricsRecorder {
             "connected_peers",
             "The number of peers that we are currently connected to",
             connected_peers.clone(),
+        );
+        let connected_relay_clients = Gauge::default();
+        sub_registry.register(
+            "connected_relay_clients",
+            "The number of relay clients that are currently connected to us",
+            connected_relay_clients.clone(),
         );
 
         let estimated_network_size = Gauge::default();
@@ -256,6 +263,7 @@ impl NetworkMetricsRecorder {
             estimated_network_size,
             percentage_of_relay_peers,
             connected_peers,
+            connected_relay_clients,
             open_connections,
             relay_reservation_health,
             peers_in_routing_table,

--- a/ant-networking/src/metrics/mod.rs
+++ b/ant-networking/src/metrics/mod.rs
@@ -47,8 +47,6 @@ pub(crate) struct NetworkMetricsRecorder {
     pub(crate) open_connections: Gauge,
     pub(crate) peers_in_routing_table: Gauge,
     pub(crate) relay_peers_in_routing_table: Gauge,
-    pub(crate) peers_in_non_full_buckets: Gauge,
-    pub(crate) relay_peers_in_non_full_buckets: Gauge,
     pub(crate) records_stored: Gauge,
     pub(crate) relay_reservation_health: Gauge<f64, AtomicU64>,
 
@@ -140,19 +138,6 @@ impl NetworkMetricsRecorder {
             "relay_peers_in_routing_table",
             "The total number of relay peers in our routing table",
             relay_peers_in_routing_table.clone(),
-        );
-
-        let peers_in_non_full_buckets = Gauge::default();
-        sub_registry.register(
-            "peers_in_non_full_buckets",
-            "The number of peers in our routing table that are not in full buckets",
-            peers_in_non_full_buckets.clone(),
-        );
-        let relay_peers_in_non_full_buckets = Gauge::default();
-        sub_registry.register(
-            "relay_peers_in_non_full_buckets",
-            "The number of relay peers in our routing table that are not in full buckets",
-            relay_peers_in_non_full_buckets.clone(),
         );
 
         let shunned_count = Counter::default();
@@ -268,8 +253,6 @@ impl NetworkMetricsRecorder {
             relay_reservation_health,
             peers_in_routing_table,
             relay_peers_in_routing_table,
-            peers_in_non_full_buckets,
-            relay_peers_in_non_full_buckets,
             relevant_records,
             max_records,
             received_payment_count,

--- a/ant-networking/src/relay_manager.rs
+++ b/ant-networking/src/relay_manager.rs
@@ -41,10 +41,8 @@ const RESERVATION_SCORE_ROLLING_WINDOW: usize = 100;
 #[cfg(feature = "open-metrics")]
 type ConnectionsFromPeer = Vec<(PeerId, ConnectionId, SystemTime, Option<bool>)>;
 
-pub(crate) fn is_a_relayed_peer(addrs: &HashSet<Multiaddr>) -> bool {
-    addrs
-        .iter()
-        .any(|multiaddr| multiaddr.iter().any(|p| matches!(p, Protocol::P2pCircuit)))
+pub(crate) fn is_a_relayed_peer<'a>(mut addrs: impl Iterator<Item = &'a Multiaddr>) -> bool {
+    addrs.any(|multiaddr| multiaddr.iter().any(|p| matches!(p, Protocol::P2pCircuit)))
 }
 
 /// Manage the relay servers that a private node is connected to.


### PR DESCRIPTION
- Remove relay clients from the `SwarmDriver::connected_relay_clients` tracker if the `Reservation` has been closed. This happens when all the connection with the relay client has been lost. Libp2p does not have an event for this yet, so we have to do a manual check for this. 
- Calculate the `peers_in_rt` value directly from the kbuckets instead of acting upon the libp2p events. The latter gave incorrect values, and it is very prone to errors, as everyone should be careful to call the `update` fn everytime we manually remove a peer from the RT.
- Add `connected_relay_clients` metric.
- Add `relay_peers_in_routing_table`, `peers_in_non_full_buckets`, `relay_peers_in_non_full_buckets` and `percentage_of_relay_peers` metrics.
