### PR TITLE
[metric] versions of nodes (upgraded percentage)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ version = "1.0.1-rc.2"
 dependencies = [
  "ant-build-info",
  "ant-evm",
+ "bincode",
  "blsttc",
  "bytes",
  "color-eyre",

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -179,6 +179,11 @@ pub enum LocalSwarmCmd {
         holder: NetworkAddress,
         keys: Vec<(NetworkAddress, ValidationType)>,
     },
+    /// Notify a fetched peer's version
+    NotifyPeerVersion {
+        peer: PeerId,
+        version: String,
+    },
 }
 
 /// Commands to send to the Swarm
@@ -353,6 +358,9 @@ impl Debug for LocalSwarmCmd {
                     f,
                     "LocalSwarmCmd::AddFreshReplicateRecords({holder:?}, {keys:?})"
                 )
+            }
+            LocalSwarmCmd::NotifyPeerVersion { peer, version } => {
+                write!(f, "LocalSwarmCmd::NotifyPeerVersion({peer:?}, {version:?})")
             }
         }
     }
@@ -983,11 +991,38 @@ impl SwarmDriver {
                 cmd_string = "AddFreshReplicateRecords";
                 let _ = self.add_keys_to_replication_fetcher(holder, keys, true);
             }
+            LocalSwarmCmd::NotifyPeerVersion { peer, version } => {
+                cmd_string = "NotifyPeerVersion";
+                self.record_node_version(peer, version);
+            }
         }
 
         self.log_handling(cmd_string.to_string(), start.elapsed());
 
         Ok(())
+    }
+
+    fn record_node_version(&mut self, peer_id: PeerId, version: String) {
+        let _ = self.peers_version.insert(peer_id, version);
+
+        // Collect all peers_in_non_full_buckets
+        let mut peers_in_non_full_buckets = vec![];
+        for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
+            let num_entires = kbucket.num_entries();
+            if num_entires >= K_VALUE.get() {
+                continue;
+            } else {
+                let peers_in_kbucket = kbucket
+                    .iter()
+                    .map(|peer_entry| peer_entry.node.key.into_preimage())
+                    .collect::<Vec<PeerId>>();
+                peers_in_non_full_buckets.extend(peers_in_kbucket);
+            }
+        }
+
+        // Ensure all existing node_version records are for those peers_in_non_full_buckets
+        self.peers_version
+            .retain(|peer_id, _version| peers_in_non_full_buckets.contains(peer_id));
     }
 
     pub(crate) fn record_node_issue(&mut self, peer_id: PeerId, issue: NodeIssue) {

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -625,6 +625,7 @@ impl NetworkBuilder {
             last_replication: None,
             last_connection_pruning_time: Instant::now(),
             network_density_samples: FifoRegister::new(100),
+            peers_version: Default::default(),
         };
 
         let network = Network::new(
@@ -735,6 +736,8 @@ pub struct SwarmDriver {
     pub(crate) last_connection_pruning_time: Instant,
     /// FIFO cache for the network density samples
     pub(crate) network_density_samples: FifoRegister,
+    /// record versions of those peers that in the non-full-kbuckets.
+    pub(crate) peers_version: HashMap<PeerId, String>,
 }
 
 impl SwarmDriver {

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -312,6 +312,11 @@ impl SwarmDriver {
         if self.metrics_recorder.is_some() {
             self.check_for_change_in_our_close_group();
         }
+
+        #[cfg(feature = "open-metrics")]
+        if let Some(metrics_recorder) = &self.metrics_recorder {
+            metrics_recorder.update_node_versions(&self.peers_version);
+        }
     }
 
     /// Update state on removal of a peer from the routing table.

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -1028,10 +1028,15 @@ impl Network {
         self.send_local_swarm_cmd(LocalSwarmCmd::NotifyPeerScores { peer_scores })
     }
 
+    pub fn notify_node_version(&self, peer: PeerId, version: String) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::NotifyPeerVersion { peer, version })
+    }
+
     /// Helper to send NetworkSwarmCmd
     fn send_network_swarm_cmd(&self, cmd: NetworkSwarmCmd) {
         send_network_swarm_cmd(self.network_swarm_cmd_sender().clone(), cmd);
     }
+
     /// Helper to send LocalSwarmCmd
     fn send_local_swarm_cmd(&self, cmd: LocalSwarmCmd) {
         send_local_swarm_cmd(self.local_swarm_cmd_sender().clone(), cmd);

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -50,3 +50,4 @@ workspace = true
 
 [dev-dependencies]
 rand = "0.8"
+bincode = "1.3"

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -422,6 +422,7 @@ mod tests {
             sign_result: bool,
         },
         GetVersion(NetworkAddress),
+        Extended,
     }
 
     #[test]
@@ -465,7 +466,7 @@ mod tests {
     #[test]
     fn test_query_extended_serialization() {
         // Create a sample QueryExtended message with extended new variant
-        let extended_query = QueryExtended::GetVersion(NetworkAddress::from_peer(PeerId::random()));
+        let extended_query = QueryExtended::Extended;
 
         // Serialize to bytes
         let serialized = bincode::serialize(&extended_query).expect("Serialization failed");

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -376,9 +376,13 @@ impl std::fmt::Debug for PrettyPrintRecordKey<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::GraphEntryAddress;
-    use crate::NetworkAddress;
+    use crate::{
+        messages::{Nonce, Query},
+        storage::GraphEntryAddress,
+        NetworkAddress, PeerId,
+    };
     use bls::rand::thread_rng;
+    use serde::{Deserialize, Serialize};
 
     #[test]
     fn verify_graph_entry_addr_is_actionable() {
@@ -390,5 +394,122 @@ mod tests {
         let net_addr_fmt = format!("{net_addr}");
 
         assert!(net_addr_fmt.contains(graph_entry_addr_hex));
+    }
+
+    #[derive(Eq, PartialEq, PartialOrd, Clone, Serialize, Deserialize, Debug)]
+    enum QueryExtended {
+        GetStoreQuote {
+            key: NetworkAddress,
+            data_type: u32,
+            data_size: usize,
+            nonce: Option<Nonce>,
+            difficulty: usize,
+        },
+        GetReplicatedRecord {
+            requester: NetworkAddress,
+            key: NetworkAddress,
+        },
+        GetChunkExistenceProof {
+            key: NetworkAddress,
+            nonce: Nonce,
+            difficulty: usize,
+        },
+        CheckNodeInProblem(NetworkAddress),
+        GetClosestPeers {
+            key: NetworkAddress,
+            num_of_peers: Option<usize>,
+            range: Option<[u8; 32]>,
+            sign_result: bool,
+        },
+        GetVersion(NetworkAddress),
+    }
+
+    #[test]
+    fn test_query_serialization_deserialization() {
+        let peer_id = PeerId::random();
+        // Create a sample Query message
+        let original_query = Query::GetStoreQuote {
+            key: NetworkAddress::from_peer(peer_id),
+            data_type: 1,
+            data_size: 100,
+            nonce: Some(0),
+            difficulty: 3,
+        };
+
+        // Serialize to bytes
+        let serialized = bincode::serialize(&original_query).expect("Serialization failed");
+
+        // Deserialize into QueryExtended
+        let deserialized: QueryExtended =
+            bincode::deserialize(&serialized).expect("Deserialization into QueryExtended failed");
+
+        // Verify the deserialized data matches the original
+        match deserialized {
+            QueryExtended::GetStoreQuote {
+                key,
+                data_type,
+                data_size,
+                nonce,
+                difficulty,
+            } => {
+                assert_eq!(key, NetworkAddress::from_peer(peer_id));
+                assert_eq!(data_type, 1);
+                assert_eq!(data_size, 100);
+                assert_eq!(nonce, Some(0));
+                assert_eq!(difficulty, 3);
+            }
+            _ => panic!("Deserialized into wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_query_extended_serialization() {
+        // Create a sample QueryExtended message with extended new variant
+        let extended_query = QueryExtended::GetVersion(NetworkAddress::from_peer(PeerId::random()));
+
+        // Serialize to bytes
+        let serialized = bincode::serialize(&extended_query).expect("Serialization failed");
+
+        // Attempt to deserialize into original Query (should fail)
+        let result: Result<Query, _> = bincode::deserialize(&serialized);
+        assert!(
+            result.is_err(),
+            "Should fail to deserialize extended enum into original"
+        );
+
+        let peer_id = PeerId::random();
+        // Create a sample QueryExtended message with old variant
+        let extended_query = QueryExtended::GetStoreQuote {
+            key: NetworkAddress::from_peer(peer_id),
+            data_type: 1,
+            data_size: 100,
+            nonce: Some(0),
+            difficulty: 3,
+        };
+
+        // Serialize to bytes
+        let serialized = bincode::serialize(&extended_query).expect("Serialization failed");
+
+        // Deserialize into Query
+        let deserialized: Query =
+            bincode::deserialize(&serialized).expect("Deserialization into Query failed");
+
+        // Verify the deserialized data matches the original
+        match deserialized {
+            Query::GetStoreQuote {
+                key,
+                data_type,
+                data_size,
+                nonce,
+                difficulty,
+            } => {
+                assert_eq!(key, NetworkAddress::from_peer(peer_id));
+                assert_eq!(data_type, 1);
+                assert_eq!(data_size, 100);
+                assert_eq!(nonce, Some(0));
+                assert_eq!(difficulty, 3);
+            }
+            _ => panic!("Deserialized into wrong variant"),
+        }
     }
 }

--- a/ant-protocol/src/messages/query.rs
+++ b/ant-protocol/src/messages/query.rs
@@ -71,13 +71,16 @@ pub enum Query {
         // For future econ usage,
         sign_result: bool,
     },
+    /// *** From now on, the order of variants shall be retained to be backward compatible
+    /// Query peer's cargo package version.
+    GetVersion(NetworkAddress),
 }
 
 impl Query {
     /// Used to send a query to the close group of the address.
     pub fn dst(&self) -> NetworkAddress {
         match self {
-            Query::CheckNodeInProblem(address) => address.clone(),
+            Query::CheckNodeInProblem(address) | Query::GetVersion(address) => address.clone(),
             // Shall not be called for this, as this is a `one-to-one` message,
             // and the destination shall be decided by the requester already.
             Query::GetStoreQuote { key, .. }
@@ -130,6 +133,9 @@ impl std::fmt::Display for Query {
                     f,
                     "Query::GetClosestPeers({key:?} {num_of_peers:?} {distance:?} {sign_result})"
                 )
+            }
+            Query::GetVersion(address) => {
+                write!(f, "Query::GetVersion({address:?})")
             }
         }
     }

--- a/ant-protocol/src/messages/response.rs
+++ b/ant-protocol/src/messages/response.rs
@@ -66,6 +66,16 @@ pub enum QueryResponse {
         // Signature of signing the above (if requested), for future economic model usage.
         signature: Option<Vec<u8>>,
     },
+    /// *** From now on, the order of variants shall be retained to be backward compatible
+    // ===== GetVersion =====
+    //
+    /// Response to [`GetVersion`]
+    ///
+    /// [`GetVersion`]: crate::messages::Query::GetVersion
+    GetVersion {
+        peer: NetworkAddress,
+        version: String,
+    },
 }
 
 // Debug implementation for QueryResponse, to avoid printing Vec<u8>
@@ -117,6 +127,9 @@ impl Debug for QueryResponse {
                     f,
                     "GetClosestPeers target {target:?} close peers {addresses:?}"
                 )
+            }
+            QueryResponse::GetVersion { peer, version } => {
+                write!(f, "GetVersion peer {peer:?} has version of {version:?}")
             }
         }
     }


### PR DESCRIPTION
### Description

This PR introduces a new metric to reflect versions of nodes in the network.
Potentially can be used to detect `upgraded percentage`.

It is also a critical pre-condition for the future cross version backward compatibility.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
