### PR TITLE
fix: records_store metrics count

### DIFF
--- a/ant-networking/src/record_store.rs
+++ b/ant-networking/src/record_store.rs
@@ -635,6 +635,11 @@ impl NodeRecordStore {
         self.records
             .insert(key.clone(), (addr.clone(), validate_type, data_type));
 
+        #[cfg(feature = "open-metrics")]
+        if let Some(metric) = &self.record_count_metric {
+            let _ = metric.set(self.records.len() as i64);
+        }
+
         // Update bucket index
         let _ = self.records_by_distance.insert(distance, key.clone());
 
@@ -707,11 +712,6 @@ impl NodeRecordStore {
 
         let filename = Self::generate_filename(key);
         let file_path = self.config.storage_dir.join(&filename);
-
-        #[cfg(feature = "open-metrics")]
-        if let Some(metric) = &self.record_count_metric {
-            let _ = metric.set(self.records.len() as i64);
-        }
 
         let encryption_details = self.encryption_details.clone();
         let cloned_cmd_sender = self.local_swarm_cmd_sender.clone();


### PR DESCRIPTION
### Description

The records_store metric counts one less than the actual stored records in the nodes. The root cause being, the  records_store metric is updated before storing the records into the Hash-map.

Fix: Update the records_store after storing the records into the hash-map.

### Related Issue

Fixes #2775 .

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
