### PR TITLE
feat!: add gas fee limit for transactions

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -241,7 +241,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 address,
                 name,
                 value,
-                max_fee_per_gas
+                max_fee_per_gas,
             } => register::edit(address, name, &value, peers.await?, max_fee_per_gas).await,
             RegisterCmd::Get { address, name } => register::get(address, name, peers.await?).await,
             RegisterCmd::List => register::list(),

--- a/ant-cli/src/commands/register.rs
+++ b/ant-cli/src/commands/register.rs
@@ -52,7 +52,12 @@ pub async fn cost(name: &str, peers: NetworkPeers) -> Result<()> {
     Ok(())
 }
 
-pub async fn create(name: &str, value: &str, peers: NetworkPeers, max_fee_per_gas: Option<u128>) -> Result<()> {
+pub async fn create(
+    name: &str,
+    value: &str,
+    peers: NetworkPeers,
+    max_fee_per_gas: Option<u128>,
+) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
     let client = crate::actions::connect_to_network(peers).await?;
@@ -86,7 +91,13 @@ pub async fn create(name: &str, value: &str, peers: NetworkPeers, max_fee_per_ga
     Ok(())
 }
 
-pub async fn edit(address: String, name: bool, value: &str, peers: NetworkPeers, max_fee_per_gas: Option<u128>,) -> Result<()> {
+pub async fn edit(
+    address: String,
+    name: bool,
+    value: &str,
+    peers: NetworkPeers,
+    max_fee_per_gas: Option<u128>,
+) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
     let client = crate::actions::connect_to_network(peers).await?;

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -8,6 +8,7 @@
 
 use crate::network::NetworkPeers;
 use crate::wallet::load_wallet;
+use autonomi::TransactionConfig;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use color_eyre::Section;
@@ -27,9 +28,14 @@ pub async fn cost(peers: NetworkPeers, expected_max_size: u64) -> Result<()> {
     Ok(())
 }
 
-pub async fn create(peers: NetworkPeers) -> Result<()> {
+pub async fn create(peers: NetworkPeers, max_fee_per_gas: Option<u128>) -> Result<()> {
     let client = crate::actions::connect_to_network(peers).await?;
-    let wallet = load_wallet(client.evm_network())?;
+    let mut wallet = load_wallet(client.evm_network())?;
+
+    if let Some(max_fee_per_gas) = max_fee_per_gas {
+        wallet.set_transaction_config(TransactionConfig::new(max_fee_per_gas))
+    }
+
     let vault_sk = crate::keys::get_vault_secret_key()?;
 
     println!("Retrieving local user data...");

--- a/ant-evm/src/lib.rs
+++ b/ant-evm/src/lib.rs
@@ -18,6 +18,7 @@ pub use evmlib::contract::payment_vault;
 pub use evmlib::cryptography;
 #[cfg(feature = "external-signer")]
 pub use evmlib::external_signer;
+pub use evmlib::transaction_config::TransactionConfig;
 pub use evmlib::utils;
 pub use evmlib::utils::get_evm_network;
 pub use evmlib::utils::{DATA_PAYMENTS_ADDRESS, PAYMENT_TOKEN_ADDRESS, RPC_URL};

--- a/ant-node/tests/common/client.rs
+++ b/ant-node/tests/common/client.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::common::get_antnode_rpc_client;
 use ant_evm::Amount;
 use ant_protocol::antnode_proto::{NodeInfoRequest, RestartRequest};
 use ant_service_management::{get_local_node_registry_path, NodeRegistry};
@@ -20,8 +21,6 @@ use test_utils::{evm::get_funded_wallet, peers_from_env};
 use tokio::sync::Mutex;
 use tonic::Request;
 use tracing::{debug, info};
-
-use crate::common::get_antnode_rpc_client;
 
 /// This is a limited hard coded value as Droplet version has to contact the faucet to get the funds.
 /// This is limited to 10 requests to the faucet, where each request yields 100 SNT
@@ -136,7 +135,7 @@ impl LocalNetwork {
             .expect("Client shall be successfully created.")
     }
 
-    fn get_funded_wallet() -> evmlib::wallet::Wallet {
+    fn get_funded_wallet() -> Wallet {
         get_funded_wallet()
     }
 

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -78,6 +78,7 @@ pub use ant_evm::EvmNetwork as Network;
 pub use ant_evm::EvmWallet as Wallet;
 pub use ant_evm::QuoteHash;
 pub use ant_evm::RewardsAddress;
+pub use ant_evm::TransactionConfig;
 pub use ant_evm::{Amount, AttoTokens};
 
 // Re-exports of address related types

--- a/evmlib/src/contract/network_token.rs
+++ b/evmlib/src/contract/network_token.rs
@@ -9,6 +9,7 @@
 use crate::common::{Address, Calldata, TxHash, U256};
 use crate::contract::network_token::NetworkTokenContract::NetworkTokenContractInstance;
 use crate::retry::{retry, send_transaction_with_retries};
+use crate::transaction_config::TransactionConfig;
 use alloy::providers::{Network, Provider};
 use alloy::sol;
 use alloy::transports::{RpcError, Transport, TransportErrorKind};
@@ -92,10 +93,22 @@ where
     }
 
     /// Approve spender to spend a raw amount of tokens.
-    pub async fn approve(&self, spender: Address, value: U256) -> Result<TxHash, Error> {
+    pub async fn approve(
+        &self,
+        spender: Address,
+        value: U256,
+        transaction_config: &TransactionConfig,
+    ) -> Result<TxHash, Error> {
         debug!("Approving spender {spender:?} to spend {value}");
         let (calldata, to) = self.approve_calldata(spender, value);
-        send_transaction_with_retries(self.contract.provider(), calldata, to, "approve").await
+        send_transaction_with_retries(
+            self.contract.provider(),
+            calldata,
+            to,
+            "approve",
+            transaction_config,
+        )
+        .await
     }
 
     /// Approve spender to spend a raw amount of tokens.
@@ -106,10 +119,22 @@ where
     }
 
     /// Transfer a raw amount of tokens.
-    pub async fn transfer(&self, receiver: Address, amount: U256) -> Result<TxHash, Error> {
+    pub async fn transfer(
+        &self,
+        receiver: Address,
+        amount: U256,
+        transaction_config: &TransactionConfig,
+    ) -> Result<TxHash, Error> {
         debug!("Transferring raw amount of tokens: {amount} to {receiver:?}");
         let (calldata, to) = self.transfer_calldata(receiver, amount);
-        send_transaction_with_retries(self.contract.provider(), calldata, to, "transfer").await
+        send_transaction_with_retries(
+            self.contract.provider(),
+            calldata,
+            to,
+            "transfer",
+            transaction_config,
+        )
+        .await
     }
 
     /// Transfer a raw amount of tokens.

--- a/evmlib/src/contract/payment_vault/handler.rs
+++ b/evmlib/src/contract/payment_vault/handler.rs
@@ -3,6 +3,7 @@ use crate::contract::payment_vault::error::Error;
 use crate::contract::payment_vault::interface::IPaymentVault;
 use crate::contract::payment_vault::interface::IPaymentVault::IPaymentVaultInstance;
 use crate::retry::{retry, send_transaction_with_retries};
+use crate::transaction_config::TransactionConfig;
 use alloy::network::Network;
 use alloy::providers::Provider;
 use alloy::transports::Transport;
@@ -61,11 +62,18 @@ where
     pub async fn pay_for_quotes<I: IntoIterator<Item: Into<IPaymentVault::DataPayment>>>(
         &self,
         data_payments: I,
+        transaction_config: &TransactionConfig,
     ) -> Result<TxHash, Error> {
         debug!("Paying for quotes.");
         let (calldata, to) = self.pay_for_quotes_calldata(data_payments)?;
-        send_transaction_with_retries(self.contract.provider(), calldata, to, "pay for quotes")
-            .await
+        send_transaction_with_retries(
+            self.contract.provider(),
+            calldata,
+            to,
+            "pay for quotes",
+            transaction_config,
+        )
+        .await
     }
 
     /// Returns the pay for quotes transaction calldata.

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -26,6 +26,7 @@ pub mod external_signer;
 pub mod quoting_metrics;
 mod retry;
 pub mod testnet;
+pub mod transaction_config;
 pub mod utils;
 pub mod wallet;
 

--- a/evmlib/src/retry.rs
+++ b/evmlib/src/retry.rs
@@ -1,4 +1,5 @@
 use crate::common::{Address, Calldata, TxHash};
+use crate::transaction_config::TransactionConfig;
 use crate::TX_TIMEOUT;
 use alloy::network::{Network, TransactionBuilder};
 use alloy::providers::{PendingTransactionBuilder, Provider};
@@ -53,6 +54,7 @@ pub(crate) async fn send_transaction_with_retries<P, T, N, E>(
     calldata: Calldata,
     to: Address,
     tx_identifier: &str,
+    transaction_config: &TransactionConfig,
 ) -> Result<TxHash, E>
 where
     T: Transport + Clone,
@@ -69,7 +71,8 @@ where
         let mut transaction_request = provider
             .transaction_request()
             .with_to(to)
-            .with_input(calldata.clone());
+            .with_input(calldata.clone())
+            .with_max_fee_per_gas(transaction_config.max_fee_per_gas);
 
         // Retry with the same nonce to replace a stuck transaction
         if let Some(nonce) = nonce {

--- a/evmlib/src/transaction_config.rs
+++ b/evmlib/src/transaction_config.rs
@@ -1,0 +1,20 @@
+const DEFAULT_MAX_FEE_PER_GAS: u128 = 40_000_000;
+
+#[derive(Clone, Debug)]
+pub struct TransactionConfig {
+    pub max_fee_per_gas: u128,
+}
+
+impl TransactionConfig {
+    pub fn new(max_fee_per_gas: u128) -> Self {
+        Self { max_fee_per_gas }
+    }
+}
+
+impl Default for TransactionConfig {
+    fn default() -> Self {
+        Self {
+            max_fee_per_gas: DEFAULT_MAX_FEE_PER_GAS,
+        }
+    }
+}

--- a/evmlib/src/transaction_config.rs
+++ b/evmlib/src/transaction_config.rs
@@ -1,4 +1,4 @@
-const DEFAULT_MAX_FEE_PER_GAS: u128 = 40_000_000;
+const DEFAULT_MAX_FEE_PER_GAS: u128 = 200_000_000; // 0.2 Gwei
 
 #[derive(Clone, Debug)]
 pub struct TransactionConfig {

--- a/evmlib/tests/gas_fee_limit.rs
+++ b/evmlib/tests/gas_fee_limit.rs
@@ -1,0 +1,14 @@
+use alloy::providers::Provider;
+use evmlib::utils::http_provider;
+use evmlib::Network;
+
+#[tokio::test]
+async fn test_gas_fee_limit() {
+    let network = Network::ArbitrumOne;
+    let provider = http_provider(network.rpc_url().clone());
+    let base_gas_price = provider.get_gas_price().await.unwrap();
+    let max_priority_fee_per_gas = provider.get_max_priority_fee_per_gas().await.unwrap();
+
+    println!("Base gas price: {base_gas_price}");
+    println!("Max priority fee per gas: {max_priority_fee_per_gas}");
+}

--- a/evmlib/tests/network_token.rs
+++ b/evmlib/tests/network_token.rs
@@ -11,6 +11,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::transports::http::{Client, Http};
 use evmlib::contract::network_token::NetworkToken;
 use evmlib::testnet::{deploy_network_token_contract, start_node};
+use evmlib::transaction_config::TransactionConfig;
 use evmlib::wallet::wallet_address;
 use std::str::FromStr;
 
@@ -73,9 +74,11 @@ async fn test_approve() {
     let transaction_value = U256::from(1);
     let spender = PrivateKeySigner::random();
 
+    let transaction_config = TransactionConfig::default();
+
     // Approve for the spender to spend a value from the funds of the owner (our default account).
     let approval_result = network_token
-        .approve(spender.address(), transaction_value)
+        .approve(spender.address(), transaction_value, &transaction_config)
         .await;
 
     assert!(

--- a/evmlib/tests/payment_vault.rs
+++ b/evmlib/tests/payment_vault.rs
@@ -17,6 +17,7 @@ use evmlib::contract::payment_vault::handler::PaymentVaultHandler;
 use evmlib::contract::payment_vault::{interface, MAX_TRANSFERS_PER_TRANSACTION};
 use evmlib::quoting_metrics::QuotingMetrics;
 use evmlib::testnet::{deploy_data_payments_contract, deploy_network_token_contract, start_node};
+use evmlib::transaction_config::TransactionConfig;
 use evmlib::utils::http_provider;
 use evmlib::wallet::wallet_address;
 use evmlib::Network;
@@ -145,6 +146,8 @@ async fn test_get_quote_on_arb_sepolia() {
 async fn test_pay_for_quotes_on_local() {
     let (_anvil, network_token, mut payment_vault) = setup().await;
 
+    let transaction_config = TransactionConfig::default();
+
     let mut quote_payments = vec![];
 
     for _ in 0..MAX_TRANSFERS_PER_TRANSACTION {
@@ -153,7 +156,11 @@ async fn test_pay_for_quotes_on_local() {
     }
 
     let _ = network_token
-        .approve(*payment_vault.contract.address(), U256::MAX)
+        .approve(
+            *payment_vault.contract.address(),
+            U256::MAX,
+            &transaction_config,
+        )
         .await
         .unwrap();
 
@@ -161,7 +168,9 @@ async fn test_pay_for_quotes_on_local() {
     // so we set it to the same as the network token contract
     payment_vault.set_provider(network_token.contract.provider().clone());
 
-    let result = payment_vault.pay_for_quotes(quote_payments).await;
+    let result = payment_vault
+        .pay_for_quotes(quote_payments, &transaction_config)
+        .await;
 
     assert!(result.is_ok(), "Failed with error: {:?}", result.err());
 }
@@ -169,6 +178,8 @@ async fn test_pay_for_quotes_on_local() {
 #[tokio::test]
 async fn test_verify_payment_on_local() {
     let (_anvil, network_token, mut payment_vault) = setup().await;
+
+    let transaction_config = TransactionConfig::default();
 
     let mut quote_payments = vec![];
 
@@ -178,7 +189,11 @@ async fn test_verify_payment_on_local() {
     }
 
     let _ = network_token
-        .approve(*payment_vault.contract.address(), U256::MAX)
+        .approve(
+            *payment_vault.contract.address(),
+            U256::MAX,
+            &transaction_config,
+        )
         .await
         .unwrap();
 
@@ -186,7 +201,9 @@ async fn test_verify_payment_on_local() {
     // so we set it to the same as the network token contract
     payment_vault.set_provider(network_token.contract.provider().clone());
 
-    let result = payment_vault.pay_for_quotes(quote_payments.clone()).await;
+    let result = payment_vault
+        .pay_for_quotes(quote_payments.clone(), &transaction_config)
+        .await;
 
     assert!(result.is_ok(), "Failed with error: {:?}", result.err());
 

--- a/evmlib/tests/wallet.rs
+++ b/evmlib/tests/wallet.rs
@@ -11,6 +11,7 @@ use evmlib::common::{Amount, TxHash};
 use evmlib::contract::payment_vault::{verify_data_payment, MAX_TRANSFERS_PER_TRANSACTION};
 use evmlib::quoting_metrics::QuotingMetrics;
 use evmlib::testnet::{deploy_data_payments_contract, deploy_network_token_contract, start_node};
+use evmlib::transaction_config::TransactionConfig;
 use evmlib::wallet::{transfer_tokens, wallet_address, Wallet};
 use evmlib::{CustomNetwork, Network};
 use std::collections::HashSet;
@@ -51,12 +52,15 @@ async fn funded_wallet(network: &Network, genesis_wallet: EthereumWallet) -> Wal
         .await
         .unwrap();
 
+    let transaction_config = TransactionConfig::default();
+
     // Fund the wallet with plenty of ERC20 tokens
     transfer_tokens(
         genesis_wallet,
         network,
         account,
         Amount::from(9999999999_u64),
+        &transaction_config,
     )
     .await
     .unwrap();


### PR DESCRIPTION
Adds a default gas fee limit for transactions. The limit is specified in a `TransactionConfig`.

CLI users can override this limit using `--max-fee-per-gas <WEI_AMOUNT>`.