### PR TITLE
fix(node): get local closest_peers_to_target during payee verification

### DIFF
--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -262,6 +262,25 @@ impl Network {
             .map_err(|_e| NetworkError::InternalMsgChannelDropped)
     }
 
+    /// Returns X close peers to the target.
+    /// Note: self is not included
+    pub async fn get_close_peers_to_the_target(
+        &self,
+        key: NetworkAddress,
+        num_of_peers: usize,
+    ) -> Result<Vec<PeerId>> {
+        let (sender, receiver) = oneshot::channel();
+        self.send_local_swarm_cmd(LocalSwarmCmd::GetCloseLocalPeersToTarget {
+            key,
+            num_of_peers,
+            sender,
+        });
+
+        receiver
+            .await
+            .map_err(|_e| NetworkError::InternalMsgChannelDropped)
+    }
+
     /// Returns the replicate candidates in range.
     pub async fn get_replicate_candidates(&self, data_addr: NetworkAddress) -> Result<Vec<PeerId>> {
         let (sender, receiver) = oneshot::channel();

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -20,7 +20,7 @@ use ant_protocol::{
     },
     NetworkAddress, PrettyPrintRecordKey,
 };
-use libp2p::kad::{Record, RecordKey};
+use libp2p::kad::{Record, RecordKey, K_VALUE};
 use xor_name::XorName;
 
 impl Node {
@@ -655,7 +655,12 @@ impl Node {
         }
 
         // verify the claimed payees are all known to us within the certain range.
-        let closest_k_peers = self.network().get_closest_k_value_local_peers().await?;
+        let mut closest_k_peers = self
+            .network()
+            .get_close_peers_to_the_target(address.clone(), K_VALUE.get())
+            .await?;
+        // push self in as the returned list doesn't contain self
+        closest_k_peers.push(self_peer_id);
         let mut payees = payment.payees();
         payees.retain(|peer_id| !closest_k_peers.contains(peer_id));
         if !payees.is_empty() {


### PR DESCRIPTION
### Description

During payment payee verification, it shall be close_peers_to_target to be used, instead of close_peers_to_self.
The latter will cause payment to be rejected (with complains of `payment contain out-of-range payee`) in same edge case due to range mis-aligmn.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
