### PR TITLE
fix(node): avoid hole in RT hinders network_discovery

### DIFF
--- a/ant-networking/src/network_discovery.rs
+++ b/ant-networking/src/network_discovery.rs
@@ -56,24 +56,20 @@ impl SwarmDriver {
     pub(crate) fn trigger_network_discovery(&mut self) {
         let now = Instant::now();
 
-        // Find the farthest bucket that is not full. This is used to skip refreshing the RT of farthest full buckets.
-        let mut first_filled_bucket = 0;
-        // unfilled kbuckets will not be returned, hence the value shall be:
-        //   * first_filled_kbucket.ilog2() - 1
-        for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
-            let Some(ilog2) = kbucket.range().0.ilog2() else {
-                continue;
-            };
-            if kbucket.num_entries() >= K_VALUE.get() {
-                first_filled_bucket = ilog2;
+        // Find the farthest bucket that is not full.
+        // This is used to skip refreshing the RT of farthest full buckets.
+        let mut farthest_unfilled_bucket = Some(255);
+        let kbuckets: Vec<_> = self.swarm.behaviour_mut().kademlia.kbuckets().collect();
+        // Iterate from 255, 254 and so on by calling `rev()` to tackle the `hole` situation.
+        for kbucket in kbuckets.iter().rev() {
+            if kbucket.num_entries() < K_VALUE.get() {
+                let Some(ilog2) = kbucket.range().0.ilog2() else {
+                    continue;
+                };
+                farthest_unfilled_bucket = Some(ilog2);
                 break;
             }
         }
-        let farthest_unfilled_bucket = if first_filled_bucket == 0 {
-            None
-        } else {
-            Some(first_filled_bucket - 1)
-        };
 
         let addrs = self
             .network_discovery


### PR DESCRIPTION
### Description

We occasionally will encounter a `hole` in RT, such as the bucket `(6, 16, 238)` in the following kBucketTable :
```
kBucketTable has 24 kbuckets 397 peers (5 relay peers), [(0, 1, 232), (1, 3, 233), (2, 1, 234), (3, 8, 235), (4, 8, 236), (5, 20, 237), (6, 16, 238), (7, 20, 239), (8, 20, 240), (9, 20, 241), (10, 20, 242), (11, 20, 243), (12, 20, 244), (13, 20, 245), (14, 20, 246), (15, 20, 247), (16, 20, 248), (17, 20, 249), (18, 20, 250), (19, 20, 251), (20, 20, 252), (21, 20, 253), (22, 20, 254), (23, 20, 255)]
```
Such hole will slow down the network_discovery pace to get the RT fully populated.
This PR contains the work to handle such eadge case and improve the iteration efficiency.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
