### PR TITLE
feat(client): initial POC of smart_equation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
  "rmp-serde",
  "self_encryption",
  "serde",
+ "serde_json",
  "serial_test",
  "sha2",
  "test-utils",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -47,6 +47,7 @@ rayon = "1.8.0"
 rmp-serde = "1.1.1"
 self_encryption = "~0.30.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
+serde_json = "1.0"
 sha2 = "0.10.6"
 thiserror = "1.0.23"
 tokio = { version = "1.35.0", features = ["sync", "fs"] }

--- a/autonomi/src/client/high_level/mod.rs
+++ b/autonomi/src/client/high_level/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod data;
 pub mod files;
+pub mod smart_equation;
 pub mod vault;
 
 /// Registers are a mutable piece of data on the Network.

--- a/autonomi/src/client/high_level/smart_equation/equation.rs
+++ b/autonomi/src/client/high_level/smart_equation/equation.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use serde::Deserialize;
+use std::{collections::HashMap, str};
+
+/// Example JSON representing the equation `a + b`
+pub const PLUS_EQUATION: &str = r#"
+    {
+      "type": "op",
+      "op": "+",
+      "args": [
+        { "type": "param", "name": "a" },
+        { "type": "param", "name": "b" }
+      ]
+    }
+    "#;
+
+/// Example JSON representing the equation `(a + 5) * b`
+pub const COMPLEX_EQUATION: &str = r#"{
+      "type": "op",
+      "op": "*",
+      "args": [
+        {
+          "type": "op",
+          "op": "+",
+          "args": [
+            { "type": "param", "name": "a" },
+            { "type": "const", "value": 5 }
+          ]
+        },
+        { "type": "param", "name": "b" }
+      ]
+    }
+    "#;
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Expr {
+    Const { value: f64 },
+    Param { name: String },
+    Op { op: String, args: Vec<Expr> },
+}
+
+fn evaluate(expr: &Expr, params: &HashMap<String, f64>) -> Result<f64, String> {
+    match expr {
+        Expr::Const { value } => Ok(*value),
+        Expr::Param { name } => params
+            .get(name)
+            .copied()
+            .ok_or_else(|| format!("Parameter '{name}' not found")),
+        Expr::Op { op, args } => {
+            let evaluated_args: Result<Vec<f64>, String> =
+                args.iter().map(|arg| evaluate(arg, params)).collect();
+            let args = evaluated_args?;
+            match op.as_str() {
+                "+" => Ok(args.iter().sum()),
+                "*" => Ok(args.iter().product()),
+                _ => Err(format!("Unknown operator: {op}")),
+            }
+        }
+    }
+}
+
+pub fn compute(params: HashMap<String, f64>, equation: &str) -> Result<f64, String> {
+    let expr: Expr =
+        serde_json::from_str(equation).map_err(|e| format!("Failed to parse JSON: {e}"))?;
+    evaluate(&expr, &params)
+}

--- a/autonomi/src/client/high_level/smart_equation/mod.rs
+++ b/autonomi/src/client/high_level/smart_equation/mod.rs
@@ -1,0 +1,127 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod equation;
+pub use equation::{compute, COMPLEX_EQUATION, PLUS_EQUATION};
+
+use crate::client::payment::PaymentOption;
+use crate::client::Client;
+use ant_evm::AttoTokens;
+use ant_protocol::storage::{Chunk, ChunkAddress, PointerAddress, PointerTarget};
+use bls::SecretKey;
+use bytes::Bytes;
+use thiserror::Error;
+use tracing::info;
+
+#[derive(Debug, Error)]
+pub enum SmartEquationError {
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+    #[error("Deserialization error: {0}")]
+    Deserialization(String),
+    #[error("Network error: {0}")]
+    Network(String),
+    #[error("Pointer not found")]
+    PointerNotFound,
+    #[error("Chunk not found")]
+    ChunkNotFound,
+    #[error("InvalidHeadPointer: {0:?}")]
+    InvalidHeadPointer(PointerTarget),
+}
+
+impl Client {
+    /// Publishes a new smart equation to the network.
+    /// Takes a serializable JSON object, stores it as a Chunk, and creates a Pointer to it.
+    pub async fn publish_smart_equation(
+        &self,
+        equation_data: String,
+        owner: &SecretKey,
+        payment_option: PaymentOption,
+    ) -> Result<(AttoTokens, PointerAddress), SmartEquationError> {
+        info!("Publishing new smart equation...");
+
+        // Create and upload the chunk
+        let chunk = Chunk::new(Bytes::from(equation_data));
+        let chunk_address = ChunkAddress::new(*chunk.name());
+        self.chunk_put(&chunk, payment_option.clone())
+            .await
+            .map_err(|e| SmartEquationError::Network(e.to_string()))?;
+
+        // Create and upload the pointer
+        let pointer_target = PointerTarget::ChunkAddress(chunk_address);
+        let (cost, pointer_address) = self
+            .pointer_create(owner, pointer_target, payment_option)
+            .await
+            .map_err(|e| SmartEquationError::Network(e.to_string()))?;
+
+        info!(
+            "Smart equation published at address: {:?} with cost of {cost}",
+            pointer_address
+        );
+        Ok((cost, pointer_address))
+    }
+
+    /// Retrieves a smart equation from the network.
+    /// Takes a PointerAddress and returns the deserialized JSON object.
+    pub async fn get_smart_equation(
+        &self,
+        pointer_address: PointerAddress,
+    ) -> Result<Bytes, SmartEquationError> {
+        info!(
+            "Retrieving smart equation at address: {:?}",
+            pointer_address
+        );
+
+        // Get the pointer
+        let pointer = self
+            .pointer_get(&pointer_address)
+            .await
+            .map_err(|_| SmartEquationError::PointerNotFound)?;
+
+        // Get the chunk
+        let chunk_addr = match pointer.target() {
+            PointerTarget::ChunkAddress(addr) => addr,
+            other => return Err(SmartEquationError::InvalidHeadPointer(other.clone())),
+        };
+        let chunk = self
+            .chunk_get(chunk_addr)
+            .await
+            .map_err(|_| SmartEquationError::ChunkNotFound)?;
+
+        info!("Smart equation successfully retrieved");
+        Ok(chunk.value)
+    }
+
+    /// Updates an existing smart equation on the network.
+    /// Takes new equation data and updates the Pointer to point to the new Chunk.
+    pub async fn update_smart_equation(
+        &self,
+        pointer_address: PointerAddress,
+        new_equation_data: String,
+        owner: &SecretKey,
+        payment_option: PaymentOption,
+    ) -> Result<(), SmartEquationError> {
+        info!("Updating smart equation at address: {:?}", pointer_address);
+
+        // Create and upload the new chunk
+        let new_chunk = Chunk::new(Bytes::from(new_equation_data));
+        let new_chunk_address = ChunkAddress::new(*new_chunk.name());
+        self.chunk_put(&new_chunk, payment_option.clone())
+            .await
+            .map_err(|e| SmartEquationError::Network(e.to_string()))?;
+
+        // Update the pointer to point to the new chunk
+        let new_pointer_target = PointerTarget::ChunkAddress(new_chunk_address);
+        self.pointer_update(owner, new_pointer_target)
+            .await
+            .map_err(|_| SmartEquationError::PointerNotFound)?;
+
+        info!("Smart equation at {pointer_address:?} successfully updated");
+        Ok(())
+    }
+}

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -26,6 +26,7 @@ mod high_level;
 pub use high_level::data;
 pub use high_level::files;
 pub use high_level::register;
+pub use high_level::smart_equation;
 pub use high_level::vault;
 
 pub mod config;

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -70,6 +70,7 @@ pub use client::data_types::scratchpad;
 pub use client::data;
 pub use client::files;
 pub use client::register;
+pub use client::smart_equation;
 pub use client::vault;
 
 // Re-exports of the evm types

--- a/autonomi/tests/smart_equation.rs
+++ b/autonomi/tests/smart_equation.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_logging::LogBuilder;
+use autonomi::client::payment::PaymentOption;
+use autonomi::smart_equation::{compute, COMPLEX_EQUATION, PLUS_EQUATION};
+use autonomi::Client;
+use serial_test::serial;
+use std::{collections::HashMap, str};
+use test_utils::evm::get_funded_wallet;
+
+#[tokio::test]
+#[serial]
+async fn smart_equation() -> Result<(), Box<dyn std::error::Error>> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("smart_equation", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let owner_key = bls::SecretKey::random();
+    let payment_option = PaymentOption::from(&wallet);
+
+    // publish smart_equation
+    let (cost, pointer_address) = client
+        .publish_smart_equation(
+            PLUS_EQUATION.to_string(),
+            &owner_key,
+            payment_option.clone(),
+        )
+        .await?;
+    println!("smart_equation published at {pointer_address:?} with cost of {cost}");
+
+    // fetch the smart_equation
+    let fetched_equation = client.get_smart_equation(pointer_address).await?;
+    let fetched_equation: &str =
+        str::from_utf8(&fetched_equation).expect("Bytes are not valid UTF-8");
+    println!("smart_equation fetched from {pointer_address:?}");
+
+    // verify the fetched smart_equation
+    let mut params = HashMap::new();
+    params.insert("a".to_string(), 3.0);
+    params.insert("b".to_string(), 4.0);
+    assert_eq!(compute(params.clone(), fetched_equation), Ok(7.0));
+
+    // update the smart_equation
+    client
+        .update_smart_equation(
+            pointer_address,
+            COMPLEX_EQUATION.to_string(),
+            &owner_key,
+            payment_option,
+        )
+        .await?;
+    println!("smart_equation at {pointer_address:?} got updated");
+
+    // Short break to allow data synced among nodes
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+    // fetch the smart_equation
+    let fetched_equation = client.get_smart_equation(pointer_address).await?;
+    let fetched_equation: &str =
+        str::from_utf8(&fetched_equation).expect("Bytes are not valid UTF-8");
+    println!("smart_equation fetched from {pointer_address:?}");
+
+    // verify the fetched smart_equation
+    assert_eq!(compute(params.clone(), fetched_equation), Ok(32.0));
+
+    Ok(())
+}


### PR DESCRIPTION
### Description

Initial POC of SmartEquation, which using Pointer pointing to a chunk.
This can be used to replace part of the quote verification flow: get a cost based on the QuotingMetrices
To be the sole place holding the equations of how to calculate the cose, which doesn't need to use smart_contract. 

The PR contains an E2E test to demo that:
1. publish an equation of `a + b` to the network
2. fetch the equation and use it to calculate
3. update the equation to `(a+5)*b`
4. fetch the equation from the network again and use it to calculate (result shall be new)

This answers one concern in the original native notken re-introduction RFC regarding having a smart_contract styple quoting verification.
This also shows a potential that with further design and expansion, we could have a non-block-chain-based smart_contract

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
