### PR TITLE
fix(node): avoid hole in RT hinders network_discovery

### DIFF
--- a/ant-networking/src/network_discovery.rs
+++ b/ant-networking/src/network_discovery.rs
@@ -56,24 +56,20 @@ impl SwarmDriver {
     pub(crate) fn trigger_network_discovery(&mut self) {
         let now = Instant::now();
 
-        // Find the farthest bucket that is not full. This is used to skip refreshing the RT of farthest full buckets.
-        let mut first_filled_bucket = 0;
-        // unfilled kbuckets will not be returned, hence the value shall be:
-        //   * first_filled_kbucket.ilog2() - 1
-        for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
-            let Some(ilog2) = kbucket.range().0.ilog2() else {
-                continue;
-            };
-            if kbucket.num_entries() >= K_VALUE.get() {
-                first_filled_bucket = ilog2;
+        // Find the farthest bucket that is not full.
+        // This is used to skip refreshing the RT of farthest full buckets.
+        let mut farthest_unfilled_bucket = Some(255);
+        let kbuckets: Vec<_> = self.swarm.behaviour_mut().kademlia.kbuckets().collect();
+        // Iterate from 255, 254 and so on by calling `rev()` to tackle the `hole` situation.
+        for kbucket in kbuckets.iter().rev() {
+            if kbucket.num_entries() < K_VALUE.get() {
+                let Some(ilog2) = kbucket.range().0.ilog2() else {
+                    continue;
+                };
+                farthest_unfilled_bucket = Some(ilog2);
                 break;
             }
         }
-        let farthest_unfilled_bucket = if first_filled_bucket == 0 {
-            None
-        } else {
-            Some(first_filled_bucket - 1)
-        };
 
         let addrs = self
             .network_discovery


### PR DESCRIPTION
This was originally #2795.

It is being cherry-picked to include in a hotfix.