### PR TITLE
fix(evmlib): construct rpc url manually

### DIFF
--- a/evmlib/tests/network_token.rs
+++ b/evmlib/tests/network_token.rs
@@ -37,9 +37,9 @@ async fn setup() -> (
         Ethereum,
     >,
 ) {
-    let node = start_node();
+    let (node, rpc_url) = start_node();
 
-    let network_token = deploy_network_token_contract(&node.endpoint_url(), &node).await;
+    let network_token = deploy_network_token_contract(&rpc_url, &node).await;
 
     (node, network_token)
 }

--- a/evmlib/tests/payment_vault.rs
+++ b/evmlib/tests/payment_vault.rs
@@ -63,8 +63,7 @@ async fn setup() -> (
         Ethereum,
     >,
 ) {
-    let node = start_node();
-    let rpc_url = node.endpoint_url();
+    let (node, rpc_url) = start_node();
 
     let network_token = deploy_network_token_contract(&rpc_url, &node).await;
 

--- a/evmlib/tests/wallet.rs
+++ b/evmlib/tests/wallet.rs
@@ -18,8 +18,7 @@ use std::collections::HashSet;
 
 #[allow(clippy::unwrap_used)]
 async fn local_testnet() -> (AnvilInstance, Network, EthereumWallet) {
-    let node = start_node();
-    let rpc_url = node.endpoint_url();
+    let (node, rpc_url) = start_node();
     let network_token = deploy_network_token_contract(&rpc_url, &node).await;
     let payment_token_address = *network_token.contract.address();
     let data_payments = deploy_data_payments_contract(&rpc_url, &node, payment_token_address).await;


### PR DESCRIPTION
- `anvil::endpoint_url()` would always return the `localhost` and would not return the value set by `ANVIL_IP_ADDR`. This causes failures when running the anvil node on a public VM.
- Thus construct the `rpc_url` manually.