### PR TITLE
chore(ci): update devskim to use ubuntu latest

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: DevSkim
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
- CI runs fails as we're using a soon-to-be outdated Ubuntu version. https://github.com/actions/runner-images/issues/11101