### PR TITLE
chore(launchpad): update homepage during panic msg

### DIFF
--- a/node-launchpad/src/utils.rs
+++ b/node-launchpad/src/utils.rs
@@ -39,7 +39,7 @@ pub fn initialize_panic_handler() -> Result<()> {
                 version: env!("CARGO_PKG_VERSION").into(),
                 name: env!("CARGO_PKG_NAME").into(),
                 authors: env!("CARGO_PKG_AUTHORS").replace(':', ", ").into(),
-                homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+                homepage: "https://autonomi.com/".into(),
             };
 
             let file_path = handle_dump(&meta, panic_info);


### PR DESCRIPTION
- Hardcode `autonomi` url instead of fetching the url from the `cargo.toml`, which is outdated. This url is printed during panics.