### PR TITLE
 feat(launchpad): node actions

### DIFF
--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -267,7 +267,9 @@ impl<T: ServiceStateActions + Send> ServiceManager<T> {
                     // crate treats as an error. We then return our own error type, which allows us
                     // to handle it here and just proceed with removing the service from the
                     // registry.
-                    println!("The user appears to have removed the {name} service manually");
+                    if self.verbosity != VerbosityLevel::Minimal {
+                        println!("The user appears to have removed the {name} service manually");
+                    }
                 }
                 ServiceError::ServiceDoesNotExists(name) => {
                     warn!("The service {name} has most probably been removed already, it does not exists. Skipping the error.");

--- a/node-launchpad/.config/config.json5
+++ b/node-launchpad/.config/config.json5
@@ -8,8 +8,8 @@
       "<h>": {"SwitchScene":"Help"},
       "<H>": {"SwitchScene":"Help"},
 
-      "<Ctrl-s>": {"StatusActions":"StartNodes"},
-      "<Ctrl-S>": {"StatusActions":"StartNodes"},
+      "<Ctrl-s>": {"StatusActions":"StartStopNode"},
+      "<Ctrl-S>": {"StatusActions":"StartStopNode"},
       "<Ctrl-Shift-s>": {"StatusActions":"StartNodes"},
       "<Ctrl-x>": {"StatusActions":"StopNodes"},
       "<Ctrl-X>": {"StatusActions":"StopNodes"},
@@ -19,6 +19,8 @@
       "<Ctrl-Shift-b>": {"StatusActions":"TriggerRewardsAddress"},
       "<l>": {"StatusActions":"TriggerNodeLogs"},
       "<L>": {"StatusActions":"TriggerNodeLogs"},
+      "<+>": {"StatusActions":"AddNode"},
+      "<->": {"StatusActions":"TriggerRemoveNode"},
 
       "up" : {"StatusActions":"PreviousTableItem"},
       "down": {"StatusActions":"NextTableItem"},

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -51,21 +51,54 @@ pub enum StatusActions {
     StopNodes,
     RemoveNodes,
     StartStopNode,
-    StartNodesCompleted,
-    StopNodesCompleted,
-    ResetNodesCompleted { trigger_start_node: bool },
+    StartNodesCompleted {
+        service_name: String,
+    },
+    StopNodesCompleted {
+        service_name: String,
+    },
+    ResetNodesCompleted {
+        trigger_start_node: bool,
+    },
+    RemoveNodesCompleted {
+        service_name: String,
+    },
+    AddNodesCompleted {
+        service_name: String,
+    },
     UpdateNodesCompleted,
-    RemovingNodesCompleted,
     SuccessfullyDetectedNatStatus,
     ErrorWhileRunningNatDetection,
-    ErrorLoadingNodeRegistry { raw_error: String },
-    ErrorGettingNodeRegistryPath { raw_error: String },
-    ErrorScalingUpNodes { raw_error: String },
-    ErrorStoppingNodes { raw_error: String },
-    ErrorResettingNodes { raw_error: String },
-    ErrorUpdatingNodes { raw_error: String },
-    ErrorRemovingNodes { raw_error: String },
-    ErrorStartingNodes { raw_error: String },
+    ErrorLoadingNodeRegistry {
+        raw_error: String,
+    },
+    ErrorGettingNodeRegistryPath {
+        raw_error: String,
+    },
+    ErrorScalingUpNodes {
+        raw_error: String,
+    },
+    ErrorResettingNodes {
+        raw_error: String,
+    },
+    ErrorUpdatingNodes {
+        raw_error: String,
+    },
+    ErrorAddingNodes {
+        raw_error: String,
+    },
+    ErrorStartingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
+    ErrorStoppingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
+    ErrorRemovingNodes {
+        services: Vec<String>,
+        raw_error: String,
+    },
     NodesStatsObtained(NodeStats),
 
     TriggerManageNodes,

--- a/node-launchpad/src/action.rs
+++ b/node-launchpad/src/action.rs
@@ -46,12 +46,16 @@ pub enum Action {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum StatusActions {
+    AddNode,
     StartNodes,
     StopNodes,
+    RemoveNodes,
+    StartStopNode,
     StartNodesCompleted,
     StopNodesCompleted,
     ResetNodesCompleted { trigger_start_node: bool },
     UpdateNodesCompleted,
+    RemovingNodesCompleted,
     SuccessfullyDetectedNatStatus,
     ErrorWhileRunningNatDetection,
     ErrorLoadingNodeRegistry { raw_error: String },
@@ -60,11 +64,14 @@ pub enum StatusActions {
     ErrorStoppingNodes { raw_error: String },
     ErrorResettingNodes { raw_error: String },
     ErrorUpdatingNodes { raw_error: String },
+    ErrorRemovingNodes { raw_error: String },
+    ErrorStartingNodes { raw_error: String },
     NodesStatsObtained(NodeStats),
 
     TriggerManageNodes,
     TriggerRewardsAddress,
     TriggerNodeLogs,
+    TriggerRemoveNode,
 
     PreviousTableItem,
     NextTableItem,

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -129,7 +129,7 @@ impl App {
         let change_connection_mode = ChangeConnectionModePopUp::new(connection_mode)?;
         let port_range = PortRangePopUp::new(connection_mode, port_from, port_to);
         let rewards_address = RewardsAddress::new(app_data.discord_username.clone());
-        let upgrade_nodes = UpgradeNodesPopUp::new(app_data.nodes_to_start);
+        let upgrade_nodes = UpgradeNodesPopUp::new();
         let remove_node = RemoveNodePopUp::default();
 
         Ok(Self {

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -106,6 +106,7 @@ impl App {
             upnp_support,
             port_from: Some(port_from),
             port_to: Some(port_to),
+            storage_mountpoint: storage_mountpoint.clone(),
         };
 
         let status = Status::new(status_config).await?;

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -16,8 +16,9 @@ use crate::{
         options::Options,
         popup::{
             change_drive::ChangeDrivePopup, connection_mode::ChangeConnectionModePopUp,
-            manage_nodes::ManageNodes, port_range::PortRangePopUp, reset_nodes::ResetNodesPopup,
-            rewards_address::RewardsAddress, upgrade_nodes::UpgradeNodesPopUp,
+            manage_nodes::ManageNodes, port_range::PortRangePopUp, remove_node::RemoveNodePopUp,
+            reset_nodes::ResetNodesPopup, rewards_address::RewardsAddress,
+            upgrade_nodes::UpgradeNodesPopUp,
         },
         status::{Status, StatusConfig},
         Component,
@@ -128,6 +129,7 @@ impl App {
         let port_range = PortRangePopUp::new(connection_mode, port_from, port_to);
         let rewards_address = RewardsAddress::new(app_data.discord_username.clone());
         let upgrade_nodes = UpgradeNodesPopUp::new(app_data.nodes_to_start);
+        let remove_node = RemoveNodePopUp::default();
 
         Ok(Self {
             config,
@@ -155,6 +157,7 @@ impl App {
                 Box::new(reset_nodes),
                 Box::new(manage_nodes),
                 Box::new(upgrade_nodes),
+                Box::new(remove_node),
             ],
             should_quit: false,
             should_suspend: false,

--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -35,11 +35,14 @@ impl StatefulWidget for Footer {
         };
 
         let commands = vec![
-            Span::styled("[Ctrl+G] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Manage Nodes", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[+] ", Style::default().fg(GHOST_WHITE)),
+            Span::styled("Add", Style::default().fg(EUCALYPTUS)),
+            Span::styled(" ", Style::default()),
+            Span::styled("[-] ", Style::default().fg(GHOST_WHITE)),
+            Span::styled("Remove", Style::default().fg(EUCALYPTUS)),
             Span::styled(" ", Style::default()),
             Span::styled("[Ctrl+S] ", command_style),
-            Span::styled("Start Nodes", text_style),
+            Span::styled("Start/Stop Node", text_style),
             Span::styled(" ", Style::default()),
             Span::styled("[L] ", command_style),
             Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),

--- a/node-launchpad/src/components/footer.rs
+++ b/node-launchpad/src/components/footer.rs
@@ -10,9 +10,10 @@ use crate::style::{COOL_GREY, EUCALYPTUS, GHOST_WHITE, LIGHT_PERIWINKLE};
 use ratatui::{prelude::*, widgets::*};
 
 pub enum NodesToStart {
-    Configured,
-    NotConfigured,
     Running,
+    NotRunning,
+    RunningSelected,
+    NotRunningSelected,
 }
 
 #[derive(Default)]
@@ -22,53 +23,99 @@ impl StatefulWidget for Footer {
     type State = NodesToStart;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let (text_style, command_style) = if matches!(state, NodesToStart::Configured) {
-            (
-                Style::default().fg(EUCALYPTUS),
-                Style::default().fg(GHOST_WHITE),
-            )
-        } else {
-            (
-                Style::default().fg(COOL_GREY),
-                Style::default().fg(LIGHT_PERIWINKLE),
-            )
-        };
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Length(3)])
+            .split(area);
+
+        let command_enabled = Style::default().fg(GHOST_WHITE);
+        let text_enabled = Style::default().fg(EUCALYPTUS);
+        let command_disabled = Style::default().fg(LIGHT_PERIWINKLE);
+        let text_disabled = Style::default().fg(COOL_GREY);
+
+        let mut remove_command_style = command_disabled;
+        let mut remove_text_style = text_disabled;
+        let mut start_stop_command_style = command_disabled;
+        let mut start_stop_text_style = text_disabled;
+        let mut open_logs_command_style = command_disabled;
+        let mut open_logs_text_style = text_disabled;
+        let mut stop_all_command_style = command_disabled;
+        let mut stop_all_text_style = text_disabled;
+
+        match state {
+            NodesToStart::Running => {
+                stop_all_command_style = command_enabled;
+                stop_all_text_style = text_enabled;
+            }
+            NodesToStart::RunningSelected => {
+                remove_command_style = command_enabled;
+                remove_text_style = text_enabled;
+                start_stop_command_style = command_enabled;
+                start_stop_text_style = text_enabled;
+                open_logs_command_style = command_enabled;
+                open_logs_text_style = text_enabled;
+                stop_all_command_style = command_enabled;
+                stop_all_text_style = text_enabled;
+            }
+            NodesToStart::NotRunning => {}
+            NodesToStart::NotRunningSelected => {
+                remove_command_style = command_enabled;
+                remove_text_style = text_enabled;
+                start_stop_command_style = command_enabled;
+                start_stop_text_style = text_enabled;
+                open_logs_command_style = command_enabled;
+                open_logs_text_style = text_enabled;
+            }
+        }
 
         let commands = vec![
-            Span::styled("[+] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Add", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[+] ", command_enabled),
+            Span::styled("Add", text_enabled),
             Span::styled(" ", Style::default()),
-            Span::styled("[-] ", Style::default().fg(GHOST_WHITE)),
-            Span::styled("Remove", Style::default().fg(EUCALYPTUS)),
+            Span::styled("[-] ", remove_command_style),
+            Span::styled("Remove", remove_text_style),
             Span::styled(" ", Style::default()),
-            Span::styled("[Ctrl+S] ", command_style),
-            Span::styled("Start/Stop Node", text_style),
+            Span::styled("[Ctrl+S] ", start_stop_command_style),
+            Span::styled("Start/Stop Node", start_stop_text_style),
             Span::styled(" ", Style::default()),
-            Span::styled("[L] ", command_style),
-            Span::styled("Open Logs", Style::default().fg(EUCALYPTUS)),
-            Span::styled(" ", Style::default()),
-            Span::styled("[Ctrl+X] ", command_style),
-            Span::styled(
-                "Stop All",
-                if matches!(state, NodesToStart::Running) {
-                    Style::default().fg(EUCALYPTUS)
-                } else {
-                    Style::default().fg(COOL_GREY)
-                },
-            ),
+            Span::styled("[L] ", open_logs_command_style),
+            Span::styled("Open Logs", open_logs_text_style),
         ];
 
-        let cell1 = Cell::from(Line::from(commands));
-        let row = Row::new(vec![cell1]);
+        let stop_all = vec![
+            Span::styled("[Ctrl+X] ", stop_all_command_style),
+            Span::styled("Stop All", stop_all_text_style),
+        ];
 
-        let table = Table::new(vec![row], vec![Constraint::Max(1)])
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(EUCALYPTUS))
-                    .padding(Padding::horizontal(1)),
-            )
-            .widths(vec![Constraint::Fill(1)]);
+        let total_width = (layout[0].width - 1) as usize;
+        let spaces = " ".repeat(total_width.saturating_sub(
+            commands.iter().map(|s| s.width()).sum::<usize>()
+                + stop_all.iter().map(|s| s.width()).sum::<usize>(),
+        ));
+
+        let commands_length = 6 + commands.iter().map(|s| s.width()).sum::<usize>() as u16;
+        let spaces_length = spaces.len().saturating_sub(6) as u16;
+        let stop_all_length = stop_all.iter().map(|s| s.width()).sum::<usize>() as u16;
+
+        let cell1 = Cell::from(Line::from(commands));
+        let cell2 = Cell::from(Line::raw(spaces));
+        let cell3 = Cell::from(Line::from(stop_all));
+        let row = Row::new(vec![cell1, cell2, cell3]);
+
+        let table = Table::new(
+            [row],
+            [
+                Constraint::Length(commands_length),
+                Constraint::Length(spaces_length),
+                Constraint::Length(stop_all_length),
+            ],
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(EUCALYPTUS))
+                .padding(Padding::horizontal(1)),
+        );
 
         StatefulWidget::render(table, area, buf, &mut TableState::default());
     }

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -68,7 +68,7 @@ impl Component for Options {
             .constraints(
                 [
                     Constraint::Length(1),
-                    Constraint::Length(7),
+                    Constraint::Length(5),
                     Constraint::Length(3),
                     Constraint::Length(3),
                     Constraint::Length(4),
@@ -93,7 +93,6 @@ impl Component for Options {
             .border_style(Style::default().fg(VERY_LIGHT_AZURE));
         let storage_drivename = Table::new(
             vec![
-                Row::new(vec![Line::from(vec![])]),
                 Row::new(vec![
                     Cell::from(
                         Line::from(vec![Span::styled(
@@ -177,7 +176,6 @@ impl Component for Options {
                         .alignment(Alignment::Right),
                     ),
                 ]),
-                Row::new(vec![Line::from(vec![])]),
             ],
             &[
                 Constraint::Length(18),

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -374,7 +374,7 @@ impl Component for Options {
                 | Scene::ChangePortsPopUp { .. }
                 | Scene::OptionsRewardsAddressPopUp
                 | Scene::ResetNodesPopUp
-                | Scene::UpgradeNodesPopUp => {
+                | Scene::UpgradeNodesPopUp { .. } => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));

--- a/node-launchpad/src/components/options.rs
+++ b/node-launchpad/src/components/options.rs
@@ -374,7 +374,7 @@ impl Component for Options {
                 | Scene::ChangePortsPopUp { .. }
                 | Scene::OptionsRewardsAddressPopUp
                 | Scene::ResetNodesPopUp
-                | Scene::UpgradeNodesPopUp { .. } => {
+                | Scene::UpgradeNodesPopUp => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));

--- a/node-launchpad/src/components/popup.rs
+++ b/node-launchpad/src/components/popup.rs
@@ -10,6 +10,7 @@ pub mod change_drive;
 pub mod connection_mode;
 pub mod manage_nodes;
 pub mod port_range;
+pub mod remove_node;
 pub mod reset_nodes;
 pub mod rewards_address;
 pub mod upgrade_nodes;

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -285,7 +285,7 @@ impl Component for ManageNodes {
         let help = Paragraph::new(vec![
             Line::raw(format!(
                 "Note: Each node will use a small amount of CPU Memory and Network Bandwidth. \
-                 We recommend starting no more than 5 at a time (max {MAX_NODE_COUNT} nodes)."
+                 We recommend starting no more than 2 at a time (max {MAX_NODE_COUNT} nodes)."
             )),
             Line::raw(""),
             Line::raw("▲▼ to change the number of nodes to start."),

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -165,7 +165,11 @@ impl Component for ManageNodes {
     fn update(&mut self, action: Action) -> Result<Option<Action>> {
         let send_back = match action {
             Action::SwitchScene(scene) => match scene {
-                Scene::ManageNodesPopUp => {
+                Scene::ManageNodesPopUp { amount_of_nodes } => {
+                    self.nodes_to_start_input = self
+                        .nodes_to_start_input
+                        .clone()
+                        .with_value(amount_of_nodes.to_string());
                     self.active = true;
                     self.old_value = self.nodes_to_start_input.value().to_string();
                     // set to entry input mode as we want to handle everything within our handle_key_events

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::super::{utils::centered_rect_fixed, Component};
 
-pub const GB_PER_NODE: usize = 35;
+pub const GB_PER_NODE: usize = 1;
 pub const MB: usize = 1000 * 1000;
 pub const GB: usize = MB * 1000;
 pub const MAX_NODE_COUNT: usize = 50;

--- a/node-launchpad/src/components/popup/manage_nodes.rs
+++ b/node-launchpad/src/components/popup/manage_nodes.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::super::{utils::centered_rect_fixed, Component};
 
-pub const GB_PER_NODE: usize = 1;
+pub const GB_PER_NODE: usize = 35;
 pub const MB: usize = 1000 * 1000;
 pub const GB: usize = MB * 1000;
 pub const MAX_NODE_COUNT: usize = 50;

--- a/node-launchpad/src/components/popup/upgrade_nodes.rs
+++ b/node-launchpad/src/components/popup/upgrade_nodes.rs
@@ -19,15 +19,15 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{prelude::*, widgets::*};
 
 pub struct UpgradeNodesPopUp {
-    nodes_to_start: usize,
+    amount_of_nodes: usize,
     /// Whether the component is active right now, capturing keystrokes + draw things.
     active: bool,
 }
 
 impl UpgradeNodesPopUp {
-    pub fn new(nodes_to_start: usize) -> Self {
+    pub fn new(amount_of_nodes: usize) -> Self {
         Self {
-            nodes_to_start,
+            amount_of_nodes,
             active: false,
         }
     }
@@ -68,10 +68,6 @@ impl Component for UpgradeNodesPopUp {
                     None
                 }
             },
-            Action::StoreNodesToStart(ref nodes_to_start) => {
-                self.nodes_to_start = *nodes_to_start;
-                None
-            }
             _ => None,
         };
         Ok(send_back)
@@ -114,9 +110,9 @@ impl Component for UpgradeNodesPopUp {
             Direction::Vertical,
             [
                 // for the text
-                Constraint::Length(9),
+                Constraint::Length(10),
                 // gap
-                Constraint::Length(4),
+                Constraint::Length(3),
                 // for the buttons
                 Constraint::Length(1),
             ],
@@ -139,10 +135,14 @@ impl Component for UpgradeNodesPopUp {
             Line::from(Span::styled(
                 format!(
                     "Upgrade time ~ {:.1?} mins ({:?} nodes * {:?} secs)",
-                    self.nodes_to_start * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
-                    self.nodes_to_start,
+                    self.amount_of_nodes * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
+                    self.amount_of_nodes,
                     node_mgmt::FIXED_INTERVAL / 1_000,
                 ),
+                Style::default().fg(LIGHT_PERIWINKLE),
+            )),
+            Line::from(Span::styled(
+                "plus, new binary download time.",
                 Style::default().fg(LIGHT_PERIWINKLE),
             )),
             Line::from(Span::styled("\n\n", Style::default())),

--- a/node-launchpad/src/components/popup/upgrade_nodes.rs
+++ b/node-launchpad/src/components/popup/upgrade_nodes.rs
@@ -19,17 +19,19 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{prelude::*, widgets::*};
 
 pub struct UpgradeNodesPopUp {
-    amount_of_nodes: usize,
     /// Whether the component is active right now, capturing keystrokes + draw things.
     active: bool,
 }
 
 impl UpgradeNodesPopUp {
-    pub fn new(amount_of_nodes: usize) -> Self {
-        Self {
-            amount_of_nodes,
-            active: false,
-        }
+    pub fn new() -> Self {
+        Self { active: false }
+    }
+}
+
+impl Default for UpgradeNodesPopUp {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -134,9 +136,7 @@ impl Component for UpgradeNodesPopUp {
             )),
             Line::from(Span::styled(
                 format!(
-                    "Upgrade time ~ {:.1?} mins ({:?} nodes * {:?} secs)",
-                    self.amount_of_nodes * (node_mgmt::FIXED_INTERVAL / 1_000) as usize / 60,
-                    self.amount_of_nodes,
+                    "Upgrade time is {:.1?} seconds per node",
                     node_mgmt::FIXED_INTERVAL / 1_000,
                 ),
                 Style::default().fg(LIGHT_PERIWINKLE),

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -1316,19 +1316,31 @@ impl Component for Status<'_> {
 
         // ==== Footer =====
 
+        let selected = self
+            .items
+            .as_ref()
+            .and_then(|items| items.selected_item())
+            .is_some();
+
         let footer = Footer::default();
         let footer_state = if let Some(ref items) = self.items {
-            if !items.items.is_empty() || self.rewards_address.is_empty() {
+            if !items.items.is_empty() || !self.rewards_address.is_empty() {
                 if !self.get_running_nodes().is_empty() {
-                    &mut NodesToStart::Running
+                    if selected {
+                        &mut NodesToStart::RunningSelected
+                    } else {
+                        &mut NodesToStart::Running
+                    }
+                } else if selected {
+                    &mut NodesToStart::NotRunningSelected
                 } else {
-                    &mut NodesToStart::Configured
+                    &mut NodesToStart::NotRunning
                 }
             } else {
-                &mut NodesToStart::NotConfigured
+                &mut NodesToStart::NotRunning
             }
         } else {
-            &mut NodesToStart::NotConfigured
+            &mut NodesToStart::NotRunning
         };
         f.render_stateful_widget(footer, layout[3], footer_state);
 

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -8,9 +8,11 @@
 
 use super::footer::NodesToStart;
 use super::header::SelectedMenuItem;
+use super::popup::manage_nodes::GB;
 use super::utils::centered_rect_fixed;
 use super::{footer::Footer, header::Header, popup::manage_nodes::GB_PER_NODE, Component, Frame};
 use crate::action::OptionsActions;
+use crate::components::popup::manage_nodes::MAX_NODE_COUNT;
 use crate::components::popup::port_range::PORT_ALLOCATION;
 use crate::components::utils::open_logs;
 use crate::config::get_launchpad_nodes_data_dir_path;
@@ -22,6 +24,7 @@ use crate::node_mgmt::{
 };
 use crate::node_mgmt::{PORT_MAX, PORT_MIN};
 use crate::style::{clear_area, COOL_GREY, INDIGO, SIZZLING_RED};
+use crate::system::{get_available_space_b, get_drive_name};
 use crate::tui::Event;
 use crate::upnp::UpnpSupport;
 use crate::{
@@ -105,6 +108,8 @@ pub struct Status<'a> {
     port_from: Option<u32>,
     // Port to
     port_to: Option<u32>,
+    storage_mountpoint: PathBuf,
+    available_disk_space_gb: usize,
     error_popup: Option<ErrorPopup>,
 }
 
@@ -118,6 +123,7 @@ pub struct StatusConfig {
     pub init_peers_config: InitialPeersConfig,
     pub port_from: Option<u32>,
     pub port_to: Option<u32>,
+    pub storage_mountpoint: PathBuf,
     pub rewards_address: String,
 }
 
@@ -145,6 +151,8 @@ impl Status<'_> {
             port_from: config.port_from,
             port_to: config.port_to,
             error_popup: None,
+            storage_mountpoint: config.storage_mountpoint.clone(),
+            available_disk_space_gb: get_available_space_b(&config.storage_mountpoint)? / GB,
         };
 
         // Nodes registry
@@ -830,7 +838,43 @@ impl Component for Status<'_> {
                 }
                 StatusActions::AddNode => {
                     debug!("Got action to Add node");
-                    //TODO: Validations regarding adding nodes. Space available, amount of nodes
+
+                    // Validations - Available space
+                    if GB_PER_NODE > self.available_disk_space_gb {
+                        self.error_popup = Some(ErrorPopup::new(
+                        "Cannot Add Node".to_string(),
+                        format!("\nEach Node requires {}GB of available space.", GB_PER_NODE),
+                        format!("{} has only {}GB remaining.\n\nYou can free up some space or change to different drive in the options.", get_drive_name(&self.storage_mountpoint)?, self.available_disk_space_gb),
+                    ));
+                        if let Some(error_popup) = &mut self.error_popup {
+                            error_popup.show();
+                        }
+                        // Switch back to entry mode so we can handle key events
+                        return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
+                    }
+
+                    // Validations - Amount of nodes
+                    let amount_of_nodes = if let Some(ref items) = self.items {
+                        items.items.len()
+                    } else {
+                        0
+                    };
+
+                    if amount_of_nodes + 1 > MAX_NODE_COUNT {
+                        self.error_popup = Some(ErrorPopup::new(
+                            "Cannot Add Node".to_string(),
+                            format!(
+                                "There are not enough ports available in your\ncustom port range to start another node ({}).",
+                                MAX_NODE_COUNT
+                            ),
+                            "\nVisit autonomi.com/support/port-error for help".to_string(),
+                        ));
+                        if let Some(error_popup) = &mut self.error_popup {
+                            error_popup.show();
+                        }
+                        // Switch back to entry mode so we can handle key events
+                        return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
+                    }
 
                     if self.rewards_address.is_empty() {
                         info!("Rewards address is not set. Ask for input.");
@@ -968,6 +1012,10 @@ impl Component for Status<'_> {
                         start_nodes_after_reset: false,
                         action_sender,
                     })?;
+            }
+            Action::OptionsActions(OptionsActions::UpdateStorageDrive(mountpoint, _drive_name)) => {
+                self.storage_mountpoint.clone_from(&mountpoint);
+                self.available_disk_space_gb = get_available_space_b(&mountpoint)? / GB;
             }
             _ => {}
         }

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -936,7 +936,7 @@ impl Component for Status<'_> {
                         data_dir_path: Some(self.data_dir_path.clone()),
                         network_id: self.network_id,
                         owner: self.rewards_address.clone(),
-                        peers_args: self.peers_args.clone(),
+                        init_peers_config: self.init_peers_config.clone(),
                         port_range: Some(port_range),
                         rewards_address: self.rewards_address.clone(),
                         run_nat_detection: self.should_we_run_nat_detection(),

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -446,7 +446,7 @@ impl Component for Status<'_> {
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));
                 }
-                Scene::ManageNodesPopUp => self.active = true,
+                Scene::ManageNodesPopUp { .. } => self.active = true,
                 _ => self.active = false,
             },
             Action::StoreNodesToStart(count) => {
@@ -537,12 +537,24 @@ impl Component for Status<'_> {
                     self.load_node_registry_and_update_states()?;
                 }
                 StatusActions::UpdateNodesCompleted => {
+                    if let Some(items) = &self.items {
+                        let items_clone = items.clone();
+                        for item in &items_clone.items {
+                            self.unlock_service(item.name.as_str());
+                        }
+                    }
                     self.clear_node_items();
                     self.load_node_registry_and_update_states()?;
                     let _ = self.update_node_items(None);
                     debug!("Update nodes completed");
                 }
                 StatusActions::ResetNodesCompleted { trigger_start_node } => {
+                    if let Some(items) = &self.items {
+                        let items_clone = items.clone();
+                        for item in &items_clone.items {
+                            self.unlock_service(item.name.as_str());
+                        }
+                    }
                     self.load_node_registry_and_update_states()?;
                     self.clear_node_items();
 
@@ -622,6 +634,12 @@ impl Component for Status<'_> {
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
                 StatusActions::ErrorUpdatingNodes { raw_error } => {
+                    if let Some(items) = &self.items {
+                        let items_clone = items.clone();
+                        for item in &items_clone.items {
+                            self.unlock_service(item.name.as_str());
+                        }
+                    }
                     self.error_popup = Some(ErrorPopup::new(
                         "Error".to_string(),
                         "Error upgrading nodes".to_string(),
@@ -694,10 +712,23 @@ impl Component for Status<'_> {
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
                 StatusActions::TriggerManageNodes => {
-                    return Ok(Some(Action::SwitchScene(Scene::ManageNodesPopUp)));
+                    let mut amount_of_nodes = 0;
+                    if let Some(items) = &mut self.items {
+                        amount_of_nodes = items.items.len();
+                    }
+
+                    return Ok(Some(Action::SwitchScene(Scene::ManageNodesPopUp {
+                        amount_of_nodes,
+                    })));
                 }
                 StatusActions::TriggerRemoveNode => {
-                    return Ok(Some(Action::SwitchScene(Scene::RemoveNodePopUp)))
+                    if let Some(_node) = self.items.as_ref().and_then(|items| items.selected_item())
+                    {
+                        return Ok(Some(Action::SwitchScene(Scene::RemoveNodePopUp)));
+                    } else {
+                        debug!("No items to be removed");
+                        return Ok(None);
+                    }
                 }
                 StatusActions::PreviousTableItem => {
                     if let Some(items) = &mut self.items {
@@ -1435,10 +1466,14 @@ impl<T> StatefulTable<T> {
     fn next(&mut self) {
         let i = match self.state.selected() {
             Some(i) => {
-                if i >= self.items.len() - 1 {
-                    0
+                if !self.items.is_empty() {
+                    if i >= self.items.len() - 1 {
+                        0
+                    } else {
+                        i + 1
+                    }
                 } else {
-                    i + 1
+                    0
                 }
             }
             None => self.last_selected.unwrap_or(0),
@@ -1450,10 +1485,14 @@ impl<T> StatefulTable<T> {
     fn previous(&mut self) {
         let i = match self.state.selected() {
             Some(i) => {
-                if i == 0 {
-                    self.items.len() - 1
+                if !self.items.is_empty() {
+                    if i == 0 {
+                        self.items.len() - 1
+                    } else {
+                        i - 1
+                    }
                 } else {
-                    i - 1
+                    0
                 }
             }
             None => self.last_selected.unwrap_or(0),

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -18,7 +18,9 @@ use crate::components::utils::open_logs;
 use crate::config::get_launchpad_nodes_data_dir_path;
 use crate::connection_mode::{ConnectionMode, NodeConnectionMode};
 use crate::error::ErrorPopup;
-use crate::node_mgmt::{MaintainNodesArgs, NodeManagement, NodeManagementTask, UpgradeNodesArgs};
+use crate::node_mgmt::{
+    MaintainNodesArgs, NodeManagement, NodeManagementTask, UpgradeNodesArgs, FIXED_INTERVAL,
+};
 use crate::node_mgmt::{PORT_MAX, PORT_MIN};
 use crate::style::{COOL_GREY, INDIGO, SIZZLING_RED};
 use crate::tui::Event;
@@ -52,7 +54,6 @@ use strum::Display;
 use throbber_widgets_tui::{self, Throbber, ThrobberState};
 use tokio::sync::mpsc::UnboundedSender;
 
-pub const FIXED_INTERVAL: u64 = 60_000;
 pub const NODE_STAT_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 /// If nat detection fails for more than 3 times, we don't want to waste time running during every node start.
 const MAX_ERRORS_WHILE_RUNNING_NAT_DETECTION: usize = 3;
@@ -181,6 +182,19 @@ impl Status<'_> {
         Ok(status)
     }
 
+    fn update_node_service_status(
+        &mut self,
+        service_name: String,
+        status: ServiceStatus,
+    ) -> Result<()> {
+        for node_item in self.node_services.iter_mut() {
+            if node_item.service_name == service_name {
+                node_item.status = status.clone();
+            }
+        }
+        Ok(())
+    }
+
     fn update_node_items(&mut self, new_status: Option<NodeStatus>) -> Result<()> {
         // Iterate over existing node services and update their corresponding NodeItem
         if let Some(ref mut items) = self.items {
@@ -206,13 +220,13 @@ impl Status<'_> {
                             ServiceStatus::Added => NodeStatus::Added,
                             ServiceStatus::Removed => NodeStatus::Removed,
                         };
+                    }
 
-                        // Starting is not part of ServiceStatus so we do it manually
-                        if let Some(LockRegistryState::StartingNodes) = self.lock_registry {
-                            item.spinner_state.calc_next();
-                            if item.status != NodeStatus::Running {
-                                item.status = NodeStatus::Starting;
-                            }
+                    // Starting is not part of ServiceStatus so we do it manually
+                    if let Some(LockRegistryState::StartingNodes) = self.lock_registry {
+                        item.spinner_state.calc_next();
+                        if item.status != NodeStatus::Running {
+                            item.status = NodeStatus::Starting
                         }
                     }
 
@@ -405,7 +419,7 @@ impl Component for Status<'_> {
                 let _ = self.update_node_items(None);
             }
             Action::SwitchScene(scene) => match scene {
-                Scene::Status | Scene::StatusRewardsAddressPopUp => {
+                Scene::Status | Scene::StatusRewardsAddressPopUp | Scene::RemoveNodePopUp => {
                     self.active = true;
                     // make sure we're in navigation mode
                     return Ok(Some(Action::SwitchInputMode(InputMode::Navigation)));
@@ -510,6 +524,13 @@ impl Component for Status<'_> {
                     }
                     debug!("Reset nodes completed");
                 }
+                StatusActions::RemovingNodesCompleted => {
+                    self.lock_registry = None;
+                    self.clear_node_items();
+                    self.load_node_registry_and_update_states()?;
+                    let _ = self.update_node_items(None);
+                    debug!("Removing nodes completed");
+                }
                 StatusActions::SuccessfullyDetectedNatStatus => {
                     debug!(
                         "Successfully detected nat status, is_nat_status_determined set to true"
@@ -584,8 +605,35 @@ impl Component for Status<'_> {
                     // Switch back to entry mode so we can handle key events
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
+                StatusActions::ErrorRemovingNodes { raw_error } => {
+                    self.error_popup = Some(ErrorPopup::new(
+                        "Error".to_string(),
+                        "Error removing node".to_string(),
+                        raw_error,
+                    ));
+                    if let Some(error_popup) = &mut self.error_popup {
+                        error_popup.show();
+                    }
+                    // Switch back to entry mode so we can handle key events
+                    return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
+                }
+                StatusActions::ErrorStartingNodes { raw_error } => {
+                    self.error_popup = Some(ErrorPopup::new(
+                        "Error".to_string(),
+                        "Error starting node. Please try again.".to_string(),
+                        raw_error,
+                    ));
+                    if let Some(error_popup) = &mut self.error_popup {
+                        error_popup.show();
+                    }
+                    // Switch back to entry mode so we can handle key events
+                    return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
+                }
                 StatusActions::TriggerManageNodes => {
                     return Ok(Some(Action::SwitchScene(Scene::ManageNodesPopUp)));
+                }
+                StatusActions::TriggerRemoveNode => {
+                    return Ok(Some(Action::SwitchScene(Scene::RemoveNodePopUp)))
                 }
                 StatusActions::PreviousTableItem => {
                     if let Some(items) = &mut self.items {
@@ -595,6 +643,49 @@ impl Component for Status<'_> {
                 StatusActions::NextTableItem => {
                     if let Some(items) = &mut self.items {
                         items.next();
+                    }
+                }
+                StatusActions::StartStopNode => {
+                    debug!("Start/Stop node");
+
+                    if let Some(node) = self.items.as_ref().and_then(|items| items.selected_item())
+                    {
+                        if self.lock_registry.is_some() {
+                            error!(
+                                "Registry is locked ({:?}) Cannot star/stop nodes now.",
+                                self.lock_registry
+                            );
+                            return Ok(None);
+                        }
+
+                        let service_name = vec![node.name.clone()];
+                        let action_sender = self.get_actions_sender()?;
+
+                        if node.status == NodeStatus::Stopped || node.status == NodeStatus::Added {
+                            debug!("Starting Node {:?}", node.name);
+
+                            self.lock_registry = Some(LockRegistryState::StartingNodes);
+
+                            self.node_management
+                                .send_task(NodeManagementTask::StartNode {
+                                    services: service_name,
+                                    action_sender,
+                                })?;
+                        } else if node.status == NodeStatus::Running {
+                            debug!("Stopping Node {:?}", node.name);
+
+                            self.lock_registry = Some(LockRegistryState::StoppingNodes);
+
+                            self.node_management
+                                .send_task(NodeManagementTask::StopNodes {
+                                    services: service_name,
+                                    action_sender,
+                                })?;
+                        } else {
+                            debug!("Cannot Start/Stop node. Node status is {:?}", node.status);
+                        }
+                    } else {
+                        debug!("Got action to Start/Stop node but no node was selected.");
                     }
                 }
                 StatusActions::StartNodes => {
@@ -674,6 +765,35 @@ impl Component for Status<'_> {
                             services: running_nodes,
                             action_sender,
                         })?;
+                }
+                StatusActions::AddNode => {
+                    //TODO: Validations regarding adding nodes. Space available.
+                }
+                StatusActions::RemoveNodes => {
+                    if let Some(node) = self.items.as_ref().and_then(|items| items.selected_item())
+                    {
+                        debug!("Got action to remove node");
+                        if self.lock_registry.is_some() {
+                            error!(
+                                "Registry is locked ({:?}) Cannot remove nodes now.",
+                                self.lock_registry
+                            );
+                            return Ok(None);
+                        }
+
+                        let action_sender = self.get_actions_sender()?;
+                        info!("Removing Node {:?}", node.name);
+
+                        let service_name = vec![node.name.clone()];
+
+                        self.node_management
+                            .send_task(NodeManagementTask::RemoveNodes {
+                                services: service_name,
+                                action_sender,
+                            })?;
+                    } else {
+                        debug!("Got action to Remove node but no node was selected.");
+                    }
                 }
                 StatusActions::TriggerRewardsAddress => {
                     if self.rewards_address.is_empty() {
@@ -928,9 +1048,12 @@ impl Component for Status<'_> {
             if items.items.is_empty() || self.rewards_address.is_empty() {
                 let line1 = Line::from(vec![
                     Span::styled("Press ", Style::default().fg(LIGHT_PERIWINKLE)),
-                    Span::styled("[Ctrl+G] ", Style::default().fg(GHOST_WHITE).bold()),
+                    Span::styled("[+] ", Style::default().fg(GHOST_WHITE).bold()),
                     Span::styled("to Add and ", Style::default().fg(LIGHT_PERIWINKLE)),
-                    Span::styled("Start Nodes ", Style::default().fg(GHOST_WHITE).bold()),
+                    Span::styled(
+                        "Start your first node ",
+                        Style::default().fg(GHOST_WHITE).bold(),
+                    ),
                     Span::styled("on this device", Style::default().fg(LIGHT_PERIWINKLE)),
                 ]);
 

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -8,10 +8,8 @@
 
 use super::footer::NodesToStart;
 use super::header::SelectedMenuItem;
-use super::{
-    footer::Footer, header::Header, popup::manage_nodes::GB_PER_NODE, utils::centered_rect_fixed,
-    Component, Frame,
-};
+use super::utils::centered_rect_fixed;
+use super::{footer::Footer, header::Header, popup::manage_nodes::GB_PER_NODE, Component, Frame};
 use crate::action::OptionsActions;
 use crate::components::popup::port_range::PORT_ALLOCATION;
 use crate::components::utils::open_logs;
@@ -20,9 +18,10 @@ use crate::connection_mode::{ConnectionMode, NodeConnectionMode};
 use crate::error::ErrorPopup;
 use crate::node_mgmt::{
     MaintainNodesArgs, NodeManagement, NodeManagementTask, UpgradeNodesArgs, FIXED_INTERVAL,
+    NODES_ALL,
 };
 use crate::node_mgmt::{PORT_MAX, PORT_MIN};
-use crate::style::{COOL_GREY, INDIGO, SIZZLING_RED};
+use crate::style::{clear_area, COOL_GREY, INDIGO, SIZZLING_RED};
 use crate::tui::Event;
 use crate::upnp::UpnpSupport;
 use crate::{
@@ -30,9 +29,7 @@ use crate::{
     config::Config,
     mode::{InputMode, Scene},
     node_stats::NodeStats,
-    style::{
-        clear_area, EUCALYPTUS, GHOST_WHITE, LIGHT_PERIWINKLE, VERY_LIGHT_AZURE, VIVID_SKY_BLUE,
-    },
+    style::{EUCALYPTUS, GHOST_WHITE, LIGHT_PERIWINKLE, VERY_LIGHT_AZURE, VIVID_SKY_BLUE},
 };
 use ant_bootstrap::InitialPeersConfig;
 use ant_node_manager::add_services::config::PortRange;
@@ -50,7 +47,6 @@ use std::{
     time::{Duration, Instant},
     vec,
 };
-use strum::Display;
 use throbber_widgets_tui::{self, Throbber, ThrobberState};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -95,9 +91,6 @@ pub struct Status<'a> {
     nodes_to_start: usize,
     // Rewards address
     rewards_address: String,
-    // Currently the node registry file does not support concurrent actions and thus can lead to
-    // inconsistent state. Another solution would be to have a file lock/db.
-    lock_registry: Option<LockRegistryState>,
     // Peers to pass into nodes for startup
     init_peers_config: InitialPeersConfig,
     // If path is provided, we don't fetch the binary from the network
@@ -113,14 +106,6 @@ pub struct Status<'a> {
     // Port to
     port_to: Option<u32>,
     error_popup: Option<ErrorPopup>,
-}
-
-#[derive(Clone, Display, Debug)]
-pub enum LockRegistryState {
-    StartingNodes,
-    StoppingNodes,
-    ResettingNodes,
-    UpdatingNodes,
 }
 
 pub struct StatusConfig {
@@ -152,7 +137,6 @@ impl Status<'_> {
             node_management: NodeManagement::new()?,
             items: None,
             nodes_to_start: config.allocated_disk_space,
-            lock_registry: None,
             rewards_address: config.rewards_address,
             antnode_path: config.antnode_path,
             data_dir_path: config.data_dir_path,
@@ -182,14 +166,37 @@ impl Status<'_> {
         Ok(status)
     }
 
-    fn update_node_service_status(
-        &mut self,
-        service_name: String,
-        status: ServiceStatus,
-    ) -> Result<()> {
-        for node_item in self.node_services.iter_mut() {
-            if node_item.service_name == service_name {
-                node_item.status = status.clone();
+    fn set_lock(&mut self, service_name: &str, locked: bool) {
+        if let Some(ref mut items) = self.items {
+            for item in &mut items.items {
+                if item.name == *service_name {
+                    item.locked = locked;
+                }
+            }
+        }
+    }
+
+    // FIXME: Can be used if NodeItem implements Copy. Dependencies cannot.
+    fn _lock_service(&mut self, service_name: &str) {
+        self.set_lock(service_name, true);
+    }
+
+    fn unlock_service(&mut self, service_name: &str) {
+        self.set_lock(service_name, false);
+    }
+
+    /// Updates the NodeStatus of a specific item in the items list based on its service name.
+    ///
+    /// # Arguments
+    ///
+    /// * `service_name` - The name of the service to update.
+    /// * `status` - The new status to assign to the item.
+    fn update_item(&mut self, service_name: String, status: NodeStatus) -> Result<()> {
+        if let Some(ref mut items) = self.items {
+            for item in &mut items.items {
+                if item.name == service_name {
+                    item.status = status;
+                }
             }
         }
         Ok(())
@@ -207,7 +214,9 @@ impl Status<'_> {
                 {
                     if let Some(status) = new_status {
                         item.status = status;
-                    } else if item.status == NodeStatus::Updating {
+                    } else if item.status == NodeStatus::Updating
+                        || item.status == NodeStatus::Starting
+                    {
                         item.spinner_state.calc_next();
                     } else if new_status != Some(NodeStatus::Updating) {
                         // Update status based on current node status
@@ -220,14 +229,6 @@ impl Status<'_> {
                             ServiceStatus::Added => NodeStatus::Added,
                             ServiceStatus::Removed => NodeStatus::Removed,
                         };
-                    }
-
-                    // Starting is not part of ServiceStatus so we do it manually
-                    if let Some(LockRegistryState::StartingNodes) = self.lock_registry {
-                        item.spinner_state.calc_next();
-                        if item.status != NodeStatus::Running {
-                            item.status = NodeStatus::Starting
-                        }
                     }
 
                     // Update peers count
@@ -265,6 +266,7 @@ impl Status<'_> {
                         peers: 0,
                         connections: 0,
                         mode: NodeConnectionMode::from(node_item),
+                        locked: false,
                         status: NodeStatus::Added, // Set initial status as Added
                         failure: node_item.get_critical_failure(),
                         spinner: Throbber::default(),
@@ -300,6 +302,7 @@ impl Status<'_> {
                         records: 0,
                         peers: 0,
                         connections: 0,
+                        locked: false,
                         mode: NodeConnectionMode::from(node_item),
                         status,
                         failure: node_item.get_critical_failure(),
@@ -358,6 +361,17 @@ impl Status<'_> {
         self.connection_mode == ConnectionMode::Automatic
             && !self.is_nat_status_determined
             && self.error_while_running_nat_detection < MAX_ERRORS_WHILE_RUNNING_NAT_DETECTION
+    }
+
+    fn nodes_starting(&self) -> bool {
+        if let Some(items) = &self.items {
+            items
+                .items
+                .iter()
+                .any(|item| item.status == NodeStatus::Starting)
+        } else {
+            false
+        }
     }
 
     fn get_running_nodes(&self) -> Vec<String> {
@@ -445,8 +459,6 @@ impl Component for Status<'_> {
                 self.rewards_address = rewards_address;
 
                 if we_have_nodes && has_changed {
-                    debug!("Setting lock_registry to ResettingNodes");
-                    self.lock_registry = Some(LockRegistryState::ResettingNodes);
                     info!("Resetting antnode services because the Rewards Address was reset.");
                     let action_sender = self.get_actions_sender()?;
                     self.node_management
@@ -457,8 +469,6 @@ impl Component for Status<'_> {
                 }
             }
             Action::StoreStorageDrive(ref drive_mountpoint, ref _drive_name) => {
-                debug!("Setting lock_registry to ResettingNodes");
-                self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 info!("Resetting antnode services because the Storage Drive was changed.");
                 let action_sender = self.get_actions_sender()?;
                 self.node_management
@@ -470,8 +480,6 @@ impl Component for Status<'_> {
                     get_launchpad_nodes_data_dir_path(&drive_mountpoint.to_path_buf(), false)?;
             }
             Action::StoreConnectionMode(connection_mode) => {
-                debug!("Setting lock_registry to ResettingNodes");
-                self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 self.connection_mode = connection_mode;
                 info!("Resetting antnode services because the Connection Mode range was changed.");
                 let action_sender = self.get_actions_sender()?;
@@ -482,8 +490,6 @@ impl Component for Status<'_> {
                     })?;
             }
             Action::StorePortRange(port_from, port_range) => {
-                debug!("Setting lock_registry to ResettingNodes");
-                self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 self.port_from = Some(port_from);
                 self.port_to = Some(port_range);
                 info!("Resetting antnode services because the Port Range was changed.");
@@ -502,19 +508,33 @@ impl Component for Status<'_> {
                 StatusActions::NodesStatsObtained(stats) => {
                     self.node_stats = stats;
                 }
-                StatusActions::StartNodesCompleted | StatusActions::StopNodesCompleted => {
-                    self.lock_registry = None;
+                StatusActions::StartNodesCompleted { service_name } => {
+                    if service_name == *NODES_ALL {
+                        if let Some(items) = &self.items {
+                            let items_clone = items.clone();
+                            for item in &items_clone.items {
+                                self.unlock_service(item.name.as_str());
+                                self.update_item(item.name.clone(), NodeStatus::Running)?;
+                            }
+                        }
+                    } else {
+                        self.unlock_service(service_name.as_str());
+                        self.update_item(service_name, NodeStatus::Running)?;
+                    }
+                    self.load_node_registry_and_update_states()?;
+                }
+                StatusActions::StopNodesCompleted { service_name } => {
+                    self.unlock_service(service_name.as_str());
+                    self.update_item(service_name, NodeStatus::Stopped)?;
                     self.load_node_registry_and_update_states()?;
                 }
                 StatusActions::UpdateNodesCompleted => {
-                    self.lock_registry = None;
                     self.clear_node_items();
                     self.load_node_registry_and_update_states()?;
                     let _ = self.update_node_items(None);
                     debug!("Update nodes completed");
                 }
                 StatusActions::ResetNodesCompleted { trigger_start_node } => {
-                    self.lock_registry = None;
                     self.load_node_registry_and_update_states()?;
                     self.clear_node_items();
 
@@ -524,9 +544,15 @@ impl Component for Status<'_> {
                     }
                     debug!("Reset nodes completed");
                 }
-                StatusActions::RemovingNodesCompleted => {
-                    self.lock_registry = None;
-                    self.clear_node_items();
+                StatusActions::AddNodesCompleted { service_name } => {
+                    self.unlock_service(service_name.as_str());
+                    self.update_item(service_name.clone(), NodeStatus::Stopped)?;
+                    self.load_node_registry_and_update_states()?;
+                    debug!("Adding {:?} completed", service_name.clone());
+                }
+                StatusActions::RemoveNodesCompleted { service_name } => {
+                    self.unlock_service(service_name.as_str());
+                    self.update_item(service_name, NodeStatus::Removed)?;
                     self.load_node_registry_and_update_states()?;
                     let _ = self.update_node_items(None);
                     debug!("Removing nodes completed");
@@ -569,7 +595,13 @@ impl Component for Status<'_> {
                     // Switch back to entry mode so we can handle key events
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
-                StatusActions::ErrorStoppingNodes { raw_error } => {
+                StatusActions::ErrorStoppingNodes {
+                    services,
+                    raw_error,
+                } => {
+                    for service_name in services {
+                        self.unlock_service(service_name.as_str());
+                    }
                     self.error_popup = Some(ErrorPopup::new(
                         "Error".to_string(),
                         "Error stopping nodes".to_string(),
@@ -605,7 +637,25 @@ impl Component for Status<'_> {
                     // Switch back to entry mode so we can handle key events
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
-                StatusActions::ErrorRemovingNodes { raw_error } => {
+                StatusActions::ErrorAddingNodes { raw_error } => {
+                    self.error_popup = Some(ErrorPopup::new(
+                        "Error".to_string(),
+                        "Error adding node".to_string(),
+                        raw_error,
+                    ));
+                    if let Some(error_popup) = &mut self.error_popup {
+                        error_popup.show();
+                    }
+                    // Switch back to entry mode so we can handle key events
+                    return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
+                }
+                StatusActions::ErrorRemovingNodes {
+                    services,
+                    raw_error,
+                } => {
+                    for service_name in services {
+                        self.unlock_service(service_name.as_str());
+                    }
                     self.error_popup = Some(ErrorPopup::new(
                         "Error".to_string(),
                         "Error removing node".to_string(),
@@ -617,7 +667,13 @@ impl Component for Status<'_> {
                     // Switch back to entry mode so we can handle key events
                     return Ok(Some(Action::SwitchInputMode(InputMode::Entry)));
                 }
-                StatusActions::ErrorStartingNodes { raw_error } => {
+                StatusActions::ErrorStartingNodes {
+                    services,
+                    raw_error,
+                } => {
+                    for service_name in services {
+                        self.unlock_service(service_name.as_str());
+                    }
                     self.error_popup = Some(ErrorPopup::new(
                         "Error".to_string(),
                         "Error starting node. Please try again.".to_string(),
@@ -648,44 +704,58 @@ impl Component for Status<'_> {
                 StatusActions::StartStopNode => {
                     debug!("Start/Stop node");
 
+                    // Check if a node is selected
                     if let Some(node) = self.items.as_ref().and_then(|items| items.selected_item())
                     {
-                        if self.lock_registry.is_some() {
-                            error!(
-                                "Registry is locked ({:?}) Cannot star/stop nodes now.",
-                                self.lock_registry
-                            );
+                        let node_index = self
+                            .items
+                            .as_ref()
+                            .unwrap()
+                            .items
+                            .iter()
+                            .position(|item| item.name == node.name)
+                            .unwrap();
+                        let action_sender = self.get_actions_sender()?;
+                        let node = &mut self.items.as_mut().unwrap().items[node_index];
+
+                        if node.status == NodeStatus::Removed {
+                            debug!("Node is removed. Cannot be started.");
                             return Ok(None);
                         }
 
+                        if node.locked {
+                            debug!("Node still performing operation");
+                            return Ok(None);
+                        }
+                        node.locked = true; // Lock the node before starting or stopping
+
                         let service_name = vec![node.name.clone()];
-                        let action_sender = self.get_actions_sender()?;
 
-                        if node.status == NodeStatus::Stopped || node.status == NodeStatus::Added {
-                            debug!("Starting Node {:?}", node.name);
-
-                            self.lock_registry = Some(LockRegistryState::StartingNodes);
-
-                            self.node_management
-                                .send_task(NodeManagementTask::StartNode {
-                                    services: service_name,
-                                    action_sender,
-                                })?;
-                        } else if node.status == NodeStatus::Running {
-                            debug!("Stopping Node {:?}", node.name);
-
-                            self.lock_registry = Some(LockRegistryState::StoppingNodes);
-
-                            self.node_management
-                                .send_task(NodeManagementTask::StopNodes {
-                                    services: service_name,
-                                    action_sender,
-                                })?;
-                        } else {
-                            debug!("Cannot Start/Stop node. Node status is {:?}", node.status);
+                        match node.status {
+                            NodeStatus::Stopped | NodeStatus::Added => {
+                                debug!("Starting Node {:?}", node.name);
+                                self.node_management
+                                    .send_task(NodeManagementTask::StartNode {
+                                        services: service_name,
+                                        action_sender,
+                                    })?;
+                                node.status = NodeStatus::Starting;
+                            }
+                            NodeStatus::Running => {
+                                debug!("Stopping Node {:?}", node.name);
+                                self.node_management
+                                    .send_task(NodeManagementTask::StopNodes {
+                                        services: service_name,
+                                        action_sender,
+                                    })?;
+                            }
+                            _ => {
+                                debug!("Cannot Start/Stop node. Node status is {:?}", node.status);
+                            }
                         }
                     } else {
                         debug!("Got action to Start/Stop node but no node was selected.");
+                        return Ok(None);
                     }
                 }
                 StatusActions::StartNodes => {
@@ -705,16 +775,17 @@ impl Component for Status<'_> {
                         )));
                     }
 
-                    if self.lock_registry.is_some() {
-                        error!(
-                            "Registry is locked ({:?}) Cannot Start nodes now.",
-                            self.lock_registry
-                        );
-                        return Ok(None);
+                    // Set status and locking
+                    if let Some(ref mut items) = self.items {
+                        for item in &mut items.items {
+                            if item.status == NodeStatus::Added
+                                || item.status == NodeStatus::Stopped
+                            {
+                                item.status = NodeStatus::Starting;
+                                item.locked = true;
+                            }
+                        }
                     }
-
-                    debug!("Setting lock_registry to StartingNodes");
-                    self.lock_registry = Some(LockRegistryState::StartingNodes);
 
                     let port_range = PortRange::Range(
                         self.port_from.unwrap_or(PORT_MIN) as u16,
@@ -746,17 +817,8 @@ impl Component for Status<'_> {
                 }
                 StatusActions::StopNodes => {
                     debug!("Got action to stop nodes");
-                    if self.lock_registry.is_some() {
-                        error!(
-                            "Registry is locked ({:?}) Cannot Stop nodes now.",
-                            self.lock_registry
-                        );
-                        return Ok(None);
-                    }
 
                     let running_nodes = self.get_running_nodes();
-                    debug!("Setting lock_registry to StoppingNodes");
-                    self.lock_registry = Some(LockRegistryState::StoppingNodes);
                     let action_sender = self.get_actions_sender()?;
                     info!("Stopping node service: {running_nodes:?}");
 
@@ -767,33 +829,92 @@ impl Component for Status<'_> {
                         })?;
                 }
                 StatusActions::AddNode => {
-                    //TODO: Validations regarding adding nodes. Space available.
+                    debug!("Got action to Add node");
+                    //TODO: Validations regarding adding nodes. Space available, amount of nodes
+
+                    if self.rewards_address.is_empty() {
+                        info!("Rewards address is not set. Ask for input.");
+                        return Ok(Some(Action::StatusActions(
+                            StatusActions::TriggerRewardsAddress,
+                        )));
+                    }
+
+                    if self.nodes_to_start == 0 {
+                        info!("Nodes to start not set. Ask for input.");
+                        return Ok(Some(Action::StatusActions(
+                            StatusActions::TriggerManageNodes,
+                        )));
+                    }
+
+                    let port_range = PortRange::Range(
+                        self.port_from.unwrap_or(PORT_MIN) as u16,
+                        self.port_to.unwrap_or(PORT_MAX) as u16,
+                    );
+
+                    let action_sender = self.get_actions_sender()?;
+
+                    let add_node_args = MaintainNodesArgs {
+                        action_sender: action_sender.clone(),
+                        antnode_path: self.antnode_path.clone(),
+                        connection_mode: self.connection_mode,
+                        count: 1,
+                        data_dir_path: Some(self.data_dir_path.clone()),
+                        network_id: self.network_id,
+                        owner: self.rewards_address.clone(),
+                        peers_args: self.peers_args.clone(),
+                        port_range: Some(port_range),
+                        rewards_address: self.rewards_address.clone(),
+                        run_nat_detection: self.should_we_run_nat_detection(),
+                    };
+
+                    self.node_management
+                        .send_task(NodeManagementTask::AddNode {
+                            args: add_node_args,
+                        })?;
                 }
                 StatusActions::RemoveNodes => {
-                    if let Some(node) = self.items.as_ref().and_then(|items| items.selected_item())
+                    debug!("Got action to remove node");
+                    // Check if a node is selected
+                    if self
+                        .items
+                        .as_ref()
+                        .and_then(|items| items.selected_item())
+                        .is_none()
                     {
-                        debug!("Got action to remove node");
-                        if self.lock_registry.is_some() {
-                            error!(
-                                "Registry is locked ({:?}) Cannot remove nodes now.",
-                                self.lock_registry
-                            );
-                            return Ok(None);
-                        }
-
-                        let action_sender = self.get_actions_sender()?;
-                        info!("Removing Node {:?}", node.name);
-
-                        let service_name = vec![node.name.clone()];
-
-                        self.node_management
-                            .send_task(NodeManagementTask::RemoveNodes {
-                                services: service_name,
-                                action_sender,
-                            })?;
-                    } else {
-                        debug!("Got action to Remove node but no node was selected.");
+                        debug!("Got action to Start/Stop node but no node was selected.");
+                        return Ok(None);
                     }
+
+                    let node_index =
+                        self.items
+                            .as_ref()
+                            .and_then(|items| {
+                                items.items.iter().position(|item| {
+                                    item.name == items.selected_item().unwrap().name
+                                })
+                            })
+                            .unwrap();
+
+                    let action_sender = self.get_actions_sender()?;
+
+                    let node = &mut self.items.as_mut().unwrap().items[node_index];
+
+                    if node.locked {
+                        debug!("Node still performing operation");
+                        return Ok(None);
+                    } else {
+                        // Lock the node before starting or stopping
+                        node.locked = true;
+                    }
+
+                    let service_name = vec![node.name.clone()];
+
+                    // Send the task to remove the node
+                    self.node_management
+                        .send_task(NodeManagementTask::RemoveNodes {
+                            services: service_name,
+                            action_sender,
+                        })?;
                 }
                 StatusActions::TriggerRewardsAddress => {
                     if self.rewards_address.is_empty() {
@@ -815,17 +936,6 @@ impl Component for Status<'_> {
             Action::OptionsActions(OptionsActions::UpdateNodes) => {
                 debug!("Got action to Update Nodes");
                 self.load_node_registry_and_update_states()?;
-                if self.lock_registry.is_some() {
-                    error!(
-                        "Registry is locked ({:?}) Cannot Update nodes now. Stop them first.",
-                        self.lock_registry
-                    );
-                    return Ok(None);
-                } else {
-                    debug!("Lock registry ({:?})", self.lock_registry);
-                };
-                debug!("Setting lock_registry to UpdatingNodes");
-                self.lock_registry = Some(LockRegistryState::UpdatingNodes);
                 let action_sender = self.get_actions_sender()?;
                 info!("Got action to update nodes");
                 let _ = self.update_node_items(Some(NodeStatus::Updating));
@@ -851,16 +961,6 @@ impl Component for Status<'_> {
             }
             Action::OptionsActions(OptionsActions::ResetNodes) => {
                 debug!("Got action to reset nodes");
-                if self.lock_registry.is_some() {
-                    error!(
-                        "Registry is locked ({:?}) Cannot Reset nodes now.",
-                        self.lock_registry
-                    );
-                    return Ok(None);
-                }
-
-                debug!("Setting lock_registry to ResettingNodes");
-                self.lock_registry = Some(LockRegistryState::ResettingNodes);
                 let action_sender = self.get_actions_sender()?;
                 info!("Got action to reset nodes");
                 self.node_management
@@ -1090,7 +1190,14 @@ impl Component for Status<'_> {
                     .title(Line::from(vec![
                         Span::styled(" Nodes", Style::default().fg(GHOST_WHITE).bold()),
                         Span::styled(
-                            format!(" ({}) ", self.nodes_to_start),
+                            format!(
+                                " ({}) ",
+                                if let Some(ref items) = self.items {
+                                    items.items.len()
+                                } else {
+                                    0
+                                }
+                            ),
                             Style::default().fg(LIGHT_PERIWINKLE),
                         ),
                     ]))
@@ -1188,78 +1295,48 @@ impl Component for Status<'_> {
             }
         }
 
-        // Status Popup
-        if let Some(registry_state) = &self.lock_registry {
-            let popup_text = match registry_state {
-                LockRegistryState::StartingNodes => {
-                    if self.should_we_run_nat_detection() {
-                        vec![
-                            Line::raw("Starting nodes..."),
-                            Line::raw(""),
-                            Line::raw(""),
-                            Line::raw("Please wait, performing initial NAT detection"),
-                            Line::raw("This may take a couple minutes."),
-                        ]
-                    } else {
-                        // We avoid rendering the popup as we have status lines now
-                        return Ok(());
-                    }
-                }
-                LockRegistryState::StoppingNodes => {
-                    vec![
-                        Line::raw(""),
-                        Line::raw(""),
-                        Line::raw(""),
-                        Line::raw("Stopping nodes..."),
-                    ]
-                }
-                LockRegistryState::ResettingNodes => {
-                    vec![
-                        Line::raw(""),
-                        Line::raw(""),
-                        Line::raw(""),
-                        Line::raw("Resetting nodes..."),
-                    ]
-                }
-                LockRegistryState::UpdatingNodes => {
-                    return Ok(());
-                }
-            };
-            if !popup_text.is_empty() {
-                let popup_area = centered_rect_fixed(50, 12, area);
-                clear_area(f, popup_area);
+        if self.nodes_starting() && self.should_we_run_nat_detection() {
+            let popup_text = vec![
+                Line::raw("Starting nodes..."),
+                Line::raw(""),
+                Line::raw(""),
+                Line::raw("Please wait, performing initial NAT detection"),
+                Line::raw("This may take a couple minutes."),
+            ];
 
-                let popup_border = Paragraph::new("").block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(" Manage Nodes ")
-                        .bold()
-                        .title_style(Style::new().fg(VIVID_SKY_BLUE))
-                        .padding(Padding::uniform(2))
-                        .border_style(Style::new().fg(GHOST_WHITE)),
-                );
+            let popup_area = centered_rect_fixed(50, 12, area);
+            clear_area(f, popup_area);
 
-                let centred_area = Layout::new(
-                    Direction::Vertical,
-                    vec![
-                        // border
-                        Constraint::Length(2),
-                        // our text goes here
-                        Constraint::Min(5),
-                        // border
-                        Constraint::Length(1),
-                    ],
-                )
-                .split(popup_area);
-                let text = Paragraph::new(popup_text)
-                    .block(Block::default().padding(Padding::horizontal(2)))
-                    .wrap(Wrap { trim: false })
-                    .alignment(Alignment::Center)
-                    .fg(EUCALYPTUS);
-                f.render_widget(text, centred_area[1]);
+            let popup_border = Paragraph::new("").block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Manage Nodes ")
+                    .bold()
+                    .title_style(Style::new().fg(VIVID_SKY_BLUE))
+                    .padding(Padding::uniform(2))
+                    .border_style(Style::new().fg(GHOST_WHITE)),
+            );
 
-                f.render_widget(popup_border, popup_area);
-            }
+            let centred_area = Layout::new(
+                Direction::Vertical,
+                vec![
+                    // border
+                    Constraint::Length(2),
+                    // our text goes here
+                    Constraint::Min(5),
+                    // border
+                    Constraint::Length(1),
+                ],
+            )
+            .split(popup_area);
+            let text = Paragraph::new(popup_text)
+                .block(Block::default().padding(Padding::horizontal(2)))
+                .wrap(Wrap { trim: false })
+                .alignment(Alignment::Center)
+                .fg(EUCALYPTUS);
+            f.render_widget(text, centred_area[1]);
+
+            f.render_widget(popup_border, popup_area);
         }
 
         Ok(())
@@ -1366,6 +1443,7 @@ pub struct NodeItem<'a> {
     records: usize,
     peers: usize,
     connections: usize,
+    locked: bool, // Semaphore for being able to change status
     mode: NodeConnectionMode,
     status: NodeStatus,
     failure: Option<(chrono::DateTime<chrono::Utc>, String)>,

--- a/node-launchpad/src/mode.rs
+++ b/node-launchpad/src/mode.rs
@@ -26,6 +26,7 @@ pub enum Scene {
     ManageNodesPopUp,
     ResetNodesPopUp,
     UpgradeNodesPopUp,
+    RemoveNodePopUp,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/node-launchpad/src/mode.rs
+++ b/node-launchpad/src/mode.rs
@@ -23,7 +23,9 @@ pub enum Scene {
     },
     StatusRewardsAddressPopUp,
     OptionsRewardsAddressPopUp,
-    ManageNodesPopUp,
+    ManageNodesPopUp {
+        amount_of_nodes: usize,
+    },
     ResetNodesPopUp,
     UpgradeNodesPopUp,
     RemoveNodePopUp,

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -19,6 +19,9 @@ pub const PORT_MIN: u32 = 1024;
 
 const NODE_ADD_MAX_RETRIES: u32 = 5;
 
+pub const FIXED_INTERVAL: u64 = 60_000;
+pub const CONNECTION_TIMEOUT_START: u64 = 120;
+
 #[derive(Debug)]
 pub enum NodeManagementTask {
     MaintainNodes {
@@ -34,6 +37,17 @@ pub enum NodeManagementTask {
     },
     UpgradeNodes {
         args: UpgradeNodesArgs,
+    },
+    AddNode {
+        action_sender: UnboundedSender<Action>,
+    },
+    RemoveNodes {
+        services: Vec<String>,
+        action_sender: UnboundedSender<Action>,
+    },
+    StartNode {
+        services: Vec<String>,
+        action_sender: UnboundedSender<Action>,
     },
 }
 
@@ -70,6 +84,17 @@ impl NodeManagement {
                             stop_nodes(services, action_sender).await;
                         }
                         NodeManagementTask::UpgradeNodes { args } => upgrade_nodes(args).await,
+                        NodeManagementTask::RemoveNodes {
+                            services,
+                            action_sender,
+                        } => remove_nodes(services, action_sender).await,
+                        NodeManagementTask::StartNode {
+                            services,
+                            action_sender,
+                        } => start_nodes(services, action_sender).await,
+                        NodeManagementTask::AddNode { .. } => {
+                            // add_node(action_sender).await
+                        }
                     }
                 }
                 // If the while loop returns, then all the LocalSpawner
@@ -248,6 +273,79 @@ async fn upgrade_nodes(args: UpgradeNodesArgs) {
     }
 }
 
+async fn remove_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
+    if let Err(err) = ant_node_manager::cmd::node::remove(
+        false,
+        vec![],
+        services.clone(),
+        VerbosityLevel::Minimal,
+    )
+    .await
+    {
+        error!("Error while removing services {err:?}");
+        send_action(
+            action_sender,
+            Action::StatusActions(StatusActions::ErrorRemovingNodes {
+                raw_error: err.to_string(),
+            }),
+        );
+    } else {
+        info!("Successfully removed services {:?}", services);
+        send_action(
+            action_sender,
+            Action::StatusActions(StatusActions::RemovingNodesCompleted),
+        );
+    }
+}
+
+// async fn add_node(action_sender: UnboundedSender<Action>) {
+//     if let Err(err) =
+//         sn_node_manager::cmd::node::add(false, vec![], services.clone(), VerbosityLevel::Minimal)
+//             .await
+//     {
+//         error!("Error while removing services {err:?}");
+//         send_action(
+//             action_sender,
+//             Action::StatusActions(StatusActions::ErrorRemovingNodes {
+//                 raw_error: err.to_string(),
+//             }),
+//         );
+//     } else {
+//         info!("Successfully removed services {:?}", services);
+//         send_action(
+//             action_sender,
+//             Action::StatusActions(StatusActions::RemovingNodesCompleted),
+//         );
+//     }
+// }
+
+async fn start_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
+    debug!("Starting node {:?}", services);
+    if let Err(err) = ant_node_manager::cmd::node::start(
+        CONNECTION_TIMEOUT_START,
+        None,
+        vec![],
+        services.clone(),
+        VerbosityLevel::Minimal,
+    )
+    .await
+    {
+        error!("Error while starting services {err:?}");
+        send_action(
+            action_sender,
+            Action::StatusActions(StatusActions::ErrorStartingNodes {
+                raw_error: err.to_string(),
+            }),
+        );
+    } else {
+        info!("Successfully started services {:?}", services);
+        send_action(
+            action_sender,
+            Action::StatusActions(StatusActions::StartNodesCompleted),
+        );
+    }
+}
+
 // --- Helper functions ---
 
 fn send_action(action_sender: UnboundedSender<Action>, action: Action) {
@@ -414,7 +512,7 @@ async fn scale_down_nodes(config: &NodeConfig, count: u16) {
     match ant_node_manager::cmd::node::maintain_n_running_nodes(
         false,
         config.auto_set_nat_flags,
-        120,
+        CONNECTION_TIMEOUT_START,
         count,
         config.data_dir_path.clone(),
         true,
@@ -487,7 +585,7 @@ async fn add_nodes(
         match ant_node_manager::cmd::node::maintain_n_running_nodes(
             false,
             config.auto_set_nat_flags,
-            120,
+            CONNECTION_TIMEOUT_START,
             config.count,
             config.data_dir_path.clone(),
             true,

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -22,6 +22,8 @@ const NODE_ADD_MAX_RETRIES: u32 = 5;
 pub const FIXED_INTERVAL: u64 = 60_000;
 pub const CONNECTION_TIMEOUT_START: u64 = 120;
 
+pub const NODES_ALL: &str = "NODES_ALL";
+
 #[derive(Debug)]
 pub enum NodeManagementTask {
     MaintainNodes {
@@ -39,7 +41,7 @@ pub enum NodeManagementTask {
         args: UpgradeNodesArgs,
     },
     AddNode {
-        action_sender: UnboundedSender<Action>,
+        args: MaintainNodesArgs,
     },
     RemoveNodes {
         services: Vec<String>,
@@ -92,9 +94,7 @@ impl NodeManagement {
                             services,
                             action_sender,
                         } => start_nodes(services, action_sender).await,
-                        NodeManagementTask::AddNode { .. } => {
-                            // add_node(action_sender).await
-                        }
+                        NodeManagementTask::AddNode { args } => add_node(args).await,
                     }
                 }
                 // If the while loop returns, then all the LocalSpawner
@@ -127,21 +127,27 @@ impl NodeManagement {
 /// Stop the specified services
 async fn stop_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
     if let Err(err) =
-        ant_node_manager::cmd::node::stop(None, vec![], services, VerbosityLevel::Minimal).await
+        ant_node_manager::cmd::node::stop(None, vec![], services.clone(), VerbosityLevel::Minimal)
+            .await
     {
         error!("Error while stopping services {err:?}");
         send_action(
             action_sender,
             Action::StatusActions(StatusActions::ErrorStoppingNodes {
+                services,
                 raw_error: err.to_string(),
             }),
         );
     } else {
         info!("Successfully stopped services");
-        send_action(
-            action_sender,
-            Action::StatusActions(StatusActions::StopNodesCompleted),
-        );
+        for service in services {
+            send_action(
+                action_sender.clone(),
+                Action::StatusActions(StatusActions::StopNodesCompleted {
+                    service_name: service,
+                }),
+            );
+        }
     }
 }
 
@@ -201,7 +207,9 @@ async fn maintain_n_running_nodes(args: MaintainNodesArgs) {
     debug!("Finished maintaining {} nodes", args.count);
     send_action(
         args.action_sender,
-        Action::StatusActions(StatusActions::StartNodesCompleted),
+        Action::StatusActions(StatusActions::StartNodesCompleted {
+            service_name: NODES_ALL.to_string(),
+        }),
     );
 }
 
@@ -286,38 +294,112 @@ async fn remove_nodes(services: Vec<String>, action_sender: UnboundedSender<Acti
         send_action(
             action_sender,
             Action::StatusActions(StatusActions::ErrorRemovingNodes {
+                services,
                 raw_error: err.to_string(),
             }),
         );
     } else {
         info!("Successfully removed services {:?}", services);
-        send_action(
-            action_sender,
-            Action::StatusActions(StatusActions::RemovingNodesCompleted),
-        );
+        for service in services {
+            send_action(
+                action_sender.clone(),
+                Action::StatusActions(StatusActions::RemoveNodesCompleted {
+                    service_name: service,
+                }),
+            );
+        }
     }
 }
 
-// async fn add_node(action_sender: UnboundedSender<Action>) {
-//     if let Err(err) =
-//         sn_node_manager::cmd::node::add(false, vec![], services.clone(), VerbosityLevel::Minimal)
-//             .await
-//     {
-//         error!("Error while removing services {err:?}");
-//         send_action(
-//             action_sender,
-//             Action::StatusActions(StatusActions::ErrorRemovingNodes {
-//                 raw_error: err.to_string(),
-//             }),
-//         );
-//     } else {
-//         info!("Successfully removed services {:?}", services);
-//         send_action(
-//             action_sender,
-//             Action::StatusActions(StatusActions::RemovingNodesCompleted),
-//         );
-//     }
-// }
+async fn add_node(args: MaintainNodesArgs) {
+    debug!("Adding node");
+
+    if args.run_nat_detection {
+        run_nat_detection(&args.action_sender).await;
+    }
+
+    let config = prepare_node_config(&args);
+
+    let node_registry = match load_node_registry(&args.action_sender).await {
+        Ok(registry) => registry,
+        Err(err) => {
+            error!("Failed to load node registry: {:?}", err);
+            return;
+        }
+    };
+    let used_ports = get_used_ports(&node_registry);
+    let (mut current_port, max_port) = get_port_range(&config.custom_ports);
+
+    while used_ports.contains(&current_port) && current_port <= max_port {
+        current_port += 1;
+    }
+
+    if current_port > max_port {
+        error!("Reached maximum port number. Unable to find an available port.");
+        send_action(
+            args.action_sender.clone(),
+            Action::StatusActions(StatusActions::ErrorAddingNodes {
+                raw_error: format!(
+                    "When adding a new node we reached maximum port number ({}).\nUnable to find an available port.",
+                    max_port
+                ),
+            }),
+        );
+    }
+
+    let port_range = Some(PortRange::Single(current_port));
+    match ant_node_manager::cmd::node::add(
+        false, // auto_restart,
+        config.auto_set_nat_flags,
+        Some(config.count),
+        config.data_dir_path,
+        true, // enable_metrics_server,
+        None, // env_variables,
+        None, // evm_network
+        config.home_network,
+        None,       // log_dir_path,
+        None,       // log_format,
+        None,       // max_archived_log_files,
+        None,       // max_log_files,
+        None,       // metrics_port,
+        None,       // network_id
+        None,       // node_ip,
+        port_range, // node_port
+        config.peers_args.clone(),
+        RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
+        None,                        // rpc_address,
+        None,                        // rpc_port,
+        config.antnode_path.clone(), // src_path,
+        config.upnp,
+        None, // url,
+        None, // user,
+        None, // version,
+        VerbosityLevel::Minimal,
+    )
+    .await
+    {
+        Err(err) => {
+            error!("Error while adding services {err:?}");
+            send_action(
+                args.action_sender,
+                Action::StatusActions(StatusActions::ErrorAddingNodes {
+                    raw_error: err.to_string(),
+                }),
+            );
+        }
+        Ok(services) => {
+            info!("Successfully added services: {:?}", services);
+            for service in services {
+                send_action(
+                    args.action_sender.clone(),
+                    Action::StatusActions(StatusActions::AddNodesCompleted {
+                        service_name: service,
+                    }),
+                );
+            }
+        }
+    }
+}
 
 async fn start_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
     debug!("Starting node {:?}", services);
@@ -334,15 +416,20 @@ async fn start_nodes(services: Vec<String>, action_sender: UnboundedSender<Actio
         send_action(
             action_sender,
             Action::StatusActions(StatusActions::ErrorStartingNodes {
+                services,
                 raw_error: err.to_string(),
             }),
         );
     } else {
         info!("Successfully started services {:?}", services);
-        send_action(
-            action_sender,
-            Action::StatusActions(StatusActions::StartNodesCompleted),
-        );
+        for service in services {
+            send_action(
+                action_sender.clone(),
+                Action::StatusActions(StatusActions::StartNodesCompleted {
+                    service_name: service,
+                }),
+            );
+        }
     }
 }
 

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -760,9 +760,8 @@ async fn add_nodes(
             action_sender.clone(),
             Action::StatusActions(StatusActions::ErrorScalingUpNodes {
                 raw_error: format!(
-                    "When trying run a node, we reached the maximum amount of retries ({}).\n\
-                    Could this be a firewall blocking nodes starting?\n\
-                    Or ports on your router already in use?",
+                    "When trying to start a node, we reached the maximum amount of retries ({}).\n\
+                    Could this be a firewall blocking nodes starting or ports on your router already in use?",
                     NODE_ADD_MAX_RETRIES
                 ),
             }),

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -300,6 +300,21 @@ async fn upgrade_nodes(args: UpgradeNodesArgs) {
 }
 
 async fn remove_nodes(services: Vec<String>, action_sender: UnboundedSender<Action>) {
+    // First we stop the nodes
+    if let Err(err) =
+        ant_node_manager::cmd::node::stop(None, vec![], services.clone(), VerbosityLevel::Minimal)
+            .await
+    {
+        error!("Error while stopping services {err:?}");
+        send_action(
+            action_sender.clone(),
+            Action::StatusActions(StatusActions::ErrorRemovingNodes {
+                services: services.clone(),
+                raw_error: err.to_string(),
+            }),
+        );
+    }
+
     if let Err(err) = ant_node_manager::cmd::node::remove(
         false,
         vec![],

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -398,12 +398,12 @@ async fn add_node(args: MaintainNodesArgs) {
         None,       // network_id
         None,       // node_ip,
         port_range, // node_port
-        config.peers_args.clone(),
+        config.init_peers_config.clone(),
         RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
         None,                        // rpc_address,
         None,                        // rpc_port,
         config.antnode_path.clone(), // src_path,
-        config.upnp,
+        !config.upnp,
         None, // url,
         None, // user,
         None, // version,

--- a/node-launchpad/src/system.rs
+++ b/node-launchpad/src/system.rs
@@ -160,3 +160,19 @@ pub fn get_available_space_b(storage_mountpoint: &PathBuf) -> Result<usize> {
 
     Ok(available_space_b)
 }
+
+// Gets the name of the drive given a mountpoint
+pub fn get_drive_name(storage_mountpoint: &PathBuf) -> Result<String> {
+    let disks = Disks::new_with_refreshed_list();
+    let name = disks
+        .list()
+        .iter()
+        .find(|disk| disk.mount_point() == storage_mountpoint)
+        .context("Cannot find the primary disk. Configuration file might be wrong.")?
+        .name()
+        .to_str()
+        .unwrap_or_default()
+        .to_string();
+
+    Ok(name)
+}


### PR DESCRIPTION
Rebased version of https://github.com/maidsafe/autonomi/pull/2444

### Description

#### Internal crates
* Changes on `node-manager` to be less verbose (`Verbosity::Minimal` on calls)

### Main feature
* Now we can start/stop, add, remove individual nodes. For this we implemented a locking mechanism (semaphore) per node (`locked` on `NodeItem`). It's set to `true` before starting a `NodeManagementTask` and `false` when succeeds or returns with error. There are some helper functions for that effect.
 
#### Validation
* Validations when adding nodes (`[+]`) regarding the maximum amount of nodes and available disk space. Some helpers were created for the error messages.
* Validation of some edge cases like operations without nodes, when the application starts from scratch.
* New popup screen when trying to remove (`[-]`) a node. Gives a warning.

### Styling
* Changed footer style and behavior depending on the application state. Now is sort of flexible when shrinking the terminal (minimal resolution 80x24).

### Extras
* Some minor error message formatting.
* Changed the legend when upgrading nodes as is difficult to pass the amount of nodes between scenes. Instead of calculating total time of upgrade, we just mention how much takes per node.


### Bug fix 🐞 
* We added `CONNECTION_TIMEOUT_START` as a constant. We were using a hardcoded value as timeout when starting nodes that was making few RPC connection attempts and failing too early. 

🛑  Do not merge straight away so we squash and merge.