### PR TITLE
fix(test): check for peers in routing table inside network spawner test

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -405,8 +405,10 @@ impl Debug for NetworkSwarmCmd {
 /// Snapshot of information kept in the Swarm's local state
 #[derive(Debug, Clone)]
 pub struct SwarmLocalState {
-    /// List of currently connected peers
+    /// List of peers that we have an established connection with.
     pub connected_peers: Vec<PeerId>,
+    /// The number of peers in the routing table
+    pub peers_in_routing_table: usize,
     /// List of addresses the node is currently listening on
     pub listeners: Vec<Multiaddr>,
 }
@@ -893,6 +895,7 @@ impl SwarmDriver {
                 cmd_string = "GetSwarmLocalState";
                 let current_state = SwarmLocalState {
                     connected_peers: self.swarm.connected_peers().cloned().collect(),
+                    peers_in_routing_table: self.peers_in_rt,
                     listeners: self.swarm.listeners().cloned().collect(),
                 };
 

--- a/ant-node/src/spawn/network_spawner.rs
+++ b/ant-node/src/spawn/network_spawner.rs
@@ -240,14 +240,18 @@ mod tests {
 
         assert_eq!(running_network.running_nodes().len(), network_size);
 
-        // Wait for nodes to dial each other
+        // Wait for nodes to fill up their RT
         sleep(Duration::from_secs(15)).await;
 
         // Validate that all nodes know each other
         for node in running_network.running_nodes() {
-            let known_peers = node.get_swarm_local_state().await.unwrap().connected_peers;
+            let peers_in_routing_table = node
+                .get_swarm_local_state()
+                .await
+                .unwrap()
+                .peers_in_routing_table;
 
-            assert_eq!(known_peers.len(), network_size - 1);
+            assert_eq!(peers_in_routing_table, network_size - 1);
         }
 
         running_network.shutdown();

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -240,8 +240,9 @@ impl Client {
 
         loop {
             let mut upload_tasks = vec![];
+            #[cfg(feature = "loud")]
             let total_chunks = chunks.len();
-            for (i, &chunk) in chunks.iter().enumerate() {
+            for (_i, &chunk) in chunks.iter().enumerate() {
                 let self_clone = self.clone();
                 let address = *chunk.address();
 
@@ -250,7 +251,7 @@ impl Client {
                     #[cfg(feature = "loud")]
                     println!(
                         "({}/{}) Chunk stored at: {} (skipping, already exists)",
-                        i + 1,
+                        _i + 1,
                         chunks.len(),
                         chunk.address().to_hex()
                     );
@@ -270,7 +271,7 @@ impl Client {
                         Ok(_addr) => {
                             println!(
                                 "({}/{}) Chunk stored at: {}",
-                                i + 1,
+                                _i + 1,
                                 total_chunks,
                                 chunk.address().to_hex()
                             );
@@ -278,7 +279,7 @@ impl Client {
                         Err((_chunk, ref err)) => {
                             println!(
                                 "({}/{}) Chunk failed to be stored at: {} ({err})",
-                                i + 1,
+                                _i + 1,
                                 total_chunks,
                                 chunk.address().to_hex()
                             );


### PR DESCRIPTION
- The network spawner test was failing on CI sometimes because we were trying to assert that we were `connected` to ALL nodes.
- Instead, we should assert that we have added all the nodes to the RT. We will not necessarily hold a live connection with all the peers we dialed.
- Also some tiny clippy fixes.