### PR TITLE
fix(network): resend in case of OutboundFailure::DialFailure

### DIFF
--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -958,7 +958,8 @@ impl Network {
 
             match error {
                 NetworkError::OutboundError(OutboundFailure::Io(_))
-                | NetworkError::OutboundError(OutboundFailure::ConnectionClosed) => {
+                | NetworkError::OutboundError(OutboundFailure::ConnectionClosed)
+                | NetworkError::OutboundError(OutboundFailure::DialFailure) => {
                     warn!(
                         "Outbound failed for {req:?} .. {error:?}, redialing once and reattempting"
                     );


### PR DESCRIPTION
### Description

Occasionally, request will be terminated due to dial out failure as the peer turn down the connection due to CONNECTION_KEEP_ALIVE_TIMEOUT.
In that case, a re-attempt shall be carried out.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
