### PR TITLE
fix(network): dial peer before sending a req

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{NetworkError, Result},
     event::TerminateNodeReason,
     log_markers::Marker,
-    GetRecordError, MsgResponder, NetworkEvent, ResponseQuorum, CLOSE_GROUP_SIZE,
+    Addresses, GetRecordError, MsgResponder, NetworkEvent, ResponseQuorum, CLOSE_GROUP_SIZE,
 };
 use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
@@ -25,6 +25,7 @@ use libp2p::{
         store::{Error as StoreError, RecordStore},
         KBucketDistance as Distance, Record, RecordKey, K_VALUE,
     },
+    swarm::dial_opts::{DialOpts, PeerCondition},
     Multiaddr, PeerId,
 };
 use std::{
@@ -82,22 +83,16 @@ pub enum LocalSwarmCmd {
     GetKBuckets {
         sender: oneshot::Sender<BTreeMap<u32, Vec<PeerId>>>,
     },
-    /// Returns the replicate candidates in range.
-    /// In case the range is too narrow, returns at lease CLOSE_GROUP_SIZE peers.
-    GetReplicateCandidates {
-        data_addr: NetworkAddress,
-        sender: oneshot::Sender<Result<Vec<PeerId>>>,
-    },
     // Returns up to K_VALUE peers from all the k-buckets from the local Routing Table.
     // And our PeerId as well.
     GetClosestKLocalPeers {
-        sender: oneshot::Sender<Vec<PeerId>>,
+        sender: oneshot::Sender<Vec<(PeerId, Addresses)>>,
     },
     // Get X closest peers to target from the local RoutingTable, self not included
     GetCloseLocalPeersToTarget {
         key: NetworkAddress,
         num_of_peers: usize,
-        sender: oneshot::Sender<Vec<PeerId>>,
+        sender: oneshot::Sender<Vec<(PeerId, Addresses)>>,
     },
     GetSwarmLocalState(oneshot::Sender<SwarmLocalState>),
     /// Check if the local RecordStore contains the provided key
@@ -191,13 +186,14 @@ pub enum NetworkSwarmCmd {
     // Get closest peers from the network
     GetClosestPeersToAddressFromNetwork {
         key: NetworkAddress,
-        sender: oneshot::Sender<Vec<PeerId>>,
+        sender: oneshot::Sender<Vec<(PeerId, Addresses)>>,
     },
 
     // Send Request to the PeerId.
     SendRequest {
         req: Request,
         peer: PeerId,
+        addrs: Addresses,
 
         // If a `sender` is provided, the requesting node will await for a `Response` from the
         // Peer. The result is then returned at the call site.
@@ -266,9 +262,6 @@ impl Debug for LocalSwarmCmd {
                     "LocalSwarmCmd::AddLocalRecordAsStored {{ key: {:?}, record_type: {record_type:?}, data_type: {data_type:?} }}",
                     PrettyPrintRecordKey::from(key)
                 )
-            }
-            LocalSwarmCmd::GetReplicateCandidates { .. } => {
-                write!(f, "LocalSwarmCmd::GetReplicateCandidates")
             }
             LocalSwarmCmd::GetClosestKLocalPeers { .. } => {
                 write!(f, "LocalSwarmCmd::GetClosestKLocalPeers")
@@ -534,7 +527,12 @@ impl SwarmDriver {
                 );
             }
 
-            NetworkSwarmCmd::SendRequest { req, peer, sender } => {
+            NetworkSwarmCmd::SendRequest {
+                req,
+                peer,
+                addrs,
+                sender,
+            } => {
                 cmd_string = "SendRequest";
                 // If `self` is the recipient, forward the request directly to our upper layer to
                 // be handled.
@@ -552,6 +550,26 @@ impl SwarmDriver {
                         trace!("Replicate cmd to self received, ignoring");
                     }
                 } else {
+                    // dial the peer and send the request
+                    if addrs.0.is_empty() {
+                        info!("No addresses for peer {peer:?} to send request. This could cause dial failure if swarm could not find the peer's addrs.");
+                    } else {
+                        let opts = DialOpts::peer_id(peer)
+                            // If we have a peer ID, we can prevent simultaneous dials.
+                            .condition(PeerCondition::NotDialing)
+                            .addresses(addrs.0.clone())
+                            .build();
+
+                        match self.swarm.dial(opts) {
+                            Ok(()) => {
+                                info!("Dialing peer {peer:?} for req_resp with address: {addrs:?}",);
+                            }
+                            Err(err) => {
+                                error!("Failed to dial peer {peer:?} for req_resp with address: {addrs:?} error: {err}",);
+                            }
+                        }
+                    }
+
                     let request_id = self
                         .swarm
                         .behaviour_mut()
@@ -881,10 +899,6 @@ impl SwarmDriver {
                 cmd_string = "GetClosestKLocalPeers";
                 let _ = sender.send(self.get_closest_k_value_local_peers());
             }
-            LocalSwarmCmd::GetReplicateCandidates { data_addr, sender } => {
-                cmd_string = "GetReplicateCandidates";
-                let _ = sender.send(self.get_replicate_candidates(&data_addr));
-            }
             LocalSwarmCmd::GetSwarmLocalState(sender) => {
                 cmd_string = "GetSwarmLocalState";
                 let current_state = SwarmLocalState {
@@ -1065,9 +1079,14 @@ impl SwarmDriver {
 
         if *is_bad {
             info!("Evicting bad peer {peer_id:?} from RT.");
-            if let Some(dead_peer) = self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id) {
+            let addrs = if let Some(dead_peer) =
+                self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id)
+            {
                 self.update_on_peer_removal(*dead_peer.node.key.preimage());
-            }
+                Addresses(dead_peer.node.value.into_vec())
+            } else {
+                Addresses(Vec::new())
+            };
 
             if let Some(bad_behaviour) = new_bad_behaviour {
                 // inform the bad node about it and add to the blocklist after that (not for connection issues)
@@ -1102,6 +1121,7 @@ impl SwarmDriver {
                 });
                 self.queue_network_swarm_cmd(NetworkSwarmCmd::SendRequest {
                     req: request,
+                    addrs,
                     peer: peer_id,
                     sender: Some(tx),
                 });
@@ -1143,7 +1163,8 @@ impl SwarmDriver {
         self.replication_targets
             .retain(|_peer_id, timestamp| *timestamp > now);
         // Only carry out replication to peer that not replicated to it recently
-        replicate_targets.retain(|peer_id| !self.replication_targets.contains_key(peer_id));
+        replicate_targets
+            .retain(|(peer_id, _addresses)| !self.replication_targets.contains_key(peer_id));
         if replicate_targets.is_empty() {
             return Ok(());
         }
@@ -1170,10 +1191,11 @@ impl SwarmDriver {
                     .map(|(addr, val_type, _data_type)| (addr, val_type))
                     .collect(),
             });
-            for peer_id in replicate_targets {
+            for (peer_id, addrs) in replicate_targets {
                 self.queue_network_swarm_cmd(NetworkSwarmCmd::SendRequest {
                     req: request.clone(),
                     peer: peer_id,
+                    addrs,
                     sender: None,
                 });
 
@@ -1191,11 +1213,10 @@ impl SwarmDriver {
     // Note that:
     //   * For general replication, replicate candidates shall be closest to self, but with wider range
     //   * For replicate fresh records, the replicate candidates shall be the closest to data
-
     pub(crate) fn get_replicate_candidates(
         &mut self,
         target: &NetworkAddress,
-    ) -> Result<Vec<PeerId>> {
+    ) -> Result<Vec<(PeerId, Addresses)>> {
         let is_periodic_replicate = target.as_peer_id().is_some();
         let expected_candidates = if is_periodic_replicate {
             CLOSE_GROUP_SIZE * 2
@@ -1205,13 +1226,13 @@ impl SwarmDriver {
 
         // get closest peers from buckets, sorted by increasing distance to the target
         let kbucket_key = target.as_kbucket_key();
-        let closest_k_peers: Vec<PeerId> = self
+        let closest_k_peers: Vec<(PeerId, Addresses)> = self
             .swarm
             .behaviour_mut()
             .kademlia
-            .get_closest_local_peers(&kbucket_key)
+            .find_closest_local_peers(&kbucket_key, &self.self_peer_id)
             // Map KBucketKey<PeerId> to PeerId.
-            .map(|key| key.into_preimage())
+            .map(|peer| (peer.node_id, Addresses(peer.multiaddrs)))
             .take(K_VALUE.get())
             .collect();
 
@@ -1239,12 +1260,16 @@ impl SwarmDriver {
 }
 
 /// Returns the nodes that within the defined distance.
-fn get_peers_in_range(peers: &[PeerId], address: &NetworkAddress, range: Distance) -> Vec<PeerId> {
+fn get_peers_in_range(
+    peers: &[(PeerId, Addresses)],
+    address: &NetworkAddress,
+    range: Distance,
+) -> Vec<(PeerId, Addresses)> {
     peers
         .iter()
-        .filter_map(|peer_id| {
+        .filter_map(|(peer_id, addresses)| {
             if address.distance(&NetworkAddress::from_peer(*peer_id)) <= range {
-                Some(*peer_id)
+                Some((*peer_id, addresses.clone()))
             } else {
                 None
             }

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -23,7 +23,7 @@ use crate::{
     relay_manager::RelayManager,
     replication_fetcher::ReplicationFetcher,
     time::{interval, spawn, Instant, Interval},
-    transport, GetRecordError, Network, NodeIssue, CLOSE_GROUP_SIZE,
+    transport, Addresses, GetRecordError, Network, NodeIssue, CLOSE_GROUP_SIZE,
 };
 #[cfg(feature = "open-metrics")]
 use crate::{
@@ -84,9 +84,9 @@ pub(crate) enum PendingGetClosestType {
     /// Thus we can just process the queries made by NetworkDiscovery without using any channels
     NetworkDiscovery,
     /// These are queries made by a function at the upper layers and contains a channel to send the result back.
-    FunctionCall(oneshot::Sender<Vec<PeerId>>),
+    FunctionCall(oneshot::Sender<Vec<(PeerId, Addresses)>>),
 }
-type PendingGetClosest = HashMap<QueryId, (PendingGetClosestType, Vec<PeerId>)>;
+type PendingGetClosest = HashMap<QueryId, (PendingGetClosestType, Vec<(PeerId, Addresses)>)>;
 
 /// Using XorName to differentiate different record content under the same key.
 type GetRecordResultMap = HashMap<XorName, (Record, HashSet<PeerId>)>;
@@ -878,7 +878,7 @@ impl SwarmDriver {
                         // Results are sorted, hence can calculate distance directly
                         // Note: self is included
                         let self_addr = NetworkAddress::from_peer(self.self_peer_id);
-                        let close_peers_distance = self_addr.distance(&NetworkAddress::from_peer(closest_k_peers[CLOSE_GROUP_SIZE + 1]));
+                        let close_peers_distance = self_addr.distance(&NetworkAddress::from_peer(closest_k_peers[CLOSE_GROUP_SIZE + 1].0));
 
                         let distance = std::cmp::max(Distance(density_distance), close_peers_distance);
 
@@ -1009,7 +1009,7 @@ impl SwarmDriver {
 
     /// Get closest K_VALUE peers from our local RoutingTable. Contains self.
     /// Is sorted for closeness to self.
-    pub(crate) fn get_closest_k_value_local_peers(&mut self) -> Vec<PeerId> {
+    pub(crate) fn get_closest_k_value_local_peers(&mut self) -> Vec<(PeerId, Addresses)> {
         // Limit ourselves to K_VALUE (20) peers.
         let peers: Vec<_> = self.get_closest_local_peers_to_target(
             &NetworkAddress::from_peer(self.self_peer_id),
@@ -1017,7 +1017,9 @@ impl SwarmDriver {
         );
 
         // Start with our own PeerID and chain the closest.
-        std::iter::once(self.self_peer_id).chain(peers).collect()
+        std::iter::once((self.self_peer_id, Default::default()))
+            .chain(peers)
+            .collect()
     }
 
     /// Get closest X peers to the target. Not containing self.
@@ -1026,13 +1028,13 @@ impl SwarmDriver {
         &mut self,
         target: &NetworkAddress,
         num_of_peers: usize,
-    ) -> Vec<PeerId> {
+    ) -> Vec<(PeerId, Addresses)> {
         self.swarm
             .behaviour_mut()
             .kademlia
-            .get_closest_local_peers(&target.as_kbucket_key())
+            .find_closest_local_peers(&target.as_kbucket_key(), &self.self_peer_id)
             // Map KBucketKey<PeerId> to PeerId.
-            .map(|key| key.into_preimage())
+            .map(|key| (key.node_id, Addresses(key.multiaddrs)))
             .take(num_of_peers)
             .collect()
     }

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -1032,6 +1032,7 @@ impl SwarmDriver {
         self.swarm
             .behaviour_mut()
             .kademlia
+            // find_closest_local_peers would ignore the 'source' in the result.
             .find_closest_local_peers(&target.as_kbucket_key(), &self.self_peer_id)
             // Map KBucketKey<PeerId> to PeerId.
             .map(|key| (key.node_id, Addresses(key.multiaddrs)))

--- a/ant-networking/src/event/request_response.rs
+++ b/ant-networking/src/event/request_response.rs
@@ -196,7 +196,11 @@ impl SwarmDriver {
         // accept replication requests from the K_VALUE peers away,
         // giving us some margin for replication
         let closest_k_peers = self.get_closest_k_value_local_peers();
-        if !closest_k_peers.contains(&holder) || holder == self.self_peer_id {
+        if !closest_k_peers
+            .iter()
+            .any(|(peer_id, _)| peer_id == &holder)
+            || holder == self.self_peer_id
+        {
             debug!("Holder {holder:?} is self or not in replication range.");
             return Ok(());
         }
@@ -219,7 +223,7 @@ impl SwarmDriver {
             is_fresh_replicate,
             closest_k_peers
                 .iter()
-                .map(|peer_id| NetworkAddress::from_peer(*peer_id))
+                .map(|(peer_id, _addrs)| NetworkAddress::from_peer(*peer_id))
                 .collect(),
         );
         if keys_to_fetch.is_empty() {

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -249,7 +249,7 @@ impl SwarmDriver {
                 established_in,
             } => {
                 event_string = "ConnectionEstablished";
-                debug!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
+                info!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
 
                 self.initial_bootstrap.on_connection_established(
                     &endpoint,

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -962,7 +962,8 @@ impl Network {
 
             match error {
                 NetworkError::OutboundError(OutboundFailure::Io(_))
-                | NetworkError::OutboundError(OutboundFailure::ConnectionClosed) => {
+                | NetworkError::OutboundError(OutboundFailure::ConnectionClosed)
+                | NetworkError::OutboundError(OutboundFailure::DialFailure) => {
                     warn!(
                         "Outbound failed for {req_str} .. {error:?}, redialing once and reattempting"
                     );

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -97,21 +97,21 @@ const MIN_WAIT_BEFORE_READING_A_PUT: Duration = Duration::from_millis(300);
 
 /// Sort the provided peers by their distance to the given `NetworkAddress`.
 /// Return with the closest expected number of entries if has.
-pub fn sort_peers_by_address<'a>(
-    peers: &'a Vec<PeerId>,
+pub fn sort_peers_by_address(
+    peers: Vec<(PeerId, Addresses)>,
     address: &NetworkAddress,
     expected_entries: usize,
-) -> Result<Vec<&'a PeerId>> {
+) -> Result<Vec<(PeerId, Addresses)>> {
     sort_peers_by_key(peers, &address.as_kbucket_key(), expected_entries)
 }
 
 /// Sort the provided peers by their distance to the given `KBucketKey`.
 /// Return with the closest expected number of entries if has.
-pub fn sort_peers_by_key<'a, T>(
-    peers: &'a Vec<PeerId>,
+pub fn sort_peers_by_key<T>(
+    peers: Vec<(PeerId, Addresses)>,
     key: &KBucketKey<T>,
     expected_entries: usize,
-) -> Result<Vec<&'a PeerId>> {
+) -> Result<Vec<(PeerId, Addresses)>> {
     // Check if there are enough peers to satisfy the request.
     // bail early if that's not the case
     if CLOSE_GROUP_SIZE > peers.len() {
@@ -124,26 +124,31 @@ pub fn sort_peers_by_key<'a, T>(
 
     // Create a vector of tuples where each tuple is a reference to a peer and its distance to the key.
     // This avoids multiple computations of the same distance in the sorting process.
-    let mut peer_distances: Vec<(&PeerId, KBucketDistance)> = Vec::with_capacity(peers.len());
+    let mut peer_distances: Vec<(PeerId, Addresses, KBucketDistance)> =
+        Vec::with_capacity(peers.len());
 
-    for peer_id in peers {
-        let addr = NetworkAddress::from_peer(*peer_id);
+    for (peer_id, addrs) in peers.into_iter() {
+        let addr = NetworkAddress::from_peer(peer_id);
         let distance = key.distance(&addr.as_kbucket_key());
-        peer_distances.push((peer_id, distance));
+        peer_distances.push((peer_id, addrs, distance));
     }
 
     // Sort the vector of tuples by the distance.
-    peer_distances.sort_by(|a, b| a.1.cmp(&b.1));
+    peer_distances.sort_by(|a, b| a.2.cmp(&b.2));
 
     // Collect the sorted peers into a new vector.
-    let sorted_peers: Vec<_> = peer_distances
+    let sorted_peers: Vec<(PeerId, Addresses)> = peer_distances
         .into_iter()
         .take(expected_entries)
-        .map(|(peer_id, _)| peer_id)
+        .map(|(peer_id, addrs, _)| (peer_id, addrs))
         .collect();
 
     Ok(sorted_peers)
 }
+
+/// A list of addresses of a peer in the routing table.
+#[derive(Clone, Debug, Default)]
+pub struct Addresses(pub Vec<Multiaddr>);
 
 #[derive(Clone, Debug)]
 /// API to interact with the underlying Swarm
@@ -217,7 +222,7 @@ impl Network {
     pub async fn client_get_all_close_peers_in_range_or_close_group(
         &self,
         key: &NetworkAddress,
-    ) -> Result<Vec<PeerId>> {
+    ) -> Result<Vec<(PeerId, Addresses)>> {
         self.get_all_close_peers_in_range_or_close_group(key, true)
             .await
     }
@@ -225,7 +230,10 @@ impl Network {
     /// Returns the closest peers to the given `NetworkAddress`, sorted by their distance to the key.
     ///
     /// Includes our node's `PeerId` while calculating the closest peers.
-    pub async fn node_get_closest_peers(&self, key: &NetworkAddress) -> Result<Vec<PeerId>> {
+    pub async fn node_get_closest_peers(
+        &self,
+        key: &NetworkAddress,
+    ) -> Result<Vec<(PeerId, Addresses)>> {
         self.get_all_close_peers_in_range_or_close_group(key, false)
             .await
     }
@@ -253,7 +261,7 @@ impl Network {
 
     /// Returns all the PeerId from all the KBuckets from our local Routing Table
     /// Also contains our own PeerId.
-    pub async fn get_closest_k_value_local_peers(&self) -> Result<Vec<PeerId>> {
+    pub async fn get_closest_k_value_local_peers(&self) -> Result<Vec<(PeerId, Addresses)>> {
         let (sender, receiver) = oneshot::channel();
         self.send_local_swarm_cmd(LocalSwarmCmd::GetClosestKLocalPeers { sender });
 
@@ -268,7 +276,7 @@ impl Network {
         &self,
         key: NetworkAddress,
         num_of_peers: usize,
-    ) -> Result<Vec<PeerId>> {
+    ) -> Result<Vec<(PeerId, Addresses)>> {
         let (sender, receiver) = oneshot::channel();
         self.send_local_swarm_cmd(LocalSwarmCmd::GetCloseLocalPeersToTarget {
             key,
@@ -279,18 +287,6 @@ impl Network {
         receiver
             .await
             .map_err(|_e| NetworkError::InternalMsgChannelDropped)
-    }
-
-    /// Returns the replicate candidates in range.
-    pub async fn get_replicate_candidates(&self, data_addr: NetworkAddress) -> Result<Vec<PeerId>> {
-        let (sender, receiver) = oneshot::channel();
-        self.send_local_swarm_cmd(LocalSwarmCmd::GetReplicateCandidates { data_addr, sender });
-
-        let candidate = receiver
-            .await
-            .map_err(|_e| NetworkError::InternalMsgChannelDropped)??;
-
-        Ok(candidate)
     }
 
     /// Get the Chunk existence proof from the close nodes to the provided chunk address.
@@ -398,7 +394,7 @@ impl Network {
             .client_get_all_close_peers_in_range_or_close_group(&record_address)
             .await?;
         // Filter out results from the ignored peers.
-        close_nodes.retain(|peer_id| !ignore_peers.contains(peer_id));
+        close_nodes.retain(|(peer_id, _)| !ignore_peers.contains(peer_id));
         info!(
             "For record {record_address:?} quoting {} nodes. ignore_peers is {ignore_peers:?}",
             close_nodes.len()
@@ -473,7 +469,7 @@ impl Network {
                     }
                 }
                 Err(err) => {
-                    error!("Got an error while requesting quote from peer {peer:?}: {err}");
+                    error!("Got an error while requesting quote from peer {peer:?}: {err:?}");
                     peers_returned_error += 1;
                 }
                 _ => {
@@ -944,11 +940,18 @@ impl Network {
     /// layers.
     ///
     /// If an outbound issue is raised, we retry once more to send the request before returning an error.
-    pub async fn send_request(&self, req: Request, peer: PeerId) -> Result<Response> {
+    pub async fn send_request(
+        &self,
+        req: Request,
+        peer: PeerId,
+        addrs: Addresses,
+    ) -> Result<Response> {
         let (sender, receiver) = oneshot::channel();
+        let req_str = format!("{req:?}");
         self.send_network_swarm_cmd(NetworkSwarmCmd::SendRequest {
             req: req.clone(),
             peer,
+            addrs: addrs.clone(),
             sender: Some(sender),
         });
         let mut r = receiver.await?;
@@ -960,22 +963,26 @@ impl Network {
                 NetworkError::OutboundError(OutboundFailure::Io(_))
                 | NetworkError::OutboundError(OutboundFailure::ConnectionClosed) => {
                     warn!(
-                        "Outbound failed for {req:?} .. {error:?}, redialing once and reattempting"
+                        "Outbound failed for {req_str} .. {error:?}, redialing once and reattempting"
                     );
                     let (sender, receiver) = oneshot::channel();
 
-                    debug!("Reattempting to send_request {req:?} to {peer:?}");
+                    debug!("Reattempting to send_request {req_str} to {peer:?}");
                     self.send_network_swarm_cmd(NetworkSwarmCmd::SendRequest {
                         req,
                         peer,
+                        addrs,
                         sender: Some(sender),
                     });
 
                     r = receiver.await?;
+                    if let Err(error) = &r {
+                        error!("Reattempt of {req_str} led to an error again. {error:?}");
+                    }
                 }
                 _ => {
                     // If the record is found, we should log the error and continue
-                    warn!("Error in response: {:?}", error);
+                    warn!("Error in response for {req_str}: {error:?}",);
                 }
             }
         }
@@ -985,10 +992,11 @@ impl Network {
 
     /// Send `Request` to the given `PeerId` and do _not_ await a response here.
     /// Instead the Response will be handled by the common `response_handler`
-    pub fn send_req_ignore_reply(&self, req: Request, peer: PeerId) {
+    pub fn send_req_ignore_reply(&self, req: Request, peer: PeerId, addrs: Addresses) {
         let swarm_cmd = NetworkSwarmCmd::SendRequest {
             req,
             peer,
+            addrs,
             sender: None,
         };
         self.send_network_swarm_cmd(swarm_cmd)
@@ -1061,7 +1069,7 @@ impl Network {
         &self,
         key: &NetworkAddress,
         client: bool,
-    ) -> Result<Vec<PeerId>> {
+    ) -> Result<Vec<(PeerId, Addresses)>> {
         let pretty_key = PrettyPrintKBucketKey(key.as_kbucket_key());
         debug!("Getting the all closest peers in range of {pretty_key:?}");
         let (sender, receiver) = oneshot::channel();
@@ -1079,7 +1087,7 @@ impl Network {
         // ensure we're not including self here
         if client {
             // remove our peer id from the calculations here:
-            closest_peers.retain(|&x| x != self.peer_id());
+            closest_peers.retain(|&(x, _)| x != self.peer_id());
             if result_len != closest_peers.len() {
                 info!("Remove self client from the closest_peers");
             }
@@ -1088,7 +1096,7 @@ impl Network {
         if tracing::level_enabled!(tracing::Level::DEBUG) {
             let close_peers_pretty_print: Vec<_> = closest_peers
                 .iter()
-                .map(|peer_id| {
+                .map(|(peer_id, _)| {
                     format!(
                         "{peer_id:?}({:?})",
                         PrettyPrintKBucketKey(NetworkAddress::from_peer(*peer_id).as_kbucket_key())
@@ -1102,8 +1110,8 @@ impl Network {
         }
 
         let expanded_close_group = CLOSE_GROUP_SIZE + CLOSE_GROUP_SIZE / 2;
-        let closest_peers = sort_peers_by_address(&closest_peers, key, expanded_close_group)?;
-        Ok(closest_peers.into_iter().cloned().collect())
+        let closest_peers = sort_peers_by_address(closest_peers, key, expanded_close_group)?;
+        Ok(closest_peers)
     }
 
     /// Send a `Request` to the provided set of peers and wait for their responses concurrently.
@@ -1112,16 +1120,16 @@ impl Network {
     /// If `get_all_responses` is false, we return the first successful response that we get
     pub async fn send_and_get_responses(
         &self,
-        peers: &[PeerId],
+        peers: &[(PeerId, Addresses)],
         req: &Request,
         get_all_responses: bool,
     ) -> BTreeMap<PeerId, Result<Response>> {
         debug!("send_and_get_responses for {req:?}");
         let mut list_of_futures = peers
             .iter()
-            .map(|peer| {
+            .map(|(peer, addrs)| {
                 Box::pin(async {
-                    let resp = self.send_request(req.clone(), *peer).await;
+                    let resp = self.send_request(req.clone(), *peer, addrs.clone()).await;
                     (*peer, resp)
                 })
             })

--- a/ant-networking/src/network_discovery.rs
+++ b/ant-networking/src/network_discovery.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::time::{interval, Instant, Interval};
+use crate::Addresses;
 use crate::{driver::PendingGetClosestType, SwarmDriver};
 use ant_protocol::NetworkAddress;
 use libp2p::kad::K_VALUE;
@@ -186,7 +187,7 @@ impl NetworkDiscovery {
         (should_network_discover, new_interval)
     }
 
-    pub(crate) fn handle_get_closest_query(&mut self, closest_peers: Vec<PeerId>) {
+    pub(crate) fn handle_get_closest_query(&mut self, closest_peers: Vec<(PeerId, Addresses)>) {
         self.candidates.handle_get_closest_query(closest_peers);
     }
 
@@ -235,12 +236,12 @@ impl NetworkDiscoveryCandidates {
     }
 
     /// The result from the kad::GetClosestPeers are again used to update our kbucket.
-    fn handle_get_closest_query(&mut self, closest_peers: Vec<PeerId>) {
+    fn handle_get_closest_query(&mut self, closest_peers: Vec<(PeerId, Addresses)>) {
         let now = Instant::now();
 
         let candidates_map: BTreeMap<u32, Vec<NetworkAddress>> = closest_peers
             .into_iter()
-            .filter_map(|peer| {
+            .filter_map(|(peer, _)| {
                 let peer = NetworkAddress::from_peer(peer);
                 let peer_key = peer.as_kbucket_key();
                 peer_key

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -660,9 +660,9 @@ impl Node {
             .get_close_peers_to_the_target(address.clone(), K_VALUE.get())
             .await?;
         // push self in as the returned list doesn't contain self
-        closest_k_peers.push(self_peer_id);
+        closest_k_peers.push((self_peer_id, Default::default()));
         let mut payees = payment.payees();
-        payees.retain(|peer_id| !closest_k_peers.contains(peer_id));
+        payees.retain(|peer_id| !closest_k_peers.iter().any(|(p, _)| p == peer_id));
         if !payees.is_empty() {
             warn!("Payment quote has out-of-range payees for record {pretty_key}");
             return Err(Error::InvalidRequest(format!(

--- a/ant-node/src/replication.rs
+++ b/ant-node/src/replication.rs
@@ -47,7 +47,13 @@ impl Node {
                     key: NetworkAddress::from_record_key(&key),
                 });
 
-                let record = match node.network().send_request(req, holder).await {
+                // Addrs are skipped for replication because the peer should be part of the RT and swarm should be
+                // able to find the multiaddr.
+                let record = match node
+                    .network()
+                    .send_request(req, holder, Default::default())
+                    .await
+                {
                     Ok(Response::Query(QueryResponse::GetReplicatedRecord(result))) => match result
                     {
                         Ok((_holder, record_content)) => {


### PR DESCRIPTION
- If we don't have an active connection to a peer while sending a request, the `req/resp` behaviour would try to dial the peer. But this assumes that the swarn could find the multiaddrs of that peer.
- If the peer is part of kad's RT, then the swarm could find the addr. But we cannot just add all the peers to the RT, i.e, say a client querying for store costs for hundreds of chunks. 
- There is a `PeerAddresses` which is a LRU cache as part of the `identify` Behaviour, where we could add these addresses to, but that directly ties in the # of requests a client could do with the size of the cache. Hence the cache approach is dropped.
- Thus, this PR modifies the `ant_networking` fn calls to accommodate for an `Addresses(Vec<MulitAddr>)` struct wherever it is necessary. 
- Replication fetcher and other components that work based on the `local RT peers` would use `empty vec` as swarm could find these addrs from the RT.