### PR TITLE
fix(network): shall use get_closest_local_peers instead of find_closest

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -1229,17 +1229,7 @@ impl SwarmDriver {
         };
 
         // get closest peers from buckets, sorted by increasing distance to the target
-        let kbucket_key = target.as_kbucket_key();
-        let closest_k_peers: Vec<(PeerId, Addresses)> = self
-            .swarm
-            .behaviour_mut()
-            .kademlia
-            // find_closest_local_peers would ignore the 'source' in the result.
-            .find_closest_local_peers(&kbucket_key, &self.self_peer_id)
-            // Map KBucketKey<PeerId> to PeerId.
-            .map(|peer| (peer.node_id, Addresses(peer.multiaddrs)))
-            .take(K_VALUE.get())
-            .collect();
+        let closest_k_peers = self.get_closest_local_peers_to_target(target, K_VALUE.get());
 
         if let Some(responsible_range) = self
             .swarm

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -249,7 +249,7 @@ impl SwarmDriver {
                 established_in,
             } => {
                 event_string = "ConnectionEstablished";
-                info!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
+                debug!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
 
                 self.initial_bootstrap.on_connection_established(
                     &endpoint,


### PR DESCRIPTION
### Description

`find_closest_local_peers` only return replication_factor number of results, which was expected to return K_VALUE results.
it shall be `get_closest_local_peers` to be used instead.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
