### PR TITLE
Improve client quoting performance

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -342,6 +342,7 @@ impl NetworkBuilder {
             .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
             .set_max_packet_size(MAX_PACKET_SIZE)
             .set_replication_factor(REPLICATION_FACTOR)
+            .set_query_timeout(KAD_QUERY_TIMEOUT_S)
             // Require iterative queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
             .disjoint_query_paths(true)
             // How many nodes _should_ store data.

--- a/ant-networking/src/event/kad.rs
+++ b/ant-networking/src/event/kad.rs
@@ -112,9 +112,9 @@ impl SwarmDriver {
                         .network_discovery
                         .handle_get_closest_query(current_closest),
                     PendingGetClosestType::FunctionCall(sender) => {
-                        sender
-                            .send(current_closest)
-                            .map_err(|_| NetworkError::InternalMsgChannelDropped)?;
+                        tokio::spawn(async move {
+                            let _ = sender.send(current_closest);
+                        });
                     }
                 }
             }


### PR DESCRIPTION
### Description

With super large production network and nodes may contain certain outdated peer infos.
`kad::get_closest` could timed out, which slow down the quoting and uploading process a lot.

Meanwhile, the client doesn't set up the query_timeout.
The default value that got used is 60s, which is way too long.

Hence, to improve the quoting performance, this PR contains following work:
1.  using `re-dial` only during the re-attempt, to avoid un-necessary time out.
2.  set client query_timeout to be 10s

With the above, the quoting time against production network reduced to 30s (from the previous 3 min 20s).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
