### PR TITLE
feat: cli analyze addr

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -227,7 +227,7 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-        timeout-minutes: 15
+        timeout-minutes: 20
 
       # FIXME: do this in a generic way for localtestnets
       - name: export default secret key

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-        timeout-minutes: 15
+        timeout-minutes: 20
 
 
       # FIXME: do this in a generic way for localtestnets

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod analyze;
 mod file;
 mod register;
 mod vault;
@@ -40,6 +41,15 @@ pub enum SubCmd {
     Wallet {
         #[command(subcommand)]
         command: WalletCmd,
+    },
+
+    /// Operations related to data analysis.
+    Analyze {
+        /// The address of the data to analyse.
+        addr: String,
+        /// Verbose output. Detailed description of the analysis.
+        #[arg(short, long)]
+        verbose: bool,
     },
 }
 
@@ -299,6 +309,9 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             WalletCmd::Export => wallet::export(),
             WalletCmd::Balance => wallet::balance(peers.await?.is_local()).await,
         },
+        Some(SubCmd::Analyze { addr, verbose }) => {
+            analyze::analyze(&addr, verbose, peers.await?).await
+        }
         None => {
             // If no subcommand is given, default to clap's error behaviour.
             Opt::command()

--- a/ant-cli/src/commands/analyze.rs
+++ b/ant-cli/src/commands/analyze.rs
@@ -1,0 +1,99 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use autonomi::{client::analyze::AnalysisError, Multiaddr, RewardsAddress, SecretKey, Wallet};
+use color_eyre::eyre::Result;
+use std::str::FromStr;
+
+use crate::network::NetworkPeers;
+
+pub async fn analyze(addr: &str, verbose: bool, peers: NetworkPeers) -> Result<()> {
+    macro_rules! println_if_verbose {
+        ($($arg:tt)*) => {
+            if verbose {
+                println!($($arg)*);
+            }
+        };
+    }
+    println_if_verbose!("Analyzing address: {}", addr);
+
+    // then connect to network and check data
+    let client = crate::actions::connect_to_network(peers).await?;
+
+    let analysis = client.analyze_address(addr, verbose).await;
+    match analysis {
+        Ok(analysis) => {
+            println_if_verbose!("Analysis successful");
+            println!("{analysis}");
+        }
+        Err(AnalysisError::UnrecognizedInput) => {
+            println!("🚨 Could not identify address type!");
+            println_if_verbose!(
+                "Provided string was not recognized as a data address, trying other types..."
+            );
+            try_other_types(addr, verbose);
+        }
+        Err(e) => {
+            println!("Analysis inconclusive: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+fn try_other_types(addr: &str, verbose: bool) {
+    macro_rules! println_if_verbose {
+        ($($arg:tt)*) => {
+            if verbose {
+                println!($($arg)*);
+            }
+        };
+    }
+
+    // local reference to private data
+    let try_private_address = crate::user_data::get_local_private_archive_access(addr).ok();
+    if let Some(data_map) = try_private_address {
+        println!("✅ Identified input as a: Local Private Archive's DataMap local address (only works on your own machine)");
+        println_if_verbose!(
+            "💡 This local address points to a DataMap which is stored on your local machine."
+        );
+        println_if_verbose!(
+            "💡 Using this DataMap you can download your Private Archive from the Network."
+        );
+        println_if_verbose!("💡 You can use the `file download` command to download the private data from the DataMap");
+        println!("DataMap in hex: {}", data_map.to_hex());
+        return;
+    }
+
+    // cryptographic keys
+    let hex_addr = addr.trim_start_matches("0x");
+    let maybe_secret_key = SecretKey::from_hex(hex_addr).ok();
+    let maybe_eth_sk = Wallet::new_from_private_key(Default::default(), hex_addr).ok();
+    if maybe_secret_key.is_some() || maybe_eth_sk.is_some() {
+        println!("🚨 Please keep your secret key safe! Don't use it as a data address!");
+        println!("✅ Identified input as a: Secret Key");
+        println_if_verbose!("💡 A Secret Key is used to sign data or transactions on the Network.");
+        return;
+    }
+    let maybe_eth_address = addr.parse::<RewardsAddress>().ok();
+    if maybe_eth_address.is_some() {
+        println!("✅ Identified input as an: Ethereum Address");
+        println_if_verbose!("💡 An Ethereum address is a cryptographic identifier for a blockchain account. It can be used to receive funds and rewards on the Network.");
+        return;
+    }
+
+    // multiaddrs
+    let maybe_multiaddr = Multiaddr::from_str(addr).ok();
+    if maybe_multiaddr.is_some() {
+        println!("✅ Identified input as a: Multiaddr");
+        println_if_verbose!("💡 A Mutliaddr is the url used to connect to a node on the Network.");
+        return;
+    }
+
+    println!("⚠️ Unrecognized input");
+}

--- a/ant-protocol/src/storage/address/chunk.rs
+++ b/ant-protocol/src/storage/address/chunk.rs
@@ -14,7 +14,7 @@ use super::AddressParseError;
 
 /// Address of a [`crate::storage::chunks::Chunk`]
 /// It is derived from the content of the chunk
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct ChunkAddress(XorName);
 
 impl ChunkAddress {
@@ -34,7 +34,7 @@ impl ChunkAddress {
     }
 
     /// Creates a new ChunkAddress from a hex string.
-    pub fn try_from_hex(hex: &str) -> Result<Self, AddressParseError> {
+    pub fn from_hex(hex: &str) -> Result<Self, AddressParseError> {
         let bytes = hex::decode(hex)?;
         let xor = XorName(
             bytes
@@ -46,6 +46,12 @@ impl ChunkAddress {
 }
 
 impl std::fmt::Display for ChunkAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for ChunkAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.to_hex())
     }

--- a/ant-protocol/src/storage/address/graph.rs
+++ b/ant-protocol/src/storage/address/graph.rs
@@ -14,7 +14,7 @@ use super::AddressParseError;
 
 /// Address of a [`crate::storage::graph::GraphEntry`]
 /// It is derived from the owner's unique public key
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct GraphEntryAddress(PublicKey);
 
 impl GraphEntryAddress {
@@ -47,6 +47,12 @@ impl GraphEntryAddress {
 }
 
 impl std::fmt::Display for GraphEntryAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for GraphEntryAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.to_hex())
     }

--- a/ant-protocol/src/storage/address/pointer_address.rs
+++ b/ant-protocol/src/storage/address/pointer_address.rs
@@ -6,7 +6,7 @@ use super::AddressParseError;
 
 /// Address of a [`crate::storage::pointer::Pointer`]
 /// It is derived from the owner's public key
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct PointerAddress(PublicKey);
 
 impl PointerAddress {
@@ -39,6 +39,12 @@ impl PointerAddress {
 }
 
 impl std::fmt::Display for PointerAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for PointerAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.to_hex())
     }

--- a/ant-protocol/src/storage/address/scratchpad.rs
+++ b/ant-protocol/src/storage/address/scratchpad.rs
@@ -15,7 +15,7 @@ use super::AddressParseError;
 
 /// Address of a [`crate::storage::scratchpad::Scratchpad`]
 /// It is derived from the owner's public key
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct ScratchpadAddress(PublicKey);
 
 impl ScratchpadAddress {
@@ -48,6 +48,12 @@ impl ScratchpadAddress {
 }
 
 impl std::fmt::Display for ScratchpadAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for ScratchpadAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.to_hex())
     }

--- a/ant-protocol/src/storage/graph.rs
+++ b/ant-protocol/src/storage/graph.rs
@@ -24,7 +24,7 @@ pub type GraphContent = [u8; 32];
 /// The protocol only ensures that the graph entry is immutable once uploaded and that the signature is valid and matches the owner.
 ///
 /// For convenience it is advised to make use of BLS key derivation to create multiple graph entries from a single key.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 pub struct GraphEntry {
     /// The owner of the graph. Note that graph entries are stored at the owner's public key
     pub owner: PublicKey,
@@ -36,6 +36,28 @@ pub struct GraphEntry {
     pub descendants: Vec<(PublicKey, GraphContent)>,
     /// signs the above 4 fields with the owners key
     pub signature: Signature,
+}
+
+impl std::fmt::Debug for GraphEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GraphEntry")
+            .field("owner", &self.owner.to_hex())
+            .field(
+                "parents",
+                &self.parents.iter().map(|p| p.to_hex()).collect::<Vec<_>>(),
+            )
+            .field("content", &hex::encode(self.content))
+            .field(
+                "descendants",
+                &self
+                    .descendants
+                    .iter()
+                    .map(|(p, c)| format!("{}: {}", p.to_hex(), hex::encode(c)))
+                    .collect::<Vec<_>>(),
+            )
+            .field("signature", &hex::encode(self.signature.to_bytes()))
+            .finish()
+    }
 }
 
 impl GraphEntry {

--- a/ant-protocol/src/storage/pointer.rs
+++ b/ant-protocol/src/storage/pointer.rs
@@ -13,7 +13,7 @@ use xor_name::XorName;
 
 /// Pointer, a mutable address pointing to other data on the Network
 /// It is stored at the owner's public key and can only be updated by the owner
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Pointer {
     owner: PublicKey,
     counter: u32,
@@ -21,6 +21,18 @@ pub struct Pointer {
     signature: Signature,
 }
 
+impl std::fmt::Debug for Pointer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pointer")
+            .field("owner", &self.owner.to_hex())
+            .field("counter", &self.counter)
+            .field("target", &self.target)
+            .field("signature", &hex::encode(self.signature.to_bytes()))
+            .finish()
+    }
+}
+
+/// The target of a pointer, the address it points to
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub enum PointerTarget {
     ChunkAddress(ChunkAddress),

--- a/ant-protocol/src/storage/scratchpad.rs
+++ b/ant-protocol/src/storage/scratchpad.rs
@@ -16,9 +16,7 @@ use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 /// Scratchpad, a mutable space for encrypted data on the Network
-#[derive(
-    Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug, Serialize, Deserialize,
-)]
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct Scratchpad {
     /// Network address. Omitted when serialising and
     /// calculated from the `encrypted_data` when deserialising.
@@ -26,13 +24,27 @@ pub struct Scratchpad {
     /// Data encoding: custom apps using scratchpad should use this so they can identify the type of data they are storing
     data_encoding: u64,
     /// Encrypted data stored in the scratchpad, it is encrypted automatically by the [`Scratchpad::new`] and [`Scratchpad::update`] methods
-    #[debug(skip)]
     encrypted_data: Bytes,
     /// Monotonically increasing counter to track the number of times this has been updated.
     /// When pushed to the network, the scratchpad with the highest counter is kept.
     counter: u64,
     /// Signature over the above fields
     signature: Signature,
+}
+
+impl std::fmt::Debug for Scratchpad {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Scratchpad")
+            .field("address", &self.address)
+            .field("data_encoding", &self.data_encoding)
+            .field(
+                "encrypted_data",
+                &format!("({} bytes of encrypted data)", self.encrypted_data.len()),
+            )
+            .field("counter", &self.counter)
+            .field("signature", &hex::encode(self.signature.to_bytes()))
+            .finish()
+    }
 }
 
 impl Scratchpad {

--- a/autonomi/src/client/analyze.rs
+++ b/autonomi/src/client/analyze.rs
@@ -1,0 +1,464 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_protocol::storage::ScratchpadAddress;
+use self_encryption::DataMap;
+
+use crate::{
+    chunk::{Chunk, ChunkAddress, DataMapChunk},
+    files::{PrivateArchive, PublicArchive},
+    graph::{GraphEntry, GraphEntryAddress},
+    pointer::{Pointer, PointerAddress},
+    register::RegisterValue,
+    scratchpad::Scratchpad,
+    self_encryption::DataMapLevel,
+    Bytes, Client, PublicKey,
+};
+
+use super::{register::RegisterAddress, GetError};
+const MAX_HEX_PRINT_LENGTH: usize = 4 * 1024;
+
+/// The result of analyzing an address
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Analysis {
+    /// A raw chunk of data
+    Chunk(Chunk),
+    /// A graph entry
+    GraphEntry(GraphEntry),
+    /// A pointer
+    Pointer(Pointer),
+    /// A scratchpad
+    Scratchpad(Scratchpad),
+    /// A register
+    Register {
+        address: RegisterAddress,
+        owner: PublicKey,
+        underlying_graph_start: GraphEntryAddress,
+        underlying_head_pointer: PointerAddress,
+        current_value: RegisterValue,
+    },
+    /// A chunk containing a data map
+    DataMap {
+        address: ChunkAddress,
+        chunks: Vec<ChunkAddress>,
+        points_to_a_data_map: bool,
+        data: Bytes,
+    },
+    /// A raw data map
+    RawDataMap {
+        chunks: Vec<ChunkAddress>,
+        points_to_a_data_map: bool,
+        data: Bytes,
+    },
+    /// A public archive
+    /// (chunk containing a data map of a public archive)
+    PublicArchive {
+        address: Option<ChunkAddress>,
+        archive: PublicArchive,
+    },
+    /// A private archive
+    /// (a data map of a private archive)
+    PrivateArchive(PrivateArchive),
+}
+
+impl std::fmt::Display for Analysis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Analysis::Chunk(chunk) => {
+                writeln!(f, "Chunk stored at: {}", chunk.address().to_hex())?;
+                writeln!(f, "Chunk content in hex: {}", hex::encode(chunk.value()))?;
+            }
+            Analysis::GraphEntry(graph_entry) => {
+                writeln!(
+                    f,
+                    "GraphEntry stored at: {}",
+                    graph_entry.address().to_hex()
+                )?;
+                writeln!(f, "{graph_entry:#?}")?;
+            }
+            Analysis::Pointer(pointer) => {
+                writeln!(f, "Pointer stored at: {}", pointer.address().to_hex())?;
+                writeln!(f, "Pointer points to: {}", pointer.target().to_hex())?;
+                writeln!(f, "{pointer:#?}")?;
+            }
+            Analysis::Scratchpad(scratchpad) => {
+                writeln!(f, "Scratchpad stored at: {}", scratchpad.address().to_hex())?;
+                writeln!(f, "{scratchpad:#?}")?;
+            }
+            Analysis::Register {
+                address,
+                owner,
+                underlying_graph_start,
+                underlying_head_pointer,
+                current_value,
+            } => {
+                writeln!(f, "Register stored at: {}", address.to_hex())?;
+                writeln!(f, "Owner: {}", owner.to_hex())?;
+                writeln!(f, "Current Value in hex: {}", hex::encode(current_value))?;
+                writeln!(f, "Underlying Graph Start: {underlying_graph_start:#?}")?;
+                writeln!(f, "Underlying Head Pointer: {underlying_head_pointer:#?}")?;
+            }
+            Analysis::DataMap {
+                address,
+                chunks,
+                points_to_a_data_map,
+                data,
+            } => {
+                writeln!(f, "DataMap stored at: {}", address.to_hex())?;
+                writeln!(f, "DataMap containing {} Chunks", chunks.len())?;
+                writeln!(f, "Content is another DataMap: {points_to_a_data_map}")?;
+                writeln!(f, "{chunks:#?}")?;
+                writeln!(f, "Decrypted Data in hex: {}", data_hex(data))?;
+            }
+            Analysis::RawDataMap {
+                chunks,
+                points_to_a_data_map,
+                data,
+            } => {
+                writeln!(f, "DataMap containing {} Chunks", chunks.len())?;
+                writeln!(f, "Content is another DataMap: {points_to_a_data_map}")?;
+                writeln!(f, "{chunks:#?}")?;
+                writeln!(f, "Decrypted Data in hex: {}", data_hex(data))?;
+            }
+            Analysis::PublicArchive { address, archive } => {
+                writeln!(
+                    f,
+                    "PublicArchive stored at: {}",
+                    address
+                        .map(|a| a.to_hex())
+                        .unwrap_or("Undefined".to_string())
+                )?;
+                writeln!(f, "PublicArchive with {} files", archive.files().len())?;
+                writeln!(f, "{archive:#?}")?;
+            }
+            Analysis::PrivateArchive(archive) => {
+                writeln!(f, "PrivateArchive with {} files", archive.files().len())?;
+                writeln!(f, "{archive:#?}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnalysisError {
+    #[error("Input was not recognized as a valid address")]
+    UnrecognizedInput,
+    #[error("Failed to get data at address {0}")]
+    GetError(#[from] GetError),
+    #[error("Although address format is valid, failed to get data at address")]
+    FailedGet,
+}
+
+impl Client {
+    /// Analyze an address and return the type of the address.
+    /// Can be run in verbose mode to make it talkative (will print information as it works).
+    pub async fn analyze_address(
+        &self,
+        address: &str,
+        verbose: bool,
+    ) -> Result<Analysis, AnalysisError> {
+        macro_rules! println_if_verbose {
+            ($($arg:tt)*) => {
+                if verbose {
+                    println!($($arg)*);
+                }
+            };
+        }
+        let hex_addr = address.trim_start_matches("0x");
+
+        // data addresses
+        let maybe_xorname = ChunkAddress::from_hex(address).ok();
+        if let Some(chunk_addr) = maybe_xorname {
+            println_if_verbose!("Identified as a Chunk address...");
+            return analyze_chunk(&chunk_addr, self, verbose).await;
+        }
+
+        // public keys
+        let maybe_public_key = PublicKey::from_hex(hex_addr).ok();
+        if let Some(public_key) = maybe_public_key {
+            println_if_verbose!("Identified as a bls Public Key, might be a key addressed type...");
+            return analyze_public_key(&public_key, self, verbose).await;
+        }
+
+        // datamaps
+        if let Ok(hex_chunk) = DataMapChunk::from_hex(hex_addr) {
+            println_if_verbose!("Detected hex encoded data, might be a DataMap...");
+            let maybe_data_map: Option<DataMapLevel> =
+                rmp_serde::from_slice(hex_chunk.0.value()).ok();
+            if let Some(_data_map) = maybe_data_map {
+                println_if_verbose!("Identified as a DataMap...");
+                return analyze_datamap(None, &hex_chunk, self, verbose).await;
+            }
+        }
+
+        Err(AnalysisError::UnrecognizedInput)
+    }
+}
+
+async fn analyze_chunk(
+    chunk_addr: &ChunkAddress,
+    client: &Client,
+    verbose: bool,
+) -> Result<Analysis, AnalysisError> {
+    macro_rules! println_if_verbose {
+        ($($arg:tt)*) => {
+            if verbose {
+                println!($($arg)*);
+            }
+        };
+    }
+
+    println_if_verbose!("Getting chunk at address: {} ...", chunk_addr.to_hex());
+    let chunk = client.chunk_get(chunk_addr).await?;
+    println_if_verbose!("Got chunk of {} bytes...", chunk.value().len());
+
+    // check if it's a data map
+    if let Ok(_data_map) = rmp_serde::from_slice::<DataMapLevel>(chunk.value()) {
+        println_if_verbose!("Identified chunk content as a DataMap...");
+        return analyze_datamap(Some(*chunk_addr), &chunk.into(), client, verbose).await;
+    }
+
+    Ok(Analysis::Chunk(chunk))
+}
+
+async fn analyze_datamap(
+    stored_at: Option<ChunkAddress>,
+    datamap: &DataMapChunk,
+    client: &Client,
+    verbose: bool,
+) -> Result<Analysis, AnalysisError> {
+    macro_rules! println_if_verbose {
+        ($($arg:tt)*) => {
+            if verbose {
+                println!($($arg)*);
+            }
+        };
+    }
+
+    let data_map_level: DataMapLevel =
+        rmp_serde::from_slice(datamap.0.value()).map_err(|_| AnalysisError::UnrecognizedInput)?;
+    let (map, points_to_a_data_map) = match data_map_level {
+        DataMapLevel::Additional(map) => {
+            println_if_verbose!("Identified a DataMap whose contents is another DataMap, the content might be pretty big...");
+            (map, true)
+        }
+        DataMapLevel::First(map) => {
+            println_if_verbose!("Identified a DataMap which directly contains data...");
+            (map, false)
+        }
+    };
+
+    println_if_verbose!("Fetching data from the Network...");
+    let data = client.data_get(datamap).await?;
+    println_if_verbose!("Data fetched from the Network...");
+
+    if let Ok(private_archive) = PrivateArchive::from_bytes(data.clone()) {
+        // public archives and private archives can be confused into each other
+        // to identify them we check if all the addresses are in fact xornames
+        // cf test_archives_serialize_deserialize for more details
+        let xorname_hex_len = xor_name::XOR_NAME_LEN * 2;
+        let all_addrs_are_xornames = private_archive
+            .map()
+            .iter()
+            .all(|(_, (data_addr, _))| data_addr.to_hex().len() == xorname_hex_len);
+        if all_addrs_are_xornames {
+            println_if_verbose!("All addresses are xornames, so it's a public archive");
+            if let Ok(public_archive) = PublicArchive::from_bytes(data.clone()) {
+                println_if_verbose!(
+                    "Identified the data pointed to by the DataMap as a PublicArchive..."
+                );
+                return Ok(Analysis::PublicArchive {
+                    address: stored_at,
+                    archive: public_archive,
+                });
+            }
+        }
+
+        println_if_verbose!("Identified the data pointed to by the DataMap as a PrivateArchive...");
+        return Ok(Analysis::PrivateArchive(private_archive));
+    }
+
+    if let Ok(public_archive) = PublicArchive::from_bytes(data.clone()) {
+        println_if_verbose!("Identified the data pointed to by the DataMap as a PublicArchive...");
+        return Ok(Analysis::PublicArchive {
+            address: stored_at,
+            archive: public_archive,
+        });
+    }
+
+    let analysis = match stored_at {
+        Some(addr) => Analysis::DataMap {
+            address: addr,
+            chunks: chunk_list_from_datamap(map),
+            data,
+            points_to_a_data_map,
+        },
+        None => Analysis::RawDataMap {
+            chunks: chunk_list_from_datamap(map),
+            data,
+            points_to_a_data_map,
+        },
+    };
+
+    Ok(analysis)
+}
+
+async fn analyze_public_key(
+    public_key: &PublicKey,
+    client: &Client,
+    verbose: bool,
+) -> Result<Analysis, AnalysisError> {
+    macro_rules! println_if_verbose {
+        ($($arg:tt)*) => {
+            if verbose {
+                println!($($arg)*);
+            }
+        };
+    }
+
+    let graph_entry_address = GraphEntryAddress::new(*public_key);
+    let pointer_address = PointerAddress::new(*public_key);
+    let register_address = RegisterAddress::new(*public_key);
+    let scratchpad_address = ScratchpadAddress::new(*public_key);
+
+    let graph_entry_res = client.graph_entry_get(&graph_entry_address);
+    let pointer_res = client.pointer_get(&pointer_address);
+    let register_res = client.register_get(&register_address);
+    let scratchpad_res = client.scratchpad_get(&scratchpad_address);
+
+    let (maybe_graph_entry, maybe_pointer, maybe_register, maybe_scratchpad) =
+        tokio::join!(graph_entry_res, pointer_res, register_res, scratchpad_res);
+
+    match (
+        maybe_graph_entry,
+        maybe_pointer,
+        maybe_register,
+        maybe_scratchpad,
+    ) {
+        (graph_entry, _, Ok(value), _) => {
+            println_if_verbose!("Identified GraphEntry, which fits the format of a Register...");
+            println_if_verbose!("GraphEntry: {:#?}", graph_entry);
+            Ok(Analysis::Register {
+                address: register_address,
+                owner: *public_key,
+                underlying_graph_start: register_address.to_underlying_graph_root(),
+                underlying_head_pointer: register_address.to_underlying_head_pointer(),
+                current_value: value,
+            })
+        }
+        (Ok(graph_entry), _, _, _) => {
+            println_if_verbose!("Identified GraphEntry...");
+            Ok(Analysis::GraphEntry(graph_entry))
+        }
+        (_, Ok(pointer), _, _) => {
+            println_if_verbose!("Identified Pointer...");
+            Ok(Analysis::Pointer(pointer))
+        }
+        (_, _, _, Ok(scratchpad)) => {
+            println_if_verbose!("Identified Scratchpad...");
+            Ok(Analysis::Scratchpad(scratchpad))
+        }
+        (Err(e1), Err(e2), Err(e3), Err(e4)) => {
+            println_if_verbose!("Failed to get graph entry: {e1}");
+            println_if_verbose!("Failed to get pointer: {e2}");
+            println_if_verbose!("Failed to get register: {e3}");
+            println_if_verbose!("Failed to get scratchpad: {e4}");
+            Err(AnalysisError::FailedGet)
+        }
+    }
+}
+
+fn chunk_list_from_datamap(map: DataMap) -> Vec<ChunkAddress> {
+    let mut chunks = Vec::new();
+    for info in map.infos() {
+        chunks.push(ChunkAddress::new(info.dst_hash));
+    }
+    chunks
+}
+
+fn data_hex(data: &Bytes) -> String {
+    if data.len() <= MAX_HEX_PRINT_LENGTH {
+        hex::encode(data)
+    } else {
+        format!("[{} bytes of data]", data.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::client::payment::PaymentOption;
+    use crate::Bytes;
+    use crate::Client;
+    use ant_logging::LogBuilder;
+    use eyre::Result;
+    use serial_test::serial;
+    use test_utils::evm::get_funded_wallet;
+
+    // this test confirms that both public and private archives can serialize and deserialize into each other
+    // this is an unfortunate side effect of the fact Bytes and XorName can be serialized and deserialized into each other
+    // this is due to the fact that XorName deserialization accepts any data longer or equal to 32 bytes
+    // which is a BUG in the XorName deserialization logic
+    #[tokio::test]
+    #[serial]
+    async fn test_archives_serialize_deserialize() -> Result<()> {
+        let _log_appender_guard =
+            LogBuilder::init_single_threaded_tokio_test("analyze private dir", false);
+
+        let client = Client::init_local().await?;
+        let wallet = get_funded_wallet();
+        let payment_option = PaymentOption::from(&wallet);
+
+        // create a public and private archive
+        let path = "tests/file/test_dir/".into();
+        let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+        let archive = client.archive_get(&archive_datamap).await?;
+        let path = "tests/file/test_dir/".into();
+        let (_cost, archive_addr) = client.dir_upload_public(path, payment_option).await?;
+        let archive_public = client.archive_get_public(&archive_addr).await?;
+
+        // they can be serialized and deserialized into each other
+        let serialized = rmp_serde::to_vec_named(&archive_public).unwrap();
+        let deserialized_as_pub: crate::client::files::archive_public::PublicArchive =
+            rmp_serde::from_slice(&serialized).unwrap();
+        let deserialized_as_private: crate::client::files::archive_private::PrivateArchive =
+            rmp_serde::from_slice(&serialized).unwrap();
+        assert_eq!(archive_public, deserialized_as_pub);
+        println!("Deserialized as private: {deserialized_as_private:#?}");
+        println!("Deserialized as public: {deserialized_as_pub:#?}");
+
+        // the other way around is also possible
+        let serialized = rmp_serde::to_vec_named(&archive).unwrap();
+        let deserialized_as_pub: crate::client::files::archive_public::PublicArchive =
+            rmp_serde::from_slice(&serialized).unwrap();
+        let deserialized_as_private: crate::client::files::archive_private::PrivateArchive =
+            rmp_serde::from_slice(&serialized).unwrap();
+        assert_eq!(archive, deserialized_as_private);
+        println!("Deserialized as private: {deserialized_as_private:#?}");
+        println!("Deserialized as public: {deserialized_as_pub:#?}");
+
+        // bytes and XorName can be serialized and deserialized into each other
+        let mut rng = rand::thread_rng();
+        let xorname = xor_name::XorName::random(&mut rng);
+        let bytes = Bytes::from("whatever data longer than 32 bytes would be okay");
+        let serialized = rmp_serde::to_vec_named(&xorname).unwrap();
+        let deserialized_as_xorname: xor_name::XorName =
+            rmp_serde::from_slice(&serialized).unwrap();
+        let _deserialized_as_bytes: Bytes = rmp_serde::from_slice(&serialized).unwrap();
+        assert_eq!(xorname, deserialized_as_xorname);
+
+        // and vice versa
+        let serialized = rmp_serde::to_vec_named(&bytes).unwrap();
+        let deserialized_as_bytes: Bytes = rmp_serde::from_slice(&serialized).unwrap();
+        let _deserialized_as_xorname: xor_name::XorName =
+            rmp_serde::from_slice(&serialized).unwrap();
+        assert_eq!(bytes, deserialized_as_bytes);
+
+        Ok(())
+    }
+}

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -72,7 +72,7 @@ pub static CHUNK_DOWNLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
 
 /// Private data on the network can be accessed with this
 /// Uploading this data in a chunk makes it publicly accessible from the address of that Chunk
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DataMapChunk(pub(crate) Chunk);
 
 impl DataMapChunk {
@@ -96,6 +96,18 @@ impl DataMapChunk {
 impl From<Chunk> for DataMapChunk {
     fn from(value: Chunk) -> Self {
         Self(value)
+    }
+}
+
+impl std::fmt::Display for DataMapChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for DataMapChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
     }
 }
 

--- a/autonomi/src/client/high_level/data/mod.rs
+++ b/autonomi/src/client/high_level/data/mod.rs
@@ -16,7 +16,7 @@ pub mod private;
 pub mod public;
 
 /// A [`DataAddress`] which points to a DataMap
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct DataAddress(XorName);
 
 impl DataAddress {
@@ -69,6 +69,12 @@ impl<'de> serde::Deserialize<'de> for DataAddress {
     {
         let xor_name = XorName::deserialize(deserializer)?;
         Ok(Self(xor_name))
+    }
+}
+
+impl std::fmt::Debug for DataAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.to_hex())
     }
 }
 

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -28,6 +28,7 @@ pub use high_level::files;
 pub use high_level::register;
 pub use high_level::vault;
 
+pub mod analyze;
 pub mod config;
 pub mod key_derivation;
 pub mod payment;

--- a/autonomi/tests/address.rs
+++ b/autonomi/tests/address.rs
@@ -37,7 +37,7 @@ async fn test_data_addresses_use() -> Result<()> {
     let chunk_addr = addr.to_hex();
     println!("Chunk: {chunk_addr}");
 
-    let parsed_chunk_addr = ChunkAddress::try_from_hex(&chunk_addr)?;
+    let parsed_chunk_addr = ChunkAddress::from_hex(&chunk_addr)?;
     assert_eq!(parsed_chunk_addr, *chunk.address());
 
     // put data

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -1,0 +1,225 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_logging::LogBuilder;
+use autonomi::client::payment::PaymentOption;
+use autonomi::pointer::PointerTarget;
+use autonomi::GraphEntryAddress;
+use autonomi::{client::analyze::Analysis, GraphEntry, Pointer, Scratchpad};
+use autonomi::{client::chunk::Chunk, Bytes, Client};
+use eyre::Result;
+use serial_test::serial;
+use test_utils::evm::get_funded_wallet;
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_chunk() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("analyze chunk", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let chunk = Chunk::new(Bytes::from("Chunk content example"));
+    let (_cost, addr) = client.chunk_put(&chunk, payment_option).await?;
+    assert_eq!(addr, *chunk.address());
+    let chunk_addr = addr.to_hex();
+    println!("Chunk: {chunk_addr}");
+
+    let analysis = client.analyze_address(&chunk_addr, true).await?;
+    assert_eq!(analysis, Analysis::Chunk(chunk));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_data() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("analyze data", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let data = Bytes::from("Private data example");
+    let (_cost, addr) = client.data_put(data, payment_option).await?;
+    let data_addr = addr.to_hex();
+    println!("Private Data (hex DataMapChunk): {data_addr}");
+
+    let analysis = client.analyze_address(&data_addr, true).await?;
+    println!("Analysis: {analysis}");
+    assert!(matches!(analysis, Analysis::RawDataMap { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_public_data() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze public data", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let data = Bytes::from("Public data example");
+    let (_cost, addr) = client.data_put_public(data, payment_option).await?;
+    let public_data_addr = addr.to_hex();
+    println!("Public Data (XorName): {public_data_addr}");
+
+    let analysis = client.analyze_address(&public_data_addr, true).await?;
+    println!("Analysis: {analysis}");
+    assert!(matches!(analysis, Analysis::DataMap { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_graph_entry() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze graph entry", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let key = bls::SecretKey::random();
+    let other_key = bls::SecretKey::random();
+    let content = [0u8; 32];
+    let graph_entry = GraphEntry::new(
+        &key,
+        vec![other_key.public_key()],
+        content,
+        vec![(other_key.public_key(), content)],
+    );
+    let (_cost, addr) = client
+        .graph_entry_put(graph_entry.clone(), payment_option)
+        .await?;
+    let graph_entry_addr = addr.to_hex();
+    println!("Graph Entry: {graph_entry_addr}");
+    let graph_entry_bls_pubkey = key.public_key().to_hex();
+    println!("Graph Entry (bls pubkey): {graph_entry_bls_pubkey}");
+
+    let analysis = client.analyze_address(&graph_entry_addr, true).await?;
+    assert_eq!(analysis, Analysis::GraphEntry(graph_entry));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_pointer() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("analyze pointer", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let target_addr = GraphEntryAddress::from_hex("b6f6ca699551882e2306ad9045e35c8837a3b99810af55ed358efe7166b7f6b4213ded09b200465f25d5d013fc7c35f9")?;
+    let key = bls::SecretKey::random();
+    let pointer = Pointer::new(&key, 0, PointerTarget::GraphEntryAddress(target_addr));
+    let (_cost, addr) = client.pointer_put(pointer.clone(), payment_option).await?;
+    let pointer_addr = addr.to_hex();
+    println!("Pointer: {pointer_addr}");
+    let pointer_bls_pubkey = key.public_key().to_hex();
+    println!("Pointer (bls pubkey): {pointer_bls_pubkey}");
+
+    let analysis = client.analyze_address(&pointer_addr, true).await?;
+    assert_eq!(analysis, Analysis::Pointer(pointer));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_scratchpad() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze scratchpad", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let key = bls::SecretKey::random();
+    let scratchpad = Scratchpad::new(&key, 0, &Bytes::from("Scratchpad content example"), 0);
+    let (_cost, addr) = client
+        .scratchpad_put(scratchpad.clone(), payment_option)
+        .await?;
+    let scratchpad_addr = addr.to_hex();
+    println!("Scratchpad: {scratchpad_addr}");
+    let scratchpad_bls_pubkey = key.public_key().to_hex();
+    println!("Scratchpad (bls pubkey): {scratchpad_bls_pubkey}");
+
+    let analysis = client.analyze_address(&scratchpad_addr, true).await?;
+    assert_eq!(analysis, Analysis::Scratchpad(scratchpad));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_register() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze register", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let key = bls::SecretKey::random();
+    let value = Client::register_value_from_bytes(b"Register content example")?;
+    let (_cost, addr) = client.register_create(&key, value, payment_option).await?;
+    let register_addr = addr.to_hex();
+    println!("Register: {register_addr}");
+    let register_bls_pubkey = key.public_key().to_hex();
+    println!("Register (bls pubkey): {register_bls_pubkey}");
+
+    let analysis = client.analyze_address(&register_addr, true).await?;
+    println!("Analysis: {analysis}");
+    assert!(matches!(analysis, Analysis::Register { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_private_dir() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze private dir", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let path = "tests/file/test_dir/".into();
+    let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+    let archive_datamap_addr = archive_datamap.to_hex();
+    println!("Private Archive (DataMap): {archive_datamap_addr}");
+
+    let analysis = client.analyze_address(&archive_datamap_addr, true).await?;
+    println!("Analysis: {analysis}");
+    assert!(matches!(analysis, Analysis::PrivateArchive { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_analyze_public_dir() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_single_threaded_tokio_test("analyze public dir", false);
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    let path = "tests/file/test_dir/".into();
+    let (_cost, archive_addr) = client.dir_upload_public(path, payment_option).await?;
+    let archive_addr_str = archive_addr.to_hex();
+    println!("Public Archive (XorName): {archive_addr_str}");
+
+    let analysis = client.analyze_address(&archive_addr_str, true).await?;
+    println!("Analysis: {analysis}");
+    assert!(matches!(analysis, Analysis::PublicArchive { .. }));
+
+    Ok(())
+}


### PR DESCRIPTION
Analyze any address using:

```
ant analyze 360597a525a9900770c5f6716a0a406a0bea10a2dbe1abe5be9f1b0b0f993851
```

Prints out the result of the analysis.

```
Chunk stored at: 360597a525a9900770c5f6716a0a406a0bea10a2dbe1abe5be9f1b0b0f993851
Chunk content in hex: 806ee175e90830b14ad8f596979815f7
```

Works for all data types including:
- chunk
- pointer
- scratchpad
- graphentry

Also including high level data types:
- data
- public archives
- private archives
- registers

Also works for raw DataMap:

```
ant analyze 81a54669727374939400dc0020ccf9cca612cceccca53611ccf7ccf67f6226ccb848493a122dcc9acceb21cca7ccef0024ccabccf7104812ccfdccecdc0020086135cc91700eccbeccbbcc931dcce8113dcceb1d5e4ccca80859ccb22ccca5ccabccd0ccf310ccc5cccc67ccb8ccbd049401dc002038ccdc4bccbb777e130b4cccf7cc8d2265cc9b0bcca2ccbdcccdccdbcc9dccf174011eccb7cce2520d224fccf542dc0020cc92cca5cceeccc5ccb5ccf4241c59cc874c42703c54582eccddcca2cce0cc98ccc2ccc5ccb36642ccaeccf0cc8f6318ccc8049402dc00203605cc97cca525cca9cc900770ccc5ccf6716a0a406a0bccea10cca2ccdbcce1ccabcce5ccbecc9f1b0b0fcc993851dc0020cc98ccf55c40ccd05a13cc91ccb172427818ccce31ccd0445acc9fccd9536e2d05ccef27466a671acce2cce305
```
```
DataMap containing 3 Chunks
Content is another DataMap: false
[
    f9a612eca53611f7f67f6226b848493a122d9aeb21a7ef0024abf7104812fdec,
    38dc4bbb777e130b4cf78d22659b0ba2bdcddb9df174011eb7e2520d224ff542,
    360597a525a9900770c5f6716a0a406a0bea10a2dbe1abe5be9f1b0b0f993851,
]
Decrypted Data in hex: 48656c6c6f2c20576f726c643f
```

Can be run in verbose mode to print extra information:

```
ant analyze -v 360597a525a9900770c5f6716a0a406a0bea10a2dbe1abe5be9f1b0b0f993851
```

