### PR TITLE
Client fixes to improve the client upload success rate and performance

### DIFF
--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -79,6 +79,8 @@ async fn main() -> Result<()> {
     let version = ant_build_info::git_info();
     info!("autonomi client built with git version: {version}");
 
+    ant_build_info::log_version_info(env!("CARGO_PKG_VERSION"), &identify_protocol_str);
+
     commands::handle_subcommand(opt).await?;
 
     Ok(())
@@ -86,7 +88,7 @@ async fn main() -> Result<()> {
 
 fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
     let logging_targets = vec![
-        ("ant_bootstrap".to_string(), Level::DEBUG),
+        ("ant_bootstrap".to_string(), Level::INFO),
         ("ant_build_info".to_string(), Level::TRACE),
         ("ant_evm".to_string(), Level::TRACE),
         ("ant_networking".to_string(), Level::INFO),
@@ -95,6 +97,7 @@ fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGua
         ("evmlib".to_string(), Level::TRACE),
         ("ant_logging".to_string(), Level::TRACE),
         ("ant_protocol".to_string(), Level::TRACE),
+        ("ant_cli".to_string(), Level::TRACE),
     ];
     let mut log_builder = LogBuilder::new(logging_targets);
     log_builder.output_dest(opt.log_output_dest.clone());

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -515,7 +515,7 @@ impl SwarmDriver {
                     peers.into_iter(),
                     quorum.get_kad_quorum(),
                 );
-                debug!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
+                info!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
 
                 if let Err(err) = sender.send(Ok(())) {
                     error!("Could not send response to PutRecordTo cmd: {:?}", err);

--- a/ant-networking/src/config.rs
+++ b/ant-networking/src/config.rs
@@ -214,13 +214,13 @@ fn verify_retry_strategy_intervals() {
 
     assert_eq!(intervals(RetryStrategy::None), Vec::<u32>::new());
     assert_eq!(intervals(RetryStrategy::Quick), vec![2, 4, 8]);
-    assert_eq!(intervals(RetryStrategy::Balanced), vec![2, 4, 8, 16, 32]);
+    assert_eq!(intervals(RetryStrategy::Balanced), vec![2, 4, 8, 8, 8]);
     assert_eq!(
         intervals(RetryStrategy::Persistent),
-        vec![2, 4, 8, 16, 32, 32, 32, 32, 32]
+        vec![2, 4, 8, 8, 8, 8, 8, 8, 8]
     );
     assert_eq!(
         intervals(RetryStrategy::N(NonZeroUsize::new(12).unwrap())),
-        vec![2, 4, 8, 16, 32, 32, 32, 32, 32, 32, 32]
+        vec![2, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8]
     );
 }

--- a/ant-networking/src/config.rs
+++ b/ant-networking/src/config.rs
@@ -59,7 +59,7 @@ impl RetryStrategy {
         let mut backoff = Backoff::new(
             self.attempts() as u32,
             Duration::from_secs(1), // First interval is double of this (see https://github.com/yoshuawuyts/exponential-backoff/issues/23)
-            Some(Duration::from_secs(32)),
+            Some(Duration::from_secs(8)),
         );
         backoff.set_factor(2); // Default.
         backoff.set_jitter(0.2); // Default is 0.3.

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -121,6 +121,9 @@ const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 /// Time before a Kad query times out if no response is received
 const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(10);
 
+/// Client requires a super long time when have get_closest query against production network
+const CLIENT_KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(60);
+
 /// Interval to trigger native libp2p::kad bootstrap.
 /// This is the max time it should take. Minimum interval at any node will be half this
 const PERIODIC_KAD_BOOTSTRAP_INTERVAL_MAX_S: u64 = 21600;
@@ -342,7 +345,7 @@ impl NetworkBuilder {
             .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
             .set_max_packet_size(MAX_PACKET_SIZE)
             .set_replication_factor(REPLICATION_FACTOR)
-            .set_query_timeout(KAD_QUERY_TIMEOUT_S)
+            .set_query_timeout(CLIENT_KAD_QUERY_TIMEOUT_S)
             // Require iterative queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
             .disjoint_query_paths(true)
             // How many nodes _should_ store data.

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -297,12 +297,20 @@ impl Network {
         nonce: Nonce,
         expected_proof: ChunkProof,
         quorum: ResponseQuorum,
-        retry_strategy: RetryStrategy,
+        _retry_strategy: RetryStrategy,
     ) -> Result<()> {
-        let total_attempts = retry_strategy.attempts();
+        // The above calling place shall already carried out same `re-attempts`.
+        // Hence here just use a fixed number.
+        let total_attempts = 2;
 
         let pretty_key = PrettyPrintRecordKey::from(&chunk_address.to_record_key()).into_owned();
         let expected_n_verified = quorum.get_value();
+
+        let request = Request::Query(Query::GetChunkExistenceProof {
+            key: chunk_address.clone(),
+            nonce,
+            difficulty: 1,
+        });
 
         let mut close_nodes = Vec::new();
         let mut retry_attempts = 0;
@@ -321,11 +329,6 @@ impl Network {
                 "Getting ChunkProof for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}",
             );
 
-            let request = Request::Query(Query::GetChunkExistenceProof {
-                key: chunk_address.clone(),
-                nonce,
-                difficulty: 1,
-            });
             let responses = self
                 .send_and_get_responses(&close_nodes, &request, true)
                 .await;


### PR DESCRIPTION
### Description

This PR contains following tweaks aiming to improve the client upload success rate and performance:
* increase client KAD_QUERY_TIMEOUT from 10s to 60s, to allow more accurate peer sets got returned from the get_closest query
* reduce some un-necessary tryouts, to reduce the overall upload process, especially during failure case.


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
