### PR TITLE
further attempts to improve the client upload success rate

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -405,7 +405,7 @@ jobs:
           done
         env:
           ANT_LOG: "v"
-        timeout-minutes: 25
+        timeout-minutes: 40
 
       - name: add more files - windows
         if: matrix.os == 'windows-latest'

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -79,6 +79,8 @@ async fn main() -> Result<()> {
     let version = ant_build_info::git_info();
     info!("autonomi client built with git version: {version}");
 
+    ant_build_info::log_version_info(env!("CARGO_PKG_VERSION"), &identify_protocol_str);
+
     commands::handle_subcommand(opt).await?;
 
     Ok(())
@@ -86,7 +88,7 @@ async fn main() -> Result<()> {
 
 fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
     let logging_targets = vec![
-        ("ant_bootstrap".to_string(), Level::DEBUG),
+        ("ant_bootstrap".to_string(), Level::INFO),
         ("ant_build_info".to_string(), Level::TRACE),
         ("ant_evm".to_string(), Level::TRACE),
         ("ant_networking".to_string(), Level::INFO),
@@ -95,6 +97,7 @@ fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGua
         ("evmlib".to_string(), Level::TRACE),
         ("ant_logging".to_string(), Level::TRACE),
         ("ant_protocol".to_string(), Level::TRACE),
+        ("ant_cli".to_string(), Level::TRACE),
     ];
     let mut log_builder = LogBuilder::new(logging_targets);
     log_builder.output_dest(opt.log_output_dest.clone());

--- a/ant-evm/src/data_payments.rs
+++ b/ant-evm/src/data_payments.rs
@@ -38,22 +38,13 @@ impl From<PeerId> for EncodedPeerId {
     }
 }
 
-/// The proof of payment for a data payment
+/// The proof of payment for a data payment, only to be used on client side
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct ProofOfPayment {
+pub struct ClientProofOfPayment {
     pub peer_quotes: Vec<(EncodedPeerId, Vec<Multiaddr>, PaymentQuote)>,
 }
 
-impl ProofOfPayment {
-    /// returns a short digest of the proof of payment to use for verification
-    pub fn digest(&self) -> Vec<(QuoteHash, QuotingMetrics, RewardsAddress)> {
-        self.peer_quotes
-            .clone()
-            .into_iter()
-            .map(|(_, _, quote)| (quote.hash(), quote.quoting_metrics, quote.rewards_address))
-            .collect()
-    }
-
+impl ClientProofOfPayment {
     /// returns the list of payees
     pub fn payees(&self) -> Vec<(PeerId, Vec<Multiaddr>)> {
         self.peer_quotes
@@ -68,18 +59,53 @@ impl ProofOfPayment {
             .collect()
     }
 
+    /// Convert to ProofOfPayment
+    pub fn to_proof_of_payment(&self) -> ProofOfPayment {
+        let peer_quotes = self
+            .peer_quotes
+            .iter()
+            .map(|(peer_id, _addrs, quote)| (peer_id.clone(), quote.clone()))
+            .collect();
+        ProofOfPayment { peer_quotes }
+    }
+}
+
+/// The proof of payment for a data payment, only to be used on node side
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct ProofOfPayment {
+    pub peer_quotes: Vec<(EncodedPeerId, PaymentQuote)>,
+}
+
+impl ProofOfPayment {
+    /// returns a short digest of the proof of payment to use for verification
+    pub fn digest(&self) -> Vec<(QuoteHash, QuotingMetrics, RewardsAddress)> {
+        self.peer_quotes
+            .clone()
+            .into_iter()
+            .map(|(_, quote)| (quote.hash(), quote.quoting_metrics, quote.rewards_address))
+            .collect()
+    }
+
+    /// returns the list of payees
+    pub fn payees(&self) -> Vec<PeerId> {
+        self.peer_quotes
+            .iter()
+            .filter_map(|(peer_id, _)| peer_id.to_peer_id().ok())
+            .collect()
+    }
+
     /// has the quote expired
     pub fn has_expired(&self) -> bool {
         self.peer_quotes
             .iter()
-            .any(|(_, _, quote)| quote.has_expired())
+            .any(|(_, quote)| quote.has_expired())
     }
 
     /// Returns all quotes by given peer id
     pub fn quotes_by_peer(&self, peer_id: &PeerId) -> Vec<&PaymentQuote> {
         self.peer_quotes
             .iter()
-            .filter_map(|(_id, _addr, quote)| {
+            .filter_map(|(_id, quote)| {
                 if let Ok(quote_peer_id) = quote.peer_id() {
                     if *peer_id == quote_peer_id {
                         return Some(quote);
@@ -93,7 +119,7 @@ impl ProofOfPayment {
     /// verifies the proof of payment is valid for the given peer id
     pub fn verify_for(&self, peer_id: PeerId) -> bool {
         // make sure I am in the list of payees
-        if !self.payees().iter().any(|(id, _addrs)| *id == peer_id) {
+        if !self.payees().contains(&peer_id) {
             warn!("Payment does not contain node peer id");
             debug!("Payment contains peer ids: {:?}", self.payees());
             debug!("Node peer id: {:?}", peer_id);
@@ -101,7 +127,7 @@ impl ProofOfPayment {
         }
 
         // verify all signatures
-        for (encoded_peer_id, _addr, quote) in self.peer_quotes.iter() {
+        for (encoded_peer_id, quote) in self.peer_quotes.iter() {
             let peer_id = match encoded_peer_id.to_peer_id() {
                 Ok(peer_id) => peer_id,
                 Err(e) => {
@@ -119,7 +145,7 @@ impl ProofOfPayment {
 
     /// Verifies whether all quotes were made for the expected data type.
     pub fn verify_data_type(&self, data_type: u32) -> bool {
-        for (_, _, quote) in self.peer_quotes.iter() {
+        for (_, quote) in self.peer_quotes.iter() {
             if quote.quoting_metrics.data_type != data_type {
                 return false;
             }

--- a/ant-evm/src/data_payments.rs
+++ b/ant-evm/src/data_payments.rs
@@ -11,7 +11,7 @@ use evmlib::{
     common::{Address as RewardsAddress, QuoteHash},
     quoting_metrics::QuotingMetrics,
 };
-use libp2p::{identity::PublicKey, PeerId};
+use libp2p::{identity::PublicKey, Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 pub use std::time::SystemTime;
 use xor_name::XorName;
@@ -41,7 +41,7 @@ impl From<PeerId> for EncodedPeerId {
 /// The proof of payment for a data payment
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ProofOfPayment {
-    pub peer_quotes: Vec<(EncodedPeerId, PaymentQuote)>,
+    pub peer_quotes: Vec<(EncodedPeerId, Vec<Multiaddr>, PaymentQuote)>,
 }
 
 impl ProofOfPayment {
@@ -50,15 +50,21 @@ impl ProofOfPayment {
         self.peer_quotes
             .clone()
             .into_iter()
-            .map(|(_, quote)| (quote.hash(), quote.quoting_metrics, quote.rewards_address))
+            .map(|(_, _, quote)| (quote.hash(), quote.quoting_metrics, quote.rewards_address))
             .collect()
     }
 
     /// returns the list of payees
-    pub fn payees(&self) -> Vec<PeerId> {
+    pub fn payees(&self) -> Vec<(PeerId, Vec<Multiaddr>)> {
         self.peer_quotes
             .iter()
-            .filter_map(|(peer_id, _)| peer_id.to_peer_id().ok())
+            .filter_map(|(peer_id, addrs, _)| {
+                if let Ok(peer_id) = peer_id.to_peer_id() {
+                    Some((peer_id, addrs.clone()))
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
@@ -66,14 +72,14 @@ impl ProofOfPayment {
     pub fn has_expired(&self) -> bool {
         self.peer_quotes
             .iter()
-            .any(|(_, quote)| quote.has_expired())
+            .any(|(_, _, quote)| quote.has_expired())
     }
 
     /// Returns all quotes by given peer id
     pub fn quotes_by_peer(&self, peer_id: &PeerId) -> Vec<&PaymentQuote> {
         self.peer_quotes
             .iter()
-            .filter_map(|(_id, quote)| {
+            .filter_map(|(_id, _addr, quote)| {
                 if let Ok(quote_peer_id) = quote.peer_id() {
                     if *peer_id == quote_peer_id {
                         return Some(quote);
@@ -87,7 +93,7 @@ impl ProofOfPayment {
     /// verifies the proof of payment is valid for the given peer id
     pub fn verify_for(&self, peer_id: PeerId) -> bool {
         // make sure I am in the list of payees
-        if !self.payees().contains(&peer_id) {
+        if !self.payees().iter().any(|(id, _addrs)| *id == peer_id) {
             warn!("Payment does not contain node peer id");
             debug!("Payment contains peer ids: {:?}", self.payees());
             debug!("Node peer id: {:?}", peer_id);
@@ -95,7 +101,7 @@ impl ProofOfPayment {
         }
 
         // verify all signatures
-        for (encoded_peer_id, quote) in self.peer_quotes.iter() {
+        for (encoded_peer_id, _addr, quote) in self.peer_quotes.iter() {
             let peer_id = match encoded_peer_id.to_peer_id() {
                 Ok(peer_id) => peer_id,
                 Err(e) => {
@@ -113,7 +119,7 @@ impl ProofOfPayment {
 
     /// Verifies whether all quotes were made for the expected data type.
     pub fn verify_data_type(&self, data_type: u32) -> bool {
-        for (_, quote) in self.peer_quotes.iter() {
+        for (_, _, quote) in self.peer_quotes.iter() {
             if quote.quoting_metrics.data_type != data_type {
                 return false;
             }

--- a/ant-evm/src/lib.rs
+++ b/ant-evm/src/lib.rs
@@ -31,7 +31,9 @@ mod amount;
 mod data_payments;
 mod error;
 
-pub use data_payments::{EncodedPeerId, PaymentQuote, ProofOfPayment, QUOTE_EXPIRATION_SECS};
+pub use data_payments::{
+    ClientProofOfPayment, EncodedPeerId, PaymentQuote, ProofOfPayment, QUOTE_EXPIRATION_SECS,
+};
 pub use evmlib::quoting_metrics::QuotingMetrics;
 
 /// Types used in the public API

--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -515,7 +515,7 @@ impl SwarmDriver {
                     peers.into_iter(),
                     quorum.get_kad_quorum(),
                 );
-                debug!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
+                info!("Sent record {record_key:?} to {peers_count:?} peers. Request id: {request_id:?}");
 
                 if let Err(err) = sender.send(Ok(())) {
                     error!("Could not send response to PutRecordTo cmd: {:?}", err);

--- a/ant-networking/src/config.rs
+++ b/ant-networking/src/config.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::Addresses;
 use ant_protocol::{
     messages::{ChunkProof, Nonce},
     PrettyPrintRecordKey, CLOSE_GROUP_SIZE,
@@ -181,7 +182,7 @@ pub struct PutRecordCfg {
     pub retry_strategy: RetryStrategy,
     /// Use the `kad::put_record_to` to PUT the record only to the specified peers. If this option is set to None, we
     /// will be using `kad::put_record` which would PUT the record to all the closest members of the record.
-    pub use_put_record_to: Option<Vec<PeerId>>,
+    pub use_put_record_to: Option<Vec<(PeerId, Addresses)>>,
     /// Enables verification after writing. The VerificationKind is used to determine the method to use.
     pub verification: Option<(VerificationKind, GetRecordCfg)>,
 }

--- a/ant-networking/src/config.rs
+++ b/ant-networking/src/config.rs
@@ -214,13 +214,13 @@ fn verify_retry_strategy_intervals() {
 
     assert_eq!(intervals(RetryStrategy::None), Vec::<u32>::new());
     assert_eq!(intervals(RetryStrategy::Quick), vec![2, 4, 8]);
-    assert_eq!(intervals(RetryStrategy::Balanced), vec![2, 4, 8, 16, 32]);
+    assert_eq!(intervals(RetryStrategy::Balanced), vec![2, 4, 8, 8, 8]);
     assert_eq!(
         intervals(RetryStrategy::Persistent),
-        vec![2, 4, 8, 16, 32, 32, 32, 32, 32]
+        vec![2, 4, 8, 8, 8, 8, 8, 8, 8]
     );
     assert_eq!(
         intervals(RetryStrategy::N(NonZeroUsize::new(12).unwrap())),
-        vec![2, 4, 8, 16, 32, 32, 32, 32, 32, 32, 32]
+        vec![2, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8]
     );
 }

--- a/ant-networking/src/config.rs
+++ b/ant-networking/src/config.rs
@@ -59,7 +59,7 @@ impl RetryStrategy {
         let mut backoff = Backoff::new(
             self.attempts() as u32,
             Duration::from_secs(1), // First interval is double of this (see https://github.com/yoshuawuyts/exponential-backoff/issues/23)
-            Some(Duration::from_secs(32)),
+            Some(Duration::from_secs(8)),
         );
         backoff.set_factor(2); // Default.
         backoff.set_jitter(0.2); // Default is 0.3.

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -121,6 +121,9 @@ const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 /// Time before a Kad query times out if no response is received
 const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(10);
 
+/// Client requires a super long time when have get_closest query against production network
+const CLIENT_KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(60);
+
 /// Interval to trigger native libp2p::kad bootstrap.
 /// This is the max time it should take. Minimum interval at any node will be half this
 const PERIODIC_KAD_BOOTSTRAP_INTERVAL_MAX_S: u64 = 21600;
@@ -342,7 +345,7 @@ impl NetworkBuilder {
             .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
             .set_max_packet_size(MAX_PACKET_SIZE)
             .set_replication_factor(REPLICATION_FACTOR)
-            .set_query_timeout(KAD_QUERY_TIMEOUT_S)
+            .set_query_timeout(CLIENT_KAD_QUERY_TIMEOUT_S)
             // Require iterative queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
             .disjoint_query_paths(true)
             // How many nodes _should_ store data.

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -313,11 +313,13 @@ impl Network {
             difficulty: 1,
         });
 
-        if close_nodes.is_empty() {
-            close_nodes = self
-                .client_get_all_close_peers_in_range_or_close_group(&chunk_address)
-                .await?;
-        }
+        // Checking both selected payees(if has) and network fetched close_nodes
+        let mut network_close_nodes = self
+            .client_get_all_close_peers_in_range_or_close_group(&chunk_address)
+            .await?;
+        network_close_nodes
+            .retain(|(peer_id, _addrs)| !close_nodes.iter().any(|(peer, _addrs)| peer == peer_id));
+        close_nodes.extend(network_close_nodes);
 
         let mut retry_attempts = 0;
         while retry_attempts < total_attempts {

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -294,6 +294,7 @@ impl Network {
     pub async fn verify_chunk_existence(
         &self,
         chunk_address: NetworkAddress,
+        mut close_nodes: Vec<(PeerId, Addresses)>,
         nonce: Nonce,
         expected_proof: ChunkProof,
         quorum: ResponseQuorum,
@@ -312,18 +313,14 @@ impl Network {
             difficulty: 1,
         });
 
-        let mut close_nodes = Vec::new();
+        if close_nodes.is_empty() {
+            close_nodes = self
+                .client_get_all_close_peers_in_range_or_close_group(&chunk_address)
+                .await?;
+        }
+
         let mut retry_attempts = 0;
         while retry_attempts < total_attempts {
-            // the check should happen before incrementing retry_attempts
-            if retry_attempts % 2 == 0 {
-                // Do not query the closest_peers during every re-try attempt.
-                // The close_nodes don't change often and the previous set of close_nodes might be taking a while to write
-                // the Chunk, so query them again incase of a failure.
-                close_nodes = self
-                    .client_get_all_close_peers_in_range_or_close_group(&chunk_address)
-                    .await?;
-            }
             retry_attempts += 1;
             info!(
                 "Getting ChunkProof for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}",
@@ -390,7 +387,7 @@ impl Network {
         data_type: u32,
         data_size: usize,
         ignore_peers: Vec<PeerId>,
-    ) -> Result<Vec<(PeerId, PaymentQuote)>> {
+    ) -> Result<Vec<(PeerId, Addresses, PaymentQuote)>> {
         // The requirement of having at least CLOSE_GROUP_SIZE
         // close nodes will be checked internally automatically.
         let mut close_nodes = self
@@ -427,7 +424,6 @@ impl Network {
         let mut peers_returned_error = 0;
 
         // loop over responses
-        let mut all_quotes = vec![];
         let mut quotes_to_pay = vec![];
         for (peer, response) in responses {
             info!("StoreCostReq for {record_address:?} received response: {response:?}");
@@ -453,8 +449,15 @@ impl Network {
                         continue;
                     }
 
-                    all_quotes.push((peer_address.clone(), quote.clone()));
-                    quotes_to_pay.push((peer, quote));
+                    let Some((_peer_id, addrs)) = close_nodes
+                        .iter()
+                        .find(|(peer_id, _addrs)| *peer_id == peer)
+                    else {
+                        warn!("Can't find the addresses of the peer {peer:?}");
+                        continue;
+                    };
+
+                    quotes_to_pay.push((peer, addrs.clone(), quote));
                 }
                 Ok(Response::Query(QueryResponse::GetStoreQuote {
                     quote: Err(ProtocolError::RecordExists(_)),
@@ -818,20 +821,26 @@ impl Network {
 
         // Waiting for a response to avoid flushing to network too quick that causing choke
         let (sender, receiver) = oneshot::channel();
-        if let Some(put_record_to_peers) = &cfg.use_put_record_to {
+        let close_nodes = if let Some(put_record_to_peers) = &cfg.use_put_record_to {
+            let peers = put_record_to_peers
+                .iter()
+                .map(|(peer_id, _addrs)| *peer_id)
+                .collect();
             self.send_network_swarm_cmd(NetworkSwarmCmd::PutRecordTo {
-                peers: put_record_to_peers.clone(),
+                peers,
                 record: record.clone(),
                 sender,
                 quorum: cfg.put_quorum,
             });
+            put_record_to_peers.clone()
         } else {
             self.send_network_swarm_cmd(NetworkSwarmCmd::PutRecord {
                 record: record.clone(),
                 sender,
                 quorum: cfg.put_quorum,
             });
-        }
+            vec![]
+        };
 
         let response = receiver.await?;
 
@@ -852,6 +861,7 @@ impl Network {
             {
                 self.verify_chunk_existence(
                     NetworkAddress::from_record_key(&record_key),
+                    close_nodes,
                     *nonce,
                     expected_proof.clone(),
                     get_cfg.get_quorum,

--- a/ant-networking/src/lib.rs
+++ b/ant-networking/src/lib.rs
@@ -297,12 +297,20 @@ impl Network {
         nonce: Nonce,
         expected_proof: ChunkProof,
         quorum: ResponseQuorum,
-        retry_strategy: RetryStrategy,
+        _retry_strategy: RetryStrategy,
     ) -> Result<()> {
-        let total_attempts = retry_strategy.attempts();
+        // The above calling place shall already carried out same `re-attempts`.
+        // Hence here just use a fixed number.
+        let total_attempts = 2;
 
         let pretty_key = PrettyPrintRecordKey::from(&chunk_address.to_record_key()).into_owned();
         let expected_n_verified = quorum.get_value();
+
+        let request = Request::Query(Query::GetChunkExistenceProof {
+            key: chunk_address.clone(),
+            nonce,
+            difficulty: 1,
+        });
 
         let mut close_nodes = Vec::new();
         let mut retry_attempts = 0;
@@ -321,11 +329,6 @@ impl Network {
                 "Getting ChunkProof for {pretty_key:?}. Attempts: {retry_attempts:?}/{total_attempts:?}",
             );
 
-            let request = Request::Query(Query::GetChunkExistenceProof {
-                key: chunk_address.clone(),
-                nonce,
-                difficulty: 1,
-            });
             let responses = self
                 .send_and_get_responses(&close_nodes, &request, true)
                 .await;

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -665,7 +665,7 @@ impl Node {
         // push self in as the returned list doesn't contain self
         closest_k_peers.push((self_peer_id, Default::default()));
         let mut payees = payment.payees();
-        payees.retain(|(peer_id, _addrs)| !closest_k_peers.iter().any(|(p, _)| p == peer_id));
+        payees.retain(|peer_id| !closest_k_peers.iter().any(|(p, _)| p == peer_id));
         if !payees.is_empty() {
             warn!("Payment quote has out-of-range payees for record {pretty_key}");
             return Err(Error::InvalidRequest(format!(

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -665,7 +665,7 @@ impl Node {
         // push self in as the returned list doesn't contain self
         closest_k_peers.push((self_peer_id, Default::default()));
         let mut payees = payment.payees();
-        payees.retain(|peer_id| !closest_k_peers.iter().any(|(p, _)| p == peer_id));
+        payees.retain(|(peer_id, _addrs)| !closest_k_peers.iter().any(|(p, _)| p == peer_id));
         if !payees.is_empty() {
             warn!("Payment quote has out-of-range payees for record {pretty_key}");
             return Err(Error::InvalidRequest(format!(

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ant_evm::EvmNetwork;
-use ant_networking::{GetRecordCfg, PutRecordCfg, VerificationKind};
+use ant_networking::{Addresses, GetRecordCfg, PutRecordCfg, VerificationKind};
 use ant_protocol::messages::ChunkProof;
 use libp2p::{kad::Record, PeerId};
 use rand::{thread_rng, Rng};
@@ -138,7 +138,7 @@ impl Strategy {
     }
 
     /// Put config for storing a record
-    pub(crate) fn put_cfg(&self, put_to: Option<Vec<PeerId>>) -> PutRecordCfg {
+    pub(crate) fn put_cfg(&self, put_to: Option<Vec<(PeerId, Addresses)>>) -> PutRecordCfg {
         PutRecordCfg {
             put_quorum: self.put_quorum,
             retry_strategy: self.put_retry,
@@ -148,7 +148,11 @@ impl Strategy {
     }
 
     /// Put config for storing a Chunk, more strict and requires a chunk proof of storage
-    pub(crate) fn chunk_put_cfg(&self, expected: Record, put_to: Vec<PeerId>) -> PutRecordCfg {
+    pub(crate) fn chunk_put_cfg(
+        &self,
+        expected: Record,
+        put_to: Vec<(PeerId, Addresses)>,
+    ) -> PutRecordCfg {
         let random_nonce = thread_rng().gen::<u64>();
         let expected_proof = ChunkProof::new(&expected.value, random_nonce);
 

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -16,7 +16,7 @@ use crate::{
     self_encryption::DataMapLevel,
     Client,
 };
-use ant_evm::{Amount, AttoTokens, ProofOfPayment};
+use ant_evm::{Amount, AttoTokens, ClientProofOfPayment};
 use ant_networking::{Addresses, NetworkError};
 use ant_protocol::{
     storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind},
@@ -173,7 +173,7 @@ impl Client {
         let record = Record {
             key: address.to_record_key(),
             value: try_serialize_record(
-                &(proof, chunk),
+                &(proof.to_proof_of_payment(), chunk),
                 RecordKind::DataWithPayment(DataTypes::Chunk),
             )
             .map_err(|_| {
@@ -292,7 +292,7 @@ impl Client {
     pub(crate) async fn chunk_upload_with_payment(
         &self,
         chunk: &Chunk,
-        payment: ProofOfPayment,
+        payment: ClientProofOfPayment,
     ) -> Result<ChunkAddress, PutError> {
         let storing_nodes: Vec<_> = payment
             .payees()
@@ -311,13 +311,14 @@ impl Client {
         let record_kind = RecordKind::DataWithPayment(DataTypes::Chunk);
         let record = Record {
             key: key.clone(),
-            value: try_serialize_record(&(payment, chunk.clone()), record_kind)
-                .map_err(|e| {
-                    PutError::Serialization(format!(
-                        "Failed to serialize chunk with payment: {e:?}"
-                    ))
-                })?
-                .to_vec(),
+            value: try_serialize_record(
+                &(payment.to_proof_of_payment(), chunk.clone()),
+                record_kind,
+            )
+            .map_err(|e| {
+                PutError::Serialization(format!("Failed to serialize chunk with payment: {e:?}"))
+            })?
+            .to_vec(),
             publisher: None,
             expires: None,
         };

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -17,7 +17,7 @@ use crate::{
     Client,
 };
 use ant_evm::{Amount, AttoTokens, ProofOfPayment};
-use ant_networking::NetworkError;
+use ant_networking::{Addresses, NetworkError};
 use ant_protocol::{
     storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind},
     NetworkAddress,
@@ -165,7 +165,11 @@ impl Client {
         };
         let total_cost = *price;
 
-        let payees = proof.payees();
+        let payees = proof
+            .payees()
+            .iter()
+            .map(|(peer_id, addrs)| (*peer_id, Addresses(addrs.clone())))
+            .collect();
         let record = Record {
             key: address.to_record_key(),
             value: try_serialize_record(
@@ -290,7 +294,11 @@ impl Client {
         chunk: &Chunk,
         payment: ProofOfPayment,
     ) -> Result<ChunkAddress, PutError> {
-        let storing_nodes = payment.payees();
+        let storing_nodes: Vec<_> = payment
+            .payees()
+            .iter()
+            .map(|(peer_id, addrs)| (*peer_id, Addresses(addrs.clone())))
+            .collect();
 
         if storing_nodes.is_empty() {
             return Err(PutError::PayeesMissing);

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -15,6 +15,7 @@ use crate::client::UploadSummary;
 
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
 use ant_networking::get_graph_entry_from_record;
+use ant_networking::Addresses;
 use ant_networking::GetRecordError;
 use ant_networking::NetworkError;
 use ant_protocol::PrettyPrintRecordKey;
@@ -129,7 +130,11 @@ impl Client {
         let total_cost = *price;
 
         // prepare the record for network storage
-        let payees = proof.payees();
+        let payees = proof
+            .payees()
+            .iter()
+            .map(|(peer_id, addrs)| (*peer_id, Addresses(addrs.clone())))
+            .collect();
         let record = Record {
             key: NetworkAddress::from_graph_entry_address(address).to_record_key(),
             value: try_serialize_record(

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -138,7 +138,7 @@ impl Client {
         let record = Record {
             key: NetworkAddress::from_graph_entry_address(address).to_record_key(),
             value: try_serialize_record(
-                &(proof, &entry),
+                &(proof.to_proof_of_payment(), &entry),
                 RecordKind::DataWithPayment(DataTypes::GraphEntry),
             )
             .map_err(|_| GraphError::Serialization)?

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -154,7 +154,7 @@ impl Client {
             let record = Record {
                 key: NetworkAddress::from_pointer_address(address).to_record_key(),
                 value: try_serialize_record(
-                    &(proof, &pointer),
+                    &(proof.to_proof_of_payment(), &pointer),
                     RecordKind::DataWithPayment(DataTypes::Pointer),
                 )
                 .map_err(|_| PointerError::Serialization)?

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -12,7 +12,7 @@ use crate::client::{
     Client,
 };
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
-use ant_networking::{GetRecordError, NetworkError};
+use ant_networking::{Addresses, GetRecordError, NetworkError};
 use ant_protocol::{
     storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind},
     NetworkAddress,
@@ -144,7 +144,13 @@ impl Client {
         let total_cost = *price;
 
         let (record, payees) = if let Some(proof) = proof {
-            let payees = Some(proof.payees());
+            let payees = Some(
+                proof
+                    .payees()
+                    .iter()
+                    .map(|(peer_id, addrs)| (*peer_id, Addresses(addrs.clone())))
+                    .collect(),
+            );
             let record = Record {
                 key: NetworkAddress::from_pointer_address(address).to_record_key(),
                 value: try_serialize_record(

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -196,7 +196,7 @@ impl Client {
             let record = Record {
                 key: net_addr.to_record_key(),
                 value: try_serialize_record(
-                    &(proof, &scratchpad),
+                    &(proof.to_proof_of_payment(), &scratchpad),
                     RecordKind::DataWithPayment(DataTypes::Scratchpad),
                 )
                 .map_err(|_| ScratchpadError::Serialization)?

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -9,7 +9,7 @@
 use crate::client::payment::{PayError, PaymentOption};
 use crate::{client::quote::CostError, Client};
 use crate::{Amount, AttoTokens};
-use ant_networking::{GetRecordError, NetworkError};
+use ant_networking::{Addresses, GetRecordError, NetworkError};
 use ant_protocol::storage::{try_serialize_record, RecordKind};
 use ant_protocol::{
     storage::{try_deserialize_record, DataTypes},
@@ -186,7 +186,13 @@ impl Client {
 
         let net_addr = NetworkAddress::from_scratchpad_address(*address);
         let (record, payees) = if let Some(proof) = proof {
-            let payees = Some(proof.payees());
+            let payees = Some(
+                proof
+                    .payees()
+                    .iter()
+                    .map(|(peer_id, addrs)| (*peer_id, Addresses(addrs.clone())))
+                    .collect(),
+            );
             let record = Record {
                 key: net_addr.to_record_key(),
                 value: try_serialize_record(

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -1,6 +1,6 @@
 use crate::client::quote::{DataTypes, StoreQuote};
 use crate::Client;
-use ant_evm::{EncodedPeerId, EvmWallet, EvmWalletError, ProofOfPayment};
+use ant_evm::{ClientProofOfPayment, EncodedPeerId, EvmWallet, EvmWalletError};
 use std::collections::HashMap;
 use xor_name::XorName;
 
@@ -9,7 +9,7 @@ use super::quote::CostError;
 pub use crate::{Amount, AttoTokens};
 
 /// Contains the proof of payments for each XOR address and the amount paid
-pub type Receipt = HashMap<XorName, (ProofOfPayment, AttoTokens)>;
+pub type Receipt = HashMap<XorName, (ClientProofOfPayment, AttoTokens)>;
 
 pub type AlreadyPaidAddressesCount = usize;
 
@@ -33,7 +33,7 @@ pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
     for (content_addr, quote_for_address) in quotes.0 {
         let price = AttoTokens::from_atto(quote_for_address.price());
 
-        let mut proof_of_payment = ProofOfPayment {
+        let mut proof_of_payment = ClientProofOfPayment {
             peer_quotes: vec![],
         };
 

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -30,7 +30,6 @@ pub enum PayError {
 
 pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
     let mut receipt = Receipt::new();
-
     for (content_addr, quote_for_address) in quotes.0 {
         let price = AttoTokens::from_atto(quote_for_address.price());
 
@@ -38,10 +37,10 @@ pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
             peer_quotes: vec![],
         };
 
-        for (peer_id, quote, _amount) in quote_for_address.0 {
+        for (peer_id, addrs, quote, _amount) in quote_for_address.0 {
             proof_of_payment
                 .peer_quotes
-                .push((EncodedPeerId::from(peer_id), quote));
+                .push((EncodedPeerId::from(peer_id), addrs.0, quote));
         }
 
         // skip empty proofs

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -11,7 +11,7 @@ use crate::client::high_level::files::FILE_UPLOAD_BATCH_SIZE;
 use crate::client::utils::process_tasks_with_max_concurrency;
 use ant_evm::payment_vault::get_market_price;
 use ant_evm::{Amount, PaymentQuote, QuotePayment, QuotingMetrics};
-use ant_networking::{Network, NetworkError};
+use ant_networking::{Addresses, Network, NetworkError};
 use ant_protocol::{storage::ChunkAddress, NetworkAddress, CLOSE_GROUP_SIZE};
 use libp2p::PeerId;
 use std::collections::HashMap;
@@ -25,11 +25,11 @@ pub use ant_protocol::storage::DataTypes;
 const GET_MARKET_PRICE_BATCH_LIMIT: usize = 2000;
 
 /// A quote for a single address
-pub struct QuoteForAddress(pub(crate) Vec<(PeerId, PaymentQuote, Amount)>);
+pub struct QuoteForAddress(pub(crate) Vec<(PeerId, Addresses, PaymentQuote, Amount)>);
 
 impl QuoteForAddress {
     pub fn price(&self) -> Amount {
-        self.0.iter().map(|(_, _, price)| price).sum()
+        self.0.iter().map(|(_, _, _, price)| price).sum()
     }
 }
 
@@ -52,11 +52,21 @@ impl StoreQuote {
     pub fn payments(&self) -> Vec<QuotePayment> {
         let mut quote_payments = vec![];
         for (_address, quote) in self.0.iter() {
-            for (_peer, quote, price) in quote.0.iter() {
+            for (_peer, _addrs, quote, price) in quote.0.iter() {
                 quote_payments.push((quote.hash(), quote.rewards_address, *price));
             }
         }
         quote_payments
+    }
+
+    pub fn payees_info(&self) -> Vec<(PeerId, Addresses)> {
+        let mut payees_info = vec![];
+        for (_address, quote) in self.0.iter() {
+            for (peer, addrs, _quote, _price) in quote.0.iter() {
+                payees_info.push((*peer, addrs.clone()));
+            }
+        }
+        payees_info
     }
 }
 
@@ -89,7 +99,7 @@ impl Client {
         &self,
         data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)>,
-    ) -> Vec<Result<(XorName, Vec<(PeerId, PaymentQuote)>), CostError>> {
+    ) -> Vec<Result<(XorName, Vec<(PeerId, Addresses, PaymentQuote)>), CostError>> {
         let futures: Vec<_> = content_addrs
             .into_iter()
             .map(|(content_addr, data_size)| {
@@ -128,13 +138,13 @@ impl Client {
             let target_addr = NetworkAddress::from_chunk_address(ChunkAddress::new(content_addr));
 
             // Only keep the quotes of the 5 closest nodes
-            raw_quotes.sort_by_key(|(peer_id, _)| {
+            raw_quotes.sort_by_key(|(peer_id, _, _)| {
                 NetworkAddress::from_peer(*peer_id).distance(&target_addr)
             });
             raw_quotes.truncate(CLOSE_GROUP_SIZE);
 
-            for (peer_id, quote) in raw_quotes.into_iter() {
-                all_quotes.push((content_addr, peer_id, quote));
+            for (peer_id, addrs, quote) in raw_quotes.into_iter() {
+                all_quotes.push((content_addr, peer_id, addrs, quote));
             }
         }
 
@@ -143,7 +153,7 @@ impl Client {
         for chunk in all_quotes.chunks(GET_MARKET_PRICE_BATCH_LIMIT) {
             let quoting_metrics: Vec<QuotingMetrics> = chunk
                 .iter()
-                .map(|(_, _, quote)| quote.quoting_metrics.clone())
+                .map(|(_, _, _, quote)| quote.quoting_metrics.clone())
                 .collect();
 
             debug!(
@@ -156,19 +166,22 @@ impl Client {
             all_prices.extend(batch_prices);
         }
 
-        let quotes_with_prices: Vec<(XorName, PeerId, PaymentQuote, Amount)> = all_quotes
-            .into_iter()
-            .zip(all_prices.into_iter())
-            .map(|((content_addr, peer_id, quote), price)| (content_addr, peer_id, quote, price))
-            .collect();
+        let quotes_with_prices: Vec<(XorName, PeerId, Addresses, PaymentQuote, Amount)> =
+            all_quotes
+                .into_iter()
+                .zip(all_prices.into_iter())
+                .map(|((content_addr, peer_id, addrs, quote), price)| {
+                    (content_addr, peer_id, addrs, quote, price)
+                })
+                .collect();
 
-        let mut quotes_per_addr: HashMap<XorName, Vec<(PeerId, PaymentQuote, Amount)>> =
+        let mut quotes_per_addr: HashMap<XorName, Vec<(PeerId, Addresses, PaymentQuote, Amount)>> =
             HashMap::new();
 
-        for (content_addr, peer_id, quote, price) in quotes_with_prices {
+        for (content_addr, peer_id, addrs, quote, price) in quotes_with_prices {
             let entry = quotes_per_addr.entry(content_addr).or_default();
-            entry.push((peer_id, quote, price));
-            entry.sort_by_key(|(_, _, price)| *price);
+            entry.push((peer_id, addrs, quote, price));
+            entry.sort_by_key(|(_, _, _, price)| *price);
         }
 
         let mut quotes_to_pay_per_addr = HashMap::new();
@@ -177,14 +190,14 @@ impl Client {
 
         for (content_addr, quotes) in quotes_per_addr {
             if quotes.len() >= MINIMUM_QUOTES_TO_PAY {
-                let (p1, q1, _) = &quotes[0];
-                let (p2, q2, _) = &quotes[1];
+                let (p1, q1, a1, _) = &quotes[0];
+                let (p2, q2, a2, _) = &quotes[1];
 
                 quotes_to_pay_per_addr.insert(
                     content_addr,
                     QuoteForAddress(vec![
-                        (*p1, q1.clone(), Amount::ZERO),
-                        (*p2, q2.clone(), Amount::ZERO),
+                        (*p1, q1.clone(), a1.clone(), Amount::ZERO),
+                        (*p2, q2.clone(), a2.clone(), Amount::ZERO),
                         quotes[2].clone(),
                         quotes[3].clone(),
                         quotes[4].clone(),
@@ -210,7 +223,7 @@ async fn fetch_store_quote(
     content_addr: XorName,
     data_type: u32,
     data_size: usize,
-) -> Result<Vec<(PeerId, PaymentQuote)>, NetworkError> {
+) -> Result<Vec<(PeerId, Addresses, PaymentQuote)>, NetworkError> {
     network
         .get_store_quote_from_network(
             NetworkAddress::from_chunk_address(ChunkAddress::new(content_addr)),
@@ -227,7 +240,7 @@ async fn fetch_store_quote_with_retries(
     content_addr: XorName,
     data_type: u32,
     data_size: usize,
-) -> Result<(XorName, Vec<(PeerId, PaymentQuote)>), CostError> {
+) -> Result<(XorName, Vec<(PeerId, Addresses, PaymentQuote)>), CostError> {
     let mut retries = 0;
 
     loop {


### PR DESCRIPTION
### Description

Contains following works to improve the client upload success rate:

- increase client KAD_QUERY_TIMEOUT from 10s to 60s, to allow more accurate peer sets got returned from the get_closest query (From PR #2837)
- reduce some un-necessary tryouts, to reduce the overall upload process, especially during failure case. (From PR #2837)
- Check both payees and network queried closest nodes for chunk existence check (on top of PR #2838)
- Dial before put_record_to, to ensure connection to be re-established, following the model within the req/rsp communication. 

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
