### PR TITLE
test: use nodespawner for verify_data_location & verify_routing_table

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -743,6 +743,51 @@ jobs:
         run: cargo build --release --bin antnode
         timeout-minutes: 30
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: install foundary
+        shell: bash
+        run: curl -L https://foundry.paradigm.xyz | bash
+
+      - name: move foundry bins to path (linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
+
+      - name: move foundry bins to path (macos)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
+
+      - name: move foundry bins to path (windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
+
+      - name: run foundry
+        shell: bash
+        run: foundryup
+
+      - name: move anvil and other bins to path (linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
+
+      - name: move anvil and other bins to path (macos)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
+
+      - name: move anvil and other bins to path (windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
+
+      - name: Verify Anvil installation
+        run: |
+          anvil --version
+
       - name: Build data location and routing table tests
         run: cargo test --release -p ant-node --test verify_data_location --test verify_routing_table --no-run
         env:
@@ -750,29 +795,6 @@ jobs:
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
-
-      - name: Start a local network
-        uses: maidsafe/ant-local-testnet-action@main
-        with:
-          action: start
-          enable-evm-testnet: true
-          node-path: target/release/antnode
-          platform: ${{ matrix.os }}
-          build: true
-
-      - name: Check if ANT_PEERS and EVM_NETWORK are set
-        shell: bash
-        run: |
-          if [[ -z "$ANT_PEERS" ]]; then
-              echo "The ANT_PEERS variable has not been set"
-              exit 1
-          elif [[ -z "$EVM_NETWORK" ]]; then
-              echo "The EVM_NETWORK variable has not been set"
-              exit 1
-          else
-              echo "ANT_PEERS has been set to $ANT_PEERS"
-              echo "EVM_NETWORK has been set to $EVM_NETWORK"
-          fi
 
       - name: Verify the location of the data on the network
         run: cargo test --release -p ant-node --test verify_data_location -- --nocapture
@@ -787,59 +809,6 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 5
-
-      # Sleep for a while to allow restarted nodes can be detected by others
-      - name: Sleep a while
-        run: sleep 300
-
-      - name: Stop the local network and upload logs
-        if: always()
-        uses: maidsafe/ant-local-testnet-action@main
-        with:
-          action: stop
-          log_file_prefix: safe_test_logs_data_location
-          platform: ${{ matrix.os }}
-
-      - name: Verify restart of nodes using rg
-        shell: bash
-        timeout-minutes: 1
-        # get the counts, then the specific line, and then the digit count only
-        # then check we have an expected level of restarts
-        #
-        # `PeerRemovedFromRoutingTable` now only happens when a peer reported as `BadNode`.
-        # Otherwise kad will remove a `dropped out node` directly from RT.
-        # So, the detection of the removal explicity will now have much less chance,
-        # due to the removal of connection_issue tracking.
-        #
-        # With the further reduction of replication frequency,
-        # it now becomes harder to detect a `dropped out node` as a `failed to replicate` node.
-        # Hence now remove the assertion check and replace with a print out only.
-        run: |
-          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
-          echo "Node dir count is $node_count"
-          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
-            rg "(\d+) matches" | rg "\d+" -o)
-          echo "Restart $restart_count nodes"
-          if ! rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats
-          then
-            echo "No peer removal count found"
-            exit 0
-          fi
-          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
-            rg "(\d+) matches" | rg "\d+" -o)
-          echo "PeerRemovedFromRoutingTable $peer_removed times"
-
-      # Only error out after uploading the logs
-      - name: Don't log raw data
-        if: matrix.os != 'windows-latest' # causes error
-        shell: bash
-        timeout-minutes: 10
-        run: |
-          if ! rg '^' "${{ matrix.ant_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
-          then
-            echo "We are logging an extremely large data"
-            exit 1
-          fi
 
   # faucet_test:
   #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/ant-node/src/spawn/network_spawner.rs
+++ b/ant-node/src/spawn/network_spawner.rs
@@ -166,6 +166,19 @@ impl RunningNetwork {
             node.shutdown();
         }
     }
+
+    pub fn update_peer(&mut self, index: usize, new_peer: RunningNode) {
+        if index < self.running_nodes.len() {
+            self.running_nodes[index] = new_peer.clone();
+            println!(
+                "Updated index: {} with peer_id: {}",
+                index,
+                new_peer.peer_id()
+            );
+        } else {
+            println!("Invalid index: {index}");
+        }
+    }
 }
 
 async fn spawn_network(

--- a/ant-node/tests/verify_data_location.rs
+++ b/ant-node/tests/verify_data_location.rs
@@ -8,31 +8,31 @@
 
 mod common;
 
-use ant_logging::LogBuilder;
-use ant_networking::sort_peers_by_key;
-use ant_protocol::{
-    antnode_proto::{NodeInfoRequest, RecordAddressesRequest},
-    NetworkAddress, PrettyPrintRecordKey, CLOSE_GROUP_SIZE,
+use ant_networking::{sleep, sort_peers_by_key};
+use ant_node::{
+    spawn::{
+        network_spawner::{NetworkSpawner, RunningNetwork},
+        node_spawner::NodeSpawner,
+    },
+    RunningNode,
 };
-use autonomi::Client;
+use ant_protocol::{NetworkAddress, PrettyPrintRecordKey, CLOSE_GROUP_SIZE};
+use autonomi::{Client, ClientConfig, InitialPeersConfig};
 use bytes::Bytes;
-use common::{
-    client::{get_all_rpc_addresses, get_client_and_funded_wallet},
-    get_all_peer_ids, get_antnode_rpc_client, NodeRestart,
-};
+use common::get_all_peer_ids;
+use evmlib::wallet::Wallet;
 use eyre::{eyre, Result};
 use itertools::Itertools;
 use libp2p::{
     kad::{KBucketKey, RecordKey},
-    PeerId,
+    Multiaddr, PeerId,
 };
 use rand::{rngs::OsRng, Rng};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    net::SocketAddr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     time::{Duration, Instant},
 };
-use tonic::Request;
 use tracing::{debug, error, info};
 
 const CHUNK_SIZE: usize = 1024;
@@ -65,9 +65,6 @@ type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
-    let _log_appender_guard =
-        LogBuilder::init_multi_threaded_tokio_test("verify_data_location", false);
-
     let churn_count = if let Ok(str) = std::env::var("CHURN_COUNT") {
         str.parse::<u8>()?
     } else {
@@ -86,62 +83,102 @@ async fn verify_data_location() -> Result<()> {
         "Performing data location verification with a churn count of {churn_count} and n_chunks {chunk_count}\nIt will take approx {:?}",
         VERIFICATION_DELAY*churn_count as u32
     );
-    let node_rpc_address = get_all_rpc_addresses(true)?;
-    let mut all_peers = get_all_peer_ids(&node_rpc_address).await?;
 
-    let (client, wallet) = get_client_and_funded_wallet().await;
+    // initiate a testnet, and spawn a network
+    let evm_testnet = evmlib::testnet::Testnet::new().await;
+    let evm_network = evm_testnet.to_network();
+    let evm_sk = evm_testnet.default_wallet_private_key();
+    let funded_wallet =
+        Wallet::new_from_private_key(evm_network.clone(), &evm_sk).expect("Invalid private key");
+    let mut network = NetworkSpawner::new()
+        .with_evm_network(evm_network.clone())
+        .with_rewards_address(funded_wallet.address())
+        .with_local(true)
+        .with_size(20)
+        .spawn()
+        .await
+        .unwrap();
+    let peer = network.bootstrap_peer().await;
+    let config = ClientConfig {
+        init_peers_config: InitialPeersConfig {
+            first: false,
+            local: true,
+            addrs: vec![peer],
+            bootstrap_cache_dir: None,
+            disable_mainnet_contacts: true,
+            ignore_cache: false,
+            network_contacts_url: vec![],
+        },
+        evm_network: evm_network.clone(),
+        strategy: autonomi::ClientOperatingStrategy::default(),
+    };
+    let client = Client::init_with_config(config).await.unwrap();
 
-    store_chunks(&client, chunk_count, &wallet).await?;
+    // let node_rpc_address = get_all_rpc_addresses(true)?;
+    let mut all_peers = get_all_peer_ids(&network)?;
 
+    store_chunks(&client, chunk_count, &funded_wallet).await?;
+    println!("verifying data location initially before churning");
     // Verify data location initially
-    verify_location(&all_peers, &node_rpc_address).await?;
+    verify_location(&all_peers, &network).await?;
+    println!("Initial verification done");
 
     // Churn nodes and verify the location of the data after VERIFICATION_DELAY
     let mut current_churn_count = 0;
 
-    let mut node_restart = NodeRestart::new(true, false)?;
     let mut node_index = 0;
-    'main: loop {
-        if current_churn_count >= churn_count {
-            break 'main Ok(());
-        }
-        current_churn_count += 1;
 
-        let antnode_rpc_endpoint = match node_restart.restart_next(false, false).await? {
-            None => {
-                // we have reached the end.
+    let mut running_nodes = network.running_nodes().clone();
+    'main: loop {
+        let mut restarted_nodes: Vec<RunningNode> = Vec::new();
+
+        for nodes in running_nodes {
+            if current_churn_count >= churn_count {
                 break 'main Ok(());
             }
-            Some(antnode_rpc_endpoint) => antnode_rpc_endpoint,
-        };
+            current_churn_count += 1;
 
-        // wait for the dead peer to be removed from the RT and the replication flow to finish
-        println!(
-            "\nNode has been restarted, waiting for {VERIFICATION_DELAY:?} before verification"
-        );
-        info!("\nNode has been restarted, waiting for {VERIFICATION_DELAY:?} before verification");
-        tokio::time::sleep(VERIFICATION_DELAY).await;
+            println!(
+                "Churn #{current_churn_count} Churning a node with peer_id {:?}",
+                nodes.peer_id()
+            );
+            info!(
+                "Churn #{current_churn_count} Churning a node with peer_id {:?}",
+                nodes.peer_id()
+            );
+            let mut initial_peers: Vec<Multiaddr> = vec![];
+            nodes.clone().shutdown();
+            sleep(Duration::from_secs(1)).await;
 
-        // get the new PeerId for the current NodeIndex
-        let mut rpc_client = get_antnode_rpc_client(antnode_rpc_endpoint).await?;
+            for peer in network.running_nodes() {
+                if let Ok(listen_addrs_with_peer_id) = peer.get_listen_addrs_with_peer_id().await {
+                    initial_peers.extend(listen_addrs_with_peer_id);
+                }
+            }
 
-        let response = rpc_client
-            .node_info(Request::new(NodeInfoRequest {}))
-            .await?;
-        let new_peer_id = PeerId::from_bytes(&response.get_ref().peer_id)?;
-        // The below indexing assumes that, the way we do iteration to retrieve all_peers inside get_all_rpc_addresses
-        // and get_all_peer_ids is the same as how we do the iteration inside NodeRestart.
-        // todo: make this more cleaner.
-        if all_peers[node_index] == new_peer_id {
-            println!("new and old peer id are the same {new_peer_id:?}");
-            return Err(eyre!("new and old peer id are the same {new_peer_id:?}"));
+            let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+            let node = NodeSpawner::new()
+                .with_socket_addr(socket_addr)
+                .with_evm_network(evm_network.clone())
+                .with_rewards_address(funded_wallet.address())
+                .with_initial_peers(initial_peers)
+                .with_local(true)
+                .with_upnp(false)
+                .with_root_dir(None)
+                .spawn()
+                .await?;
+            sleep(Duration::from_secs(2)).await;
+            let new_peer_id = node.peer_id();
+            println!("A new Node joined the network with peer_id {new_peer_id:?}");
+            restarted_nodes.push(node.clone());
+            network.update_peer(node_index, node);
+            all_peers[node_index] = new_peer_id;
+            node_index += 1;
+
+            print_node_close_groups(&all_peers);
+            verify_location(&all_peers, &network).await?;
         }
-        all_peers[node_index] = new_peer_id;
-        node_index += 1;
-
-        print_node_close_groups(&all_peers);
-
-        verify_location(&all_peers, &node_rpc_address).await?;
+        running_nodes = restarted_nodes;
     }
 }
 
@@ -173,17 +210,19 @@ fn print_node_close_groups(all_peers: &[PeerId]) {
     }
 }
 
-async fn get_records_and_holders(node_rpc_addresses: &[SocketAddr]) -> Result<RecordHolders> {
+async fn get_records_and_holders(running_network: &RunningNetwork) -> Result<RecordHolders> {
     let mut record_holders = RecordHolders::default();
 
-    for (node_index, rpc_address) in node_rpc_addresses.iter().enumerate() {
-        let mut rpc_client = get_antnode_rpc_client(*rpc_address).await?;
+    for (node_index, running_node) in running_network.running_nodes().iter().enumerate() {
+        println!("Getting records for node index {node_index}");
+        let records_response = running_node
+            .get_all_record_addresses()
+            .await?
+            .into_iter()
+            .map(|addr| addr.as_bytes())
+            .collect::<Vec<_>>();
 
-        let records_response = rpc_client
-            .record_addresses(Request::new(RecordAddressesRequest {}))
-            .await?;
-
-        for bytes in records_response.get_ref().addresses.iter() {
+        for bytes in records_response.iter() {
             let key = RecordKey::from(bytes.clone());
             let holders = record_holders.entry(key).or_insert(HashSet::new());
             holders.insert(node_index);
@@ -195,18 +234,21 @@ async fn get_records_and_holders(node_rpc_addresses: &[SocketAddr]) -> Result<Re
 
 // Fetches the record_holders and verifies that the record is stored by the actual closest peers to the RecordKey
 // It has a retry loop built in.
-async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAddr]) -> Result<()> {
+async fn verify_location(all_peers: &Vec<PeerId>, running_network: &RunningNetwork) -> Result<()> {
     let mut failed = HashMap::new();
 
     println!("*********************************************");
     println!("Verifying data across all peers {all_peers:?}");
     info!("*********************************************");
     info!("Verifying data across all peers {all_peers:?}");
-
     let mut verification_attempts = 0;
     while verification_attempts < VERIFICATION_ATTEMPTS {
         failed.clear();
-        let record_holders = get_records_and_holders(node_rpc_addresses).await?;
+        println!(
+            "Verifying data location attempt {}",
+            verification_attempts + 1
+        );
+        let record_holders = get_records_and_holders(running_network).await?;
         for (key, actual_holders_idx) in record_holders.iter() {
             println!("Verifying {:?}", PrettyPrintRecordKey::from(key));
             info!("Verifying {:?}", PrettyPrintRecordKey::from(key));
@@ -222,6 +264,7 @@ async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAd
             .into_iter()
             .map(|(peer_id, _)| peer_id)
             .collect::<BTreeSet<_>>();
+            println!("peers are sorted by the key");
 
             let actual_holders = actual_holders_idx
                 .iter()


### PR DESCRIPTION
ant-node testcases: 
1. verify_data_location
2. verify_routing_table

The above testcases currently uses antctl to spawn a local network, and perform the concerned functionality tests, remove the dependency on antctl, and use nodespawner to run nodes as threads inside the same program. This is done, to remove dependency on rpc server to extract record_address and kbucket table data.