### PR TITLE
feat(autonomi): add `get_node_version` method to `Client`

### DIFF
--- a/ant-networking/src/version.rs
+++ b/ant-networking/src/version.rs
@@ -1,0 +1,66 @@
+use std::fmt::Display;
+
+pub struct Version {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl Version {
+    pub fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    pub fn is_minimum(&self, other: &Version) -> bool {
+        self.major > other.major
+            || (self.major == other.major && self.minor > other.minor)
+            || (self.major == other.major && self.minor == other.minor && self.patch >= other.patch)
+    }
+
+    pub fn is_maximum(&self, other: &Version) -> bool {
+        self.major < other.major
+            || (self.major == other.major && self.minor < other.minor)
+            || (self.major == other.major && self.minor == other.minor && self.patch <= other.patch)
+    }
+
+    pub fn is_exact(&self, other: &Version) -> bool {
+        self.major == other.major && self.minor == other.minor && self.patch == other.patch
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let parts: Vec<&str> = value.split('.').collect();
+        if parts.len() != 3 {
+            return Err("Invalid version format. Expected major.minor.patch".to_string());
+        }
+
+        let major = parts[0]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse major version as u16".to_string())?;
+        let minor = parts[1]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse minor version as u16".to_string())?;
+        let patch = parts[2]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse patch version as u16".to_string())?;
+
+        Ok(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -183,6 +183,12 @@ impl NetworkAddress {
     }
 }
 
+impl From<ChunkAddress> for NetworkAddress {
+    fn from(chunk_address: ChunkAddress) -> Self {
+        NetworkAddress::ChunkAddress(chunk_address)
+    }
+}
+
 impl Debug for NetworkAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name_str = match self {

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -39,6 +39,7 @@ pub mod quote;
 pub mod external_signer;
 
 // private module with utility functions
+mod network;
 mod utils;
 
 use ant_bootstrap::{BootstrapCacheStore, InitialPeersConfig};

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -1,0 +1,10 @@
+use crate::Client;
+use ant_networking::version::Version;
+use libp2p::PeerId;
+
+impl Client {
+    /// Request the node version of a peer on the network.
+    pub async fn get_node_version(&self, peer_id: PeerId) -> Result<Version, String> {
+        self.network.get_node_version(peer_id).await
+    }
+}

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -1,10 +1,23 @@
 use crate::Client;
 use ant_networking::version::Version;
+use ant_networking::{Addresses, NetworkError};
+use ant_protocol::NetworkAddress;
 use libp2p::PeerId;
 
 impl Client {
     /// Request the node version of a peer on the network.
     pub async fn get_node_version(&self, peer_id: PeerId) -> Result<Version, String> {
         self.network.get_node_version(peer_id).await
+    }
+
+    /// Retrieve the closest peers to the given network address.
+    /// This function queries the network to find all peers in the close group nearest to the provided network address.
+    pub async fn get_closest_to_address(
+        &self,
+        network_address: &NetworkAddress,
+    ) -> Result<Vec<(PeerId, Addresses)>, NetworkError> {
+        self.network
+            .client_get_all_close_peers_in_range_or_close_group(network_address)
+            .await
     }
 }

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -11,7 +11,7 @@ use crate::client::high_level::files::FILE_UPLOAD_BATCH_SIZE;
 use crate::client::utils::process_tasks_with_max_concurrency;
 use ant_evm::payment_vault::get_market_price;
 use ant_evm::{Amount, PaymentQuote, QuotePayment, QuotingMetrics};
-use ant_networking::{Addresses, Network, NetworkError};
+use ant_networking::{Network, NetworkError};
 use ant_protocol::{storage::ChunkAddress, NetworkAddress, CLOSE_GROUP_SIZE};
 use libp2p::PeerId;
 use std::collections::HashMap;
@@ -82,17 +82,6 @@ pub enum CostError {
 }
 
 impl Client {
-    /// Retrieve the closest peers to the given network address.
-    /// This function queries the network to find all peers in the close group nearest to the provided network address.
-    pub async fn get_closest_to_address(
-        &self,
-        network_address: &NetworkAddress,
-    ) -> Result<Vec<(PeerId, Addresses)>, NetworkError> {
-        self.network
-            .client_get_all_close_peers_in_range_or_close_group(network_address)
-            .await
-    }
-
     /// Get raw quotes from nodes.
     /// These quotes do not include actual record prices.
     /// You will likely want to use `get_store_quotes` instead.


### PR DESCRIPTION
- adds `get_node_version` method to `Client`.
- adds `impl From<ChunkAddress> for NetworkAddress`. (Makes it easier to use `Client::get_closest_for_address`, as `NetworkAddress` is a private type.)
- moves `get_closest_to_address` method from `quote` mod to `network`.

Changes needed for the emission service and relayer reward feature.