### PR TITLE
chore(network): remove logging on too many faults on listener

### DIFF
--- a/ant-networking/src/external_address.rs
+++ b/ant-networking/src/external_address.rs
@@ -340,7 +340,6 @@ impl ExternalAddressManager {
         stats.error = stats.error.saturating_add(1);
 
         if stats.is_faulty() {
-            info!("Connection on port {port} is considered as faulty. Removing all addresses with this port");
             // remove all the addresses with this port
             let mut removed_confirmed = Vec::new();
             let mut removed_candidates = Vec::new();


### PR DESCRIPTION
- The log line is emitted even for `Listeners`, but listeners lead to a NO OP, so this log line is incorrect and leads to lot of spam. 
- There are still other log lines to denote the removal of other `candidates` & `condifred` external addrs. So this line is fine to remove.