### PR TITLE
fix(node): put validation chunk size

### DIFF
--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -433,13 +433,15 @@ impl Node {
         let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
 
         // reject if chunk is too large
-        if chunk.size() > Chunk::MAX_SIZE {
+        if chunk.size() > Chunk::MAX_ENCRYPTED_SIZE {
             warn!(
                 "Chunk at {pretty_key:?} is too large: {} bytes, when max size is {} bytes",
                 chunk.size(),
-                Chunk::MAX_SIZE
+                Chunk::MAX_ENCRYPTED_SIZE
             );
-            return Err(ProtocolError::OversizedChunk(chunk.size(), Chunk::MAX_SIZE).into());
+            return Err(
+                ProtocolError::OversizedChunk(chunk.size(), Chunk::MAX_ENCRYPTED_SIZE).into(),
+            );
         }
 
         let record = Record {

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -25,8 +25,12 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// The maximum size of a chunk is 4MB
-    pub const MAX_SIZE: usize = 4 * 1024 * 1024;
+    /// The maximum size of a chunk is 4MB.
+    /// Note that due to encryption it can turn out bigger. See `Chunk::MAX_ENCRYPTED_SIZE`.
+    const MAX_SIZE: usize = 4 * 1024 * 1024;
+
+    /// The maximum size of an encrypted chunk is 4MB + 16 bytes due to Pkcs7 encryption padding.
+    pub const MAX_ENCRYPTED_SIZE: usize = Self::MAX_SIZE + 16;
 
     /// Creates a new instance of `Chunk`.
     pub fn new(value: Bytes) -> Self {
@@ -63,7 +67,7 @@ impl Chunk {
 
     /// Returns true if the chunk is too big
     pub fn is_too_big(&self) -> bool {
-        self.size() > Self::MAX_SIZE
+        self.size() > Self::MAX_ENCRYPTED_SIZE
     }
 }
 

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -155,11 +155,11 @@ impl Client {
     ) -> Result<(AttoTokens, ChunkAddress), PutError> {
         let address = chunk.network_address();
 
-        if chunk.size() > Chunk::MAX_SIZE {
+        if chunk.size() > Chunk::MAX_ENCRYPTED_SIZE {
             return Err(PutError::Serialization(format!(
                 "Chunk is too large: {} bytes, when max size is {}",
                 chunk.size(),
-                Chunk::MAX_SIZE
+                Chunk::MAX_ENCRYPTED_SIZE
             )));
         }
 
@@ -229,7 +229,10 @@ impl Client {
 
         let xor = *addr.xorname();
         let store_quote = self
-            .get_store_quotes(DataTypes::Chunk, std::iter::once((xor, Chunk::MAX_SIZE)))
+            .get_store_quotes(
+                DataTypes::Chunk,
+                std::iter::once((xor, Chunk::MAX_ENCRYPTED_SIZE)),
+            )
             .await?;
         let total_cost = AttoTokens::from_atto(
             store_quote

--- a/autonomi/tests/chunk.rs
+++ b/autonomi/tests/chunk.rs
@@ -61,13 +61,13 @@ async fn chunk_put_1mb() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn chunk_put_max_size() -> Result<()> {
-    chunk_put_with_size(Chunk::MAX_SIZE).await // 4MB
+    chunk_put_with_size(Chunk::MAX_ENCRYPTED_SIZE).await // 4MB + 16 bytes (encryption padding)
 }
 
 #[tokio::test]
 #[serial]
 async fn chunk_put_oversize() -> Result<()> {
-    let result = chunk_put_with_size(Chunk::MAX_SIZE + 1).await; // 4MB + 1 byte
+    let result = chunk_put_with_size(Chunk::MAX_ENCRYPTED_SIZE + 1).await; // 4MB + 16 bytes + 1 byte
 
     // Verify we get the expected error
     match result {


### PR DESCRIPTION
Self encryption can add some padding to the chunk content needed for encryption. This will ignore the set max chunk size. To fix dealing with this in a backwards compatible way, we add a margin of 16 bytes in the max chunk size to account for padding.