### PR TITLE
fix(node): put validation chunk size with brotli overhead

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,6 +14,7 @@ env:
   WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
   GENESIS_PK: 9377ab39708a59d02d09bfd3c9bc7548faab9e0c2a2700b9ac7d5c14f0842f0b4bb0df411b6abd3f1a92b9aa1ebf5c3d
   GENESIS_SK: 5ec88891c1098a0fede5b98b07f8abc931d7247b7aa310d21ab430cc957f9f02
+  MAX_CHUNK_SIZE: 4194304
 
 jobs:
   build:
@@ -227,8 +228,6 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-          # set the max chunk size for `self_encryption`
-          MAX_CHUNK_SIZE: 4194304
         timeout-minutes: 20
 
       # FIXME: do this in a generic way for localtestnets

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,9 +5,9 @@ on:
   # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
   # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [ main, alpha*, beta*, rc* ]
   pull_request:
-    branches: ["*"]
+    branches: [ "*" ]
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
@@ -107,7 +107,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -134,7 +134,7 @@ jobs:
       - name: Run node tests
         timeout-minutes: 25
         run: cargo test --release --package ant-node --lib
-      
+
       - name: Run launchpad tests
         timeout-minutes: 25
         run: cargo test --release --package node-launchpad
@@ -227,6 +227,8 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+          # set the max chunk size for `self_encryption`
+          MAX_CHUNK_SIZE: 4194304
         timeout-minutes: 20
 
       # FIXME: do this in a generic way for localtestnets

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,8 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+          # set the max chunk size for `self_encryption`
+          MAX_CHUNK_SIZE: 4194304
         timeout-minutes: 20
 
 
@@ -224,7 +226,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
 
@@ -265,7 +267,7 @@ jobs:
       - name: Run logging tests
         timeout-minutes: 25
         run: cargo test --release --package ant-logging
-  
+
       - name: post notification to slack on failure
         if: ${{ failure() }}
         uses: bryannice/gitactions-slack-notification@2.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   WORKFLOW_URL: https://github.com/maidsafe/stableset_net/actions/runs
+  MAX_CHUNK_SIZE: 4194304
 
 jobs:
   e2e:
@@ -66,8 +67,6 @@ jobs:
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-          # set the max chunk size for `self_encryption`
-          MAX_CHUNK_SIZE: 4194304
         timeout-minutes: 20
 
 

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -433,15 +433,13 @@ impl Node {
         let pretty_key = PrettyPrintRecordKey::from(&key).into_owned();
 
         // reject if chunk is too large
-        if chunk.size() > Chunk::MAX_ENCRYPTED_SIZE {
+        if chunk.size() > Chunk::MAX_SIZE {
             warn!(
                 "Chunk at {pretty_key:?} is too large: {} bytes, when max size is {} bytes",
                 chunk.size(),
-                Chunk::MAX_ENCRYPTED_SIZE
+                Chunk::MAX_SIZE
             );
-            return Err(
-                ProtocolError::OversizedChunk(chunk.size(), Chunk::MAX_ENCRYPTED_SIZE).into(),
-            );
+            return Err(ProtocolError::OversizedChunk(chunk.size(), Chunk::MAX_SIZE).into());
         }
 
         let record = Record {

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -13,9 +13,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use xor_name::XorName;
 
-/// The maximum size of an unencrypted/raw chunk is 4MB.
-const MAX_RAW_SIZE: usize = 4 * 1024 * 1024;
-
 /// This is the max manually observed overhead when compressing random 4MB of data using Brotli.
 /// It might be possible there could be edge-cases where the overhead is even higher.
 const BROTLI_MAX_OVERHEAD_BYTES: usize = 16;
@@ -36,10 +33,14 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// The maximum size of an encrypted chunk is 4MB
-    /// + 16 bytes Brotli compression overhead for random data
+    /// The maximum size of an unencrypted/raw chunk is 4MB.
+    pub const MAX_RAW_SIZE: usize = 4 * 1024 * 1024;
+
+    /// The maximum size of an encrypted chunk is 4MB + 32 bytes.
+    /// + 16 bytes Brotli compression overhead for random data.
     /// + 16 bytes due to Pkcs7 encryption padding.
-    pub const MAX_SIZE: usize = MAX_RAW_SIZE + BROTLI_MAX_OVERHEAD_BYTES + PKCS7_MAX_PADDING_BYTES;
+    pub const MAX_SIZE: usize =
+        Self::MAX_RAW_SIZE + BROTLI_MAX_OVERHEAD_BYTES + PKCS7_MAX_PADDING_BYTES;
 
     /// Creates a new instance of `Chunk`.
     pub fn new(value: Bytes) -> Self {

--- a/ant-protocol/src/storage/chunks.rs
+++ b/ant-protocol/src/storage/chunks.rs
@@ -13,6 +13,17 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use xor_name::XorName;
 
+/// The maximum size of an unencrypted/raw chunk is 4MB.
+const MAX_RAW_SIZE: usize = 4 * 1024 * 1024;
+
+/// This is the max manually observed overhead when compressing random 4MB of data using Brotli.
+/// It might be possible there could be edge-cases where the overhead is even higher.
+const BROTLI_MAX_OVERHEAD_BYTES: usize = 16;
+
+/// When encrypting chunks, a bit of padding is added to make the size a multiple of 16.
+/// When the chunk size is already a multiple of 16, a full block padding will be added.
+const PKCS7_MAX_PADDING_BYTES: usize = 16;
+
 /// Chunk, an immutable chunk of data
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug)]
 pub struct Chunk {
@@ -25,12 +36,10 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// The maximum size of a chunk is 4MB.
-    /// Note that due to encryption it can turn out bigger. See `Chunk::MAX_ENCRYPTED_SIZE`.
-    const MAX_SIZE: usize = 4 * 1024 * 1024;
-
-    /// The maximum size of an encrypted chunk is 4MB + 16 bytes due to Pkcs7 encryption padding.
-    pub const MAX_ENCRYPTED_SIZE: usize = Self::MAX_SIZE + 16;
+    /// The maximum size of an encrypted chunk is 4MB
+    /// + 16 bytes Brotli compression overhead for random data
+    /// + 16 bytes due to Pkcs7 encryption padding.
+    pub const MAX_SIZE: usize = MAX_RAW_SIZE + BROTLI_MAX_OVERHEAD_BYTES + PKCS7_MAX_PADDING_BYTES;
 
     /// Creates a new instance of `Chunk`.
     pub fn new(value: Bytes) -> Self {
@@ -67,7 +76,7 @@ impl Chunk {
 
     /// Returns true if the chunk is too big
     pub fn is_too_big(&self) -> bool {
-        self.size() > Self::MAX_ENCRYPTED_SIZE
+        self.size() > Self::MAX_SIZE
     }
 }
 

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -155,11 +155,11 @@ impl Client {
     ) -> Result<(AttoTokens, ChunkAddress), PutError> {
         let address = chunk.network_address();
 
-        if chunk.size() > Chunk::MAX_ENCRYPTED_SIZE {
+        if chunk.size() > Chunk::MAX_SIZE {
             return Err(PutError::Serialization(format!(
                 "Chunk is too large: {} bytes, when max size is {}",
                 chunk.size(),
-                Chunk::MAX_ENCRYPTED_SIZE
+                Chunk::MAX_SIZE
             )));
         }
 
@@ -229,10 +229,7 @@ impl Client {
 
         let xor = *addr.xorname();
         let store_quote = self
-            .get_store_quotes(
-                DataTypes::Chunk,
-                std::iter::once((xor, Chunk::MAX_ENCRYPTED_SIZE)),
-            )
+            .get_store_quotes(DataTypes::Chunk, std::iter::once((xor, Chunk::MAX_SIZE)))
             .await?;
         let total_cost = AttoTokens::from_atto(
             store_quote

--- a/autonomi/tests/chunk.rs
+++ b/autonomi/tests/chunk.rs
@@ -8,8 +8,10 @@
 
 use ant_logging::LogBuilder;
 use autonomi::client::payment::PaymentOption;
+use autonomi::self_encryption::encrypt;
 use autonomi::{client::chunk::Chunk, Client};
 use eyre::Result;
+use self_encryption::test_helpers::random_bytes;
 use serial_test::serial;
 use test_utils::{evm::get_funded_wallet, gen_random_data};
 
@@ -85,6 +87,24 @@ async fn chunk_put_oversize() -> Result<()> {
         }
         Ok(_) => {
             panic!("Expected error for oversized chunk, but operation succeeded");
+        }
+    }
+}
+
+// Test needs to be run with `MAX_CHUNK_SIZE=4194304` to set the chunk size for `self_encryption`.
+#[test]
+fn chunk_max_size_after_encryption() {
+    const NUM_FILES: usize = 10;
+
+    for _ in 0..NUM_FILES {
+        // Generate random files of 3 * the max raw chunk size, so that we get 3 chunks at max capacity.
+        let random_file = random_bytes(Chunk::MAX_RAW_SIZE * 3);
+
+        let (_, chunks) = encrypt(random_file).unwrap();
+
+        for chunk in chunks {
+            // Make sure that after compression and encryption, the chunk sizes are acceptable.
+            assert!(chunk.size() <= Chunk::MAX_SIZE);
         }
     }
 }

--- a/autonomi/tests/chunk.rs
+++ b/autonomi/tests/chunk.rs
@@ -61,13 +61,15 @@ async fn chunk_put_1mb() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn chunk_put_max_size() -> Result<()> {
-    chunk_put_with_size(Chunk::MAX_ENCRYPTED_SIZE).await // 4MB + 16 bytes (encryption padding)
+    // 4MB + 16 bytes (Brotli compression overhead) + 16 bytes (encryption padding)
+    chunk_put_with_size(Chunk::MAX_SIZE).await
 }
 
 #[tokio::test]
 #[serial]
 async fn chunk_put_oversize() -> Result<()> {
-    let result = chunk_put_with_size(Chunk::MAX_ENCRYPTED_SIZE + 1).await; // 4MB + 16 bytes + 1 byte
+    // 4MB + 16 bytes (Brotli compression overhead) + 16 bytes (encryption padding) + 1 byte
+    let result = chunk_put_with_size(Chunk::MAX_SIZE + 1).await;
 
     // Verify we get the expected error
     match result {


### PR DESCRIPTION
Follow-up PR on: https://github.com/maidsafe/autonomi/pull/2862

Also take the overhead of Brotli compression into consideration.