### PR TITLE
refactor!(evmlib): remove deprecated `Network::ArbitrumSepolia`

### DIFF
--- a/ant-cli/src/wallet/mod.rs
+++ b/ant-cli/src/wallet/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod encryption;
 pub(crate) mod fs;
 pub(crate) mod input;
 
-pub const DUMMY_NETWORK: Network = Network::ArbitrumSepolia;
+pub const DUMMY_NETWORK: Network = Network::ArbitrumSepoliaTest;
 
 /// Load wallet from ENV or disk
 pub(crate) fn load_wallet(evm_network: &Network) -> color_eyre::Result<Wallet> {

--- a/ant-node-manager/src/bin/cli/subcommands/evm_network.rs
+++ b/ant-node-manager/src/bin/cli/subcommands/evm_network.rs
@@ -16,9 +16,6 @@ pub enum EvmNetworkCommand {
     /// Use the Arbitrum One network
     EvmArbitrumOne,
 
-    /// Use the Arbitrum Sepolia network
-    EvmArbitrumSepolia,
-
     /// Use the Arbitrum Sepolia network with test contracts
     EvmArbitrumSepoliaTest,
 
@@ -47,7 +44,6 @@ impl TryInto<EvmNetwork> for EvmNetworkCommand {
     fn try_into(self) -> Result<EvmNetwork> {
         match self {
             Self::EvmArbitrumOne => Ok(EvmNetwork::ArbitrumOne),
-            Self::EvmArbitrumSepolia => Ok(EvmNetwork::ArbitrumSepolia),
             Self::EvmArbitrumSepoliaTest => Ok(EvmNetwork::ArbitrumSepoliaTest),
             Self::EvmLocal => {
                 let network = get_evm_network(true)?;

--- a/ant-node/src/bin/antnode/subcommands.rs
+++ b/ant-node/src/bin/antnode/subcommands.rs
@@ -7,9 +7,6 @@ pub(crate) enum EvmNetworkCommand {
     /// Use the Arbitrum One network
     EvmArbitrumOne,
 
-    /// Use the Arbitrum Sepolia network
-    EvmArbitrumSepolia,
-
     /// Use the Arbitrum Sepolia network with test contracts
     EvmArbitrumSepoliaTest,
 
@@ -34,7 +31,6 @@ impl Into<EvmNetwork> for EvmNetworkCommand {
     fn into(self) -> EvmNetwork {
         match self {
             Self::EvmArbitrumOne => EvmNetwork::ArbitrumOne,
-            Self::EvmArbitrumSepolia => EvmNetwork::ArbitrumSepolia,
             Self::EvmArbitrumSepoliaTest => EvmNetwork::ArbitrumSepoliaTest,
             Self::EvmCustom {
                 rpc_url,

--- a/ant-node/src/spawn/node_spawner.rs
+++ b/ant-node/src/spawn/node_spawner.rs
@@ -200,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_node() {
-        let evm_network = EvmNetwork::ArbitrumSepolia;
+        let evm_network = EvmNetwork::ArbitrumSepoliaTest;
 
         let running_node = NodeSpawner::new()
             .with_evm_network(evm_network)

--- a/ant-service-management/src/node/tests.rs
+++ b/ant-service-management/src/node/tests.rs
@@ -31,7 +31,7 @@ fn create_test_v1_struct() -> NodeServiceDataV1 {
                 PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
             ]),
             data_dir_path: PathBuf::from("/home/user/.local/share/safe/node/1"),
-            evm_network: EvmNetwork::ArbitrumSepolia,
+            evm_network: EvmNetwork::ArbitrumSepoliaTest,
             initial_peers_config: InitialPeersConfig {
                 first: false,
                 local: false,

--- a/autonomi/README.md
+++ b/autonomi/README.md
@@ -42,13 +42,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-In the above example the wallet is setup to use the default EVM network (Arbitrum One). Instead we can use a different network:
+In the above example the wallet is setup to use the default EVM network (Arbitrum One). Instead we can use a different
+network:
+
 ```rust
 use autonomi::{EvmNetwork, Wallet};
 // Arbitrum Sepolia
-let wallet = Wallet::new_from_private_key(EvmNetwork::ArbitrumSepolia, key)?;
+let wallet = Wallet::new_from_private_key(EvmNetwork::ArbitrumSepoliaTest, key) ?;
 // Custom (e.g. local testnet)
-let wallet = Wallet::new_from_private_key(EvmNetwork::new_custom("<rpc URL>", "<payment token address>", "<data payment address>"), key)?;
+let wallet = Wallet::new_from_private_key(EvmNetwork::new_custom("<rpc URL>", "<payment token address>", "<data payment address>"), key) ?;
 ```
 
 ## Running tests
@@ -56,7 +58,8 @@ let wallet = Wallet::new_from_private_key(EvmNetwork::new_custom("<rpc URL>", "<
 To run the tests, we can run a local network:
 
 1. Run a local EVM node:
-    > Note: To run the EVM node, Foundry is required to be installed: https://book.getfoundry.sh/getting-started/installation
+   > Note: To run the EVM node, Foundry is required to be
+   installed: https://book.getfoundry.sh/getting-started/installation
 
     ```sh
     cargo run --bin evm-testnet
@@ -74,7 +77,8 @@ To run the tests, we can run a local network:
 
 ### Using a live testnet or mainnet
 
-Using the hardcoded `Arbitrum One` option as an example, but you can also use the command flags of the steps above and point it to a live network.
+Using the hardcoded `Arbitrum One` option as an example, but you can also use the command flags of the steps above and
+point it to a live network.
 
 1. Run a local network:
 
@@ -82,7 +86,8 @@ Using the hardcoded `Arbitrum One` option as an example, but you can also use th
 cargo run --bin antctl -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-arbitrum-one
 ```
 
-2. Then pass the private key of the wallet, and ensure it has enough gas and payment tokens on the network (in this case Arbitrum One):
+2. Then pass the private key of the wallet, and ensure it has enough gas and payment tokens on the network (in this case
+   Arbitrum One):
 
 ```sh
 EVM_NETWORK=arbitrum-one EVM_PRIVATE_KEY=<PRIVATE_KEY> cargo test --package autonomi
@@ -90,7 +95,8 @@ EVM_NETWORK=arbitrum-one EVM_PRIVATE_KEY=<PRIVATE_KEY> cargo test --package auto
 
 ## Using funds from the Deployer Wallet
 
-You can use the `Deployer wallet private key` printed in the EVM node output to initialise a wallet from with almost infinite gas and payment tokens. Example:
+You can use the `Deployer wallet private key` printed in the EVM node output to initialise a wallet from with almost
+infinite gas and payment tokens. Example:
 
 ```rust
 let rpc_url = "http://localhost:54370/";
@@ -99,9 +105,9 @@ let data_payments_address = "0x8464135c8F25Da09e49BC8782676a84730C318bC";
 let private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
 let network = Network::Custom(CustomNetwork::new(
-    rpc_url,
-    payment_token_address,
-    data_payments_address,
+rpc_url,
+payment_token_address,
+data_payments_address,
 ));
 
 let deployer_wallet = Wallet::new_from_private_key(network, private_key).unwrap();
@@ -109,8 +115,8 @@ let receiving_wallet = Wallet::new_with_random_wallet(network);
 
 // Send 10 payment tokens (atto)
 let _ = deployer_wallet
-    .transfer_tokens(receiving_wallet.address(), Amount::from(10))
-    .await;
+.transfer_tokens(receiving_wallet.address(), Amount::from(10))
+.await;
 ```
 
 Alternatively, you can provide the wallet address that should own all the gas and payment tokens to the EVM testnet

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -48,17 +48,11 @@ static PUBLIC_ARBITRUM_SEPOLIA_HTTP_RPC_URL: LazyLock<reqwest::Url> = LazyLock::
 const ARBITRUM_ONE_PAYMENT_TOKEN_ADDRESS: Address =
     address!("a78d8321B20c4Ef90eCd72f2588AA985A4BDb684");
 
-const ARBITRUM_SEPOLIA_PAYMENT_TOKEN_ADDRESS: Address =
-    address!("BE1802c27C324a28aeBcd7eeC7D734246C807194");
-
 const ARBITRUM_SEPOLIA_TEST_PAYMENT_TOKEN_ADDRESS: Address =
     address!("4bc1aCE0E66170375462cB4E6Af42Ad4D5EC689C");
 
 const ARBITRUM_ONE_DATA_PAYMENTS_ADDRESS: Address =
     address!("B1b5219f8Aaa18037A2506626Dd0406a46f70BcC");
-
-const ARBITRUM_SEPOLIA_DATA_PAYMENTS_ADDRESS: Address =
-    address!("993C7739f50899A997fEF20860554b8a28113634");
 
 const ARBITRUM_SEPOLIA_TEST_DATA_PAYMENTS_ADDRESS: Address =
     address!("7f0842a78f7d4085d975ba91d630d680f91b1295");
@@ -88,7 +82,6 @@ impl CustomNetwork {
 pub enum Network {
     #[default]
     ArbitrumOne,
-    ArbitrumSepolia,
     ArbitrumSepoliaTest,
     Custom(CustomNetwork),
 }
@@ -97,7 +90,6 @@ impl std::fmt::Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Network::ArbitrumOne => write!(f, "evm-arbitrum-one"),
-            Network::ArbitrumSepolia => write!(f, "evm-arbitrum-sepolia"),
             Network::ArbitrumSepoliaTest => write!(f, "evm-arbitrum-sepolia-test"),
             Network::Custom(_) => write!(f, "evm-custom"),
         }
@@ -110,7 +102,6 @@ impl std::str::FromStr for Network {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "evm-arbitrum-one" => Ok(Network::ArbitrumOne),
-            "evm-arbitrum-sepolia" => Ok(Network::ArbitrumSepolia),
             "evm-arbitrum-sepolia-test" => Ok(Network::ArbitrumSepoliaTest),
             _ => Err(()),
         }
@@ -135,7 +126,6 @@ impl Network {
     pub fn identifier(&self) -> &str {
         match self {
             Network::ArbitrumOne => "arbitrum-one",
-            Network::ArbitrumSepolia => "arbitrum-sepolia",
             Network::ArbitrumSepoliaTest => "arbitrum-sepolia-test",
             Network::Custom(_) => "custom",
         }
@@ -144,7 +134,6 @@ impl Network {
     pub fn rpc_url(&self) -> &reqwest::Url {
         match self {
             Network::ArbitrumOne => &PUBLIC_ARBITRUM_ONE_HTTP_RPC_URL,
-            Network::ArbitrumSepolia => &PUBLIC_ARBITRUM_SEPOLIA_HTTP_RPC_URL,
             Network::ArbitrumSepoliaTest => &PUBLIC_ARBITRUM_SEPOLIA_HTTP_RPC_URL,
             Network::Custom(custom) => &custom.rpc_url_http,
         }
@@ -153,7 +142,6 @@ impl Network {
     pub fn payment_token_address(&self) -> &Address {
         match self {
             Network::ArbitrumOne => &ARBITRUM_ONE_PAYMENT_TOKEN_ADDRESS,
-            Network::ArbitrumSepolia => &ARBITRUM_SEPOLIA_PAYMENT_TOKEN_ADDRESS,
             Network::ArbitrumSepoliaTest => &ARBITRUM_SEPOLIA_TEST_PAYMENT_TOKEN_ADDRESS,
             Network::Custom(custom) => &custom.payment_token_address,
         }
@@ -162,7 +150,6 @@ impl Network {
     pub fn data_payments_address(&self) -> &Address {
         match self {
             Network::ArbitrumOne => &ARBITRUM_ONE_DATA_PAYMENTS_ADDRESS,
-            Network::ArbitrumSepolia => &ARBITRUM_SEPOLIA_DATA_PAYMENTS_ADDRESS,
             Network::ArbitrumSepoliaTest => &ARBITRUM_SEPOLIA_TEST_DATA_PAYMENTS_ADDRESS,
             Network::Custom(custom) => &custom.data_payments_address,
         }

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -120,10 +120,6 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
         .map(|v| v == "arbitrum-one")
         .unwrap_or(false);
 
-    let use_arbitrum_sepolia = std::env::var("EVM_NETWORK")
-        .map(|v| v == "arbitrum-sepolia")
-        .unwrap_or(false);
-
     let use_arbitrum_sepolia_test = std::env::var("EVM_NETWORK")
         .map(|v| v == "arbitrum-sepolia-test")
         .unwrap_or(false);
@@ -131,9 +127,6 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
     if use_arbitrum_one {
         info!("Using Arbitrum One EVM network as EVM_NETWORK is set to 'arbitrum-one'");
         Ok(Network::ArbitrumOne)
-    } else if use_arbitrum_sepolia {
-        info!("Using Arbitrum Sepolia EVM network as EVM_NETWORK is set to 'arbitrum-sepolia'");
-        Ok(Network::ArbitrumSepolia)
     } else if use_arbitrum_sepolia_test {
         info!("Using Arbitrum Sepolia Test EVM network as EVM_NETWORK is set to 'arbitrum-sepolia-test'");
         Ok(Network::ArbitrumSepoliaTest)

--- a/evmlib/tests/payment_vault.rs
+++ b/evmlib/tests/payment_vault.rs
@@ -122,7 +122,7 @@ async fn test_deploy() {
 
 #[tokio::test]
 async fn test_get_quote_on_arb_sepolia() {
-    let network = Network::ArbitrumSepolia;
+    let network = Network::ArbitrumSepoliaTest;
     let provider = http_provider(network.rpc_url().clone());
     let payment_vault = PaymentVaultHandler::new(*network.data_payments_address(), provider);
 


### PR DESCRIPTION
Removes the deprecated `Network::ArbitrumSepolia` preset (was used for the public testnet before launch). Should use `Network::ArbitrumSepoliaTest` or `Network::ArbitrumOne` instead.