### PR TITLE
chore(network): only filtering peers_version when update metrics

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -1049,25 +1049,6 @@ impl SwarmDriver {
 
     fn record_node_version(&mut self, peer_id: PeerId, version: String) {
         let _ = self.peers_version.insert(peer_id, version);
-
-        // Collect all peers_in_non_full_buckets
-        let mut peers_in_non_full_buckets = vec![];
-        for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
-            let num_entires = kbucket.num_entries();
-            if num_entires >= K_VALUE.get() {
-                continue;
-            } else {
-                let peers_in_kbucket = kbucket
-                    .iter()
-                    .map(|peer_entry| peer_entry.node.key.into_preimage())
-                    .collect::<Vec<PeerId>>();
-                peers_in_non_full_buckets.extend(peers_in_kbucket);
-            }
-        }
-
-        // Ensure all existing node_version records are for those peers_in_non_full_buckets
-        self.peers_version
-            .retain(|peer_id, _version| peers_in_non_full_buckets.contains(peer_id));
     }
 
     pub(crate) fn record_node_issue(&mut self, peer_id: PeerId, issue: NodeIssue) {

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -860,6 +860,25 @@ impl SwarmDriver {
                         }
                     }
 
+                    // Collect all peers_in_non_full_buckets
+                    let mut peers_in_non_full_buckets = vec![];
+                    for kbucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
+                        let num_entires = kbucket.num_entries();
+                        if num_entires >= K_VALUE.get() {
+                            continue;
+                        } else {
+                            let peers_in_kbucket = kbucket
+                                .iter()
+                                .map(|peer_entry| peer_entry.node.key.into_preimage())
+                                .collect::<Vec<PeerId>>();
+                            peers_in_non_full_buckets.extend(peers_in_kbucket);
+                        }
+                    }
+
+                    // Ensure all existing node_version records are for those peers_in_non_full_buckets
+                    self.peers_version
+                        .retain(|peer_id, _version| peers_in_non_full_buckets.contains(peer_id));
+
                     #[cfg(feature = "open-metrics")]
                     if let Some(metrics_recorder) = &self.metrics_recorder {
                         metrics_recorder.update_node_versions(&self.peers_version);


### PR DESCRIPTION
### Description

peers_version only need to get filtered (remove those entry of peers that in full_bucket or dead),
when being used to update metrics.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
