### PR TITLE
refactor: get closest peer / get close group functions

### DIFF
--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -1027,7 +1027,7 @@ impl Node {
         for _ in 0..10 {
             let target = NetworkAddress::from(PeerId::random());
             // Result is sorted and only return CLOSE_GROUP_SIZE entries
-            let peers = network.node_get_closest_peers(&target).await;
+            let peers = network.get_n_closest_peers(&target, CLOSE_GROUP_SIZE).await;
             if let Ok(peers) = peers {
                 if peers.len() >= CLOSE_GROUP_SIZE {
                     // Calculate the distance to the farthest.

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -13,13 +13,12 @@ use libp2p::PeerId;
 
 impl Client {
     /// Retrieve the closest peers to the given network address.
-    /// This function queries the network to find all peers in the close group nearest to the provided network address.
     pub async fn get_closest_to_address(
         &self,
         network_address: impl Into<NetworkAddress>,
     ) -> Result<Vec<(PeerId, Addresses)>, NetworkError> {
         self.network
-            .client_get_all_close_peers_in_range_or_close_group(&network_address.into())
+            .get_closest_peers(&network_address.into())
             .await
     }
 }


### PR DESCRIPTION
Refactors / renames `get_all_close_peers_in_range_or_close_group` and related functions.

Improves maintainability and removes a redundant double sort on peer keys.