### PR TITLE
fix(network): eliminate the chance that round_robin_index got stalled

### DIFF
--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -852,12 +852,13 @@ impl SwarmDriver {
 
                 // runs every bootstrap_interval time
                 _ = network_discover_interval.tick() => {
+                    round_robin_index += 1;
+                    if round_robin_index > 255 {
+                        round_robin_index = 0;
+                    }
+
                     if let Some(new_interval) = self.run_network_discover_continuously(network_discover_interval.period(), round_robin_index).await {
                         network_discover_interval = new_interval;
-                        round_robin_index += 1;
-                        if round_robin_index > 255 {
-                            round_robin_index = 0;
-                        }
                     }
 
                     #[cfg(feature = "open-metrics")]


### PR DESCRIPTION
### Description

It is observed that libp2p could report a peer being newly added into RT repeatedly.
This then could get the round_robin_index (used for refresh scheme to pick target buckets) stalled.
The work is to eliminate such chance, to ensure the round_robin_index keeps rolling all the time.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
