### PR TITLE
feat(log): log to file if a file path is passed

### DIFF
--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -126,40 +126,72 @@ impl TracingLayers {
                 .with_writer(std::io::stderr)
                 .boxed(),
             LogOutputDest::Path(path) => {
-                std::fs::create_dir_all(path)?;
-                if print_updates_to_stdout {
-                    println!("Logging to directory: {path:?}");
-                }
+                // convert to aboslute path
+                let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                let is_file = path.is_file() || path.extension().is_some();
 
-                // the number of normal files
-                let max_uncompressed_log_files =
-                    max_uncompressed_log_files.unwrap_or(MAX_UNCOMPRESSED_LOG_FILES);
-                // the total number of files; should be greater than uncompressed
-                let max_log_files = if let Some(max_compressed_log_files) = max_compressed_log_files
-                {
-                    max_compressed_log_files + max_uncompressed_log_files
+                if is_file {
+                    if let Some(parent) = path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+
+                    let file = std::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(&path)?;
+                    if print_updates_to_stdout {
+                        println!("Logging to file: {path:?}");
+                    }
+
+                    match format {
+                        LogFormat::Json => tracing_fmt::layer()
+                            .json()
+                            .flatten_event(true)
+                            .with_writer(file)
+                            .boxed(),
+                        LogFormat::Default => tracing_fmt::layer()
+                            .with_ansi(false)
+                            .with_writer(file)
+                            .event_format(LogFormatter)
+                            .boxed(),
+                    }
                 } else {
-                    std::cmp::max(max_uncompressed_log_files, MAX_LOG_FILES)
-                };
-                let (file_rotation, worker_guard) = appender::file_rotater(
-                    path,
-                    MAX_LOG_SIZE,
-                    max_uncompressed_log_files,
-                    max_log_files,
-                );
-                self.log_appender_guard = Some(worker_guard);
+                    std::fs::create_dir_all(&path)?;
+                    if print_updates_to_stdout {
+                        println!("Logging to directory: {path:?}");
+                    }
 
-                match format {
-                    LogFormat::Json => tracing_fmt::layer()
-                        .json()
-                        .flatten_event(true)
-                        .with_writer(file_rotation)
-                        .boxed(),
-                    LogFormat::Default => tracing_fmt::layer()
-                        .with_ansi(false)
-                        .with_writer(file_rotation)
-                        .event_format(LogFormatter)
-                        .boxed(),
+                    // the number of normal files
+                    let max_uncompressed_log_files =
+                        max_uncompressed_log_files.unwrap_or(MAX_UNCOMPRESSED_LOG_FILES);
+                    // the total number of files; should be greater than uncompressed
+                    let max_log_files =
+                        if let Some(max_compressed_log_files) = max_compressed_log_files {
+                            max_compressed_log_files + max_uncompressed_log_files
+                        } else {
+                            std::cmp::max(max_uncompressed_log_files, MAX_LOG_FILES)
+                        };
+                    let (file_rotation, worker_guard) = appender::file_rotater(
+                        &path,
+                        MAX_LOG_SIZE,
+                        max_uncompressed_log_files,
+                        max_log_files,
+                    );
+                    self.log_appender_guard = Some(worker_guard);
+
+                    match format {
+                        LogFormat::Json => tracing_fmt::layer()
+                            .json()
+                            .flatten_event(true)
+                            .with_writer(file_rotation)
+                            .boxed(),
+                        LogFormat::Default => tracing_fmt::layer()
+                            .with_ansi(false)
+                            .with_writer(file_rotation)
+                            .event_format(LogFormatter)
+                            .boxed(),
+                    }
                 }
             }
         };

--- a/ant-logging/src/lib.rs
+++ b/ant-logging/src/lib.rs
@@ -157,14 +157,18 @@ impl LogBuilder {
     pub fn initialize(self) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
         let mut layers = TracingLayers::default();
 
-        let reload_handle = layers.fmt_layer(
-            self.default_logging_targets.clone(),
-            &self.output_dest,
-            self.format,
-            self.max_log_files,
-            self.max_archived_log_files,
-            self.print_updates_to_stdout,
-        )?;
+        let reload_handle = layers
+            .fmt_layer(
+                self.default_logging_targets.clone(),
+                &self.output_dest,
+                self.format,
+                self.max_log_files,
+                self.max_archived_log_files,
+                self.print_updates_to_stdout,
+            )
+            .inspect_err(|err| {
+                eprintln!("Failed to get TracingLayers: {err}");
+            })?;
 
         #[cfg(feature = "otlp")]
         {


### PR DESCRIPTION
- Log directly to a file without file-rotation, if a file path is provided.