### PR TITLE
chore: refactor NetworkAddress logging format

### DIFF
--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -188,37 +188,37 @@ impl Debug for NetworkAddress {
         let name_str = match self {
             NetworkAddress::PeerId(_) => {
                 if let Some(peer_id) = self.as_peer_id() {
-                    format!("NetworkAddress::PeerId({peer_id} - ")
+                    format!("NetworkAddress::{peer_id:?} - (")
                 } else {
                     "NetworkAddress::PeerId(".to_string()
                 }
             }
             NetworkAddress::ChunkAddress(chunk_address) => {
                 format!(
-                    "NetworkAddress::ChunkAddress({} - ",
+                    "NetworkAddress::ChunkAddress({}) - (",
                     &chunk_address.to_hex()
                 )
             }
             NetworkAddress::GraphEntryAddress(graph_entry_address) => {
                 format!(
-                    "NetworkAddress::GraphEntryAddress({} - ",
+                    "NetworkAddress::GraphEntryAddress({}) - (",
                     &graph_entry_address.to_hex()
                 )
             }
             NetworkAddress::ScratchpadAddress(scratchpad_address) => {
                 format!(
-                    "NetworkAddress::ScratchpadAddress({} - ",
+                    "NetworkAddress::ScratchpadAddress({}) - (",
                     &scratchpad_address.to_hex()
                 )
             }
             NetworkAddress::PointerAddress(pointer_address) => {
                 format!(
-                    "NetworkAddress::PointerAddress({} - ",
+                    "NetworkAddress::PointerAddress({}) - (",
                     &pointer_address.to_hex()
                 )
             }
             NetworkAddress::RecordKey(bytes) => {
-                format!("NetworkAddress::RecordKey({:?} - ", hex::encode(bytes))
+                format!("NetworkAddress::RecordKey({:?}) - (", hex::encode(bytes))
             }
         };
 


### PR DESCRIPTION
### Description

refactor NetworkAddress logging format, change from
```
NetworkAddress::PeerId(12D3KooWAMpmMViGYakJV5iQehSYxxLfcjRakb3Zapjw8mVaKJeN - 6d0994aba0bb0c5db2c293e77b33ccc4ddbfc27dcf0a6b960489faf7418fedf5)
```
to
```
NetworkAddress::PeerId("12D3KooWAMpmMViGYakJV5iQehSYxxLfcjRakb3Zapjw8mVaKJeN") - (6d0994aba0bb0c5db2c293e77b33ccc4ddbfc27dcf0a6b960489faf7418fedf5)
```


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
