### PR TITLE
feat(network): default chunk_batch_size to 1

### DIFF
--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -43,12 +43,7 @@ pub(crate) static CHUNK_UPLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     let batch_size = std::env::var("CHUNK_UPLOAD_BATCH_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(
-            std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1)
-                * 8,
-        );
+        .unwrap_or(1);
     info!("Chunk upload batch size: {}", batch_size);
     batch_size
 });
@@ -60,12 +55,7 @@ pub static CHUNK_DOWNLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     let batch_size = std::env::var("CHUNK_DOWNLOAD_BATCH_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(
-            std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1)
-                * 8,
-        );
+        .unwrap_or(1);
     info!("Chunk download batch size: {}", batch_size);
     batch_size
 });


### PR DESCRIPTION
### Description

Default both CHUNK_UPLOAD_BATCH_SIZE and CHUNK_DOWNLOAD_BATCH_SIZE to 1.

During the upload/download test against the Alpha network, it proved that reducing the batch_size help with lifting up the success rate, especially for users with poor connection.
We prefer the default value to be the most robust and stable one.
Users can tweak batch_size value for a better performance, if the connection condition allows.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
