### PR TITLE
passing the data_with_churn CI runs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -801,51 +801,6 @@ jobs:
         run: cargo build --release --bin antnode
         timeout-minutes: 30
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: install foundary
-        shell: bash
-        run: curl -L https://foundry.paradigm.xyz | bash
-
-      - name: move foundry bins to path (linux)
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
-
-      - name: move foundry bins to path (macos)
-        if: matrix.os == 'macos-latest'
-        shell: bash
-        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
-
-      - name: move foundry bins to path (windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
-
-      - name: run foundry
-        shell: bash
-        run: foundryup
-
-      - name: move anvil and other bins to path (linux)
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
-
-      - name: move anvil and other bins to path (macos)
-        if: matrix.os == 'macos-latest'
-        shell: bash
-        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
-
-      - name: move anvil and other bins to path (windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
-
-      - name: Verify Anvil installation
-        run: |
-          anvil --version
-
       - name: Build data location and routing table tests
         run: cargo test --release -p ant-node --test verify_data_location --test verify_routing_table --no-run
         env:
@@ -853,6 +808,29 @@ jobs:
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: start
+          enable-evm-testnet: true
+          node-path: target/release/antnode
+          platform: ${{ matrix.os }}
+          build: true
+
+      - name: Check if ANT_PEERS and EVM_NETWORK are set
+        shell: bash
+        run: |
+          if [[ -z "$ANT_PEERS" ]]; then
+              echo "The ANT_PEERS variable has not been set"
+              exit 1
+          elif [[ -z "$EVM_NETWORK" ]]; then
+              echo "The EVM_NETWORK variable has not been set"
+              exit 1
+          else
+              echo "ANT_PEERS has been set to $ANT_PEERS"
+              echo "EVM_NETWORK has been set to $EVM_NETWORK"
+          fi
 
       - name: Verify the location of the data on the network
         run: cargo test --release -p ant-node --test verify_data_location -- --nocapture
@@ -867,6 +845,59 @@ jobs:
         env:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 5
+
+      # Sleep for a while to allow restarted nodes can be detected by others
+      - name: Sleep a while
+        run: sleep 300
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_data_location
+          platform: ${{ matrix.os }}
+
+      - name: Verify restart of nodes using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of restarts
+        #
+        # `PeerRemovedFromRoutingTable` now only happens when a peer reported as `BadNode`.
+        # Otherwise kad will remove a `dropped out node` directly from RT.
+        # So, the detection of the removal explicity will now have much less chance,
+        # due to the removal of connection_issue tracking.
+        #
+        # With the further reduction of replication frequency,
+        # it now becomes harder to detect a `dropped out node` as a `failed to replicate` node.
+        # Hence now remove the assertion check and replace with a print out only.
+        run: |
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          echo "Node dir count is $node_count"
+          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Restart $restart_count nodes"
+          if ! rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats
+          then
+            echo "No peer removal count found"
+            exit 0
+          fi
+          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "PeerRemovedFromRoutingTable $peer_removed times"
+
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.ant_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi
 
   # faucet_test:
   #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -654,51 +654,6 @@ jobs:
         run: cargo build --release --bin antnode
         timeout-minutes: 30
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: install foundary
-        shell: bash
-        run: curl -L https://foundry.paradigm.xyz | bash
-
-      - name: move foundry bins to path (linux)
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
-
-      - name: move foundry bins to path (macos)
-        if: matrix.os == 'macos-latest'
-        shell: bash
-        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
-
-      - name: move foundry bins to path (windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
-
-      - name: run foundry
-        shell: bash
-        run: foundryup
-
-      - name: move anvil and other bins to path (linux)
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: sudo mv /home/runner/.config/.foundry/bin/* /usr/local/bin
-
-      - name: move anvil and other bins to path (macos)
-        if: matrix.os == 'macos-latest'
-        shell: bash
-        run: sudo mv /Users/runner/.foundry/bin/* /usr/local/bin
-
-      - name: move anvil and other bins to path (windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: Copy-Item -Path C:\Users\runneradmin\.foundry\bin\* -Destination C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
-
-      - name: Verify Anvil installation
-        run: |
-          anvil --version
-
       - name: Build churn tests
         run: cargo test --release -p ant-node --test data_with_churn --no-run
         env:
@@ -707,15 +662,117 @@ jobs:
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
 
+      - name: Start a local network
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: start
+          enable-evm-testnet: true
+          node-path: target/release/antnode
+          platform: ${{ matrix.os }}
+          build: true
+
+      - name: Check if ANT_PEERS and EVM_NETWORK are set
+        shell: bash
+        run: |
+          if [[ -z "$ANT_PEERS" ]]; then
+            echo "The ANT_PEERS variable has not been set"
+            exit 1
+          elif [[ -z "$EVM_NETWORK" ]]; then
+            echo "The EVM_NETWORK variable has not been set"
+            exit 1
+          else
+            echo "ANT_PEERS has been set to $ANT_PEERS"
+            echo "EVM_NETWORK has been set to $EVM_NETWORK"
+          fi
+
       - name: Chunks data integrity during nodes churn
         run: cargo test --release -p ant-node --test data_with_churn -- --nocapture
         env:
           TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
-          EVM_NETWORK: local
           ANT_LOG: "all"
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
+
+      # Sleep for a while to allow restarted nodes can be detected by others
+      - name: Sleep a while
+        run: sleep 300
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: safe_test_logs_churn
+          platform: ${{ matrix.os }}
+
+      - name: Get total node count
+        shell: bash
+        timeout-minutes: 1
+        run: |
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          echo "Node dir count is $node_count"
+
+      - name: Get restart of nodes using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of restarts
+        # TODO: make this use an env var, or relate to testnet size
+        run: |
+          restart_count=$(rg "Node is restarting in" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Restarted $restart_count nodes"
+
+      # `PeerRemovedFromRoutingTable` now only happens when a peer reported as `BadNode`.
+      # Otherwise kad will remove a `dropped out node` directly from RT.
+      # So, the detection of the removal explicity will now have much less chance,
+      # due to the removal of connection_issue tracking.
+      - name: Get peers removed from nodes using rg
+        shell: bash
+        timeout-minutes: 1
+        run: |
+          peer_removed=$(rg "PeerRemovedFromRoutingTable" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o) || { echo "Failed to extract peer removal count"; exit 0; }
+          if [ -z "$peer_removed" ]; then
+            echo "No peer removal count found"
+            exit 1
+          fi
+          echo "PeerRemovedFromRoutingTable $peer_removed times"
+
+        # TODO: reenable this once the testnet dir creation is tidied up to avoid a large count here
+        # if [ $restart_count -lt $node_count ]; then
+        #   echo "Restart count of: $restart_count is less than the node count of: $node_count"
+        #   exit 1
+        # fi
+
+      - name: Verify data replication using rg
+        shell: bash
+        timeout-minutes: 1
+        # get the counts, then the specific line, and then the digit count only
+        # then check we have an expected level of replication
+        # TODO: make this use an env var, or relate to testnet size
+        run: |
+          fetching_attempt_count=$(rg "FetchingKeysForReplication" "${{ matrix.node_data_path }}" -c --stats | \
+            rg "(\d+) matches" | rg "\d+" -o)
+          echo "Carried out $fetching_attempt_count fetching attempts"
+          node_count=$(ls "${{ matrix.node_data_path }}" | wc -l)
+          if [ $fetching_attempt_count -lt $node_count ]; then
+            echo "Replication fetching attempts of: $fetching_attempt_count is less than the node count of: $node_count"
+            exit 1
+          fi
+
+      # Only error out after uploading the logs
+      - name: Don't log raw data
+        if: matrix.os != 'windows-latest' # causes error
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          if ! rg '^' "${{ matrix.ant_path }}"/*/*/logs | awk 'length($0) > 15000 { print; exit 1 }'
+          then
+            echo "We are logging an extremely large data"
+            exit 1
+          fi
 
   verify_data_location_routing_table:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/ant-node/src/spawn/network_spawner.rs
+++ b/ant-node/src/spawn/network_spawner.rs
@@ -166,19 +166,6 @@ impl RunningNetwork {
             node.shutdown();
         }
     }
-
-    pub fn update_peer(&mut self, index: usize, new_peer: RunningNode) {
-        if index < self.running_nodes.len() {
-            self.running_nodes[index] = new_peer.clone();
-            println!(
-                "Updated index: {} with peer_id: {}",
-                index,
-                new_peer.peer_id()
-            );
-        } else {
-            println!("Invalid index: {index}");
-        }
-    }
 }
 
 async fn spawn_network(

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -8,34 +8,26 @@
 
 mod common;
 
-use crate::common::client::get_node_count;
-use ant_evm::Amount;
-use ant_logging::LogBuilder;
-use ant_node::{
-    spawn::{
-        network_spawner::{NetworkSpawner, RunningNetwork},
-        node_spawner::NodeSpawner,
-    },
-    RunningNode,
+use crate::common::{
+    client::{get_client_and_funded_wallet, get_node_count},
+    NodeRestart,
 };
+use ant_logging::LogBuilder;
 use ant_protocol::{
     storage::{ChunkAddress, GraphEntry, GraphEntryAddress, PointerTarget, ScratchpadAddress},
     NetworkAddress,
 };
-use autonomi::{data::DataAddress, Client, ClientConfig, InitialPeersConfig, Wallet};
+use autonomi::{data::DataAddress, Client, Wallet};
 use bls::{PublicKey, SecretKey};
 use bytes::Bytes;
-use evmlib::Network;
+use common::client::transfer_to_new_wallet;
 use eyre::{bail, ErrReport, Result};
-use libp2p::Multiaddr;
 use rand::Rng;
 use self_encryption::MAX_CHUNK_SIZE;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     fmt,
     fs::create_dir_all,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    str::FromStr,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
@@ -86,34 +78,6 @@ type ContentErredList = Arc<RwLock<BTreeMap<NetworkAddress, ContentError>>>;
 #[tokio::test(flavor = "multi_thread")]
 async fn data_availability_during_churn() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_multi_threaded_tokio_test("data_with_churn", false);
-    let evm_testnet = evmlib::testnet::Testnet::new().await;
-    let evm_network = evm_testnet.to_network();
-    let evm_sk = evm_testnet.default_wallet_private_key();
-    let funded_wallet =
-        Wallet::new_from_private_key(evm_network.clone(), &evm_sk).expect("Invalid private key");
-    let network = NetworkSpawner::new()
-        .with_evm_network(evm_network.clone())
-        .with_rewards_address(funded_wallet.address())
-        .with_local(true)
-        .with_size(20)
-        .spawn()
-        .await
-        .unwrap();
-    let peer = network.bootstrap_peer().await;
-    let config = ClientConfig {
-        init_peers_config: InitialPeersConfig {
-            first: false,
-            local: true,
-            addrs: vec![peer],
-            bootstrap_cache_dir: None,
-            disable_mainnet_contacts: true,
-            ignore_cache: false,
-            network_contacts_url: vec![],
-        },
-        evm_network: evm_network.clone(),
-        strategy: Default::default(),
-    };
-    let client = Client::init_with_config(config).await.unwrap();
 
     let test_duration = if let Ok(str) = std::env::var("TEST_DURATION_MINS") {
         Duration::from_secs(60 * str.parse::<u64>()?)
@@ -154,9 +118,11 @@ async fn data_availability_during_churn() -> Result<()> {
         if chunks_only { " (Chunks only)" } else { "" }
     );
 
+    let (client, main_wallet) = get_client_and_funded_wallet().await;
+
     info!(
         "Client and wallet created. Main wallet address: {:?}",
-        funded_wallet.address()
+        main_wallet.address()
     );
 
     // Shared bucket where we keep track of content created/stored on the network
@@ -165,17 +131,7 @@ async fn data_availability_during_churn() -> Result<()> {
     println!("Uploading some chunks before carry out node churning");
     info!("Uploading some chunks before carry out node churning");
 
-    let chunk_wallet = Wallet::new_with_random_wallet(evm_network.clone());
-    funded_wallet
-        .transfer_tokens(chunk_wallet.address(), Amount::from(TOKENS_TO_TRANSFER))
-        .await?;
-    funded_wallet
-        .transfer_gas_tokens(
-            chunk_wallet.address(),
-            Amount::from_str("10000000000000000000")?,
-        )
-        .await?;
-
+    let chunk_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
     // Spawn a task to store Chunks at random locations, at a higher frequency than the churning events
     let store_chunks_handle = store_chunks_task(
         client.clone(),
@@ -187,16 +143,7 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to create Pointers at random locations,
     // at a higher frequency than the churning events
     let create_pointer_handle = if !chunks_only {
-        let pointer_wallet = Wallet::new_with_random_wallet(evm_network.clone());
-        funded_wallet
-            .transfer_tokens(pointer_wallet.address(), Amount::from(TOKENS_TO_TRANSFER))
-            .await?;
-        funded_wallet
-            .transfer_gas_tokens(
-                pointer_wallet.address(),
-                Amount::from_str("10000000000000000000")?,
-            )
-            .await?;
+        let pointer_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
         let create_pointer_handle = create_pointers_task(
             client.clone(),
             pointer_wallet,
@@ -211,19 +158,7 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to create GraphEntry at random locations,
     // at a higher frequency than the churning events
     let create_graph_entry_handle = if !chunks_only {
-        let graph_entry_wallet = Wallet::new_with_random_wallet(evm_network.clone());
-        funded_wallet
-            .transfer_tokens(
-                graph_entry_wallet.address(),
-                Amount::from(TOKENS_TO_TRANSFER),
-            )
-            .await?;
-        funded_wallet
-            .transfer_gas_tokens(
-                graph_entry_wallet.address(),
-                Amount::from_str("10000000000000000000")?,
-            )
-            .await?;
+        let graph_entry_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
         let create_graph_entry_handle = create_graph_entry_task(
             client.clone(),
             graph_entry_wallet,
@@ -238,19 +173,7 @@ async fn data_availability_during_churn() -> Result<()> {
     // Spawn a task to create ScratchPad at random locations,
     // at a higher frequency than the churning events
     let create_scratchpad_handle = if !chunks_only {
-        let scratchpad_wallet = Wallet::new_with_random_wallet(evm_network.clone());
-        funded_wallet
-            .transfer_tokens(
-                scratchpad_wallet.address(),
-                Amount::from(TOKENS_TO_TRANSFER),
-            )
-            .await?;
-        funded_wallet
-            .transfer_gas_tokens(
-                scratchpad_wallet.address(),
-                Amount::from_str("10000000000000000000")?,
-            )
-            .await?;
+        let scratchpad_wallet = transfer_to_new_wallet(&main_wallet, TOKENS_TO_TRANSFER).await?;
         let create_scratchpad_handle = create_scratchpad_task(
             client.clone(),
             scratchpad_wallet,
@@ -263,18 +186,7 @@ async fn data_availability_during_churn() -> Result<()> {
     };
 
     // Spawn a task to churn nodes
-    tokio::spawn(async move {
-        let _ = data_churn_with_network_restart(
-            network,
-            &evm_network,
-            &funded_wallet,
-            true,
-            false,
-            churn_period,
-            test_duration,
-        )
-        .await;
-    });
+    churn_nodes_task(Arc::clone(&churn_count), test_duration, churn_period);
 
     // Shared bucket where we keep track of the content which erred when creating/storing/fetching.
     // We remove them from this bucket if we are then able to query/fetch them successfully.
@@ -396,81 +308,6 @@ async fn data_availability_during_churn() -> Result<()> {
     }
 
     println!("Test passed after running for {:?}.", start_time.elapsed());
-    Ok(())
-}
-
-async fn data_churn_with_network_restart(
-    running_network: RunningNetwork,
-    evm_network: &Network,
-    funded_wallet: &Wallet,
-    local: bool,
-    upnp: bool,
-    churn_period: Duration,
-    total_period: Duration,
-) -> Result<()> {
-    println!("data churning for the network spawner initiated");
-    let start = Instant::now();
-    let mut churn_count = 1;
-
-    let mut running_nodes = running_network.running_nodes().clone();
-    'outer: loop {
-        let mut restarted_nodes: Vec<RunningNode> = Vec::new();
-        let mut initial_peers: Vec<Multiaddr> = vec![];
-        for peer in running_nodes.iter() {
-            if let Ok(listen_addrs_with_peer_id) = peer.get_listen_addrs_with_peer_id().await {
-                initial_peers.extend(listen_addrs_with_peer_id);
-            }
-        }
-        for nodes in running_nodes.clone() {
-            sleep(churn_period).await;
-            if start.elapsed() > total_period {
-                println!("Total period elapsed. Stopping the churn.");
-                info!("Total period elapsed. Stopping the churn.");
-                break 'outer;
-            }
-            println!(
-                "Churn #{churn_count} Churning a node with peer_id {:?}",
-                nodes.peer_id()
-            );
-            nodes.clone().shutdown();
-            println!("Restarting the node with peer_id {:?}", nodes.peer_id());
-
-            churn_count += 1;
-            let mut temp_peer = initial_peers.clone();
-            if let Ok(listen_addrs_with_peer_id) = nodes.get_listen_addrs_with_peer_id().await {
-                for exclude_addr in listen_addrs_with_peer_id {
-                    initial_peers = temp_peer
-                        .iter() // Use iter() to borrow, not move
-                        .filter(|addr| *addr != &exclude_addr) // Deref to compare values
-                        .cloned() // Clone to collect into a new Vec
-                        .collect();
-                    temp_peer = initial_peers.clone();
-                }
-            }
-
-            let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-            let node = NodeSpawner::new()
-                .with_socket_addr(socket_addr)
-                .with_evm_network(evm_network.clone())
-                .with_rewards_address(funded_wallet.address())
-                .with_initial_peers(initial_peers.clone())
-                .with_local(local)
-                .with_upnp(upnp)
-                .with_root_dir(None)
-                .spawn()
-                .await?;
-            sleep(Duration::from_secs(2)).await;
-            if let Ok(listen_addrs_with_peer_id) = node.get_listen_addrs_with_peer_id().await {
-                initial_peers.extend(listen_addrs_with_peer_id);
-            }
-            println!(
-                "A new Node joined the network with peer_id {:?}",
-                node.peer_id()
-            );
-            restarted_nodes.push(node);
-        }
-        running_nodes = restarted_nodes;
-    }
     Ok(())
 }
 
@@ -925,6 +762,37 @@ fn query_content_task(
                 }
             }
         }
+    });
+}
+
+// Spawns a task which periodically picks up a node, and restarts it to cause churn in the network.
+fn churn_nodes_task(
+    churn_count: Arc<RwLock<usize>>,
+    test_duration: Duration,
+    churn_period: Duration,
+) {
+    let start = Instant::now();
+    let _handle: JoinHandle<Result<()>> = tokio::spawn(async move {
+        let mut node_restart = NodeRestart::new(true, false)?;
+
+        loop {
+            sleep(churn_period).await;
+
+            // break out if we've run the duration of churn
+            if start.elapsed() > test_duration {
+                debug!("Test duration reached, stopping churn nodes task");
+                break;
+            }
+
+            if let Err(err) = node_restart.restart_next(true, true).await {
+                println!("Failed to restart node {err}");
+                info!("Failed to restart node {err}");
+                continue;
+            }
+
+            *churn_count.write().await += 1;
+        }
+        Ok(())
     });
 }
 

--- a/ant-node/tests/verify_data_location.rs
+++ b/ant-node/tests/verify_data_location.rs
@@ -8,31 +8,31 @@
 
 mod common;
 
-use ant_networking::{sleep, sort_peers_by_key};
-use ant_node::{
-    spawn::{
-        network_spawner::{NetworkSpawner, RunningNetwork},
-        node_spawner::NodeSpawner,
-    },
-    RunningNode,
+use ant_logging::LogBuilder;
+use ant_networking::sort_peers_by_key;
+use ant_protocol::{
+    antnode_proto::{NodeInfoRequest, RecordAddressesRequest},
+    NetworkAddress, PrettyPrintRecordKey, CLOSE_GROUP_SIZE,
 };
-use ant_protocol::{NetworkAddress, PrettyPrintRecordKey, CLOSE_GROUP_SIZE};
-use autonomi::{Client, ClientConfig, InitialPeersConfig};
+use autonomi::Client;
 use bytes::Bytes;
-use common::get_all_peer_ids;
-use evmlib::wallet::Wallet;
+use common::{
+    client::{get_all_rpc_addresses, get_client_and_funded_wallet},
+    get_all_peer_ids, get_antnode_rpc_client, NodeRestart,
+};
 use eyre::{eyre, Result};
 use itertools::Itertools;
 use libp2p::{
     kad::{KBucketKey, RecordKey},
-    Multiaddr, PeerId,
+    PeerId,
 };
 use rand::{rngs::OsRng, Rng};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     time::{Duration, Instant},
 };
+use tonic::Request;
 use tracing::{debug, error, info};
 
 const CHUNK_SIZE: usize = 1024;
@@ -65,6 +65,9 @@ type RecordHolders = HashMap<RecordKey, HashSet<NodeIndex>>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_data_location() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_multi_threaded_tokio_test("verify_data_location", false);
+
     let churn_count = if let Ok(str) = std::env::var("CHURN_COUNT") {
         str.parse::<u8>()?
     } else {
@@ -83,102 +86,62 @@ async fn verify_data_location() -> Result<()> {
         "Performing data location verification with a churn count of {churn_count} and n_chunks {chunk_count}\nIt will take approx {:?}",
         VERIFICATION_DELAY*churn_count as u32
     );
+    let node_rpc_address = get_all_rpc_addresses(true)?;
+    let mut all_peers = get_all_peer_ids(&node_rpc_address).await?;
 
-    // initiate a testnet, and spawn a network
-    let evm_testnet = evmlib::testnet::Testnet::new().await;
-    let evm_network = evm_testnet.to_network();
-    let evm_sk = evm_testnet.default_wallet_private_key();
-    let funded_wallet =
-        Wallet::new_from_private_key(evm_network.clone(), &evm_sk).expect("Invalid private key");
-    let mut network = NetworkSpawner::new()
-        .with_evm_network(evm_network.clone())
-        .with_rewards_address(funded_wallet.address())
-        .with_local(true)
-        .with_size(20)
-        .spawn()
-        .await
-        .unwrap();
-    let peer = network.bootstrap_peer().await;
-    let config = ClientConfig {
-        init_peers_config: InitialPeersConfig {
-            first: false,
-            local: true,
-            addrs: vec![peer],
-            bootstrap_cache_dir: None,
-            disable_mainnet_contacts: true,
-            ignore_cache: false,
-            network_contacts_url: vec![],
-        },
-        evm_network: evm_network.clone(),
-        strategy: Default::default(),
-    };
-    let client = Client::init_with_config(config).await.unwrap();
+    let (client, wallet) = get_client_and_funded_wallet().await;
 
-    // let node_rpc_address = get_all_rpc_addresses(true)?;
-    let mut all_peers = get_all_peer_ids(&network)?;
+    store_chunks(&client, chunk_count, &wallet).await?;
 
-    store_chunks(&client, chunk_count, &funded_wallet).await?;
-    println!("verifying data location initially before churning");
     // Verify data location initially
-    verify_location(&all_peers, &network).await?;
-    println!("Initial verification done");
+    verify_location(&all_peers, &node_rpc_address).await?;
 
     // Churn nodes and verify the location of the data after VERIFICATION_DELAY
     let mut current_churn_count = 0;
 
+    let mut node_restart = NodeRestart::new(true, false)?;
     let mut node_index = 0;
-
-    let mut running_nodes = network.running_nodes().clone();
     'main: loop {
-        let mut restarted_nodes: Vec<RunningNode> = Vec::new();
+        if current_churn_count >= churn_count {
+            break 'main Ok(());
+        }
+        current_churn_count += 1;
 
-        for nodes in running_nodes {
-            if current_churn_count >= churn_count {
+        let antnode_rpc_endpoint = match node_restart.restart_next(false, false).await? {
+            None => {
+                // we have reached the end.
                 break 'main Ok(());
             }
-            current_churn_count += 1;
+            Some(antnode_rpc_endpoint) => antnode_rpc_endpoint,
+        };
 
-            println!(
-                "Churn #{current_churn_count} Churning a node with peer_id {:?}",
-                nodes.peer_id()
-            );
-            info!(
-                "Churn #{current_churn_count} Churning a node with peer_id {:?}",
-                nodes.peer_id()
-            );
-            let mut initial_peers: Vec<Multiaddr> = vec![];
-            nodes.clone().shutdown();
-            sleep(Duration::from_secs(1)).await;
+        // wait for the dead peer to be removed from the RT and the replication flow to finish
+        println!(
+            "\nNode has been restarted, waiting for {VERIFICATION_DELAY:?} before verification"
+        );
+        info!("\nNode has been restarted, waiting for {VERIFICATION_DELAY:?} before verification");
+        tokio::time::sleep(VERIFICATION_DELAY).await;
 
-            for peer in network.running_nodes() {
-                if let Ok(listen_addrs_with_peer_id) = peer.get_listen_addrs_with_peer_id().await {
-                    initial_peers.extend(listen_addrs_with_peer_id);
-                }
-            }
+        // get the new PeerId for the current NodeIndex
+        let mut rpc_client = get_antnode_rpc_client(antnode_rpc_endpoint).await?;
 
-            let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-            let node = NodeSpawner::new()
-                .with_socket_addr(socket_addr)
-                .with_evm_network(evm_network.clone())
-                .with_rewards_address(funded_wallet.address())
-                .with_initial_peers(initial_peers)
-                .with_local(true)
-                .with_upnp(false)
-                .with_root_dir(None)
-                .spawn()
-                .await?;
-            sleep(Duration::from_secs(2)).await;
-            let new_peer_id = node.peer_id();
-            println!("A new Node joined the network with peer_id {new_peer_id:?}");
-            restarted_nodes.push(node.clone());
-            network.update_peer(node_index, node);
-            all_peers[node_index] = new_peer_id;
-            node_index += 1;
-
-            print_node_close_groups(&all_peers);
-            verify_location(&all_peers, &network).await?;
+        let response = rpc_client
+            .node_info(Request::new(NodeInfoRequest {}))
+            .await?;
+        let new_peer_id = PeerId::from_bytes(&response.get_ref().peer_id)?;
+        // The below indexing assumes that, the way we do iteration to retrieve all_peers inside get_all_rpc_addresses
+        // and get_all_peer_ids is the same as how we do the iteration inside NodeRestart.
+        // todo: make this more cleaner.
+        if all_peers[node_index] == new_peer_id {
+            println!("new and old peer id are the same {new_peer_id:?}");
+            return Err(eyre!("new and old peer id are the same {new_peer_id:?}"));
         }
-        running_nodes = restarted_nodes;
+        all_peers[node_index] = new_peer_id;
+        node_index += 1;
+
+        print_node_close_groups(&all_peers);
+
+        verify_location(&all_peers, &node_rpc_address).await?;
     }
 }
 
@@ -210,19 +173,17 @@ fn print_node_close_groups(all_peers: &[PeerId]) {
     }
 }
 
-async fn get_records_and_holders(running_network: &RunningNetwork) -> Result<RecordHolders> {
+async fn get_records_and_holders(node_rpc_addresses: &[SocketAddr]) -> Result<RecordHolders> {
     let mut record_holders = RecordHolders::default();
 
-    for (node_index, running_node) in running_network.running_nodes().iter().enumerate() {
-        println!("Getting records for node index {node_index}");
-        let records_response = running_node
-            .get_all_record_addresses()
-            .await?
-            .into_iter()
-            .map(|addr| addr.as_bytes())
-            .collect::<Vec<_>>();
+    for (node_index, rpc_address) in node_rpc_addresses.iter().enumerate() {
+        let mut rpc_client = get_antnode_rpc_client(*rpc_address).await?;
 
-        for bytes in records_response.iter() {
+        let records_response = rpc_client
+            .record_addresses(Request::new(RecordAddressesRequest {}))
+            .await?;
+
+        for bytes in records_response.get_ref().addresses.iter() {
             let key = RecordKey::from(bytes.clone());
             let holders = record_holders.entry(key).or_insert(HashSet::new());
             holders.insert(node_index);
@@ -234,21 +195,18 @@ async fn get_records_and_holders(running_network: &RunningNetwork) -> Result<Rec
 
 // Fetches the record_holders and verifies that the record is stored by the actual closest peers to the RecordKey
 // It has a retry loop built in.
-async fn verify_location(all_peers: &Vec<PeerId>, running_network: &RunningNetwork) -> Result<()> {
+async fn verify_location(all_peers: &Vec<PeerId>, node_rpc_addresses: &[SocketAddr]) -> Result<()> {
     let mut failed = HashMap::new();
 
     println!("*********************************************");
     println!("Verifying data across all peers {all_peers:?}");
     info!("*********************************************");
     info!("Verifying data across all peers {all_peers:?}");
+
     let mut verification_attempts = 0;
     while verification_attempts < VERIFICATION_ATTEMPTS {
         failed.clear();
-        println!(
-            "Verifying data location attempt {}",
-            verification_attempts + 1
-        );
-        let record_holders = get_records_and_holders(running_network).await?;
+        let record_holders = get_records_and_holders(node_rpc_addresses).await?;
         for (key, actual_holders_idx) in record_holders.iter() {
             println!("Verifying {:?}", PrettyPrintRecordKey::from(key));
             info!("Verifying {:?}", PrettyPrintRecordKey::from(key));
@@ -264,7 +222,6 @@ async fn verify_location(all_peers: &Vec<PeerId>, running_network: &RunningNetwo
             .into_iter()
             .map(|(peer_id, _)| peer_id)
             .collect::<BTreeSet<_>>();
-            println!("peers are sorted by the key");
 
             let actual_holders = actual_holders_idx
                 .iter()

--- a/ant-node/tests/verify_routing_table.rs
+++ b/ant-node/tests/verify_routing_table.rs
@@ -9,19 +9,19 @@
 #![allow(clippy::mutable_key_type)]
 mod common;
 
-use crate::common::get_all_peer_ids;
-use ant_node::spawn::network_spawner::NetworkSpawner;
-use ant_protocol::antnode_proto::k_buckets_response;
-use autonomi::Wallet;
+use crate::common::{client::get_all_rpc_addresses, get_all_peer_ids, get_antnode_rpc_client};
+use ant_logging::LogBuilder;
+use ant_protocol::antnode_proto::KBucketsRequest;
 use color_eyre::Result;
 use libp2p::{
     kad::{KBucketKey, K_VALUE},
     PeerId,
 };
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     time::Duration,
 };
+use tonic::Request;
 use tracing::{error, info, trace};
 
 /// Sleep for sometime for the nodes for discover each other before verification
@@ -30,6 +30,9 @@ const SLEEP_BEFORE_VERIFICATION: Duration = Duration::from_secs(5);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_routing_table() -> Result<()> {
+    let _log_appender_guard =
+        LogBuilder::init_multi_threaded_tokio_test("verify_routing_table", false);
+
     let sleep_duration = std::env::var("SLEEP_BEFORE_VERIFICATION")
         .map(|value| {
             value
@@ -41,40 +44,20 @@ async fn verify_routing_table() -> Result<()> {
     info!("Sleeping for {sleep_duration:?} before verification");
     tokio::time::sleep(sleep_duration).await;
 
-    // initiate a testnet, and spawn a network
-    let evm_testnet = evmlib::testnet::Testnet::new().await;
-    let evm_network = evm_testnet.to_network();
-    let evm_sk = evm_testnet.default_wallet_private_key();
-    let funded_wallet =
-        Wallet::new_from_private_key(evm_network.clone(), &evm_sk).expect("Invalid private key");
-    let network = NetworkSpawner::new()
-        .with_evm_network(evm_network.clone())
-        .with_rewards_address(funded_wallet.address())
-        .with_local(true)
-        .with_size(20)
-        .spawn()
-        .await
-        .unwrap();
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    // let node_rpc_address = get_all_rpc_addresses(true)?;
-    let all_peers = get_all_peer_ids(&network)?;
+    let node_rpc_address = get_all_rpc_addresses(false)?;
 
+    let all_peers = get_all_peer_ids(&node_rpc_address).await?;
     trace!("All peers: {all_peers:?}");
     let mut all_failed_list = BTreeMap::new();
 
-    for (node_index, running_node) in network.running_nodes().iter().enumerate() {
-        let k_buckets: HashMap<u32, k_buckets_response::Peers> = running_node
-            .get_kbuckets()
-            .await
-            .expect("failed to get k-buckets")
-            .into_iter()
-            .map(|(ilog2_distance, peers)| {
-                let peers = peers.into_iter().map(|peer| peer.to_bytes()).collect();
-                let peers = k_buckets_response::Peers { peers };
-                (ilog2_distance, peers)
-            })
-            .collect();
+    for (node_index, rpc_address) in node_rpc_address.iter().enumerate() {
+        let mut rpc_client = get_antnode_rpc_client(*rpc_address).await?;
 
+        let response = rpc_client
+            .k_buckets(Request::new(KBucketsRequest {}))
+            .await?;
+
+        let k_buckets = response.get_ref().kbuckets.clone();
         let k_buckets = k_buckets
             .into_iter()
             .map(|(ilog2, peers)| {

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -133,7 +133,7 @@ impl NetworkDriver {
         let store = MemoryStore::with_config(peer_id, store_cfg);
         let mut kad_cfg = libp2p::kad::Config::new(KAD_STREAM_PROTOCOL_ID);
         kad_cfg
-            .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
+            .set_kbucket_inserts(libp2p::kad::BucketInserts::OnConnected)
             .set_max_packet_size(MAX_PACKET_SIZE)
             .set_parallelism(KAD_ALPHA)
             .set_replication_factor(REPLICATION_FACTOR)


### PR DESCRIPTION
### Description

* revert the use of NodeSpawner in CI runs, so that logging Artifacts of data_with_churn and verify_location tests can be properly generated
* use `libp2p::kad::BucketInserts::OnConnected` for client network to pass the data_with_churn test


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
