### PR TITLE
feat: easy alpha for the rest of us

### DIFF
--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -177,7 +177,7 @@ impl Client {
                 network_contacts_url: vec!["http://146.190.225.26/bootstrap_cache.json".to_string()],
                 local: false,
                 disable_mainnet_contacts: true,
-                ignore_cache: true,
+                ignore_cache: false,
                 bootstrap_cache_dir: None,
             },
             evm_network: EvmNetwork::ArbitrumSepoliaTest,

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -168,6 +168,25 @@ impl Client {
         .await
     }
 
+    /// Initialize a client that is configured to be connected to the the alpha network (Impossible Futures).
+    pub async fn init_alpha() -> Result<Self, ConnectError> {
+        let client_config = ClientConfig {
+            init_peers_config: InitialPeersConfig {
+                first: false,
+                addrs: vec![],
+                network_contacts_url: vec!["http://146.190.225.26/bootstrap_cache.json".to_string()],
+                local: false,
+                disable_mainnet_contacts: true,
+                ignore_cache: true,
+                bootstrap_cache_dir: None,
+            },
+            evm_network: EvmNetwork::ArbitrumSepoliaTest,
+            strategy: Default::default(),
+            network_id: Some(2),
+        };
+        Self::init_with_config(client_config).await
+    }
+
     /// Initialize a client that bootstraps from a list of peers.
     ///
     /// If any of the provided peers is a global address, the client will not be local.

--- a/autonomi/src/python.rs
+++ b/autonomi/src/python.rs
@@ -64,6 +64,17 @@ impl PyClient {
         })
     }
 
+    /// Initialize a client that is configured to be connected to the alpha network.
+    #[staticmethod]
+    fn init_alpha(py: Python) -> PyResult<Bound<PyAny>> {
+        future_into_py(py, async {
+            let inner = Client::init_alpha()
+                .await
+                .map_err(|e| PyConnectionError::new_err(format!("Failed to connect: {e}")))?;
+            Ok(PyClient { inner })
+        })
+    }
+
     /// Initialize a client that bootstraps from a list of peers.
     ///
     /// If any of the provided peers is a global address, the client will not be local.

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -72,6 +72,14 @@ impl Client {
         Ok(Self(client))
     }
 
+    /// Initialize a client that is configured to be connected to the alpha network.
+    #[napi(factory)]
+    pub async fn init_alpha() -> Result<Self> {
+        let client = autonomi::Client::init_alpha().await.map_err(map_error)?;
+
+        Ok(Self(client))
+    }
+
     /// Initialize a client that bootstraps from a list of peers.
     ///
     /// If any of the provided peers is a global address, the client will not be local.


### PR DESCRIPTION
Made connection to alpha net a 'tad' simpler... 

```diff
-     ant_protocol::version::set_network_id(2); // what does this even do??
- 
-     let client_config = ClientConfig {
-         init_peers_config: InitialPeersConfig {
-             first: false,
-             addrs: vec![], // need addresses here.. maybe? where are the docs??
-             network_contacts_url: // what is this??? 
-             local: false,
-             disable_mainnet_contacts: true, // if this is set wrong it won't work, or so I read in discord...
-             ignore_cache: true,
-             bootstrap_cache_dir: None,
-         },
-         evm_network: EvmNetwork::ArbitrumSepoliaTest,
-         strategy: Default::default(),
-         network_id: Some(2),
-     };
-     let client = Client::init_with_config(client_config).await?;
-
-     // help! Why is this so hard? :(

+     Client::init_alpha()
```