### PR TITLE
client further config tweaking for more rubost performance on slow connection

### DIFF
--- a/ant-networking/src/network_builder.rs
+++ b/ant-networking/src/network_builder.rs
@@ -73,6 +73,9 @@ const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 /// Time before a Kad query times out if no response is received
 const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(10);
 
+/// Client requires a super long time when have get_closest query against production network
+const CLIENT_KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(120);
+
 // Init during compilation, instead of runtime error that should never happen
 // Option<T>::expect will be stabilised as const in the future (https://github.com/rust-lang/rust/issues/67441)
 const REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(CLOSE_GROUP_SIZE + 2) {
@@ -204,7 +207,6 @@ impl NetworkBuilder {
             // .disjoint_query_paths(true)
             // Records never expire
             .set_record_ttl(None)
-            .set_replication_factor(REPLICATION_FACTOR)
             .set_periodic_bootstrap_interval(Some(Duration::from_secs(bootstrap_interval)))
             // Emit PUT events for validation prior to insertion into the RecordStore.
             // This is no longer needed as the record_storage::put now can carry out validation.
@@ -277,7 +279,7 @@ impl NetworkBuilder {
         let _ = kad_cfg
             .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
             .set_max_packet_size(MAX_PACKET_SIZE)
-            .set_replication_factor(REPLICATION_FACTOR)
+            .set_query_timeout(CLIENT_KAD_QUERY_TIMEOUT_S)
             // may consider to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
             // however, this has the risk of libp2p report back partial-correct result in case of high peer query failure rate.
             // .disjoint_query_paths(true)

--- a/ant-networking/src/network_builder.rs
+++ b/ant-networking/src/network_builder.rs
@@ -199,8 +199,9 @@ impl NetworkBuilder {
             // How many nodes _should_ store data.
             .set_replication_factor(REPLICATION_FACTOR)
             .set_query_timeout(KAD_QUERY_TIMEOUT_S)
-            // Require iterative queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
-            .disjoint_query_paths(true)
+            // may consider to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
+            // however, this has the risk of libp2p report back partial-correct result in case of high peer query failure rate.
+            // .disjoint_query_paths(true)
             // Records never expire
             .set_record_ttl(None)
             .set_replication_factor(REPLICATION_FACTOR)
@@ -273,13 +274,13 @@ impl NetworkBuilder {
         // to outbound-only mode and don't listen on any address
         let mut kad_cfg = kad::Config::new(KAD_STREAM_PROTOCOL_ID); // default query timeout is 60 secs
 
-        // 1mb packet size
         let _ = kad_cfg
             .set_kbucket_inserts(libp2p::kad::BucketInserts::Manual)
             .set_max_packet_size(MAX_PACKET_SIZE)
             .set_replication_factor(REPLICATION_FACTOR)
-            // Require iterative queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
-            .disjoint_query_paths(true)
+            // may consider to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
+            // however, this has the risk of libp2p report back partial-correct result in case of high peer query failure rate.
+            // .disjoint_query_paths(true)
             // How many nodes _should_ store data.
             .set_replication_factor(REPLICATION_FACTOR);
 

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -150,9 +150,9 @@ impl Client {
             }
         }
 
-        info!("Paying for {} chunks..", combined_xor_names.len());
+        info!("Quoting for {} chunks..", combined_xor_names.len());
         #[cfg(feature = "loud")]
-        println!("Paying for {} chunks..", combined_xor_names.len());
+        println!("Quoting for {} chunks..", combined_xor_names.len());
 
         let (receipt, skipped_payments_amount) = self
             .pay_for_content_addrs(

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -155,9 +155,9 @@ impl Client {
             }
         }
 
-        info!("Paying for {} chunks..", combined_xor_names.len());
+        info!("Quoting for {} chunks..", combined_xor_names.len());
         #[cfg(feature = "loud")]
-        println!("Paying for {} chunks..", combined_xor_names.len());
+        println!("Quoting for {} chunks..", combined_xor_names.len());
 
         let (receipt, skipped_payments_amount) = self
             .pay_for_content_addrs(

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -24,12 +24,7 @@ pub static FILE_UPLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     let batch_size = std::env::var("FILE_UPLOAD_BATCH_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(
-            std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1)
-                * 8,
-        );
+        .unwrap_or(1);
     info!("File upload batch size: {}", batch_size);
     batch_size
 });

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -121,6 +121,10 @@ impl Client {
         let number_of_content_addrs = content_addrs.clone().count();
         let quotes = self.get_store_quotes(data_type, content_addrs).await?;
 
+        info!("Paying for {} chunks..", quotes.len());
+        #[cfg(feature = "loud")]
+        println!("Paying for {} chunks..", quotes.len());
+
         if !quotes.is_empty() {
             // Make sure nobody else can use the wallet while we are paying
             debug!("Waiting for wallet lock");
@@ -141,7 +145,13 @@ impl Client {
         }
 
         let skipped_chunks = number_of_content_addrs - quotes.len();
-        trace!(
+        info!(
+            "Chunk payments of {} chunks completed. {} chunks were free / already paid for",
+            quotes.len(),
+            skipped_chunks
+        );
+        #[cfg(feature = "loud")]
+        println!(
             "Chunk payments of {} chunks completed. {} chunks were free / already paid for",
             quotes.len(),
             skipped_chunks

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Client;
-use crate::client::high_level::files::FILE_UPLOAD_BATCH_SIZE;
+use crate::client::data_types::chunk::CHUNK_UPLOAD_BATCH_SIZE;
 use crate::client::utils::process_tasks_with_max_concurrency;
 use ant_evm::payment_vault::get_market_price;
 use ant_evm::{Amount, PaymentQuote, QuotePayment, QuotingMetrics};
@@ -102,7 +102,9 @@ impl Client {
             })
             .collect();
 
-        process_tasks_with_max_concurrency(futures, *FILE_UPLOAD_BATCH_SIZE).await
+        let parallism = std::cmp::min(*CHUNK_UPLOAD_BATCH_SIZE * 8, 128);
+
+        process_tasks_with_max_concurrency(futures, parallism).await
     }
 
     pub async fn get_store_quotes(

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -249,8 +249,9 @@ async fn fetch_store_quote_with_retries(
                             required: CLOSE_GROUP_SIZE,
                         });
                     }
+                } else {
+                    break Ok((content_addr, quote));
                 }
-                break Ok((content_addr, quote));
             }
             Err(err) if retries < 2 => {
                 retries += 1;


### PR DESCRIPTION
### Description

Contains following changes:
* disable disjoint_query_path: using disjoint paths seems having the risk of libp2p report back partial-correct result in case of high peer query failure rate.
* change the quoting parallism to be CHUNK_UPLOAD_BATCH_SIZE * 8 and capped at 128.
* fixed a bug that no-reattempt in case of not get enough closest peers
* increase default client query timeout from 60s to 120s
* default FILE_UPLOAD_BATCH_SIZE to 1
* correct misleading `Paying for X chunks` printout to `Quoting for X chunks` 

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
