### PR TITLE
fix(network): variance is now being calculated correctly

### DIFF
--- a/ant-bootstrap/src/config.rs
+++ b/ant-bootstrap/src/config.rs
@@ -24,8 +24,8 @@ const MAX_ADDRS_PER_PEER: usize = 6;
 // Min time until we save the bootstrap cache to disk. 5 mins
 const MIN_BOOTSTRAP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
-// Max time until we save the bootstrap cache to disk. 24 hours
-const MAX_BOOTSTRAP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+// Max time until we save the bootstrap cache to disk. 3 hours
+const MAX_BOOTSTRAP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(3 * 60 * 60);
 
 /// Configuration for the bootstrap cache
 #[derive(Clone, Debug)]

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -402,7 +402,7 @@ impl SwarmDriver {
 
                     // save the cache to disk
                     spawn(async move {
-                        if let Err(err) = old_cache.sync_and_flush_to_disk(true) {
+                        if let Err(err) = old_cache.sync_and_flush_to_disk() {
                             error!("Failed to save bootstrap cache: {err}");
                         }
                     });

--- a/ant-networking/src/driver.rs
+++ b/ant-networking/src/driver.rs
@@ -591,9 +591,10 @@ impl SwarmDriver {
 
     /// Returns a new duration that is within +/- variance of the provided duration.
     fn duration_with_variance(duration: Duration, variance: u32) -> Duration {
-        let actual_variance = duration / variance;
+        let variance = duration.as_secs() as f64 * (variance as f64 / 100.0);
+
         let random_adjustment =
-            Duration::from_secs(rand::thread_rng().gen_range(0..actual_variance.as_secs()));
+            Duration::from_secs(rand::thread_rng().gen_range(0..variance as u64));
         if random_adjustment.as_secs() % 2 == 0 {
             duration - random_adjustment
         } else {
@@ -619,12 +620,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_duration_variance_fn() {
-        let duration = Duration::from_secs(100);
+        let duration = Duration::from_secs(150);
         let variance = 10;
+        let expected_variance = Duration::from_secs(15); // 10% of 150
         for _ in 0..10000 {
             let new_duration = crate::SwarmDriver::duration_with_variance(duration, variance);
-            if new_duration < duration - duration / variance
-                || new_duration > duration + duration / variance
+            println!("new_duration: {new_duration:?}");
+            if new_duration < duration - expected_variance
+                || new_duration > duration + expected_variance
             {
                 panic!("new_duration: {new_duration:?} is not within the expected range",);
             }

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -45,6 +45,7 @@ pub(crate) struct KBucketStatus {
     pub(crate) total_peers: usize,
     pub(crate) total_relay_peers: usize,
     pub(crate) peers_in_non_full_buckets: usize,
+    #[cfg(feature = "open-metrics")]
     pub(crate) relay_peers_in_non_full_buckets: usize,
     pub(crate) num_of_full_buckets: usize,
     pub(crate) kbucket_table_stats: Vec<(usize, usize, u32)>,
@@ -405,6 +406,7 @@ impl SwarmDriver {
             total_peers,
             total_relay_peers,
             peers_in_non_full_buckets,
+            #[cfg(feature = "open-metrics")]
             relay_peers_in_non_full_buckets,
             num_of_full_buckets,
             kbucket_table_stats,

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -186,7 +186,7 @@ impl SwarmDriver {
 
                                 // Save cache to disk.
                                 crate::time::spawn(async move {
-                                    if let Err(err) = old_cache.sync_and_flush_to_disk(true) {
+                                    if let Err(err) = old_cache.sync_and_flush_to_disk() {
                                         error!("Failed to save bootstrap cache: {err}");
                                     }
                                 });

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -282,7 +282,7 @@ fn main() -> Result<()> {
         bootstrap_cache.write()?;
     } else {
         // Else we check/clean the file, write it back, and ensure its existence.
-        bootstrap_cache.sync_and_flush_to_disk(true)?;
+        bootstrap_cache.sync_and_flush_to_disk()?;
     }
 
     let msg = format!(


### PR DESCRIPTION
- We should not cleanup expired addrs from the cache as the network could be stale for a while. This moves the caches towards being more a fifo.
- The max bootstrap sync interval has been increased
- Fixed a bug with the variance calculation that led to values being all over the place.