### PR TITLE
Easy alpha for cli

### DIFF
--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -66,13 +66,14 @@ pub async fn connect_to_network_with_config(
     match res {
         Ok(client) => {
             info!("Connected to the Network");
-            progress_bar.finish_with_message("Connected to the Network");
+            progress_bar.finish_with_message(format!("Connected to the {network_id:?} Network"));
             let client = client.with_strategy(operation_config);
             Ok(client)
         }
         Err(e) => {
             error!("Failed to connect to the network: {e}");
-            progress_bar.finish_with_message("Failed to connect to the network");
+            progress_bar
+                .finish_with_message(format!("Failed to connect to the {network_id:?} Network"));
             let exit_code = connect_error_exit_code(&e);
             Err((
                 eyre!(e).wrap_err("Failed to connect to the network"),

--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::exit_code::{connect_error_exit_code, evm_util_error_exit_code, ExitCodeError};
+use crate::opt::NetworkId;
 use autonomi::client::config::ClientOperatingStrategy;
 use autonomi::{get_evm_network, Client, ClientConfig, InitialPeersConfig};
 use color_eyre::eyre::eyre;
@@ -15,15 +16,17 @@ use std::time::Duration;
 
 pub async fn connect_to_network(
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<Client, ExitCodeError> {
     connect_to_network_with_config(init_peers_config, Default::default(), network_id).await
 }
 
+/// Connect to the network with the given configuration.
+/// If the NetworkId is different from Custom, the InitialPeersConfig will be ignored.
 pub async fn connect_to_network_with_config(
     init_peers_config: InitialPeersConfig,
     operation_config: ClientOperatingStrategy,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<Client, ExitCodeError> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.enable_steady_tick(Duration::from_millis(120));
@@ -31,30 +34,40 @@ pub async fn connect_to_network_with_config(
     let new_style = progress_bar.style().tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈🔗");
     progress_bar.set_style(new_style);
 
-    if init_peers_config.local {
-        progress_bar.set_message("Connecting to a local Autonomi Network...");
-    } else {
-        progress_bar.set_message("Connecting to The Autonomi Network...");
+    let res = match network_id {
+        NetworkId::Local => {
+            progress_bar.set_message("Connecting to a local Autonomi Network...");
+            Client::init_local().await
+        }
+        NetworkId::Main => {
+            progress_bar.set_message("Connecting to The Autonomi Network...");
+            Client::init().await
+        }
+        NetworkId::Alpha => {
+            progress_bar.set_message("Connecting to the Alpha Autonomi Network...");
+            Client::init_alpha().await
+        }
+        NetworkId::Custom => {
+            progress_bar.set_message("Connecting to a custom Autonomi Network...");
+            let evm_network = get_evm_network(init_peers_config.local).map_err(|err| {
+                let exit_code = evm_util_error_exit_code(&err);
+                (err.into(), exit_code)
+            })?;
+            let config = ClientConfig {
+                init_peers_config,
+                evm_network,
+                strategy: operation_config.clone(),
+                network_id: None,
+            };
+            Client::init_with_config(config).await
+        }
     };
-
-    let evm_network = get_evm_network(init_peers_config.local).map_err(|err| {
-        let exit_code = evm_util_error_exit_code(&err);
-        (err.into(), exit_code)
-    })?;
-
-    let config = ClientConfig {
-        init_peers_config,
-        evm_network,
-        strategy: operation_config,
-        network_id,
-    };
-
-    let res = Client::init_with_config(config).await;
 
     match res {
         Ok(client) => {
             info!("Connected to the Network");
             progress_bar.finish_with_message("Connected to the Network");
+            let client = client.with_strategy(operation_config);
             Ok(client)
         }
         Err(e) => {

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -69,11 +69,6 @@ pub enum FileCmd {
         /// Upload the file as public. Everyone can see public data on the Network.
         #[arg(short, long)]
         public: bool,
-        /// Experimental: Optionally specify the quorum for the verification of the upload.
-        ///
-        /// Possible values are: "one", "majority", "all", n (where n is a number greater than 0)
-        #[arg(short, long, value_parser = parse_quorum)]
-        quorum: Option<Quorum>,
         /// Optional: Specify the maximum fee per gas in u128.
         #[arg(long)]
         max_fee_per_gas: Option<u128>,
@@ -252,18 +247,10 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Upload {
                 file,
                 public,
-                quorum,
                 max_fee_per_gas,
             } => {
-                if let Err((err, exit_code)) = file::upload(
-                    &file,
-                    public,
-                    opt.peers,
-                    quorum,
-                    max_fee_per_gas,
-                    opt.network_id,
-                )
-                .await
+                if let Err((err, exit_code)) =
+                    file::upload(&file, public, opt.peers, max_fee_per_gas, opt.network_id).await
                 {
                     eprintln!("{err:?}");
                     std::process::exit(exit_code);

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -353,7 +353,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 password,
             } => wallet::import(private_key, no_password, password),
             WalletCmd::Export => wallet::export(),
-            WalletCmd::Balance => wallet::balance(opt.peers.local).await,
+            WalletCmd::Balance => wallet::balance(opt.peers.local, opt.network_id).await,
         },
         Some(SubCmd::Analyze { addr, verbose }) => {
             analyze::analyze(&addr, verbose, opt.peers, opt.network_id).await

--- a/ant-cli/src/commands/analyze.rs
+++ b/ant-cli/src/commands/analyze.rs
@@ -13,11 +13,13 @@ use autonomi::{
 use color_eyre::eyre::Result;
 use std::str::FromStr;
 
+use crate::opt::NetworkId;
+
 pub async fn analyze(
     addr: &str,
     verbose: bool,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     macro_rules! println_if_verbose {
         ($($arg:tt)*) => {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::exit_code::{upload_exit_code, ExitCodeError, IO_ERROR};
+use crate::opt::NetworkId;
 use crate::utils::collect_upload_summary;
 use crate::wallet::load_wallet;
 use autonomi::client::config::ClientOperatingStrategy;
@@ -20,7 +21,7 @@ use std::path::PathBuf;
 pub async fn cost(
     file: &str,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
@@ -45,7 +46,7 @@ pub async fn upload(
     init_peers_config: InitialPeersConfig,
     optional_verification_quorum: Option<Quorum>,
     max_fee_per_gas: Option<u128>,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<(), ExitCodeError> {
     let mut config = ClientOperatingStrategy::new();
     if let Some(verification_quorum) = optional_verification_quorum {
@@ -158,7 +159,7 @@ pub async fn download(
     dest_path: &str,
     init_peers_config: InitialPeersConfig,
     quorum: Option<Quorum>,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<(), ExitCodeError> {
     let mut config = ClientOperatingStrategy::new();
     if let Some(quorum) = quorum {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -44,18 +44,10 @@ pub async fn upload(
     file: &str,
     public: bool,
     init_peers_config: InitialPeersConfig,
-    optional_verification_quorum: Option<Quorum>,
     max_fee_per_gas: Option<u128>,
     network_id: NetworkId,
 ) -> Result<(), ExitCodeError> {
-    let mut config = ClientOperatingStrategy::new();
-    if let Some(verification_quorum) = optional_verification_quorum {
-        config.chunks.verification_quorum = verification_quorum;
-    }
-
-    let mut client =
-        crate::actions::connect_to_network_with_config(init_peers_config, config, network_id)
-            .await?;
+    let mut client = crate::actions::connect_to_network(init_peers_config, network_id).await?;
 
     let mut wallet = load_wallet(client.evm_network()).map_err(|err| (err, IO_ERROR))?;
 

--- a/ant-cli/src/commands/register.rs
+++ b/ant-cli/src/commands/register.rs
@@ -8,6 +8,7 @@
 
 #![allow(deprecated)]
 
+use crate::opt::NetworkId;
 use crate::wallet::load_wallet;
 use autonomi::client::register::RegisterAddress;
 use autonomi::client::register::SecretKey as RegisterSecretKey;
@@ -39,7 +40,7 @@ pub fn generate_key(overwrite: bool) -> Result<()> {
 pub async fn cost(
     name: &str,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
@@ -64,7 +65,7 @@ pub async fn create(
     hex: bool,
     init_peers_config: InitialPeersConfig,
     max_fee_per_gas: Option<u128>,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
@@ -122,7 +123,7 @@ pub async fn edit(
     hex: bool,
     init_peers_config: InitialPeersConfig,
     max_fee_per_gas: Option<u128>,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let main_registers_key = crate::keys::get_register_signing_key()
         .wrap_err("The register key is required to perform this action")?;
@@ -182,7 +183,7 @@ pub async fn get(
     name: bool,
     hex: bool,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
@@ -245,7 +246,7 @@ pub async fn history(
     name: bool,
     hex: bool,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::opt::NetworkId;
 use crate::wallet::load_wallet;
 use autonomi::{InitialPeersConfig, TransactionConfig};
 use color_eyre::eyre::Context;
@@ -15,7 +16,7 @@ use color_eyre::Section;
 pub async fn cost(
     init_peers_config: InitialPeersConfig,
     expected_max_size: u64,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
@@ -37,7 +38,7 @@ pub async fn cost(
 pub async fn create(
     init_peers_config: InitialPeersConfig,
     max_fee_per_gas: Option<u128>,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
@@ -78,7 +79,7 @@ pub async fn create(
 pub async fn sync(
     force: bool,
     init_peers_config: InitialPeersConfig,
-    network_id: Option<u8>,
+    network_id: NetworkId,
 ) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
@@ -118,7 +119,7 @@ pub async fn sync(
     Ok(())
 }
 
-pub async fn load(init_peers_config: InitialPeersConfig, network_id: Option<u8>) -> Result<()> {
+pub async fn load(init_peers_config: InitialPeersConfig, network_id: NetworkId) -> Result<()> {
     let client = crate::actions::connect_to_network(init_peers_config, network_id)
         .await
         .map_err(|(err, _)| err)?;

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::opt::NetworkId;
 use crate::wallet::fs::{select_wallet_private_key, store_private_key};
 use crate::wallet::input::request_password;
 use crate::wallet::DUMMY_NETWORK;
-use autonomi::get_evm_network;
 use autonomi::Wallet;
 use color_eyre::eyre::eyre;
 use color_eyre::Result;
@@ -81,8 +81,8 @@ pub fn export() -> Result<()> {
     Ok(())
 }
 
-pub async fn balance(local: bool) -> Result<()> {
-    let network = get_evm_network(local)?;
+pub async fn balance(local: bool, network_id: NetworkId) -> Result<()> {
+    let network = network_id.evm_network(local)?;
     let wallet = crate::wallet::load_wallet(&network)?;
 
     let token_balance = wallet.balance_of_tokens().await?;

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -102,6 +102,7 @@ pub(crate) fn bootstrap_error_exit_code(err: &BootstrapError) -> i32 {
 
 pub(crate) fn connect_error_exit_code(err: &ConnectError) -> i32 {
     match err {
+        ConnectError::EvmNetworkError(_) => 61,
         ConnectError::Bootstrap(error) => bootstrap_error_exit_code(error),
         ConnectError::TimedOut => 59,
         ConnectError::TimedOutWithIncompatibleProtocol(_, _) => 60,

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -27,13 +27,14 @@ use color_eyre::Result;
 use ant_logging::metrics::init_metrics;
 use ant_logging::{LogBuilder, LogFormat, ReloadHandle, WorkerGuard};
 use autonomi::version;
+use opt::NetworkId;
 use opt::Opt;
 use tracing::Level;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install().expect("Failed to initialise error handler");
-    let opt = Opt::parse();
+    let mut opt = Opt::parse();
 
     // The clone is necessary to resolve a clippy warning related to a mutex.
     let identify_protocol_str = version::IDENTIFY_PROTOCOL_STR
@@ -71,6 +72,9 @@ async fn main() -> Result<()> {
     let _log_guards = init_logging_and_metrics(&opt)?;
     if opt.peers.local {
         tokio::spawn(init_metrics(std::process::id()));
+
+        // --local flag overrides the network ID
+        opt.network_id = NetworkId::Local;
     }
 
     info!("\"{}\"", std::env::args().collect::<Vec<_>>().join(" "));

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -34,9 +34,6 @@ use tracing::Level;
 async fn main() -> Result<()> {
     color_eyre::install().expect("Failed to initialise error handler");
     let opt = Opt::parse();
-    if let Some(network_id) = opt.network_id {
-        version::set_network_id(network_id);
-    }
 
     // The clone is necessary to resolve a clippy warning related to a mutex.
     let identify_protocol_str = version::IDENTIFY_PROTOCOL_STR

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -237,7 +237,7 @@ impl Client {
             let mut upload_tasks = vec![];
             #[cfg(feature = "loud")]
             let total_chunks = chunks.len();
-            for (i, &chunk) in chunks.iter().enumerate() {
+            for (_i, &chunk) in chunks.iter().enumerate() {
                 let self_clone = self.clone();
                 let address = *chunk.address();
 
@@ -246,7 +246,7 @@ impl Client {
                     #[cfg(feature = "loud")]
                     println!(
                         "({}/{}) Chunk stored at: {} (skipping, already exists)",
-                        i + 1,
+                        _i + 1,
                         chunks.len(),
                         chunk.address().to_hex()
                     );
@@ -266,7 +266,7 @@ impl Client {
                         Ok(_addr) => {
                             println!(
                                 "({}/{}) Chunk stored at: {}",
-                                i + 1,
+                                _i + 1,
                                 total_chunks,
                                 chunk.address().to_hex()
                             );
@@ -274,7 +274,7 @@ impl Client {
                         Err((_chunk, ref err)) => {
                             println!(
                                 "({}/{}) Chunk failed to be stored at: {} ({err})",
-                                i + 1,
+                                _i + 1,
                                 total_chunks,
                                 chunk.address().to_hex()
                             );


### PR DESCRIPTION
The `network-id` flag can now be used as the SOLE config option to connect to various networks (no need to provide other flags):
```
ant --network-id=2 file download ...
```

More info:

```
      --network-id <NETWORK_ID>
          Specify the network ID to use. This will allow you to run the CLI on a different network.
          Note that this overrides all other network config options (except in the Custom Network
          case).
          
          Valid values are:
           - 0: Local Network
           - 1: Mainnet (default)
           - 2: Alpha Network
           - 3: Custom Network (obtained through environment variables and other network config flags)
          
          [default: 1]
```

