### PR TITLE
chore: reduce non-mandatory loggings

### DIFF
--- a/ant-networking/src/cmd.rs
+++ b/ant-networking/src/cmd.rs
@@ -590,7 +590,7 @@ impl SwarmDriver {
 
                             match self.swarm.dial(opts) {
                                 Ok(()) => {
-                                    info!("Dialing peer {peer:?} for req_resp with address: {addrs:?}",);
+                                    debug!("Dialing peer {peer:?} for req_resp with address: {addrs:?}",);
                                 }
                                 Err(err) => {
                                     error!("Failed to dial peer {peer:?} for req_resp with address: {addrs:?} error: {err}",);

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -111,7 +111,7 @@ impl SwarmDriver {
 
                 event_string = "relay_server_event";
 
-                info!(?event, "relay server event");
+                debug!(?event, "relay server event");
 
                 match *event {
                     libp2p::relay::Event::ReservationReqAccepted {


### PR DESCRIPTION

### Description

Contains following reductions:
    1. Reduce two node logs of GetVersion from Debug to Trace
    2. Reduce one node log of Fetched Version from Info to Trace
    3. Reduce one network log of Dial before Request from Info to Debug
    4. Reduce two network logs of Circuit from Info to Debug

There shall be no longer following periodical logs flushed to disk and ELK:
```
{"level":"INFO","message":"relay server event","event":"CircuitReqAccepted { ... }","target":"ant_networking::event::swarm"}
{"level":"INFO","message":"relay server event","event":"CircuitClosed { ... }","target":"ant_networking::event::swarm"}
{"level":"INFO","message":"Dialing peer ... for req_resp with address: ...","target":"ant_networking::cmd"}
{"level":"INFO","message":"Fetched peer version ...","target":"ant_node::node"}
{"level":"DEBUG","message":"Handling NetworkEvent \"NetworkEvent::QueryRequestReceived(GetVersion(...))\"","target":"ant_node::node"}
{"level":"DEBUG","message":"Sending response Query(GetVersion ...) has version of \"2025.4.1.1\")","target":"ant_node::node"}
```

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
