### PR TITLE
chore: avoid extra escape backslash in json format

### DIFF
--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -432,7 +432,7 @@ impl Node {
         let start = Instant::now();
         let event_string = format!("{event:?}");
         let event_header;
-        debug!("Handling NetworkEvent {event_string:?}");
+        debug!("Handling {event_string}");
 
         match event {
             NetworkEvent::PeerAdded(peer_id, connected_peers) => {


### PR DESCRIPTION
### Description

avoid extra escape backslash when logging in json format.
Previously, the raw log message looks like:
```
Handling NetworkEvent "NetworkEvent::PeerAdded(PeerId(\"12D3KooWJWeHoz4KCmX9jNcqMGEkk3qEBfTabRrbWWmVw8cGGGVA\"), 1)"
```
and corresponde json format log is:
```
Handling NetworkEvent \"NetworkEvent::PeerAdded(PeerId(\\\"12D3KooWJWeHoz4KCmX9jNcqMGEkk3qEBfTabRrbWWmVw8cGGGVA\\\"), 1)\"
```

It's now changed to:
```
Handling NetworkEvent::PeerAdded(PeerId("12D3KooWJWeHoz4KCmX9jNcqMGEkk3qEBfTabRrbWWmVw8cGGGVA"), 1)
```
and corresponde json format log is:
```
Handling NetworkEvent::PeerAdded(PeerId(\"12D3KooWJWeHoz4KCmX9jNcqMGEkk3qEBfTabRrbWWmVw8cGGGVA\"), 1)
```

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
