### PR TITLE
feat(cli): batch entire quote-pay-upload flow to overcome quote expiracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5276,8 +5276,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "bytes",
  "either",
@@ -5313,8 +5312,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5324,8 +5322,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297bfc6cabb70c6180707f8fa05661b77ecb9cb67e8e8e1c469301358fa21d0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5349,8 +5346,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5360,8 +5356,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "either",
  "fnv",
@@ -5379,15 +5374,14 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.11",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "async-trait",
  "futures",
@@ -5402,8 +5396,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec",
@@ -5434,8 +5427,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5474,8 +5466,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5502,8 +5493,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -5521,8 +5511,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5539,8 +5528,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5563,8 +5551,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5585,8 +5572,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a41e346681395877118c270cf993f90d57d045fbf0913ca2f07b59ec6062e4"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5609,8 +5595,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -5628,8 +5613,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "either",
  "fnv",
@@ -5651,11 +5635,9 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
  "quote",
  "syn 2.0.96",
 ]
@@ -5663,8 +5645,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5679,8 +5660,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaebc1069dea12c5b86a597eaaddae0317c2c2cb9ec99dc94f82fd340f5c78b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5698,8 +5678,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5713,8 +5692,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf5d48a4d8fad8a49fbf23816a878cac25623549f415d74da8ef4327e6196a9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "either",
  "futures",
@@ -5734,8 +5712,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "either",
  "futures",
@@ -6035,7 +6012,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -6058,7 +6035,7 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6070,15 +6047,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -7432,14 +7408,13 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
+ "thiserror 2.0.11",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -8187,8 +8162,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#82c81af51dba5768fa1dbadee70398120f5e618d"
 dependencies = [
  "futures",
  "pin-project",
@@ -9685,12 +9659,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }
 dirs-next = "~2.0.0"
 futures = "0.3.30"
-libp2p = { version = "0.55.0", features = ["serde"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["serde"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -17,7 +17,7 @@ test-utils = []
 custom_debug = "~0.6.1"
 evmlib = { path = "../evmlib", version = "0.3.0" }
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 ring = "0.17.12"
 rmp-serde = "1.1.1"

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -34,7 +34,7 @@ hyper = { version = "0.14", features = [
     "http1",
 ], optional = true }
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [
     "tokio",
     "dns",
     "upnp",

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -42,7 +42,7 @@ colored = "2.0.4"
 color-eyre = "0.6.3"
 dirs-next = "2.0.0"
 indicatif = { version = "0.17.5", features = ["tokio"] }
-libp2p = { version = "0.55.0", features = [] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 rand = "0.8.5"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -27,7 +27,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["kad"]}
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -44,7 +44,7 @@ file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = ["tokio", "dns", "kad", "macros"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["tokio", "dns", "kad", "macros"] }
 num-traits = "0.2"
 prometheus-client = { version = "0.22", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -23,7 +23,7 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 prometheus-client = { version = "0.22" }
 prost = { version = "0.9", optional = true }
 rand = "0.8"

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -16,7 +16,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.49" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.4", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
-libp2p = { version = "0.55.0", features = ["kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["kad"] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -39,7 +39,7 @@ const-hex = "1.12.0"
 eyre = "0.6.5"
 futures = "0.3.30"
 hex = "~0.4.3"
-libp2p = "0.55.0"
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout" }
 pyo3 = { version = "0.23.4", optional = true, features = ["extension-module", "abi3-py38"] }
 pyo3-async-runtimes = { version = "0.23", optional = true, features = ["tokio-runtime"] }
 rand = "0.8.5"

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -15,18 +15,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::archive_private::{PrivateArchive, PrivateArchiveDataMap};
-use super::{get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE};
-use super::{DownloadError, UploadError};
+use super::{get_relative_file_path_from_abs_file_and_folder_path, FILE_ENCRYPT_BATCH_SIZE};
+use super::{CombinedChunks, DownloadError, UploadError};
 
 use crate::client::payment::PaymentOption;
-use crate::client::PutError;
 use crate::client::{data_types::chunk::DataMapChunk, utils::process_tasks_with_max_concurrency};
 use crate::self_encryption::encrypt;
 use crate::{AttoTokens, Client};
-use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
-use xor_name::XorName;
 
 impl Client {
     /// Download a private file from network to local file system
@@ -69,8 +66,6 @@ impl Client {
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PrivateArchive), UploadError> {
         info!("Uploading directory as private: {dir_path:?}");
-        let start = tokio::time::Instant::now();
-
         let mut encryption_tasks = vec![];
 
         for entry in walkdir::WalkDir::new(&dir_path) {
@@ -106,11 +101,6 @@ impl Client {
 
                 debug!("Encryption of {file_path:?} took: {:.2?}", now.elapsed());
 
-                let xor_names: Vec<_> = chunks
-                    .iter()
-                    .map(|chunk| (*chunk.name(), chunk.size()))
-                    .collect();
-
                 let metadata = super::fs_public::metadata_from_entry(&entry);
 
                 let relative_path =
@@ -118,29 +108,26 @@ impl Client {
 
                 Ok((
                     file_path.to_string_lossy().to_string(),
-                    xor_names,
                     chunks,
                     (relative_path, DataMapChunk::from(data_map_chunk), metadata),
                 ))
             });
         }
 
-        let mut combined_xor_names: Vec<(XorName, usize)> = vec![];
-        let mut combined_chunks: Vec<(String, Vec<Chunk>)> = vec![];
+        let mut combined_chunks: CombinedChunks = vec![];
         let mut private_archive = PrivateArchive::new();
 
         let encryption_results =
-            process_tasks_with_max_concurrency(encryption_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+            process_tasks_with_max_concurrency(encryption_tasks, *FILE_ENCRYPT_BATCH_SIZE).await;
 
         for encryption_result in encryption_results {
             match encryption_result {
-                Ok((file_path, xor_names, chunked_file, file_data)) => {
+                Ok((file_path, chunked_file, file_data)) => {
                     info!("Successfully encrypted file: {file_path:?}");
                     #[cfg(feature = "loud")]
                     println!("Successfully encrypted file: {file_path:?}");
 
-                    combined_xor_names.extend(xor_names);
-                    combined_chunks.push((file_path, chunked_file));
+                    combined_chunks.push(((file_path, None), chunked_file));
                     let (relative_path, data_map_chunk, file_metadata) = file_data;
                     private_archive.add_file(relative_path, data_map_chunk, file_metadata);
                 }
@@ -150,79 +137,7 @@ impl Client {
             }
         }
 
-        info!("Quoting for {} chunks..", combined_xor_names.len());
-        #[cfg(feature = "loud")]
-        println!("Quoting for {} chunks..", combined_xor_names.len());
-
-        let (receipt, skipped_payments_amount) = self
-            .pay_for_content_addrs(
-                DataTypes::Chunk,
-                combined_xor_names.into_iter(),
-                payment_option,
-            )
-            .await
-            .inspect_err(|err| error!("Error paying for data: {err:?}"))
-            .map_err(PutError::from)?;
-
-        info!("{skipped_payments_amount} chunks were free");
-
-        let files_to_upload_amount = combined_chunks.len();
-
-        let mut upload_tasks = vec![];
-
-        for (name, chunks) in combined_chunks {
-            let receipt_clone = receipt.clone();
-
-            upload_tasks.push(async move {
-                info!("Uploading file: {name} ({} chunks)..", chunks.len());
-                #[cfg(feature = "loud")]
-                println!("Uploading file: {name} ({} chunks)..", chunks.len());
-
-                // todo: handle failed uploads
-                let mut failed_uploads = self
-                    .upload_chunks_with_retries(chunks.iter().collect(), &receipt_clone)
-                    .await;
-
-                let chunks_uploaded = chunks.len() - failed_uploads.len();
-
-                // Return the last chunk upload error
-                if let Some(last_chunk_fail) = failed_uploads.pop() {
-                    error!(
-                        "Error uploading chunk ({:?}): {:?}",
-                        last_chunk_fail.0.address(),
-                        last_chunk_fail.1
-                    );
-
-                    (name, Err(UploadError::from(last_chunk_fail.1)))
-                } else {
-                    info!("Successfully uploaded {name} ({} chunks)", chunks.len());
-                    #[cfg(feature = "loud")]
-                    println!("Successfully uploaded {name} ({} chunks)", chunks.len());
-
-                    (name, Ok(chunks_uploaded))
-                }
-            });
-        }
-
-        let uploads =
-            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
-
-        info!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        #[cfg(feature = "loud")]
-        println!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        let total_cost = self
-            .process_upload_results(uploads, receipt, skipped_payments_amount)
-            .await?;
+        let total_cost = self.pay_and_upload(payment_option, combined_chunks).await?;
 
         Ok((total_cost, private_archive))
     }

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -7,20 +7,18 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::archive_public::{ArchiveAddress, PublicArchive};
-use super::{DownloadError, FileCostError, Metadata, UploadError};
+use super::{CombinedChunks, DownloadError, FileCostError, Metadata, UploadError};
 use crate::client::high_level::files::{
-    get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE,
+    get_relative_file_path_from_abs_file_and_folder_path, FILE_ENCRYPT_BATCH_SIZE,
 };
 use crate::client::payment::PaymentOption;
+use crate::client::Client;
 use crate::client::{high_level::data::DataAddress, utils::process_tasks_with_max_concurrency};
-use crate::client::{Client, PutError};
 use crate::self_encryption::encrypt;
 use crate::AttoTokens;
 use ant_networking::time::{Duration, SystemTime};
-use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
-use xor_name::XorName;
 
 impl Client {
     /// Download file from network to local file system
@@ -70,7 +68,6 @@ impl Client {
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PublicArchive), UploadError> {
         info!("Uploading directory: {dir_path:?}");
-        let start = tokio::time::Instant::now();
 
         let mut encryption_tasks = vec![];
 
@@ -111,11 +108,6 @@ impl Client {
 
                 chunks.push(data_map_chunk);
 
-                let xor_names: Vec<_> = chunks
-                    .iter()
-                    .map(|chunk| (*chunk.name(), chunk.size()))
-                    .collect();
-
                 let metadata = metadata_from_entry(&entry);
 
                 let relative_path =
@@ -123,30 +115,27 @@ impl Client {
 
                 Ok((
                     file_path.to_string_lossy().to_string(),
-                    xor_names,
                     chunks,
                     (relative_path, DataAddress::new(data_address), metadata),
                 ))
             });
         }
 
-        let mut combined_xor_names: Vec<(XorName, usize)> = vec![];
-        let mut combined_chunks: Vec<((String, DataAddress), Vec<Chunk>)> = vec![];
+        let mut combined_chunks: CombinedChunks = vec![];
         let mut public_archive = PublicArchive::new();
 
         let encryption_results =
-            process_tasks_with_max_concurrency(encryption_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+            process_tasks_with_max_concurrency(encryption_tasks, *FILE_ENCRYPT_BATCH_SIZE).await;
 
         for encryption_result in encryption_results {
             match encryption_result {
-                Ok((file_path, xor_names, chunks, file_data)) => {
+                Ok((file_path, chunks, file_data)) => {
                     info!("Successfully encrypted file: {file_path:?}");
                     #[cfg(feature = "loud")]
                     println!("Successfully encrypted file: {file_path:?}");
 
-                    combined_xor_names.extend(xor_names);
                     let (relative_path, data_address, file_metadata) = file_data;
-                    combined_chunks.push(((file_path, data_address), chunks));
+                    combined_chunks.push(((file_path, Some(data_address)), chunks));
                     public_archive.add_file(relative_path, data_address, file_metadata);
                 }
                 Err(err_msg) => {
@@ -155,87 +144,7 @@ impl Client {
             }
         }
 
-        info!("Quoting for {} chunks..", combined_xor_names.len());
-        #[cfg(feature = "loud")]
-        println!("Quoting for {} chunks..", combined_xor_names.len());
-
-        let (receipt, skipped_payments_amount) = self
-            .pay_for_content_addrs(
-                DataTypes::Chunk,
-                combined_xor_names.into_iter(),
-                payment_option,
-            )
-            .await
-            .inspect_err(|err| error!("Error paying for data: {err:?}"))
-            .map_err(PutError::from)?;
-
-        info!("{skipped_payments_amount} chunks were free");
-
-        let files_to_upload_amount = combined_chunks.len();
-
-        let mut upload_tasks = vec![];
-
-        for ((name, data_address), chunks) in combined_chunks {
-            let receipt_clone = receipt.clone();
-
-            upload_tasks.push(async move {
-                info!("Uploading file: {name} ({} chunks)..", chunks.len());
-                #[cfg(feature = "loud")]
-                println!("Uploading file: {name} ({} chunks)..", chunks.len());
-
-                // todo: handle failed uploads
-                let mut failed_uploads = self
-                    .upload_chunks_with_retries(chunks.iter().collect(), &receipt_clone)
-                    .await;
-
-                let chunks_uploaded = chunks.len() - failed_uploads.len();
-
-                // Return the last chunk upload error
-                if let Some(last_chunk_fail) = failed_uploads.pop() {
-                    error!(
-                        "Error uploading chunk ({:?}): {:?}",
-                        last_chunk_fail.0.address(),
-                        last_chunk_fail.1
-                    );
-
-                    (name, Err(UploadError::from(last_chunk_fail.1)))
-                } else {
-                    info!(
-                        "Successfully uploaded {name} ({} chunks) to: {}",
-                        chunks.len(),
-                        hex::encode(data_address.xorname())
-                    );
-                    #[cfg(feature = "loud")]
-                    println!(
-                        "Successfully uploaded {name} ({} chunks) to: {}",
-                        chunks.len(),
-                        hex::encode(data_address.xorname())
-                    );
-
-                    (name, Ok(chunks_uploaded))
-                }
-            });
-        }
-
-        let uploads =
-            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
-
-        info!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        #[cfg(feature = "loud")]
-        println!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        let total_cost = self
-            .process_upload_results(uploads, receipt, skipped_payments_amount)
-            .await?;
+        let total_cost = self.pay_and_upload(payment_option, combined_chunks).await?;
 
         Ok((total_cost, public_archive))
     }

--- a/autonomi/src/client/high_level/files/fs_shared.rs
+++ b/autonomi/src/client/high_level/files/fs_shared.rs
@@ -1,57 +1,215 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::CombinedChunks;
+use crate::client::high_level::data::DataAddress;
+use crate::client::payment::PaymentOption;
 use crate::client::payment::Receipt;
-use crate::client::{ClientEvent, UploadSummary};
+use crate::client::{ClientEvent, PutError, UploadSummary};
 use crate::files::UploadError;
 use crate::Client;
 use ant_evm::{Amount, AttoTokens};
+use ant_protocol::storage::{Chunk, DataTypes};
+use std::sync::LazyLock;
+
+/// Number of batch size of an entire quote-pay-upload flow to process.
+/// This is mainly to avoid upload failure due to quote expiracy (1 hour).
+/// Suggested to be the hourly throughput of the chunks can be handled.
+///
+/// Can be overridden by the `UPLOAD_FLOW_BATCH_SIZE` environment variable.
+static UPLOAD_FLOW_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("UPLOAD_FLOW_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    info!("Upload flow batch size: {}", batch_size);
+    batch_size
+});
 
 impl Client {
-    pub(crate) async fn process_upload_results(
+    /// Processes upload results and calculates total cost
+    /// Returns total tokens spent or the first encountered upload error
+    async fn calculate_total_cost(
         &self,
-        uploads: Vec<(String, Result<usize, UploadError>)>,
-        receipt: Receipt,
-        skipped_payments_amount: usize,
+        upload_results: Vec<(String, Result<usize, UploadError>)>,
+        payment_receipts: Vec<Receipt>,
+        free_chunks_counts: Vec<usize>,
     ) -> Result<AttoTokens, UploadError> {
-        let mut total_chunks_uploaded = 0;
-        let mut last_err: Option<UploadError> = None;
-
-        for (name, result) in uploads {
-            match result {
-                Ok(chunks_uploaded) => {
-                    total_chunks_uploaded += chunks_uploaded;
+        // Process upload results and track errors
+        let (total_uploaded, last_error) = upload_results.into_iter().fold(
+            (0, None),
+            |(mut total, mut last_err), (file_name, result)| {
+                match result {
+                    Ok(chunks_uploaded) => total += chunks_uploaded,
+                    Err(err) => {
+                        error!("Failed to upload file {file_name}: {err:?}");
+                        #[cfg(feature = "loud")]
+                        println!("Failed to upload file {file_name}: {err:?}");
+                        last_err = Some(err);
+                    }
                 }
-                Err(err) => {
-                    error!("Error uploading file {name}: {err:?}");
-                    #[cfg(feature = "loud")]
-                    println!("Error uploading file {name}: {err:?}");
+                (total, last_err)
+            },
+        );
 
-                    last_err = Some(err);
-                }
-            }
-        }
-
-        // todo: bundle the errors together in a new error type
-        // Throw an error if not all files were uploaded successfully
-        if let Some(err) = last_err {
+        // Return early if any upload failed
+        if let Some(err) = last_error {
             return Err(err);
         }
 
-        let tokens_spent = receipt
-            .values()
-            .map(|(_, cost)| cost.as_atto())
-            .sum::<Amount>();
+        // Calculate total tokens spent across all receipts
+        let total_tokens: Amount = payment_receipts
+            .into_iter()
+            .flat_map(|receipt| receipt.into_values().map(|(_, cost)| cost.as_atto()))
+            .sum();
 
-        // Reporting
-        if let Some(channel) = self.client_event_sender.as_ref() {
+        let total_free_chunks = free_chunks_counts.iter().sum::<usize>();
+
+        // Send completion event if channel exists
+        if let Some(sender) = &self.client_event_sender {
             let summary = UploadSummary {
-                records_paid: total_chunks_uploaded.saturating_sub(skipped_payments_amount),
-                records_already_paid: skipped_payments_amount,
-                tokens_spent,
+                records_paid: total_uploaded.saturating_sub(total_free_chunks),
+                records_already_paid: total_free_chunks,
+                tokens_spent: total_tokens,
             };
-            if let Err(err) = channel.send(ClientEvent::UploadComplete(summary)).await {
-                error!("Failed to send client event: {err:?}");
+
+            if let Err(err) = sender.send(ClientEvent::UploadComplete(summary)).await {
+                error!("Failed to send upload completion event: {err:?}");
             }
         }
 
-        Ok(AttoTokens::from_atto(tokens_spent))
+        Ok(AttoTokens::from_atto(total_tokens))
+    }
+
+    /// Processes file uploads with payment in batches
+    /// Returns total cost of uploads or error if any upload fails
+    pub(crate) async fn pay_and_upload(
+        &self,
+        payment_option: PaymentOption,
+        combined_chunks: CombinedChunks,
+    ) -> Result<AttoTokens, UploadError> {
+        let start = tokio::time::Instant::now();
+        let total_files = combined_chunks.len();
+        let mut upload_results = Vec::with_capacity(total_files);
+        let mut receipts = Vec::new();
+        let mut free_chunks_counts = Vec::new();
+
+        // Process each file's chunks in batches
+        for ((file_name, data_address), mut chunks) in combined_chunks {
+            info!("Processing file: {file_name} ({} chunks)", chunks.len());
+            #[cfg(feature = "loud")]
+            println!("Processing file: {file_name} ({} chunks)", chunks.len());
+
+            // Process all chunks for this file in batches
+            while !chunks.is_empty() {
+                self.process_chunk_batch(
+                    &file_name,
+                    data_address,
+                    &mut chunks,
+                    &mut upload_results,
+                    &mut receipts,
+                    &mut free_chunks_counts,
+                    payment_option.clone(),
+                )
+                .await?;
+            }
+        }
+
+        info!(
+            "Upload of {total_files} files completed in {:?}",
+            start.elapsed()
+        );
+        #[cfg(feature = "loud")]
+        println!(
+            "Upload of {total_files} files completed in {:?}",
+            start.elapsed()
+        );
+
+        self.calculate_total_cost(upload_results, receipts, free_chunks_counts)
+            .await
+    }
+
+    /// Processes a single batch of chunks (quote -> pay -> upload)
+    /// Returns error if any chunk in batch fails to upload
+    #[allow(clippy::too_many_arguments)]
+    async fn process_chunk_batch(
+        &self,
+        file_name: &str,
+        data_address: Option<DataAddress>,
+        remaining_chunks: &mut Vec<Chunk>,
+        upload_results: &mut Vec<(String, Result<usize, UploadError>)>,
+        receipts: &mut Vec<Receipt>,
+        free_chunks_counts: &mut Vec<usize>,
+        payment_option: PaymentOption,
+    ) -> Result<(), UploadError> {
+        // Take next batch of chunks (up to UPLOAD_FLOW_BATCH_SIZE)
+        let batch: Vec<_> = remaining_chunks
+            .drain(..std::cmp::min(remaining_chunks.len(), *UPLOAD_FLOW_BATCH_SIZE))
+            .collect();
+
+        // Prepare payment info for batch
+        let payment_info: Vec<_> = batch
+            .iter()
+            .map(|chunk| (*chunk.name(), chunk.size()))
+            .collect();
+
+        info!("Processing batch of {} chunks", batch.len());
+        #[cfg(feature = "loud")]
+        println!("Processing batch of {} chunks", batch.len());
+
+        // Process payment for this batch
+        let (receipt, free_chunks) = self
+            .pay_for_content_addrs(DataTypes::Chunk, payment_info.into_iter(), payment_option)
+            .await
+            .inspect_err(|err| error!("Payment failed: {err:?}"))
+            .map_err(PutError::from)?;
+
+        if free_chunks > 0 {
+            info!("{free_chunks} chunks were free in this batch");
+        }
+
+        // Upload all chunks in batch with retries
+        let mut failed_uploads = self
+            .upload_chunks_with_retries(batch.iter().collect(), &receipt)
+            .await;
+        let successful_uploads = batch.len() - failed_uploads.len();
+
+        // Handle upload results
+        let result = match failed_uploads.pop() {
+            Some((chunk, error)) => {
+                error!("Failed to upload chunk ({:?}): {error:?}", chunk.address());
+                (file_name.to_string(), Err(UploadError::from(error)))
+            }
+            None => {
+                let destination = data_address
+                    .as_ref()
+                    .map(|addr| format!(" to: {}", hex::encode(addr.xorname())))
+                    .unwrap_or_default();
+
+                info!(
+                    "Successfully uploaded {file_name} ({} chunks){destination}",
+                    batch.len()
+                );
+                #[cfg(feature = "loud")]
+                println!(
+                    "Successfully uploaded {file_name} ({} chunks){destination}",
+                    batch.len()
+                );
+
+                (file_name.to_string(), Ok(successful_uploads))
+            }
+        };
+
+        // Store results
+        upload_results.push(result);
+        receipts.push(receipt);
+        free_chunks_counts.push(free_chunks);
+
+        Ok(())
     }
 }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }
 futures = "~0.3.13"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [
     "tokio",
     "tcp",
     "noise",

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.3.0" }
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Description

Due to the limitation of quote expiracy (1 hour), the current `quote all, then upload all` flow blocks user with poor connection to upload big files or directory containing many files.

This PR change to `batch entire quote-pay-upload flow`, on per-file and rolling window size on chunks level.

Changes to the environment settings:
* `FILE_ENCRYPT_BATCH_SIZE` : newly added, default to `num_of_thread_parallism * 8`
* `FILE_UPLOAD_BATCH_SIZE` : no longer effective for most cases, only used within Vault upload.
* `UPLOAD_FLOW_BATCH_SIZE`: newly added, default to `50` . This is mainly to avoid upload failure due to quote expiracy (1 hour). Suggested to be the hourly throughput of the chunks can be handled.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
