### PR TITLE
feat: provide `--alpha` argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ version = "0.3.13"
 dependencies = [
  "ant-build-info",
  "ant-logging",
+ "ant-protocol",
  "autonomi",
  "clap",
  "color-eyre",

--- a/ant-bootstrap/src/contacts.rs
+++ b/ant-bootstrap/src/contacts.rs
@@ -21,6 +21,13 @@ const MAINNET_CONTACTS: &[&str] = &[
     "http://139.59.201.153/bootstrap_cache.json",
     "http://139.59.200.27/bootstrap_cache.json",
 ];
+const ALPHANET_CONTACTS: &[&str] = &[
+    "http://188.166.133.208/bootstrap_cache.json",
+    "http://188.166.133.125/bootstrap_cache.json",
+    "http://178.128.137.64/bootstrap_cache.json",
+    "http://159.223.242.7/bootstrap_cache.json",
+    "http://143.244.197.147/bootstrap_cache.json",
+];
 
 /// The client fetch timeout
 const FETCH_TIMEOUT_SECS: u64 = 30;
@@ -74,6 +81,17 @@ impl ContactsFetcher {
             .map(|url| url.parse().expect("Failed to parse static URL"))
             .collect();
         fetcher.endpoints = mainnet_contact;
+        Ok(fetcher)
+    }
+
+    /// Create a new struct with the alphanet endpoints
+    pub fn with_alphanet_endpoints() -> Result<Self> {
+        let mut fetcher = Self::new()?;
+        let alphanet_contact = ALPHANET_CONTACTS
+            .iter()
+            .map(|url| url.parse().expect("Failed to parse static URL"))
+            .collect();
+        fetcher.endpoints = alphanet_contact;
         Ok(fetcher)
     }
 

--- a/ant-bootstrap/src/initial_peers.rs
+++ b/ant-bootstrap/src/initial_peers.rs
@@ -12,19 +12,19 @@ use crate::{
     error::{Error, Result},
     BootstrapAddr, BootstrapCacheConfig, BootstrapCacheStore, ContactsFetcher,
 };
+use ant_protocol::version::{get_network_id, MAINNET_ID};
 use clap::Args;
 use libp2p::Multiaddr;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
 /// The name of the environment variable that can be used to pass peers to the node.
 pub const ANT_PEERS_ENV: &str = "ANT_PEERS";
 
-/// Configurations to fetch the initial peers which is used to bootstrap the network.
-/// This could optionally also be used as a command line argument struct.
+/// Previous version of InitialPeersConfig with the disable_mainnet_contacts field
 #[derive(Args, Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct InitialPeersConfig {
+pub struct InitialPeersConfigV0 {
     /// Set to indicate this is the first node in a new network
     ///
     /// If this argument is used, any others will be ignored because they do not apply to the first
@@ -77,9 +77,75 @@ pub struct InitialPeersConfig {
     pub bootstrap_cache_dir: Option<PathBuf>,
 }
 
+/// Latest version of InitialPeersConfig without the disable_mainnet_contacts field
+#[derive(Args, Debug, Clone, Default, PartialEq, Serialize)]
+pub struct InitialPeersConfigV1 {
+    /// Set to indicate this is the first node in a new network
+    ///
+    /// If this argument is used, any others will be ignored because they do not apply to the first
+    /// node.
+    #[clap(long, default_value = "false")]
+    pub first: bool,
+    /// Addr(s) to use for bootstrap, in a 'multiaddr' format containing the peer ID.
+    ///
+    /// A multiaddr looks like
+    /// '/ip4/1.2.3.4/tcp/1200/tcp/p2p/12D3KooWRi6wF7yxWLuPSNskXc6kQ5cJ6eaymeMbCRdTnMesPgFx' where
+    /// `1.2.3.4` is the IP, `1200` is the port and the (optional) last part is the peer ID.
+    ///
+    /// This argument can be provided multiple times to connect to multiple peers.
+    ///
+    /// Alternatively, the `ANT_PEERS` environment variable can provide a comma-separated peer
+    /// list.
+    #[clap(
+        long = "peer",
+        value_name = "multiaddr",
+        value_delimiter = ',',
+        conflicts_with = "first"
+    )]
+    pub addrs: Vec<Multiaddr>,
+    /// Specify the URL to fetch the network contacts from.
+    ///
+    /// The URL can point to a text file containing Multiaddresses separated by newline character, or
+    /// a bootstrap cache JSON file.
+    #[clap(long, conflicts_with = "first", value_delimiter = ',')]
+    pub network_contacts_url: Vec<String>,
+    /// Set to indicate this is a local network.
+    #[clap(long, conflicts_with = "network_contacts_url", default_value = "false")]
+    pub local: bool,
+    /// Set to not load the bootstrap addresses from the local cache.
+    #[clap(long, default_value = "false")]
+    pub ignore_cache: bool,
+    /// The directory to load and store the bootstrap cache. If not provided, the default path will be used.
+    ///
+    /// The JSON filename will be derived automatically from the network ID
+    ///
+    /// The default location is platform specific:
+    ///  - Linux: $HOME/.local/share/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
+    ///  - macOS: $HOME/Library/Application Support/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
+    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\bootstrap_cache/bootstrap_cache_<network_id>.json
+    #[clap(long)]
+    pub bootstrap_cache_dir: Option<PathBuf>,
+}
+
+impl From<InitialPeersConfigV0> for InitialPeersConfigV1 {
+    fn from(v0: InitialPeersConfigV0) -> Self {
+        Self {
+            first: v0.first,
+            addrs: v0.addrs,
+            network_contacts_url: v0.network_contacts_url,
+            local: v0.local,
+            ignore_cache: v0.ignore_cache,
+            bootstrap_cache_dir: v0.bootstrap_cache_dir,
+        }
+    }
+}
+
+pub type InitialPeersConfig = InitialPeersConfigV1;
+
 impl InitialPeersConfig {
-    /// Get bootstrap peers sorted by the failure rate. The peer with the lowest failure rate will be
-    /// the first in the list.
+    /// Get bootstrap peers sorted by the failure rate.
+    ///
+    /// The peer with the lowest failure rate will be the first in the list.
     pub async fn get_addrs(
         &self,
         config: Option<BootstrapCacheConfig>,
@@ -93,8 +159,9 @@ impl InitialPeersConfig {
             .collect())
     }
 
-    /// Get bootstrap peers sorted by the failure rate. The peer with the lowest failure rate will be
-    /// the first in the list.
+    /// Get bootstrap peers sorted by the failure rate.
+    ///
+    /// The peer with the lowest failure rate will be the first in the list.
     pub async fn get_bootstrap_addr(
         &self,
         config: Option<BootstrapCacheConfig>,
@@ -169,7 +236,6 @@ impl InitialPeersConfig {
             info!("Ignoring cache, not loading bootstrap addresses from cache");
         }
 
-        // If we have a network contacts URL, fetch addrs from there.
         if !self.local && !self.network_contacts_url.is_empty() {
             info!(
                 "Fetching bootstrap address from network contacts URLs: {:?}",
@@ -197,7 +263,7 @@ impl InitialPeersConfig {
             }
         }
 
-        if !self.local && !self.disable_mainnet_contacts {
+        if !self.local && get_network_id() == MAINNET_ID {
             let mut contacts_fetcher = ContactsFetcher::with_mainnet_endpoints()?;
             if let Some(count) = count {
                 contacts_fetcher.set_max_addrs(count);
@@ -241,7 +307,6 @@ impl InitialPeersConfig {
         bootstrap_addresses
     }
 
-    /// Get the path to the bootstrap cache JSON file if `Self::bootstrap_cache_dir` is set
     pub fn get_bootstrap_cache_path(&self) -> Result<Option<PathBuf>> {
         if let Some(dir) = &self.bootstrap_cache_dir {
             if dir.is_file() {
@@ -257,5 +322,190 @@ impl InitialPeersConfig {
         } else {
             Ok(None)
         }
+    }
+}
+
+// Implementation of custom deserialization for InitialPeersConfig to automatically convert from V0 to V1
+impl<'de> Deserialize<'de> for InitialPeersConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct InitialPeersConfigHelper {
+            first: bool,
+            addrs: Vec<Multiaddr>,
+            network_contacts_url: Vec<String>,
+            local: bool,
+            ignore_cache: bool,
+            bootstrap_cache_dir: Option<PathBuf>,
+        }
+
+        let helper = InitialPeersConfigHelper::deserialize(deserializer)?;
+
+        Ok(InitialPeersConfigV1 {
+            first: helper.first,
+            addrs: helper.addrs,
+            network_contacts_url: helper.network_contacts_url,
+            local: helper.local,
+            ignore_cache: helper.ignore_cache,
+            bootstrap_cache_dir: helper.bootstrap_cache_dir,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_convert_from_v0_to_v1() {
+        let v0 = InitialPeersConfigV0 {
+            first: false,
+            addrs: vec![],
+            network_contacts_url: vec!["https://example.com".to_string()],
+            local: true,
+            disable_mainnet_contacts: true,
+            ignore_cache: false,
+            bootstrap_cache_dir: Some(PathBuf::from("/tmp/cache")),
+        };
+
+        let v1: InitialPeersConfigV1 = v0.clone().into();
+
+        assert_eq!(v1.first, v0.first);
+        assert_eq!(v1.addrs, v0.addrs);
+        assert_eq!(v1.network_contacts_url, v0.network_contacts_url);
+        assert_eq!(v1.local, v0.local);
+        assert_eq!(v1.ignore_cache, v0.ignore_cache);
+        assert_eq!(v1.bootstrap_cache_dir, v0.bootstrap_cache_dir);
+
+        // Verify the disable_mainnet_contacts field is not present in V1
+        // by checking the serialized JSON output
+        let v1_json = serde_json::to_value(v1).unwrap();
+        let obj = v1_json.as_object().unwrap();
+        assert!(!obj.contains_key("disable_mainnet_contacts"));
+    }
+
+    #[test]
+    fn test_serialize_deserialize_v0() {
+        let v0 = InitialPeersConfigV0 {
+            first: false,
+            addrs: vec![],
+            network_contacts_url: vec!["https://example.com".to_string()],
+            local: true,
+            disable_mainnet_contacts: true,
+            ignore_cache: false,
+            bootstrap_cache_dir: Some(PathBuf::from("/tmp/cache")),
+        };
+
+        let json_str = serde_json::to_string(&v0).unwrap();
+        let v0_deserialized: InitialPeersConfigV0 = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(v0_deserialized.first, v0.first);
+        assert_eq!(v0_deserialized.addrs, v0.addrs);
+        assert_eq!(
+            v0_deserialized.network_contacts_url,
+            v0.network_contacts_url
+        );
+        assert_eq!(v0_deserialized.local, v0.local);
+        assert_eq!(
+            v0_deserialized.disable_mainnet_contacts,
+            v0.disable_mainnet_contacts
+        );
+        assert_eq!(v0_deserialized.ignore_cache, v0.ignore_cache);
+        assert_eq!(v0_deserialized.bootstrap_cache_dir, v0.bootstrap_cache_dir);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_v1() {
+        let v1 = InitialPeersConfigV1 {
+            first: true,
+            addrs: vec![],
+            network_contacts_url: vec!["https://example.org".to_string()],
+            local: false,
+            ignore_cache: true,
+            bootstrap_cache_dir: None,
+        };
+
+        let json_str = serde_json::to_string(&v1).unwrap();
+        let v1_deserialized: InitialPeersConfigV1 = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(v1_deserialized.first, v1.first);
+        assert_eq!(v1_deserialized.addrs, v1.addrs);
+        assert_eq!(
+            v1_deserialized.network_contacts_url,
+            v1.network_contacts_url
+        );
+        assert_eq!(v1_deserialized.local, v1.local);
+        assert_eq!(v1_deserialized.ignore_cache, v1.ignore_cache);
+        assert_eq!(v1_deserialized.bootstrap_cache_dir, v1.bootstrap_cache_dir);
+    }
+
+    #[test]
+    fn test_deserialize_v0_as_initial_peers_config() {
+        let json = json!({
+            "first": false,
+            "addrs": [],
+            "network_contacts_url": ["https://example.com"],
+            "local": true,
+            "disable_mainnet_contacts": true,
+            "ignore_cache": false,
+            "bootstrap_cache_dir": "/tmp/cache"
+        });
+
+        let config: InitialPeersConfig = serde_json::from_value(json).unwrap();
+
+        assert!(!config.first);
+        assert_eq!(config.addrs.len(), 0);
+        assert_eq!(config.network_contacts_url, vec!["https://example.com"]);
+        assert!(config.local);
+        assert!(!config.ignore_cache);
+        assert_eq!(
+            config.bootstrap_cache_dir,
+            Some(PathBuf::from("/tmp/cache"))
+        );
+    }
+
+    #[test]
+    fn test_deserialize_v1_as_initial_peers_config() {
+        let json = json!({
+            "first": true,
+            "addrs": [],
+            "network_contacts_url": ["https://example.org"],
+            "local": false,
+            "ignore_cache": true,
+            "bootstrap_cache_dir": null
+        });
+
+        let config: InitialPeersConfig = serde_json::from_value(json).unwrap();
+
+        assert!(config.first);
+        assert_eq!(config.addrs.len(), 0);
+        assert_eq!(config.network_contacts_url, vec!["https://example.org"]);
+        assert!(!config.local);
+        assert!(config.ignore_cache);
+        assert_eq!(config.bootstrap_cache_dir, None);
+    }
+
+    #[test]
+    fn test_deserialize_with_multiaddr() {
+        let addr_str = "/ip4/127.0.0.1/tcp/8080";
+        let addr = addr_str.parse::<Multiaddr>().unwrap();
+
+        let json = json!({
+            "first": false,
+            "addrs": [addr_str],
+            "network_contacts_url": [],
+            "local": false,
+            "disable_mainnet_contacts": false,
+            "ignore_cache": false,
+            "bootstrap_cache_dir": null
+        });
+
+        let config: InitialPeersConfig = serde_json::from_value(json).unwrap();
+
+        assert_eq!(config.addrs.len(), 1);
+        assert_eq!(config.addrs[0], addr);
     }
 }

--- a/ant-bootstrap/src/lib.rs
+++ b/ant-bootstrap/src/lib.rs
@@ -27,7 +27,7 @@ pub mod contacts;
 pub mod error;
 mod initial_peers;
 
-use ant_protocol::version::{get_network_id, get_truncate_version_str};
+use ant_protocol::version::{get_network_id_str, get_truncate_version_str};
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
@@ -37,7 +37,9 @@ pub use cache_store::BootstrapCacheStore;
 pub use config::BootstrapCacheConfig;
 pub use contacts::ContactsFetcher;
 pub use error::{Error, Result};
-pub use initial_peers::{InitialPeersConfig, ANT_PEERS_ENV};
+pub use initial_peers::{
+    InitialPeersConfig, InitialPeersConfigV0, InitialPeersConfigV1, ANT_PEERS_ENV,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Set of addresses for a particular PeerId
@@ -255,5 +257,5 @@ pub fn multiaddr_get_peer_id(addr: &Multiaddr) -> Option<PeerId> {
 }
 
 pub fn get_network_version() -> String {
-    format!("{}_{}", get_network_id(), get_truncate_version_str())
+    format!("{}_{}", get_network_id_str(), get_truncate_version_str())
 }

--- a/ant-bootstrap/tests/address_format_tests.rs
+++ b/ant-bootstrap/tests/address_format_tests.rs
@@ -47,7 +47,6 @@ async fn test_multiaddr_format_parsing() -> Result<(), Box<dyn std::error::Error
             addrs: vec![addr.clone()],
             network_contacts_url: vec![],
             local: false,
-            disable_mainnet_contacts: true,
             ignore_cache: true,
             bootstrap_cache_dir: None,
         };
@@ -85,7 +84,6 @@ async fn test_network_contacts_format() -> Result<(), Box<dyn std::error::Error>
         addrs: vec![],
         network_contacts_url: vec![format!("{}/peers", mock_server.uri()).parse()?],
         local: false,
-        disable_mainnet_contacts: true,
         ignore_cache: true,
         bootstrap_cache_dir: None,
     };

--- a/ant-bootstrap/tests/address_format_tests.rs
+++ b/ant-bootstrap/tests/address_format_tests.rs
@@ -43,6 +43,7 @@ async fn test_multiaddr_format_parsing() -> Result<(), Box<dyn std::error::Error
         let (_temp_dir, _config) = setup().await; // Fresh config for each test case
         let addr = addr_str.parse::<Multiaddr>()?;
         let args = InitialPeersConfig {
+            alpha: false,
             first: false,
             addrs: vec![addr.clone()],
             network_contacts_url: vec![],
@@ -80,6 +81,7 @@ async fn test_network_contacts_format() -> Result<(), Box<dyn std::error::Error>
         .await;
 
     let args = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![format!("{}/peers", mock_server.uri()).parse()?],

--- a/ant-bootstrap/tests/address_format_tests.rs
+++ b/ant-bootstrap/tests/address_format_tests.rs
@@ -47,7 +47,7 @@ async fn test_multiaddr_format_parsing() -> Result<(), Box<dyn std::error::Error
             first: false,
             addrs: vec![addr.clone()],
             network_contacts_url: vec![],
-            local: false,
+            local: true,
             ignore_cache: true,
             bootstrap_cache_dir: None,
         };
@@ -90,7 +90,9 @@ async fn test_network_contacts_format() -> Result<(), Box<dyn std::error::Error>
         bootstrap_cache_dir: None,
     };
 
-    let addrs = args.get_bootstrap_addr(None, None).await?;
+    // Without specifying the count the code will not return early and will then add contacts from
+    // the production environment.
+    let addrs = args.get_bootstrap_addr(None, Some(2)).await?;
     assert_eq!(
         addrs.len(),
         2,

--- a/ant-bootstrap/tests/cli_integration_tests.rs
+++ b/ant-bootstrap/tests/cli_integration_tests.rs
@@ -33,7 +33,6 @@ async fn test_first_flag() -> Result<(), Box<dyn std::error::Error>> {
         addrs: vec![],
         network_contacts_url: vec![],
         local: false,
-        disable_mainnet_contacts: false,
         ignore_cache: false,
         bootstrap_cache_dir: None,
     };
@@ -59,7 +58,6 @@ async fn test_peer_argument() -> Result<(), Box<dyn std::error::Error>> {
         addrs: vec![peer_addr.clone()],
         network_contacts_url: vec![],
         local: false,
-        disable_mainnet_contacts: true,
         ignore_cache: false,
         bootstrap_cache_dir: None,
     };
@@ -94,7 +92,6 @@ async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Erro
         addrs: vec![],
         network_contacts_url: vec![format!("{}/peers", mock_server.uri()).parse()?],
         local: false,
-        disable_mainnet_contacts: true,
         ignore_cache: true,
         bootstrap_cache_dir: None,
     };
@@ -127,7 +124,6 @@ async fn test_test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
         addrs: vec![peer_addr.clone()],
         network_contacts_url: vec![],
         local: false,
-        disable_mainnet_contacts: true,
         ignore_cache: false,
         bootstrap_cache_dir: None,
     };

--- a/ant-bootstrap/tests/cli_integration_tests.rs
+++ b/ant-bootstrap/tests/cli_integration_tests.rs
@@ -29,6 +29,7 @@ async fn test_first_flag() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, config) = setup().await;
 
     let args = InitialPeersConfig {
+        alpha: false,
         first: true,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -54,6 +55,7 @@ async fn test_peer_argument() -> Result<(), Box<dyn std::error::Error>> {
             .parse()?;
 
     let args = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![peer_addr.clone()],
         network_contacts_url: vec![],
@@ -88,6 +90,7 @@ async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Erro
         .await;
 
     let args = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![format!("{}/peers", mock_server.uri()).parse()?],
@@ -120,6 +123,7 @@ async fn test_test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
     let config = BootstrapCacheConfig::empty().with_cache_path(&cache_path);
 
     let args = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![peer_addr.clone()],
         network_contacts_url: vec![],

--- a/ant-bootstrap/tests/cli_integration_tests.rs
+++ b/ant-bootstrap/tests/cli_integration_tests.rs
@@ -64,7 +64,7 @@ async fn test_peer_argument() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap_cache_dir: None,
     };
 
-    let addrs = args.get_addrs(None, None).await?;
+    let addrs = args.get_addrs(None, Some(1)).await?;
 
     assert_eq!(addrs.len(), 1, "Should have one addr");
     assert_eq!(addrs[0], peer_addr, "Should have the correct address");
@@ -99,7 +99,7 @@ async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Erro
         bootstrap_cache_dir: None,
     };
 
-    let addrs = args.get_addrs(Some(config), None).await?;
+    let addrs = args.get_addrs(Some(config), Some(2)).await?;
     assert_eq!(
         addrs.len(),
         2,
@@ -110,7 +110,7 @@ async fn test_network_contacts_fallback() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[tokio::test]
-async fn test_test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = LogBuilder::init_single_threaded_tokio_test("cli_integration_tests", false);
 
     let temp_dir = TempDir::new()?;
@@ -132,7 +132,7 @@ async fn test_test_network_peers() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap_cache_dir: None,
     };
 
-    let addrs = args.get_addrs(Some(config), None).await?;
+    let addrs = args.get_addrs(Some(config), Some(1)).await?;
 
     assert_eq!(addrs.len(), 1, "Should have exactly one test network peer");
     assert_eq!(

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -25,6 +25,7 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.27" }
 ant-logging = { path = "../ant-logging", version = "0.2.49" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.4" }
 autonomi = { path = "../autonomi", version = "0.4.5", features = ["loud"] }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -352,7 +352,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 password,
             } => wallet::import(private_key, no_password, password),
             WalletCmd::Export => wallet::export(),
-            WalletCmd::Balance => wallet::balance(opt.peers.local).await,
+            WalletCmd::Balance => wallet::balance(opt.peers.local, opt.network_id).await,
         },
         Some(SubCmd::Analyze { addr, verbose }) => {
             analyze::analyze(&addr, verbose, opt.peers, opt.network_id).await

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -81,8 +81,8 @@ pub fn export() -> Result<()> {
     Ok(())
 }
 
-pub async fn balance(local: bool) -> Result<()> {
-    let network = get_evm_network(local)?;
+pub async fn balance(local: bool, network_id: Option<u8>) -> Result<()> {
+    let network = get_evm_network(local, network_id)?;
     let wallet = crate::wallet::load_wallet(&network)?;
 
     let token_balance = wallet.balance_of_tokens().await?;

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -26,6 +26,7 @@ use color_eyre::Result;
 
 use ant_logging::metrics::init_metrics;
 use ant_logging::{LogBuilder, LogFormat, ReloadHandle, WorkerGuard};
+use ant_protocol::version::ALPHANET_ID;
 use autonomi::version;
 use opt::Opt;
 use tracing::Level;
@@ -34,7 +35,9 @@ use tracing::Level;
 async fn main() -> Result<()> {
     color_eyre::install().expect("Failed to initialise error handler");
     let opt = Opt::parse();
-    if let Some(network_id) = opt.network_id {
+    if opt.peers.alpha {
+        version::set_network_id(ALPHANET_ID);
+    } else if let Some(network_id) = opt.network_id {
         version::set_network_id(network_id);
     }
 

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -53,9 +53,14 @@ pub(crate) struct Opt {
     #[clap(long, value_parser = LogOutputDest::parse_from_str, verbatim_doc_comment, default_value = "data-dir")]
     pub log_output_dest: LogOutputDest,
 
-    /// Specify the network ID to use. This will allow you to run the CLI on a different network.
+    /// Specify the ID of the network to connect to.
     ///
-    /// By default, the network ID is set to 1, which represents the mainnet.
+    /// By default, the ID is set to 1 for the mainnet.
+    ///
+    /// If the --alpha argument is used, the ID will automatically be set to 2.
+    ///
+    /// Otherwise, if you are connecting to a testnet, supply the ID of the testnet using this
+    /// argument. It will be a value between 3 and 255.
     #[clap(long, verbatim_doc_comment)]
     pub network_id: Option<u8>,
 

--- a/ant-networking/src/network_builder.rs
+++ b/ant-networking/src/network_builder.rs
@@ -29,7 +29,7 @@ use crate::{
 use ant_bootstrap::BootstrapCacheStore;
 use ant_protocol::{
     version::{
-        get_network_id, IDENTIFY_CLIENT_VERSION_STR, IDENTIFY_NODE_VERSION_STR,
+        get_network_id_str, IDENTIFY_CLIENT_VERSION_STR, IDENTIFY_NODE_VERSION_STR,
         IDENTIFY_PROTOCOL_STR, REQ_RESPONSE_VERSION_STR,
     },
     NetworkAddress, PrettyPrintKBucketKey,
@@ -222,7 +222,7 @@ impl NetworkBuilder {
             check_and_wipe_storage_dir_if_necessary(
                 root_dir.clone(),
                 storage_dir_path.clone(),
-                get_network_id(),
+                get_network_id_str(),
             )?;
 
             // Configures the disk_store to store records under the provided path and increase the max record size

--- a/ant-node-manager/src/add_services/config.rs
+++ b/ant-node-manager/src/add_services/config.rs
@@ -493,7 +493,6 @@ mod tests {
         builder.init_peers_config.network_contacts_url =
             vec!["http://localhost:8080".parse().unwrap()];
         builder.init_peers_config.ignore_cache = true;
-        builder.init_peers_config.disable_mainnet_contacts = true;
         builder.service_user = Some("antnode-user".to_string());
 
         let result = builder.build().unwrap();
@@ -511,7 +510,6 @@ mod tests {
             "/ip4/127.0.0.1/tcp/8080,/ip4/192.168.1.1/tcp/8081",
             "--network-contacts-url",
             "http://localhost:8080",
-            "--testnet",
             "--ignore-cache",
             "--network-id",
             "5",

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -112,6 +112,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
         .in_sequence(&mut seq);
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: true,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -262,6 +263,7 @@ async fn add_genesis_node_should_return_an_error_if_there_is_already_a_genesis_n
     let latest_version = "0.96.4";
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: true,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -400,6 +402,7 @@ async fn add_genesis_node_should_return_an_error_if_count_is_greater_than_1() ->
         daemon: None,
     };
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: true,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -1106,6 +1109,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: true,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -1260,6 +1264,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let initial_peers_config = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![
             "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
@@ -1419,6 +1424,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -1573,6 +1579,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![
@@ -1737,6 +1744,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let init_peers_config = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -1891,6 +1899,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
     let initial_peers_config = InitialPeersConfig {
+        alpha: false,
         first: false,
         addrs: vec![],
         network_contacts_url: vec![],
@@ -6135,6 +6144,161 @@ async fn add_node_should_auto_restart() -> Result<()> {
     .await?;
 
     assert!(node_registry.nodes[0].auto_restart);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
+    let tmp_data_dir = assert_fs::TempDir::new()?;
+    let node_reg_path = tmp_data_dir.child("node_reg.json");
+
+    let mut mock_service_control = MockServiceControl::new();
+
+    let mut node_registry = NodeRegistry {
+        auditor: None,
+        faucet: None,
+        save_path: node_reg_path.to_path_buf(),
+        nat_status: None,
+        nodes: vec![],
+        environment_variables: None,
+        daemon: None,
+    };
+    let latest_version = "0.96.4";
+    let temp_dir = assert_fs::TempDir::new()?;
+    let node_data_dir = temp_dir.child("data");
+    node_data_dir.create_dir_all()?;
+    let node_logs_dir = temp_dir.child("logs");
+    node_logs_dir.create_dir_all()?;
+    let antnode_download_path = temp_dir.child(ANTNODE_FILE_NAME);
+    antnode_download_path.write_binary(b"fake antnode bin")?;
+
+    let init_peers_config = InitialPeersConfig {
+        alpha: true,
+        first: false,
+        addrs: vec![],
+        network_contacts_url: vec![],
+        local: false,
+        ignore_cache: false,
+        bootstrap_cache_dir: None,
+    };
+
+    let mut seq = Sequence::new();
+
+    mock_service_control
+        .expect_get_available_port()
+        .times(1)
+        .returning(|| Ok(12001))
+        .in_sequence(&mut seq);
+
+    mock_service_control
+        .expect_install()
+        .times(1)
+        .with(
+            eq(ServiceInstallCtx {
+                args: vec![
+                    OsString::from("--rpc"),
+                    OsString::from("127.0.0.1:12001"),
+                    OsString::from("--root-dir"),
+                    OsString::from(
+                        node_data_dir
+                            .to_path_buf()
+                            .join("antnode1")
+                            .to_string_lossy()
+                            .to_string(),
+                    ),
+                    OsString::from("--log-output-dest"),
+                    OsString::from(
+                        node_logs_dir
+                            .to_path_buf()
+                            .join("antnode1")
+                            .to_string_lossy()
+                            .to_string(),
+                    ),
+                    OsString::from("--alpha"),
+                    OsString::from("--rewards-address"),
+                    OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("evm-custom"),
+                    OsString::from("--rpc-url"),
+                    OsString::from("http://localhost:8545/"),
+                    OsString::from("--payment-token-address"),
+                    OsString::from("0x5FbDB2315678afecb367f032d93F642f64180aa3"),
+                    OsString::from("--data-payments-address"),
+                    OsString::from("0x8464135c8F25Da09e49BC8782676a84730C318bC"),
+                ],
+                autostart: false,
+                contents: None,
+                environment: None,
+                label: "antnode1".parse()?,
+                program: node_data_dir
+                    .to_path_buf()
+                    .join("antnode1")
+                    .join(ANTNODE_FILE_NAME),
+                username: Some(get_username()),
+                working_directory: None,
+                disable_restart_on_failure: true,
+            }),
+            eq(false),
+        )
+        .returning(|_, _| Ok(()))
+        .in_sequence(&mut seq);
+
+    add_node(
+        AddNodeServiceOptions {
+            auto_restart: false,
+            auto_set_nat_flags: false,
+            count: None,
+            delete_antnode_src: true,
+            enable_metrics_server: false,
+            env_variables: None,
+            relay: false,
+            log_format: None,
+            max_archived_log_files: None,
+            max_log_files: None,
+            metrics_port: None,
+            network_id: None,
+            node_ip: None,
+            node_port: None,
+            init_peers_config: init_peers_config.clone(),
+            rpc_address: None,
+            rpc_port: None,
+            antnode_dir_path: temp_dir.to_path_buf(),
+            antnode_src_path: antnode_download_path.to_path_buf(),
+            service_data_dir_path: node_data_dir.to_path_buf(),
+            service_log_dir_path: node_logs_dir.to_path_buf(),
+            no_upnp: false,
+            user: Some(get_username()),
+            user_mode: false,
+            version: latest_version.to_string(),
+            evm_network: EvmNetwork::Custom(CustomNetwork {
+                rpc_url_http: "http://localhost:8545".parse()?,
+                payment_token_address: RewardsAddress::from_str(
+                    "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+                )?,
+                data_payments_address: RewardsAddress::from_str(
+                    "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+                )?,
+            }),
+            rewards_address: RewardsAddress::from_str(
+                "0x03B770D9cD32077cC0bF330c13C114a87643B124",
+            )?,
+        },
+        &mut node_registry,
+        &mock_service_control,
+        VerbosityLevel::Normal,
+    )
+    .await?;
+
+    antnode_download_path.assert(predicate::path::missing());
+    node_data_dir.assert(predicate::path::is_dir());
+    node_logs_dir.assert(predicate::path::is_dir());
+    assert_eq!(node_registry.nodes.len(), 1);
+    assert_eq!(node_registry.nodes[0].version, latest_version);
+    assert_eq!(
+        node_registry.nodes[0].initial_peers_config,
+        init_peers_config
+    );
+    assert!(node_registry.nodes[0].initial_peers_config.alpha);
 
     Ok(())
 }

--- a/ant-node-manager/src/bin/cli/subcommands/evm_network.rs
+++ b/ant-node-manager/src/bin/cli/subcommands/evm_network.rs
@@ -50,7 +50,7 @@ impl TryInto<EvmNetwork> for EvmNetworkCommand {
             Self::EvmArbitrumSepolia => Ok(EvmNetwork::ArbitrumSepolia),
             Self::EvmArbitrumSepoliaTest => Ok(EvmNetwork::ArbitrumSepoliaTest),
             Self::EvmLocal => {
-                let network = get_evm_network(true)?;
+                let network = get_evm_network(true, None)?;
                 Ok(network)
             }
             Self::EvmCustom {

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -2758,7 +2758,6 @@ mod tests {
                 addrs: vec![],
                 network_contacts_url: vec![],
                 local: false,
-                disable_mainnet_contacts: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,
             },
@@ -2940,7 +2939,6 @@ mod tests {
                 ],
                 network_contacts_url: vec![],
                 local: false,
-                disable_mainnet_contacts: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,
             },
@@ -3277,7 +3275,6 @@ network_id: None,
                 addrs: vec![],
                 network_contacts_url: vec![],
                 local: true,
-                disable_mainnet_contacts: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,
             },
@@ -3457,7 +3454,6 @@ network_id: None,
                     "http://localhost:8081/contacts.json".to_string(),
                 ],
                 local: false,
-                disable_mainnet_contacts: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,
             },
@@ -3516,182 +3512,6 @@ network_id: None,
                 .network_contacts_url
                 .len(),
             2
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn upgrade_should_retain_the_testnet_flag() -> Result<()> {
-        let current_version = "0.1.0";
-        let target_version = "0.2.0";
-
-        let tmp_data_dir = assert_fs::TempDir::new()?;
-        let current_install_dir = tmp_data_dir.child("antnode_install");
-        current_install_dir.create_dir_all()?;
-
-        let current_node_bin = current_install_dir.child("antnode");
-        current_node_bin.write_binary(b"fake antnode binary")?;
-        let target_node_bin = tmp_data_dir.child("antnode");
-        target_node_bin.write_binary(b"fake antnode binary")?;
-
-        let mut mock_service_control = MockServiceControl::new();
-        let mut mock_rpc_client = MockRpcClient::new();
-
-        // before binary upgrade
-        mock_service_control
-            .expect_get_process_pid()
-            .with(eq(current_node_bin.to_path_buf().clone()))
-            .times(1)
-            .returning(|_| Ok(1000));
-        mock_service_control
-            .expect_stop()
-            .with(eq("antnode1"), eq(false))
-            .times(1)
-            .returning(|_, _| Ok(()));
-
-        // after binary upgrade
-        mock_service_control
-            .expect_uninstall()
-            .with(eq("antnode1"), eq(false))
-            .times(1)
-            .returning(|_, _| Ok(()));
-        mock_service_control
-            .expect_install()
-            .with(
-                eq(ServiceInstallCtx {
-                    args: vec![
-                        OsString::from("--rpc"),
-                        OsString::from("127.0.0.1:8081"),
-                        OsString::from("--root-dir"),
-                        OsString::from("/var/antctl/services/antnode1"),
-                        OsString::from("--log-output-dest"),
-                        OsString::from("/var/log/antnode/antnode1"),
-                        OsString::from("--testnet"),
-                        OsString::from("--rewards-address"),
-                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
-                        OsString::from("evm-arbitrum-one"),
-                    ],
-                    autostart: false,
-                    contents: None,
-                    environment: None,
-                    label: "antnode1".parse()?,
-                    program: current_node_bin.to_path_buf(),
-                    username: Some("ant".to_string()),
-                    working_directory: None,
-                    disable_restart_on_failure: true,
-                }),
-                eq(false),
-            )
-            .times(1)
-            .returning(|_, _| Ok(()));
-
-        // after service restart
-        mock_service_control
-            .expect_start()
-            .with(eq("antnode1"), eq(false))
-            .times(1)
-            .returning(|_, _| Ok(()));
-        mock_service_control
-            .expect_wait()
-            .with(eq(3000))
-            .times(1)
-            .returning(|_| ());
-        mock_service_control
-            .expect_get_process_pid()
-            .with(eq(current_node_bin.to_path_buf().clone()))
-            .times(1)
-            .returning(|_| Ok(100));
-
-        mock_rpc_client.expect_node_info().times(1).returning(|| {
-            Ok(NodeInfo {
-                pid: 2000,
-                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
-                data_path: PathBuf::from("/var/antctl/services/antnode1"),
-                log_path: PathBuf::from("/var/log/antnode/antnode1"),
-                version: target_version.to_string(),
-                uptime: std::time::Duration::from_secs(1), // the service was just started
-                wallet_balance: 0,
-            })
-        });
-        mock_rpc_client
-            .expect_network_info()
-            .times(1)
-            .returning(|| {
-                Ok(NetworkInfo {
-                    connected_peers: Vec::new(),
-                    listeners: Vec::new(),
-                })
-            });
-
-        let mut service_data = NodeServiceData {
-            auto_restart: false,
-            connected_peers: None,
-            data_dir_path: PathBuf::from("/var/antctl/services/antnode1"),
-            evm_network: EvmNetwork::ArbitrumOne,
-            relay: false,
-            initial_peers_config: InitialPeersConfig {
-                first: false,
-                addrs: vec![],
-                network_contacts_url: vec![],
-                local: false,
-                disable_mainnet_contacts: true,
-                ignore_cache: false,
-                bootstrap_cache_dir: None,
-            },
-            listen_addr: None,
-            log_dir_path: PathBuf::from("/var/log/antnode/antnode1"),
-            log_format: None,
-            max_archived_log_files: None,
-            max_log_files: None,
-            metrics_port: None,
-            network_id: None,
-            node_ip: None,
-            node_port: None,
-            number: 1,
-            peer_id: Some(PeerId::from_str(
-                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
-            )?),
-            pid: Some(1000),
-            rewards_address: RewardsAddress::from_str(
-                "0x03B770D9cD32077cC0bF330c13C114a87643B124",
-            )?,
-            reward_balance: Some(AttoTokens::zero()),
-            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
-            antnode_path: current_node_bin.to_path_buf(),
-            schema_version: NODE_SERVICE_DATA_SCHEMA_LATEST,
-            service_name: "antnode1".to_string(),
-            status: ServiceStatus::Running,
-            no_upnp: false,
-            user: Some("ant".to_string()),
-            user_mode: false,
-            version: current_version.to_string(),
-        };
-        let service = NodeService::new(&mut service_data, Box::new(mock_rpc_client));
-
-        let mut service_manager = ServiceManager::new(
-            service,
-            Box::new(mock_service_control),
-            VerbosityLevel::Normal,
-        );
-
-        service_manager
-            .upgrade(UpgradeOptions {
-                auto_restart: false,
-                env_variables: None,
-                force: false,
-                start_service: true,
-                target_bin_path: target_node_bin.to_path_buf(),
-                target_version: Version::parse(target_version).unwrap(),
-            })
-            .await?;
-
-        assert!(
-            service_manager
-                .service
-                .service_data
-                .initial_peers_config
-                .disable_mainnet_contacts
         );
 
         Ok(())
@@ -3811,7 +3631,6 @@ network_id: None,
                 addrs: vec![],
                 network_contacts_url: vec![],
                 local: false,
-                disable_mainnet_contacts: false,
                 ignore_cache: true,
                 bootstrap_cache_dir: None,
             },
@@ -3988,7 +3807,6 @@ network_id: None,
                 addrs: vec![],
                 network_contacts_url: vec![],
                 local: false,
-                disable_mainnet_contacts: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: Some(PathBuf::from(
                     "/var/antctl/services/antnode1/bootstrap_cache",

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -2645,6 +2645,182 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn upgrade_should_retain_the_alpha_flag() -> Result<()> {
+        let current_version = "0.1.0";
+        let target_version = "0.2.0";
+
+        let tmp_data_dir = assert_fs::TempDir::new()?;
+        let current_install_dir = tmp_data_dir.child("antnode_install");
+        current_install_dir.create_dir_all()?;
+
+        let current_node_bin = current_install_dir.child("antnode");
+        current_node_bin.write_binary(b"fake antnode binary")?;
+        let target_node_bin = tmp_data_dir.child("antnode");
+        target_node_bin.write_binary(b"fake antnode binary")?;
+
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        // before binary upgrade
+        mock_service_control
+            .expect_get_process_pid()
+            .with(eq(current_node_bin.to_path_buf().clone()))
+            .times(1)
+            .returning(|_| Ok(1000));
+        mock_service_control
+            .expect_stop()
+            .with(eq("antnode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // after binary upgrade
+        mock_service_control
+            .expect_uninstall()
+            .with(eq("antnode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_service_control
+            .expect_install()
+            .with(
+                eq(ServiceInstallCtx {
+                    args: vec![
+                        OsString::from("--rpc"),
+                        OsString::from("127.0.0.1:8081"),
+                        OsString::from("--root-dir"),
+                        OsString::from("/var/antctl/services/antnode1"),
+                        OsString::from("--log-output-dest"),
+                        OsString::from("/var/log/antnode/antnode1"),
+                        OsString::from("--alpha"),
+                        OsString::from("--rewards-address"),
+                        OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                        OsString::from("evm-arbitrum-one"),
+                    ],
+                    autostart: false,
+                    contents: None,
+                    environment: None,
+                    label: "antnode1".parse()?,
+                    program: current_node_bin.to_path_buf(),
+                    username: Some("ant".to_string()),
+                    working_directory: None,
+                    disable_restart_on_failure: true,
+                }),
+                eq(false),
+            )
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // after service restart
+        mock_service_control
+            .expect_start()
+            .with(eq("antnode1"), eq(false))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_service_control
+            .expect_wait()
+            .with(eq(3000))
+            .times(1)
+            .returning(|_| ());
+        mock_service_control
+            .expect_get_process_pid()
+            .with(eq(current_node_bin.to_path_buf().clone()))
+            .times(1)
+            .returning(|_| Ok(100));
+
+        mock_rpc_client.expect_node_info().times(1).returning(|| {
+            Ok(NodeInfo {
+                pid: 2000,
+                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
+                data_path: PathBuf::from("/var/antctl/services/antnode1"),
+                log_path: PathBuf::from("/var/log/antnode/antnode1"),
+                version: target_version.to_string(),
+                uptime: std::time::Duration::from_secs(1), // the service was just started
+                wallet_balance: 0,
+            })
+        });
+        mock_rpc_client
+            .expect_network_info()
+            .times(1)
+            .returning(|| {
+                Ok(NetworkInfo {
+                    connected_peers: Vec::new(),
+                    listeners: Vec::new(),
+                })
+            });
+
+        let mut service_data = NodeServiceData {
+            auto_restart: false,
+            connected_peers: None,
+            data_dir_path: PathBuf::from("/var/antctl/services/antnode1"),
+            evm_network: EvmNetwork::ArbitrumOne,
+            relay: false,
+            initial_peers_config: InitialPeersConfig {
+                alpha: true,
+                first: false,
+                addrs: vec![],
+                network_contacts_url: vec![],
+                local: false,
+                ignore_cache: false,
+                bootstrap_cache_dir: None,
+            },
+            listen_addr: None,
+            log_dir_path: PathBuf::from("/var/log/antnode/antnode1"),
+            log_format: None,
+            max_archived_log_files: None,
+            max_log_files: None,
+            metrics_port: None,
+            network_id: None,
+            node_ip: None,
+            node_port: None,
+            number: 1,
+            peer_id: Some(PeerId::from_str(
+                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
+            )?),
+            pid: Some(1000),
+            rewards_address: RewardsAddress::from_str(
+                "0x03B770D9cD32077cC0bF330c13C114a87643B124",
+            )?,
+            reward_balance: Some(AttoTokens::zero()),
+            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081),
+            antnode_path: current_node_bin.to_path_buf(),
+            schema_version: NODE_SERVICE_DATA_SCHEMA_LATEST,
+            service_name: "antnode1".to_string(),
+            status: ServiceStatus::Running,
+            no_upnp: false,
+            user: Some("ant".to_string()),
+            user_mode: false,
+            version: current_version.to_string(),
+        };
+        let service = NodeService::new(&mut service_data, Box::new(mock_rpc_client));
+
+        let mut service_manager = ServiceManager::new(
+            service,
+            Box::new(mock_service_control),
+            VerbosityLevel::Normal,
+        );
+
+        service_manager
+            .upgrade(UpgradeOptions {
+                auto_restart: false,
+                env_variables: None,
+                force: false,
+                start_service: true,
+                target_bin_path: target_node_bin.to_path_buf(),
+                target_version: Version::parse(target_version).unwrap(),
+            })
+            .await?;
+
+        assert!(
+            service_manager
+                .service
+                .service_data
+                .initial_peers_config
+                .alpha
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn upgrade_should_retain_the_first_flag() -> Result<()> {
         let current_version = "0.1.0";
         let target_version = "0.2.0";
@@ -2754,6 +2930,7 @@ mod tests {
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config: InitialPeersConfig {
+                alpha: false,
                 first: true,
                 addrs: vec![],
                 network_contacts_url: vec![],
@@ -2932,6 +3109,7 @@ mod tests {
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config:  InitialPeersConfig {
+                alpha: false,
                 first: false,
                 addrs: vec![
                     "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
@@ -3271,6 +3449,7 @@ network_id: None,
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config: InitialPeersConfig {
+                alpha: false,
                 first: false,
                 addrs: vec![],
                 network_contacts_url: vec![],
@@ -3447,6 +3626,7 @@ network_id: None,
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config: InitialPeersConfig {
+                alpha: false,
                 first: false,
                 addrs: vec![],
                 network_contacts_url: vec![
@@ -3627,6 +3807,7 @@ network_id: None,
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config: InitialPeersConfig {
+                alpha: false,
                 first: false,
                 addrs: vec![],
                 network_contacts_url: vec![],
@@ -3803,6 +3984,7 @@ network_id: None,
             evm_network: EvmNetwork::ArbitrumOne,
             relay: false,
             initial_peers_config: InitialPeersConfig {
+                alpha: false,
                 first: false,
                 addrs: vec![],
                 network_contacts_url: vec![],

--- a/ant-node-manager/src/local.rs
+++ b/ant-node-manager/src/local.rs
@@ -420,7 +420,6 @@ pub async fn run_node(
             addrs: vec![],
             network_contacts_url: vec![],
             local: true,
-            disable_mainnet_contacts: true,
             ignore_cache: true,
             bootstrap_cache_dir: None,
         },

--- a/ant-node-manager/src/local.rs
+++ b/ant-node-manager/src/local.rs
@@ -416,6 +416,7 @@ pub async fn run_node(
         evm_network: run_options.evm_network.unwrap_or(EvmNetwork::ArbitrumOne),
         relay: false,
         initial_peers_config: InitialPeersConfig {
+            alpha: false,
             first: run_options.first,
             addrs: vec![],
             network_contacts_url: vec![],

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -217,7 +217,9 @@ fn main() -> Result<()> {
     color_eyre::install()?;
     let opt = Opt::parse();
 
-    if let Some(network_id) = opt.network_id {
+    if opt.peers.alpha {
+        version::set_network_id(version::ALPHANET_ID);
+    } else if let Some(network_id) = opt.network_id {
         version::set_network_id(network_id);
     }
 

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -261,7 +261,7 @@ fn main() -> Result<()> {
 
     let evm_network: EvmNetwork = match opt.evm_network.as_ref() {
         Some(evm_network) => Ok(evm_network.clone().into()),
-        None => match get_evm_network(opt.peers.local) {
+        None => match get_evm_network(opt.peers.local, opt.network_id) {
             Ok(net) => Ok(net),
             Err(_) => Err(eyre!(
                 "EVM network not specified. Please specify a network using the subcommand or by setting the `EVM_NETWORK` environment variable."

--- a/ant-protocol/src/version.rs
+++ b/ant-protocol/src/version.rs
@@ -8,6 +8,9 @@
 
 use std::sync::{LazyLock, RwLock};
 
+pub const MAINNET_ID: u8 = 1;
+pub const ALPHANET_ID: u8 = 2;
+
 /// The network_id is used to differentiate between different networks.
 /// The default is set to 1 and it represents the mainnet.
 pub static NETWORK_ID: LazyLock<RwLock<u8>> = LazyLock::new(|| RwLock::new(1));
@@ -70,8 +73,14 @@ pub fn set_network_id(id: u8) {
     info!("Network id set to: {id}");
 }
 
+pub fn get_network_id() -> u8 {
+    *NETWORK_ID
+        .read()
+        .expect("Failed to obtain read lock for NETWORK_ID")
+}
+
 /// Get the current NETWORK_ID as string.
-pub fn get_network_id() -> String {
+pub fn get_network_id_str() -> String {
     format!(
         "{}",
         *NETWORK_ID
@@ -129,7 +138,7 @@ mod tests {
         println!("\nTruncated version: {truncated}");
 
         // Test network id string
-        let network_id = get_network_id();
+        let network_id = get_network_id_str();
         println!("Network ID string: {network_id}");
 
         Ok(())

--- a/ant-service-management/src/node/mod.rs
+++ b/ant-service-management/src/node/mod.rs
@@ -272,6 +272,9 @@ pub fn push_arguments_from_initial_peers_config(
     init_peers_config: &InitialPeersConfig,
     args: &mut Vec<OsString>,
 ) {
+    if init_peers_config.alpha {
+        args.push(OsString::from("--alpha"));
+    }
     if init_peers_config.first {
         args.push(OsString::from("--first"));
     }

--- a/ant-service-management/src/node/mod.rs
+++ b/ant-service-management/src/node/mod.rs
@@ -9,6 +9,7 @@
 mod node_service_data;
 mod node_service_data_v0;
 mod node_service_data_v1;
+mod node_service_data_v2;
 #[cfg(test)]
 mod tests;
 
@@ -297,9 +298,6 @@ pub fn push_arguments_from_initial_peers_config(
                 .collect::<Vec<_>>()
                 .join(","),
         ));
-    }
-    if init_peers_config.disable_mainnet_contacts {
-        args.push(OsString::from("--testnet"));
     }
     if init_peers_config.ignore_cache {
         args.push(OsString::from("--ignore-cache"));

--- a/ant-service-management/src/node/node_service_data_v0.rs
+++ b/ant-service-management/src/node/node_service_data_v0.rs
@@ -9,7 +9,7 @@
 use super::node_service_data_v1::{NodeServiceDataV1, NODE_SERVICE_DATA_SCHEMA_V1};
 use super::NodeServiceData;
 use crate::ServiceStatus;
-use ant_bootstrap::InitialPeersConfig;
+use ant_bootstrap::InitialPeersConfigV0;
 use ant_evm::{AttoTokens, EvmNetwork, RewardsAddress};
 use ant_logging::LogFormat;
 use libp2p::{Multiaddr, PeerId};
@@ -46,7 +46,7 @@ pub(super) struct NodeServiceDataV0 {
     pub number: u16,
     #[serde(deserialize_with = "NodeServiceData::deserialize_peer_id")]
     pub peer_id: Option<PeerId>,
-    pub peers_args: InitialPeersConfig,
+    pub peers_args: InitialPeersConfigV0,
     pub pid: Option<u32>,
     #[serde(default)]
     pub rewards_address: RewardsAddress,
@@ -74,7 +74,7 @@ impl From<NodeServiceDataV0> for NodeServiceDataV1 {
             connected_peers: v0.connected_peers,
             data_dir_path: v0.data_dir_path,
             evm_network: v0.evm_network,
-            // Renamed field
+            // Renamed field and convert InitialPeersConfigV0 to InitialPeersConfigV1
             initial_peers_config: v0.peers_args,
             listen_addr: v0.listen_addr,
             log_dir_path: v0.log_dir_path,

--- a/ant-service-management/src/node/tests.rs
+++ b/ant-service-management/src/node/tests.rs
@@ -80,6 +80,7 @@ fn create_test_v2_struct() -> NodeServiceDataV2 {
         data_dir_path: v1_struct.data_dir_path,
         evm_network: v1_struct.evm_network,
         initial_peers_config: InitialPeersConfig {
+            alpha: false,
             first: false,
             local: false,
             addrs: vec![],
@@ -406,6 +407,7 @@ fn test_v1_to_v2_conversion() {
     let v2_config = &v2_struct.initial_peers_config;
 
     // The disable_mainnet_contacts field from V1 is not present in V2
+    assert!(!v2_config.alpha);
     assert_eq!(v2_config.first, v1_config.first);
     assert_eq!(v2_config.local, v1_config.local);
     assert_eq!(v2_config.addrs, v1_config.addrs);

--- a/ant-service-management/src/node/tests.rs
+++ b/ant-service-management/src/node/tests.rs
@@ -10,9 +10,10 @@
 use super::{
     node_service_data::NodeServiceData,
     node_service_data_v1::{NodeServiceDataV1, NODE_SERVICE_DATA_SCHEMA_V1},
+    node_service_data_v2::{NodeServiceDataV2, NODE_SERVICE_DATA_SCHEMA_V2},
 };
 use crate::ServiceStatus;
-use ant_bootstrap::InitialPeersConfig;
+use ant_bootstrap::{InitialPeersConfig, InitialPeersConfigV0};
 use ant_evm::{AttoTokens, EvmNetwork, RewardsAddress};
 use libp2p::{Multiaddr, PeerId};
 use std::{
@@ -21,53 +22,94 @@ use std::{
     str::FromStr,
 };
 
-// Helper function to create a test V1 struct directly
 fn create_test_v1_struct() -> NodeServiceDataV1 {
     NodeServiceDataV1 {
-            schema_version: NODE_SERVICE_DATA_SCHEMA_V1,
-            antnode_path: PathBuf::from("/usr/bin/antnode"),
-            auto_restart: true,
-            connected_peers: Some(vec![
-                PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
-            ]),
-            data_dir_path: PathBuf::from("/home/user/.local/share/safe/node/1"),
-            evm_network: EvmNetwork::ArbitrumSepolia,
-            initial_peers_config: InitialPeersConfig {
-                first: false,
-                local: false,
-                addrs: vec![],
-                network_contacts_url: vec![],
-                disable_mainnet_contacts: false,
-                ignore_cache: false,
-                bootstrap_cache_dir: None,
-            },
-            listen_addr: Some(vec![
-                Multiaddr::from_str("/ip4/127.0.0.1/udp/56215/quic-v1/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
-            ]),
-            log_dir_path: PathBuf::from("/home/user/.local/share/safe/node/1/logs"),
-            log_format: Some(ant_logging::LogFormat::Default),
-            max_archived_log_files: Some(5),
-            max_log_files: Some(10),
-            metrics_port: Some(8080),
-            network_id: Some(1),
-            node_ip: Some(Ipv4Addr::new(127, 0, 0, 1)),
-            node_port: Some(56215),
-            no_upnp: false,
-            number: 1,
-            peer_id: Some(
-                PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
-            ),
-            pid: Some(12345),
-            relay: true,
-            rewards_address: RewardsAddress::from_str("0x1234567890123456789012345678901234567890").unwrap(),
-            reward_balance: Some(AttoTokens::from_u128(1000000000000000000u128)),
-            rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000),
-            service_name: "safenode-1".to_string(),
-            status: ServiceStatus::Running,
-            user: Some("safe_user".to_string()),
-            user_mode: true,
-            version: "0.1.0".to_string(),
-        }
+        schema_version: NODE_SERVICE_DATA_SCHEMA_V1,
+        antnode_path: PathBuf::from("/usr/bin/antnode"),
+        auto_restart: true,
+        connected_peers: Some(vec![
+            PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
+        ]),
+        data_dir_path: PathBuf::from("/home/user/.local/share/safe/node/1"),
+        evm_network: EvmNetwork::ArbitrumSepolia,
+        initial_peers_config: InitialPeersConfigV0 {
+            first: false,
+            local: false,
+            addrs: vec![],
+            network_contacts_url: vec![],
+            ignore_cache: false,
+            bootstrap_cache_dir: None,
+            disable_mainnet_contacts: false,
+        },
+        listen_addr: Some(vec![
+            Multiaddr::from_str("/ip4/127.0.0.1/udp/56215/quic-v1/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
+        ]),
+        log_dir_path: PathBuf::from("/home/user/.local/share/safe/node/1/logs"),
+        log_format: Some(ant_logging::LogFormat::Default),
+        max_archived_log_files: Some(5),
+        max_log_files: Some(10),
+        metrics_port: Some(8080),
+        network_id: Some(1),
+        node_ip: Some(Ipv4Addr::new(127, 0, 0, 1)),
+        node_port: Some(56215),
+        no_upnp: false,
+        number: 1,
+        peer_id: Some(
+            PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap(),
+        ),
+        pid: Some(12345),
+        relay: true,
+        rewards_address: RewardsAddress::from_str("0x1234567890123456789012345678901234567890").unwrap(),
+        reward_balance: Some(AttoTokens::from_u128(1000000000000000000u128)),
+        rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000),
+        service_name: "safenode-1".to_string(),
+        status: ServiceStatus::Running,
+        user: Some("safe_user".to_string()),
+        user_mode: true,
+        version: "0.1.0".to_string(),
+    }
+}
+
+fn create_test_v2_struct() -> NodeServiceDataV2 {
+    let v1_struct = create_test_v1_struct();
+    NodeServiceDataV2 {
+        schema_version: NODE_SERVICE_DATA_SCHEMA_V2,
+        antnode_path: v1_struct.antnode_path,
+        auto_restart: v1_struct.auto_restart,
+        connected_peers: v1_struct.connected_peers,
+        data_dir_path: v1_struct.data_dir_path,
+        evm_network: v1_struct.evm_network,
+        initial_peers_config: InitialPeersConfig {
+            first: false,
+            local: false,
+            addrs: vec![],
+            network_contacts_url: vec![],
+            ignore_cache: false,
+            bootstrap_cache_dir: None,
+        },
+        listen_addr: v1_struct.listen_addr,
+        log_dir_path: v1_struct.log_dir_path,
+        log_format: v1_struct.log_format,
+        max_archived_log_files: v1_struct.max_archived_log_files,
+        max_log_files: v1_struct.max_log_files,
+        metrics_port: v1_struct.metrics_port,
+        network_id: v1_struct.network_id,
+        node_ip: v1_struct.node_ip,
+        node_port: v1_struct.node_port,
+        no_upnp: v1_struct.no_upnp,
+        number: v1_struct.number,
+        peer_id: v1_struct.peer_id,
+        pid: v1_struct.pid,
+        relay: v1_struct.relay,
+        rewards_address: v1_struct.rewards_address,
+        reward_balance: v1_struct.reward_balance,
+        rpc_socket_addr: v1_struct.rpc_socket_addr,
+        service_name: v1_struct.service_name,
+        status: v1_struct.status,
+        user: v1_struct.user,
+        user_mode: v1_struct.user_mode,
+        version: v1_struct.version,
+    }
 }
 
 fn create_test_v1_json() -> serde_json::Value {
@@ -75,26 +117,39 @@ fn create_test_v1_json() -> serde_json::Value {
     serde_json::to_value(test_struct).expect("Failed to serialize test struct to JSON")
 }
 
+fn create_test_v2_json() -> serde_json::Value {
+    let test_struct = create_test_v2_struct();
+    serde_json::to_value(test_struct).expect("Failed to serialize test struct to JSON")
+}
+
+/// Create a test V0 JSON by converting a V1 JSON.
+///
+/// Elements of the V1 JSON are removed or renamed to match the V0 format.
 fn create_test_v0_json() -> serde_json::Value {
-    // Start with V1 JSON and transform it to V0 format
     let v1_value = create_test_v1_json();
 
-    // Convert to V0 format by modifying the JSON structure
     if let serde_json::Value::Object(mut map) = v1_value {
-        // Remove schema_version (not present in V0)
         map.remove("schema_version");
 
-        // Rename initial_peers_config to peers_args
         if let Some(initial_peers_config) = map.remove("initial_peers_config") {
-            map.insert("peers_args".to_string(), initial_peers_config);
+            if let serde_json::Value::Object(mut peers_config) = initial_peers_config {
+                peers_config.insert(
+                    "disable_mainnet_contacts".to_string(),
+                    serde_json::Value::Bool(false),
+                );
+                map.insert(
+                    "peers_args".to_string(),
+                    serde_json::Value::Object(peers_config),
+                );
+            } else {
+                map.insert("peers_args".to_string(), initial_peers_config);
+            }
         }
 
-        // Convert relay to home_network
         if let Some(relay) = map.remove("relay") {
             map.insert("home_network".to_string(), relay);
         }
 
-        // Convert no_upnp to upnp (with inverted value)
         if let Some(serde_json::Value::Bool(no_upnp)) = map.remove("no_upnp") {
             map.insert("upnp".to_string(), serde_json::Value::Bool(!no_upnp));
         }
@@ -103,6 +158,34 @@ fn create_test_v0_json() -> serde_json::Value {
     } else {
         panic!("Failed to convert V1 JSON to V0 format");
     }
+}
+
+#[test]
+fn test_deserialize_v2_format() {
+    let json_data = create_test_v2_json();
+    let service_data: Result<NodeServiceData, _> = serde_json::from_value(json_data);
+
+    assert!(
+        service_data.is_ok(),
+        "Failed to deserialize V2 format: {:?}",
+        service_data.err()
+    );
+    let data = service_data.unwrap();
+
+    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V2);
+    assert_eq!(data.service_name, "safenode-1");
+    assert_eq!(data.node_port, Some(56215));
+    assert!(!data.no_upnp);
+    assert!(data.relay);
+
+    let expected_peer_id =
+        PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap();
+    assert_eq!(data.peer_id, Some(expected_peer_id));
+
+    assert!(data.connected_peers.is_some());
+    let connected_peers = data.connected_peers.unwrap();
+    assert_eq!(connected_peers.len(), 1);
+    assert_eq!(connected_peers[0], expected_peer_id);
 }
 
 #[test]
@@ -117,19 +200,16 @@ fn test_deserialize_v1_format() {
     );
     let data = service_data.unwrap();
 
-    // Verify a few key fields to ensure proper deserialization
-    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V1);
+    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V2);
     assert_eq!(data.service_name, "safenode-1");
     assert_eq!(data.node_port, Some(56215));
     assert!(!data.no_upnp);
     assert!(data.relay);
 
-    // Verify PeerId deserialization
     let expected_peer_id =
         PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap();
     assert_eq!(data.peer_id, Some(expected_peer_id));
 
-    // Verify connected_peers deserialization
     assert!(data.connected_peers.is_some());
     let connected_peers = data.connected_peers.unwrap();
     assert_eq!(connected_peers.len(), 1);
@@ -148,18 +228,13 @@ fn test_deserialize_v0_format() {
     );
     let data = service_data.unwrap();
 
-    // Verify the automatic version upgrade
-    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V1);
+    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V2);
 
-    // Verify renamed fields
     assert!(data.relay); // Was home_network in V0
     assert!(!data.no_upnp); // Was !upnp in V0
-
-    // Verify other key fields
     assert_eq!(data.service_name, "safenode-1");
     assert_eq!(data.node_port, Some(56215));
 
-    // Verify PeerId deserialization
     let expected_peer_id =
         PeerId::from_str("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN").unwrap();
     assert_eq!(data.peer_id, Some(expected_peer_id));
@@ -169,10 +244,8 @@ fn test_deserialize_v0_format() {
 fn test_peer_id_serialization() {
     let test_data = create_test_v1_struct();
 
-    // Serialize to JSON
     let serialized = serde_json::to_value(&test_data).unwrap();
 
-    // Check peer_id is serialized as string
     if let serde_json::Value::Object(map) = &serialized {
         if let Some(peer_id) = map.get("peer_id") {
             assert!(peer_id.is_string());
@@ -187,7 +260,6 @@ fn test_peer_id_serialization() {
         panic!("Serialized output is not an object");
     }
 
-    // Deserialize back and check peer_id
     let deserialized: NodeServiceData = serde_json::from_value(serialized).unwrap();
     assert_eq!(
         deserialized.peer_id.unwrap().to_string(),
@@ -199,10 +271,8 @@ fn test_peer_id_serialization() {
 fn test_connected_peers_serialization() {
     let test_data = create_test_v1_struct();
 
-    // Serialize to JSON
     let serialized = serde_json::to_value(&test_data).unwrap();
 
-    // Check connected_peers is serialized as array of strings
     if let serde_json::Value::Object(map) = &serialized {
         if let Some(serde_json::Value::Array(peers)) = map.get("connected_peers") {
             assert_eq!(peers.len(), 1);
@@ -218,7 +288,6 @@ fn test_connected_peers_serialization() {
         panic!("Serialized output is not an object");
     }
 
-    // Deserialize back and check connected_peers
     let deserialized: NodeServiceData = serde_json::from_value(serialized).unwrap();
     let connected_peers = deserialized.connected_peers.unwrap();
     assert_eq!(connected_peers.len(), 1);
@@ -230,18 +299,14 @@ fn test_connected_peers_serialization() {
 
 #[test]
 fn test_v0_to_v1_field_transformations() {
-    // Create a modified V1 struct with specific values
     let mut test_struct = create_test_v1_struct();
     test_struct.no_upnp = false;
     test_struct.relay = true;
 
-    // Convert to V0 format manually
     let mut v0_json = serde_json::to_value(test_struct).unwrap();
     if let serde_json::Value::Object(ref mut map) = v0_json {
-        // Remove schema_version
         map.remove("schema_version");
 
-        // Rename fields and transform values
         map.remove("no_upnp");
         map.insert("upnp".to_string(), serde_json::Value::Bool(true)); // Inverted from no_upnp
 
@@ -263,7 +328,6 @@ fn test_v0_to_v1_field_transformations() {
         );
     }
 
-    // Deserialize V0 format
     let service_data: Result<NodeServiceData, _> = serde_json::from_value(v0_json);
     assert!(
         service_data.is_ok(),
@@ -284,7 +348,6 @@ fn test_v0_to_v1_field_transformations() {
 fn test_direct_v1_deserialization() {
     let json_data = create_test_v1_json();
 
-    // Use the direct V1 deserialization method
     let service_data = serde_json::from_value::<NodeServiceDataV1>(json_data);
 
     assert!(
@@ -294,7 +357,119 @@ fn test_direct_v1_deserialization() {
     );
     let data = service_data.unwrap();
 
-    // Verify a few key fields
     assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V1);
     assert_eq!(data.service_name, "safenode-1");
+}
+
+#[test]
+fn test_direct_v2_deserialization() {
+    let json_data = create_test_v2_json();
+
+    let service_data = serde_json::from_value::<NodeServiceDataV2>(json_data);
+
+    assert!(
+        service_data.is_ok(),
+        "Failed to directly deserialize as V2: {:?}",
+        service_data.err()
+    );
+    let data = service_data.unwrap();
+
+    assert_eq!(data.schema_version, NODE_SERVICE_DATA_SCHEMA_V2);
+    assert_eq!(data.service_name, "safenode-1");
+
+    // Check specifically for the V2 initial_peers_config which doesn't have disable_mainnet_contacts
+    let config = data.initial_peers_config;
+    assert!(!config.first);
+    assert!(!config.local);
+    assert_eq!(config.addrs.len(), 0);
+    assert_eq!(config.network_contacts_url.len(), 0);
+    assert!(!config.ignore_cache);
+    assert!(config.bootstrap_cache_dir.is_none());
+}
+
+#[test]
+fn test_v1_to_v2_conversion() {
+    let v1_struct = create_test_v1_struct();
+    let v2_struct: NodeServiceDataV2 = v1_struct.clone().into();
+
+    assert_eq!(v2_struct.schema_version, NODE_SERVICE_DATA_SCHEMA_V2);
+
+    assert_eq!(v2_struct.antnode_path, v1_struct.antnode_path);
+    assert_eq!(v2_struct.auto_restart, v1_struct.auto_restart);
+    assert_eq!(v2_struct.service_name, v1_struct.service_name);
+    assert_eq!(v2_struct.connected_peers, v1_struct.connected_peers);
+    assert_eq!(v2_struct.node_port, v1_struct.node_port);
+    assert_eq!(v2_struct.no_upnp, v1_struct.no_upnp);
+    assert_eq!(v2_struct.relay, v1_struct.relay);
+
+    let v1_config = &v1_struct.initial_peers_config;
+    let v2_config = &v2_struct.initial_peers_config;
+
+    // The disable_mainnet_contacts field from V1 is not present in V2
+    assert_eq!(v2_config.first, v1_config.first);
+    assert_eq!(v2_config.local, v1_config.local);
+    assert_eq!(v2_config.addrs, v1_config.addrs);
+    assert_eq!(
+        v2_config.network_contacts_url,
+        v1_config.network_contacts_url
+    );
+    assert_eq!(v2_config.ignore_cache, v1_config.ignore_cache);
+    assert_eq!(v2_config.bootstrap_cache_dir, v1_config.bootstrap_cache_dir);
+}
+
+#[test]
+fn test_peer_id_serialization_v2() {
+    let test_data = create_test_v2_struct();
+
+    let serialized = serde_json::to_value(&test_data).unwrap();
+
+    if let serde_json::Value::Object(map) = &serialized {
+        if let Some(peer_id) = map.get("peer_id") {
+            assert!(peer_id.is_string());
+            assert_eq!(
+                peer_id.as_str().unwrap(),
+                "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+            );
+        } else {
+            panic!("peer_id field missing from serialized output");
+        }
+    } else {
+        panic!("Serialized output is not an object");
+    }
+
+    let deserialized: NodeServiceData = serde_json::from_value(serialized).unwrap();
+    assert_eq!(
+        deserialized.peer_id.unwrap().to_string(),
+        "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+    );
+}
+
+#[test]
+fn test_connected_peers_serialization_v2() {
+    let test_data = create_test_v2_struct();
+
+    let serialized = serde_json::to_value(&test_data).unwrap();
+
+    if let serde_json::Value::Object(map) = &serialized {
+        if let Some(serde_json::Value::Array(peers)) = map.get("connected_peers") {
+            assert_eq!(peers.len(), 1);
+            assert!(peers[0].is_string());
+            assert_eq!(
+                peers[0].as_str().unwrap(),
+                "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+            );
+        } else {
+            panic!("connected_peers field missing or not an array");
+        }
+    } else {
+        panic!("Serialized output is not an object");
+    }
+
+    let deserialized: NodeServiceData = serde_json::from_value(serialized).unwrap();
+    let connected_peers = deserialized.connected_peers.unwrap();
+    assert_eq!(connected_peers.len(), 1);
+    assert_eq!(
+        connected_peers[0].to_string(),
+        "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+    );
 }

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -172,11 +172,11 @@ impl Client {
     pub async fn init_alpha() -> Result<Self, ConnectError> {
         let client_config = ClientConfig {
             init_peers_config: InitialPeersConfig {
+                alpha: true,
                 first: false,
                 addrs: vec![],
-                network_contacts_url: vec!["http://146.190.225.26/bootstrap_cache.json".to_string()],
+                network_contacts_url: vec![],
                 local: false,
-                disable_mainnet_contacts: true,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,
             },

--- a/autonomi/tests/wallet.rs
+++ b/autonomi/tests/wallet.rs
@@ -17,7 +17,7 @@ use test_utils::evm::get_funded_wallet;
 async fn from_private_key() {
     let private_key = "0xdb1049e76a813c94be0df47ec3e20533ca676b1b9fef2ddbce9daa117e4da4aa";
     let network =
-        get_evm_network(true).expect("Could not get EVM network from environment variables");
+        get_evm_network(true, None).expect("Could not get EVM network from environment variables");
     let wallet = Wallet::new_from_private_key(network, private_key).unwrap();
 
     assert_eq!(
@@ -31,7 +31,7 @@ async fn send_tokens() {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test("wallet", false);
 
     let network =
-        get_evm_network(true).expect("Could not get EVM network from environment variables");
+        get_evm_network(true, None).expect("Could not get EVM network from environment variables");
     let wallet = get_funded_wallet();
 
     let receiving_wallet = Wallet::new_with_random_wallet(network);

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -119,7 +119,7 @@ impl std::str::FromStr for Network {
 
 impl Network {
     pub fn new(local: bool) -> Result<Self, utils::Error> {
-        get_evm_network(local).inspect_err(|err| {
+        get_evm_network(local, None).inspect_err(|err| {
             warn!("Failed to select EVM network from ENV: {err}");
         })
     }

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -22,9 +22,11 @@ use rand::Rng;
 use std::env;
 use std::path::PathBuf;
 
+const MAINNET_ID: u8 = 1;
+const ALPHANET_ID: u8 = 2;
+
 pub const EVM_TESTNET_CSV_FILENAME: &str = "evm_testnet_data.csv";
 
-/// environment variable to connect to a custom EVM network
 pub const RPC_URL: &str = "RPC_URL";
 const RPC_URL_BUILD_TIME_VAL: Option<&str> = option_env!("RPC_URL");
 pub const PAYMENT_TOKEN_ADDRESS: &str = "PAYMENT_TOKEN_ADDRESS";
@@ -52,12 +54,19 @@ use std::sync::OnceLock;
 
 static EVM_NETWORK: OnceLock<Network> = OnceLock::new();
 
-/// Initialize the EVM Network parameters from environment variables or local CSV file.
+/// Initialize the EVM Network.
 ///
-/// It will first try to get the network from the environment variables.
-/// If it fails and `local` is true, it will try to get the network from the local CSV file.
-/// If both fail, it will return the default network.
-pub fn get_evm_network(local: bool) -> Result<Network, Error> {
+/// Try to obtain it first from environment variables. If that fails and `local` is true,
+/// try to get it from the local CSV file. Lastly, attempt to obtain it based on the network ID,
+/// where 1 is reserved for the mainnet, 2 is reserved for the alpha network, and any other value
+/// between 3 and 255 is reserved for testnets. In the case of a testnet, the network to use must
+/// be configured via the environment variables. We can't just default to Sepolia because sometimes
+/// we want to use Anvil.
+///
+/// If all of these fail an error will be returned. It doesn't really make sense to have a default
+/// for the EVM network. Doing so actually results in confusion for users where sometimes payments
+/// can be rejected because they are on the wrong network.
+pub fn get_evm_network(local: bool, network_id: Option<u8>) -> Result<Network, Error> {
     if let Some(network) = EVM_NETWORK.get() {
         return Ok(network.clone());
     }
@@ -66,7 +75,31 @@ pub fn get_evm_network(local: bool) -> Result<Network, Error> {
         Ok(evm_network) => Ok(evm_network),
         Err(_) if local => Ok(local_evm_network_from_csv()
             .map_err(|e| Error::FailedToGetEvmNetwork(e.to_string()))?),
-        Err(_) => Ok(Network::default()),
+        Err(_) => {
+            if let Some(id) = network_id {
+                match id {
+                    MAINNET_ID => {
+                        info!("Using Arbitrum One based on network ID {}", id);
+                        Ok(Network::ArbitrumOne)
+                    }
+                    ALPHANET_ID => {
+                        info!("Using Arbitrum Sepolia Test based on network ID {}", id);
+                        Ok(Network::ArbitrumSepoliaTest)
+                    }
+                    _ => {
+                        error!("Network ID {} requires EVM network configuration via environment variables", id);
+                        Err(Error::FailedToGetEvmNetwork(format!(
+                            "Network ID {id} requires EVM network to be configured via environment variables" 
+                        )))
+                    }
+                }
+            } else {
+                error!("Failed to obtain the desired EVM network via any means");
+                Err(Error::FailedToGetEvmNetwork(
+                    "Failed to obtain the desired EVM network via any means".to_string(),
+                ))
+            }
+        }
     };
 
     if let Ok(network) = res.as_ref() {
@@ -147,9 +180,9 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
     } else if use_local_evm {
         local_evm_network_from_csv()
     } else {
-        error!("Failed to obtain EVM Network through any means");
+        error!("Failed to obtain the desired EVM Network through environment variables");
         Err(Error::FailedToGetEvmNetwork(
-            "Failed to obtain EVM Network through any means".to_string(),
+            "Failed to obtain the desired EVM Network through environment variables".to_string(),
         ))
     }
 }

--- a/node-launchpad/README.md
+++ b/node-launchpad/README.md
@@ -41,12 +41,11 @@ pre-built node binary and connect it to a network with a custom network ID.
 | Option | Description |
 |--------|-------------|
 | `--network-id <ID>` | Specify the network ID to connect to. Default is 1 for mainnet |
-| `--testnet` | Disable mainnet contacts (for test networks) |
 | `--antnode-path <PATH>` | Path to the pre-built node binary |
 | `--network-contacts-url <URL>` | Comma-separated list of URL containing the bootstrap cache. Can be ignored if `--peer` is used |
 | `--peer <MULTIADDR>` | Comma-separated list of peer multiaddresses. Can be ignored if `--network-contacts-url` is used |
 
 
 ```bash
-./node-launchpad --network-id 2 --testnet --antnode-path /path/to/antnode --peer /ip4/1.2.3.4/tcp/12000/p2p/12D3KooWAbCxMV2Zm3Pe4HcAokWDG9w8UMLpDiKpMxwLK3mixpkL
+./node-launchpad --network-id 3 --antnode-path /path/to/antnode --peer /ip4/1.2.3.4/tcp/12000/p2p/12D3KooWAbCxMV2Zm3Pe4HcAokWDG9w8UMLpDiKpMxwLK3mixpkL
 ```

--- a/test-utils/src/evm.rs
+++ b/test-utils/src/evm.rs
@@ -11,7 +11,7 @@ use evmlib::{utils::get_evm_network, wallet::Wallet, Network};
 use std::env;
 
 pub fn get_funded_wallet() -> evmlib::wallet::Wallet {
-    let network = get_evm_network(true).expect("Failed to get local EVM network from CSV");
+    let network = get_evm_network(true, None).expect("Failed to get local EVM network from CSV");
     if matches!(network, Network::ArbitrumOne) {
         panic!("You're trying to use ArbitrumOne network. Use a custom network for testing.");
     }
@@ -25,7 +25,7 @@ pub fn get_funded_wallet() -> evmlib::wallet::Wallet {
 }
 
 pub fn get_new_wallet() -> Result<Wallet> {
-    let network = get_evm_network(true).expect("Failed to get local EVM network from CSV");
+    let network = get_evm_network(true, None).expect("Failed to get local EVM network from CSV");
     if matches!(network, Network::ArbitrumOne) {
         bail!("You're trying to use ArbitrumOne network. Use a custom network for testing.");
     }


### PR DESCRIPTION
- 3c7896cd2 **chore!: remove the `--testnet` argument**

  BREAKING CHANGE: the `ant`, `antctl` and `antnode` binaries will no longer support the `--testnet`
  argument.

  This argument will no longer be required because we can designate we are using a testnet by setting
  `--network-id` to any value above 2, where 1 will be reserved for `mainnet` and 2 will be reserved
  for `alphanet`.

  Due to maintaining backwards compatibility with the node service data that is used by `antctl`, we
  had to introduce backwards compatibility with the `InitialPeersConfig` struct, thus it now has two
  versions. A new version of `NodeServiceData` was introduced for the removal of the argument, and we
  will also add a new `--alpha` flag argument to this same version.

- 98483e2a7 **feat: provide `--alpha` argument**

  The `ant`, `antnode` and `antctl` binaries will all now support an `--alpha` argument as part of
  their peer configurations.

  When the argument is used, a network ID of 2 will be applied, and the initial peers will be fetched
  from a set of five static IP addresses that have been allocated for the alpha network. So if users
  want to connect to this network, they need only use this switch rather than manually supplying
  `--network-id`, `--network-contacts-url` and/or `--peer` arguments.

- 8440449b0 **feat: select evm network based on network id**

  The doc comments on the `get_evm_network` function provide more detail, but the summary is:
  * The `EVM_NETWORK` and associated variables are checked first. They allow the selection of a preset
    or a custom configuration.
  * Otherwise if these variables are not being used:
      + If no network ID is being used and it's not a local network, we use network ID `1` and so we
        select Arbitrum One.
      + If the `--alpha` argument has been used we use network ID `2` and so we select Arbitrum
        Sepolia Test.
      + If a network ID has been explicitly supplied we are in a testnet scenario and therefore we
        will assert that the `EVM_NETWORK` variables must be used.

  If these conditions are not met the binary will error. I think this is better than selecting a
  default network because when I've been testing with users I've seen this result in confusion about
  exactly which EVM network was being selected.