### PR TITLE
chore(network): extended libp2p::kad::OutboundSubstream timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5380,8 +5380,7 @@ checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 [[package]]
 name = "libp2p"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "bytes",
  "either",
@@ -5417,8 +5416,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5428,8 +5426,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297bfc6cabb70c6180707f8fa05661b77ecb9cb67e8e8e1c469301358fa21d0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5453,8 +5450,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5464,8 +5460,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "either",
  "fnv",
@@ -5483,15 +5478,14 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.11",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "async-trait",
  "futures",
@@ -5506,8 +5500,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec",
@@ -5538,8 +5531,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5578,8 +5570,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5606,8 +5597,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -5625,8 +5615,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5643,8 +5632,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5667,8 +5655,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5689,8 +5676,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a41e346681395877118c270cf993f90d57d045fbf0913ca2f07b59ec6062e4"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5713,8 +5699,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -5732,8 +5717,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "either",
  "fnv",
@@ -5755,11 +5739,9 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
@@ -5767,8 +5749,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5783,8 +5764,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaebc1069dea12c5b86a597eaaddae0317c2c2cb9ec99dc94f82fd340f5c78b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5802,8 +5782,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5817,8 +5796,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf5d48a4d8fad8a49fbf23816a878cac25623549f415d74da8ef4327e6196a9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "either",
  "futures",
@@ -5838,8 +5816,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "either",
  "futures",
@@ -6159,7 +6136,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -6182,7 +6159,7 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6194,15 +6171,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -7557,14 +7533,13 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
+ "thiserror 2.0.11",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -8317,8 +8292,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=extend_outbound_stream_timeout#9200d45475f1f299feba84f61e48bab9695f7bfb"
 dependencies = [
  "futures",
  "pin-project",
@@ -9839,12 +9813,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }
 dirs-next = "~2.0.0"
 futures = "0.3.30"
-libp2p = { version = "0.55.0", features = ["serde"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["serde"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -17,7 +17,7 @@ test-utils = []
 custom_debug = "~0.6.1"
 evmlib = { path = "../evmlib", version = "0.3.0" }
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 ring = "0.17.12"
 rmp-serde = "1.1.1"

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -34,7 +34,7 @@ hyper = { version = "0.14", features = [
     "http1",
 ], optional = true }
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [
     "tokio",
     "dns",
     "upnp",

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -42,7 +42,7 @@ colored = "2.0.4"
 color-eyre = "0.6.3"
 dirs-next = "2.0.0"
 indicatif = { version = "0.17.5", features = ["tokio"] }
-libp2p = { version = "0.55.0", features = [] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 rand = "0.8.5"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -27,7 +27,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["kad"]}
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -44,7 +44,7 @@ file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = ["tokio", "dns", "kad", "macros"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["tokio", "dns", "kad", "macros"] }
 num-traits = "0.2"
 prometheus-client = { version = "0.22", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -23,7 +23,7 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 prometheus-client = { version = "0.22" }
 prost = { version = "0.9", optional = true }
 rand = "0.8"

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -16,7 +16,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.49" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.4", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
-libp2p = { version = "0.55.0", features = ["kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["kad"] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -39,7 +39,7 @@ const-hex = "1.12.0"
 eyre = "0.6.5"
 futures = "0.3.30"
 hex = "~0.4.3"
-libp2p = "0.55.0"
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout" }
 pyo3 = { version = "0.23.4", optional = true, features = ["extension-module", "abi3-py38"] }
 pyo3-async-runtimes = { version = "0.23", optional = true, features = ["tokio-runtime"] }
 rand = "0.8.5"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }
 futures = "~0.3.13"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = [
     "tokio",
     "tcp",
     "noise",

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.3.0" }
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "extend_outbound_stream_timeout", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Description

extend libp2p::kad::OutboundSubstream timeout

NOTE: This PR just for test runs to showing the effect of changing such parameter. 
           A new released libp2p version is required to allow the change become effective.


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
