### PR TITLE
chore: use the static alpha network contacts

### DIFF
--- a/ant-bootstrap/src/contacts.rs
+++ b/ant-bootstrap/src/contacts.rs
@@ -13,7 +13,7 @@ use reqwest::Client;
 use std::time::Duration;
 use url::Url;
 
-const MAINNET_CONTACTS: &[&str] = &[
+pub const MAINNET_CONTACTS: &[&str] = &[
     "https://sn-testnet.s3.eu-west-2.amazonaws.com/network-contacts",
     "http://159.89.251.80/bootstrap_cache.json",
     "http://159.65.210.89/bootstrap_cache.json",
@@ -21,7 +21,7 @@ const MAINNET_CONTACTS: &[&str] = &[
     "http://139.59.201.153/bootstrap_cache.json",
     "http://139.59.200.27/bootstrap_cache.json",
 ];
-const ALPHANET_CONTACTS: &[&str] = &[
+pub const ALPHANET_CONTACTS: &[&str] = &[
     "http://188.166.133.208/bootstrap_cache.json",
     "http://188.166.133.125/bootstrap_cache.json",
     "http://178.128.137.64/bootstrap_cache.json",

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -42,7 +42,7 @@ pub mod external_signer;
 mod network;
 mod utils;
 
-use ant_bootstrap::{BootstrapCacheStore, InitialPeersConfig};
+use ant_bootstrap::{contacts::ALPHANET_CONTACTS, BootstrapCacheStore, InitialPeersConfig};
 pub use ant_evm::Amount;
 use ant_evm::EvmNetwork;
 use ant_networking::{
@@ -174,7 +174,7 @@ impl Client {
             init_peers_config: InitialPeersConfig {
                 first: false,
                 addrs: vec![],
-                network_contacts_url: vec!["http://146.190.225.26/bootstrap_cache.json".to_string()],
+                network_contacts_url: ALPHANET_CONTACTS.iter().map(|s| s.to_string()).collect(),
                 local: false,
                 ignore_cache: false,
                 bootstrap_cache_dir: None,


### PR DESCRIPTION
These IP addresses will remain static for the alpha network, just like the five we have for the production network.
