### PR TITLE
fix(test): allow margin for `test_spawn_network`

### DIFF
--- a/ant-node/src/spawn/network_spawner.rs
+++ b/ant-node/src/spawn/network_spawner.rs
@@ -252,7 +252,9 @@ mod tests {
                 .unwrap()
                 .peers_in_routing_table;
 
-            assert_eq!(peers_in_routing_table, network_size - 1);
+            assert!(
+                peers_in_routing_table >= network_size - 2 && peers_in_routing_table < network_size
+            );
         }
 
         running_network.shutdown();


### PR DESCRIPTION
Allows the network size in `test_spawn_network` to be in between full network size -2 and full network size -1 (18-19), instead of just full network size -1.