### PR TITLE
fix: correctly obtain evm network for `wallet balance`

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -333,7 +333,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 password,
             } => wallet::import(private_key, no_password, password),
             WalletCmd::Export => wallet::export(),
-            WalletCmd::Balance => wallet::balance(network_context.peers.local).await,
+            WalletCmd::Balance => wallet::balance(network_context).await,
         },
         Some(SubCmd::Analyze { addr, verbose }) => {
             analyze::analyze(&addr, verbose, network_context).await

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::actions::NetworkContext;
 use crate::wallet::fs::{select_wallet_private_key, store_private_key};
 use crate::wallet::input::request_password;
 use crate::wallet::DUMMY_NETWORK;
@@ -81,8 +82,11 @@ pub fn export() -> Result<()> {
     Ok(())
 }
 
-pub async fn balance(local: bool) -> Result<()> {
-    let network = get_evm_network(local, None)?;
+pub async fn balance(network_context: NetworkContext) -> Result<()> {
+    let network = get_evm_network(
+        network_context.peers.local,
+        Some(network_context.network_id),
+    )?;
     let wallet = crate::wallet::load_wallet(&network)?;
 
     let token_balance = wallet.balance_of_tokens().await?;

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -174,9 +174,9 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
     } else if use_local_evm {
         local_evm_network_from_csv()
     } else {
-        error!("Failed to obtain the desired EVM Network through environment variables");
+        error!("Failed to obtain the desired EVM network through environment variables");
         Err(Error::FailedToGetEvmNetwork(
-            "Failed to obtain the desired EVM Network through environment variables".to_string(),
+            "Failed to obtain the desired EVM network through environment variables".to_string(),
         ))
     }
 }


### PR DESCRIPTION
When the `--alpha` argument was introduced, this command was not updated to provide the network ID, which is a factor when obtaining the EVM provider.

This meant when the `EVM_NETWORK` argument was not used, the command would error.

It now works as expected, where not explicitly setting the EVM network will result in Arbitrum One being used.