### PR TITLE
feat: separate payment and upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5382,8 +5382,7 @@ checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 [[package]]
 name = "libp2p"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "bytes",
  "either",
@@ -5419,8 +5418,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5430,8 +5428,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297bfc6cabb70c6180707f8fa05661b77ecb9cb67e8e8e1c469301358fa21d0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5455,8 +5452,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5466,8 +5462,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "either",
  "fnv",
@@ -5485,15 +5480,14 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.11",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "async-trait",
  "futures",
@@ -5508,8 +5502,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec",
@@ -5540,8 +5533,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5580,8 +5572,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5608,8 +5599,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -5627,8 +5617,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5645,8 +5634,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5669,8 +5657,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5691,8 +5678,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a41e346681395877118c270cf993f90d57d045fbf0913ca2f07b59ec6062e4"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5715,8 +5701,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -5734,8 +5719,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "either",
  "fnv",
@@ -5757,11 +5741,9 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
@@ -5769,8 +5751,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5785,8 +5766,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaebc1069dea12c5b86a597eaaddae0317c2c2cb9ec99dc94f82fd340f5c78b"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5804,8 +5784,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5819,8 +5798,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf5d48a4d8fad8a49fbf23816a878cac25623549f415d74da8ef4327e6196a9"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "either",
  "futures",
@@ -5840,8 +5818,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "either",
  "futures",
@@ -6161,7 +6138,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -6184,7 +6161,7 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6196,15 +6173,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -7559,14 +7535,13 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
+ "thiserror 2.0.11",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -8319,8 +8294,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/maqi/rust-libp2p.git?branch=lift_up_max_request_msg_size#bc32a3af854b0e187b329fd60576e6fbc58d1655"
 dependencies = [
  "futures",
  "pin-project",
@@ -9854,12 +9828,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }
 dirs-next = "~2.0.0"
 futures = "0.3.30"
-libp2p = { version = "0.55.0", features = ["serde"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["serde"] }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -78,6 +78,8 @@ pub(crate) fn put_error_exit_code(err: &PutError) -> i32 {
         PutError::Wallet(_) => 42,
         PutError::Batch(_) => 44,
         PutError::PayeesMissing => 45,
+        PutError::NetworkError(_) => NETWORK_ERROR,
+        PutError::ProtocolError(_) => PROTOCOL_ERROR,
     }
 }
 

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -17,7 +17,7 @@ test-utils = []
 custom_debug = "~0.6.1"
 evmlib = { path = "../evmlib", version = "0.4.0" }
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 ring = "0.17.12"
 rmp-serde = "1.1.1"

--- a/ant-networking/Cargo.toml
+++ b/ant-networking/Cargo.toml
@@ -34,7 +34,7 @@ hyper = { version = "0.14", features = [
     "http1",
 ], optional = true }
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = [
     "tokio",
     "dns",
     "upnp",

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -174,6 +174,17 @@ pub enum NetworkEvent {
             Option<ProofOfPayment>,
         )>,
     },
+    /// Notify a payment has been made
+    PaymentNotification {
+        holder: NetworkAddress,
+        record_info: (NetworkAddress, DataTypes, ValidationType, ProofOfPayment),
+    },
+    /// A record got uploaded
+    UploadRecord {
+        holder: NetworkAddress,
+        address: NetworkAddress,
+        serialized_record: Vec<u8>,
+    },
     /// Peers of picked bucket for version query.
     PeersForVersionQuery(Vec<(PeerId, Addresses)>),
 }
@@ -245,6 +256,26 @@ impl Debug for NetworkEvent {
                 write!(
                     f,
                     "NetworkEvent::FreshReplicateToFetch({holder:?}, {keys:?})"
+                )
+            }
+            NetworkEvent::PaymentNotification {
+                holder,
+                record_info,
+            } => {
+                write!(
+                    f,
+                    "NetworkEvent::PaymentNotification({holder:?}, {record_info:?})"
+                )
+            }
+            NetworkEvent::UploadRecord {
+                holder,
+                address,
+                serialized_record,
+            } => {
+                write!(
+                    f,
+                    "NetworkEvent::PaymentNotification({holder:?}, {address:?} - {:?})",
+                    serialized_record.len()
                 )
             }
             NetworkEvent::PeersForVersionQuery(peers) => {

--- a/ant-networking/src/event/mod.rs
+++ b/ant-networking/src/event/mod.rs
@@ -174,17 +174,6 @@ pub enum NetworkEvent {
             Option<ProofOfPayment>,
         )>,
     },
-    /// Notify a payment has been made
-    PaymentNotification {
-        holder: NetworkAddress,
-        record_info: (NetworkAddress, DataTypes, ValidationType, ProofOfPayment),
-    },
-    /// A record got uploaded
-    UploadRecord {
-        holder: NetworkAddress,
-        address: NetworkAddress,
-        serialized_record: Vec<u8>,
-    },
     /// Peers of picked bucket for version query.
     PeersForVersionQuery(Vec<(PeerId, Addresses)>),
 }
@@ -256,26 +245,6 @@ impl Debug for NetworkEvent {
                 write!(
                     f,
                     "NetworkEvent::FreshReplicateToFetch({holder:?}, {keys:?})"
-                )
-            }
-            NetworkEvent::PaymentNotification {
-                holder,
-                record_info,
-            } => {
-                write!(
-                    f,
-                    "NetworkEvent::PaymentNotification({holder:?}, {record_info:?})"
-                )
-            }
-            NetworkEvent::UploadRecord {
-                holder,
-                address,
-                serialized_record,
-            } => {
-                write!(
-                    f,
-                    "NetworkEvent::PaymentNotification({holder:?}, {address:?} - {:?})",
-                    serialized_record.len()
                 )
             }
             NetworkEvent::PeersForVersionQuery(peers) => {

--- a/ant-networking/src/event/request_response.rs
+++ b/ant-networking/src/event/request_response.rs
@@ -68,44 +68,6 @@ impl SwarmDriver {
 
                             self.send_event(NetworkEvent::FreshReplicateToFetch { holder, keys });
                         }
-                        Request::Cmd(ant_protocol::messages::Cmd::PaymentNotification {
-                            holder,
-                            record_info,
-                        }) => {
-                            let response = Response::Cmd(
-                                ant_protocol::messages::CmdResponse::PaymentNotification(Ok(())),
-                            );
-
-                            self.queue_network_swarm_cmd(NetworkSwarmCmd::SendResponse {
-                                resp: response,
-                                channel: MsgResponder::FromPeer(channel),
-                            });
-
-                            self.send_event(NetworkEvent::PaymentNotification {
-                                holder,
-                                record_info,
-                            });
-                        }
-                        Request::Cmd(ant_protocol::messages::Cmd::UploadRecord {
-                            holder,
-                            address,
-                            serialized_record,
-                        }) => {
-                            let response = Response::Cmd(
-                                ant_protocol::messages::CmdResponse::UploadRecord(Ok(())),
-                            );
-
-                            self.queue_network_swarm_cmd(NetworkSwarmCmd::SendResponse {
-                                resp: response,
-                                channel: MsgResponder::FromPeer(channel),
-                            });
-
-                            self.send_event(NetworkEvent::UploadRecord {
-                                holder,
-                                address,
-                                serialized_record,
-                            });
-                        }
                         Request::Cmd(ant_protocol::messages::Cmd::PeerConsideredAsBad {
                             detected_by,
                             bad_peer,

--- a/ant-networking/src/event/request_response.rs
+++ b/ant-networking/src/event/request_response.rs
@@ -68,6 +68,44 @@ impl SwarmDriver {
 
                             self.send_event(NetworkEvent::FreshReplicateToFetch { holder, keys });
                         }
+                        Request::Cmd(ant_protocol::messages::Cmd::PaymentNotification {
+                            holder,
+                            record_info,
+                        }) => {
+                            let response = Response::Cmd(
+                                ant_protocol::messages::CmdResponse::PaymentNotification(Ok(())),
+                            );
+
+                            self.queue_network_swarm_cmd(NetworkSwarmCmd::SendResponse {
+                                resp: response,
+                                channel: MsgResponder::FromPeer(channel),
+                            });
+
+                            self.send_event(NetworkEvent::PaymentNotification {
+                                holder,
+                                record_info,
+                            });
+                        }
+                        Request::Cmd(ant_protocol::messages::Cmd::UploadRecord {
+                            holder,
+                            address,
+                            serialized_record,
+                        }) => {
+                            let response = Response::Cmd(
+                                ant_protocol::messages::CmdResponse::UploadRecord(Ok(())),
+                            );
+
+                            self.queue_network_swarm_cmd(NetworkSwarmCmd::SendResponse {
+                                resp: response,
+                                channel: MsgResponder::FromPeer(channel),
+                            });
+
+                            self.send_event(NetworkEvent::UploadRecord {
+                                holder,
+                                address,
+                                serialized_record,
+                            });
+                        }
                         Request::Cmd(ant_protocol::messages::Cmd::PeerConsideredAsBad {
                             detected_by,
                             bad_peer,

--- a/ant-networking/src/record_store_api.rs
+++ b/ant-networking/src/record_store_api.rs
@@ -95,6 +95,16 @@ impl UnifiedRecordStore {
         }
     }
 
+    pub(crate) fn is_expected(&self, key: &RecordKey) -> Result<bool> {
+        match self {
+            Self::Client(_) => {
+                error!("Calling 'is_expected' at Client. This should not happen");
+                Err(NetworkError::OperationNotAllowedOnClientRecordStore)
+            }
+            Self::Node(store) => Ok(store.is_expected(key)),
+        }
+    }
+
     pub(crate) fn record_addresses(&self) -> Result<HashMap<NetworkAddress, ValidationType>> {
         match self {
             Self::Client(_) => {
@@ -150,12 +160,12 @@ impl UnifiedRecordStore {
         }
     }
 
-    pub(crate) fn payment_received(&mut self) {
+    pub(crate) fn payment_received(&mut self, key: RecordKey) {
         match self {
             Self::Client(_) => {
                 error!("Calling payment_received at Client. This should not happen");
             }
-            Self::Node(store) => store.payment_received(),
+            Self::Node(store) => store.payment_received(key),
         }
     }
 

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -42,7 +42,7 @@ colored = "2.0.4"
 color-eyre = "0.6.3"
 dirs-next = "2.0.0"
 indicatif = { version = "0.17.5", features = ["tokio"] }
-libp2p = { version = "0.55.0", features = [] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = [] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 rand = "0.8.5"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -27,7 +27,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["kad"]}
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["kad"]}
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 thiserror = "1.0.23"
 # # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -44,7 +44,7 @@ file-rotate = "0.7.3"
 futures = "~0.3.13"
 hex = "~0.4.3"
 itertools = "~0.12.1"
-libp2p = { version = "0.55.0", features = ["tokio", "dns", "kad", "macros"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["tokio", "dns", "kad", "macros"] }
 num-traits = "0.2"
 prometheus-client = { version = "0.22", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems

--- a/ant-node/src/replication.rs
+++ b/ant-node/src/replication.rs
@@ -232,47 +232,44 @@ impl Node {
     }
 
     // Validate a received payment notification, and insert it into expectation list if necessary.
-    pub(crate) fn handle_payment_notification(
+    pub(crate) async fn handle_payment_notification(
         &self,
         _holder: NetworkAddress,
         record_info: (NetworkAddress, DataTypes, ValidationType, ProofOfPayment),
-    ) {
-        let node = self.clone();
+    ) -> Result<bool> {
         let (addr, data_type, _val_type, payment) = record_info;
-        let _handle = spawn(async move {
-            // Check whether record already exists
-            match node
-                .validate_key_and_existence(&addr, &addr.to_record_key())
-                .await
-            {
-                Ok(true) => {
-                    info!(
-                        "Received a payment notification of an already existing record of {addr:?}"
-                    );
-                    return;
-                }
-                Ok(false) => {
-                    info!("Received a payment notification of {addr:?}");
-                }
-                Err(err) => {
-                    info!("When received a payment notification, failed to verify the local existence of {addr:?} with error {err:?}");
-                    return;
-                }
-            }
 
-            // Payment must be valid
-            match node
-                .payment_for_us_exists_and_is_still_valid(&addr, data_type, payment)
-                .await
-            {
-                Ok(_) => {}
-                Err(err) => {
-                    info!("ProofOfPayment of {addr:?} is invalid with error {err:?}");
-                    return;
-                }
+        // Check whether record already exists
+        match self
+            .validate_key_and_existence(&addr, &addr.to_record_key())
+            .await
+        {
+            Ok(true) => {
+                info!("Received a payment notification of an already existing record of {addr:?}");
+                return Ok(true);
             }
+            Ok(false) => {
+                info!("Received a payment notification of {addr:?}");
+            }
+            Err(err) => {
+                info!("When received a payment notification, failed to verify the local existence of {addr:?} with error {err:?}");
+                return Err(err);
+            }
+        }
 
-            node.network().notify_payment(addr);
-        });
+        // Payment must be valid
+        match self
+            .payment_for_us_exists_and_is_still_valid(&addr, data_type, payment)
+            .await
+        {
+            Ok(_) => {}
+            Err(err) => {
+                info!("ProofOfPayment of {addr:?} is invalid with error {err:?}");
+                return Err(err);
+            }
+        }
+
+        self.network().notify_payment(addr);
+        Ok(true)
     }
 }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -23,7 +23,7 @@ crdts = { version = "7.3", default-features = false, features = ["merkle"] }
 custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["identify", "kad"] }
 prometheus-client = { version = "0.22" }
 prost = { version = "0.9", optional = true }
 rand = "0.8"

--- a/ant-protocol/src/error.rs
+++ b/ant-protocol/src/error.rs
@@ -77,6 +77,11 @@ pub enum Error {
     // The record already exists at this node
     #[error("The record already exists, so do not charge for it: {0:?}")]
     RecordExists(PrettyPrintRecordKey<'static>),
+
+    // ---------- other errors
+    // Place holder of other network errors
+    #[error("Other netowrk erros {0}")]
+    OtherFailure(String),
 }
 
 impl From<Error> for store::Error {

--- a/ant-protocol/src/error.rs
+++ b/ant-protocol/src/error.rs
@@ -52,6 +52,10 @@ pub enum Error {
     GetStoreQuoteFailed,
     #[error("There was an error generating the payment quote")]
     QuoteGenerationFailed,
+    #[error("There was an error when handling PaymentNotifiction: {0}")]
+    PaymentNotificationFailed(String),
+    #[error("There was an error when handling UploadRecord: {0}")]
+    UploadRecordFailed(String),
 
     // ---------- replication errors
     /// Replication not found.

--- a/ant-protocol/src/messages/cmd.rs
+++ b/ant-protocol/src/messages/cmd.rs
@@ -43,26 +43,6 @@ pub enum Cmd {
             Option<ProofOfPayment>,
         )>,
     },
-    /// Write operation to notify holder a payment got made to it.
-    ///
-    /// [`NetworkAddress`]: crate::NetworkAddress
-    PaymentNotification {
-        /// Holder of the correspondent record.
-        holder: NetworkAddress,
-        /// Keys of copy that shall be replicated.
-        record_info: (NetworkAddress, DataTypes, ValidationType, ProofOfPayment),
-    },
-    /// Write operation to upload a record.
-    ///
-    /// [`NetworkAddress`]: crate::NetworkAddress
-    UploadRecord {
-        /// Holder of the record.
-        holder: NetworkAddress,
-        /// serialized record.
-        serialized_record: Vec<u8>,
-        /// Address of the record.
-        address: NetworkAddress,
-    },
     /// Notify the peer it is now being considered as BAD due to the included behaviour
     PeerConsideredAsBad {
         detected_by: NetworkAddress,
@@ -90,24 +70,6 @@ impl std::fmt::Debug for Cmd {
                     .field("first_ten_keys", &first_ten_keys)
                     .finish()
             }
-            Cmd::PaymentNotification {
-                holder,
-                record_info,
-            } => f
-                .debug_struct("Cmd::PaymentNotification")
-                .field("holder", holder)
-                .field("record_info", &record_info.0)
-                .finish(),
-            Cmd::UploadRecord {
-                holder,
-                address,
-                serialized_record,
-            } => f
-                .debug_struct("Cmd::UploadRecord")
-                .field("holder", holder)
-                .field("record address", &address)
-                .field("serialized_record", &serialized_record.len())
-                .finish(),
             Cmd::PeerConsideredAsBad {
                 detected_by,
                 bad_peer,
@@ -128,8 +90,6 @@ impl Cmd {
         match self {
             Cmd::Replicate { holder, .. } => holder.clone(),
             Cmd::FreshReplicate { holder, .. } => holder.clone(),
-            Cmd::PaymentNotification { holder, .. } => holder.clone(),
-            Cmd::UploadRecord { holder, .. } => holder.clone(),
             Cmd::PeerConsideredAsBad { bad_peer, .. } => bad_peer.clone(),
         }
     }
@@ -152,29 +112,6 @@ impl std::fmt::Display for Cmd {
                     "Cmd::Replicate({:?} has {} keys)",
                     holder.as_peer_id(),
                     keys.len()
-                )
-            }
-            Cmd::PaymentNotification {
-                holder,
-                record_info,
-            } => {
-                write!(
-                    f,
-                    "Cmd::PaymentNotification({:?} got paid for record {:?})",
-                    holder.as_peer_id(),
-                    record_info.0
-                )
-            }
-            Cmd::UploadRecord {
-                holder,
-                address,
-                serialized_record,
-            } => {
-                write!(
-                    f,
-                    "Cmd::UploadRecord(To {:?}, with record {address:?} has {} data_size)",
-                    holder.as_peer_id(),
-                    serialized_record.len()
                 )
             }
             Cmd::PeerConsideredAsBad {

--- a/ant-protocol/src/messages/response.rs
+++ b/ant-protocol/src/messages/response.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 /// The response to a query, containing the query result.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QueryResponse {
-    // ===== GetStoreQuote =====
+    // ===== Upload related =====
     //
     /// Response to [`GetStoreQuote`]
     ///
@@ -32,6 +32,33 @@ pub enum QueryResponse {
         /// Storage proofs based on requested target address and difficulty
         storage_proofs: Vec<(NetworkAddress, Result<ChunkProof>)>,
     },
+    /// Response to [`PaymentNotification`]
+    ///
+    /// [`PaymentNotification`]: crate::messages::Query::PaymentNotification
+    PaymentNotification {
+        /// Result of payment notification.
+        result: Result<bool>,
+        /// Node's Peer Address
+        peer_address: NetworkAddress,
+        /// Correspondent Record Address
+        record_addr: NetworkAddress,
+    },
+    /// Response to [`UploadRecord`]
+    ///
+    /// [`UploadRecord`]: crate::messages::Query::UploadRecord
+    UploadRecord {
+        /// Result of record upload.
+        result: Result<bool>,
+        /// Node's Peer Address
+        peer_address: NetworkAddress,
+        /// Correspondent Record Address
+        record_addr: NetworkAddress,
+    },
+    // ===== Status Check =====
+    //
+    /// Response to [`CheckNodeInProblem`]
+    ///
+    /// [`CheckNodeInProblem`]: crate::messages::Query::CheckNodeInProblem
     CheckNodeInProblem {
         /// Address of the peer that queried
         reporter_address: NetworkAddress,
@@ -66,7 +93,6 @@ pub enum QueryResponse {
         // Signature of signing the above (if requested), for future economic model usage.
         signature: Option<Vec<u8>>,
     },
-    /// *** From now on, the order of variants shall be retained to be backward compatible
     // ===== GetVersion =====
     //
     /// Response to [`GetVersion`]
@@ -92,6 +118,26 @@ impl Debug for QueryResponse {
                     f,
                     "GetStoreQuote(quote: {quote:?}, from {peer_address:?} w/ payment_address: {payment_address:?}, and {} storage proofs)",
                     storage_proofs.len()
+                )
+            }
+            QueryResponse::PaymentNotification {
+                result,
+                peer_address,
+                record_addr,
+            } => {
+                write!(
+                    f,
+                    "PaymentNotification(payment of {record_addr:?} sent to {peer_address:?} with result {result:?})",
+                )
+            }
+            QueryResponse::UploadRecord {
+                result,
+                peer_address,
+                record_addr,
+            } => {
+                write!(
+                    f,
+                    "UploadRecord(Record {record_addr:?} uploaded to {peer_address:?} with result {result:?})",
                 )
             }
             QueryResponse::CheckNodeInProblem {
@@ -145,10 +191,6 @@ pub enum CmdResponse {
     Replicate(Result<()>),
     /// Response to fresh replication cmd
     FreshReplicate(Result<()>),
-    /// Response to payment notification cmd
-    PaymentNotification(Result<()>),
-    /// Response to upload record cmd
-    UploadRecord(Result<()>),
     //
     // ===== PeerConsideredAsBad =====
     //

--- a/ant-protocol/src/messages/response.rs
+++ b/ant-protocol/src/messages/response.rs
@@ -145,6 +145,10 @@ pub enum CmdResponse {
     Replicate(Result<()>),
     /// Response to fresh replication cmd
     FreshReplicate(Result<()>),
+    /// Response to payment notification cmd
+    PaymentNotification(Result<()>),
+    /// Response to upload record cmd
+    UploadRecord(Result<()>),
     //
     // ===== PeerConsideredAsBad =====
     //

--- a/ant-protocol/src/storage/header.rs
+++ b/ant-protocol/src/storage/header.rs
@@ -17,7 +17,9 @@ use std::fmt::Display;
 use xor_name::XorName;
 
 /// Data types that natively suppported by autonomi network.
-#[derive(EncodeLabelValue, Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(
+    EncodeLabelValue, Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq, PartialOrd, Hash,
+)]
 pub enum DataTypes {
     Chunk,
     GraphEntry,
@@ -49,7 +51,7 @@ impl DataTypes {
 /// Indicates the type of the record content.
 /// This is to be only used within the node instance to reflect different content version.
 /// Hence, only need to have two entries: Chunk and NonChunk.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, PartialOrd, Hash)]
 pub enum ValidationType {
     Chunk,
     NonChunk(XorName),

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -16,7 +16,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.49" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.5", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
-libp2p = { version = "0.55.0", features = ["kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["kad"] }
 libp2p-identity = { version = "0.2.7", features = ["rand"] }
 prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -40,7 +40,7 @@ exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
 hex = "~0.4.3"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = [
     "tokio",
     "dns",
     "upnp",

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -20,7 +20,7 @@ use crate::{
 use ant_evm::{Amount, AttoTokens};
 pub use ant_protocol::storage::{Chunk, ChunkAddress};
 use ant_protocol::{
-    messages::{Cmd, Request},
+    messages::{Query, Request},
     storage::{
         try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind,
         ValidationType,
@@ -250,7 +250,7 @@ impl Client {
                     proof.to_proof_of_payment(),
                 );
                 for (peer_id, addrs) in proof.payees() {
-                    let request = Request::Cmd(Cmd::PaymentNotification {
+                    let request = Request::Query(Query::PaymentNotification {
                         holder: NetworkAddress::from(peer_id),
                         record_info: record_info.clone(),
                     });
@@ -326,7 +326,7 @@ impl Client {
             };
 
             for (peer_id, addrs) in proof.payees() {
-                let request = Request::Cmd(Cmd::UploadRecord {
+                let request = Request::Query(Query::UploadRecord {
                     holder: NetworkAddress::from(peer_id),
                     address: NetworkAddress::from(address),
                     serialized_record: serialized_record.clone(),

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -46,8 +46,6 @@ mod utils;
 use payment::Receipt;
 pub use put_error_state::ChunkBatchUploadState;
 
-use crate::networking::Multiaddr;
-use crate::networking::NetworkAddress;
 use ant_bootstrap::{contacts::ALPHANET_CONTACTS, InitialPeersConfig};
 pub use ant_evm::Amount;
 use ant_evm::EvmNetwork;
@@ -64,8 +62,7 @@ const CLIENT_EVENT_CHANNEL_SIZE: usize = 100;
 
 // Amount of peers to confirm into our routing table before we consider the client ready.
 use crate::client::config::ClientOperatingStrategy;
-use crate::networking::multiaddr_is_global;
-use crate::networking::{Network, NetworkError};
+use crate::networking::{multiaddr_is_global, Multiaddr, Network, NetworkAddress, NetworkError};
 use ant_protocol::storage::RecordKind;
 pub use ant_protocol::CLOSE_GROUP_SIZE;
 
@@ -143,6 +140,10 @@ pub enum PutError {
     },
     #[error("Batch upload: {0}")]
     Batch(ChunkBatchUploadState),
+    #[error("Error occurred during network operation: {0}")]
+    NetworkError(#[from] NetworkError),
+    #[error("Error occurred during serialize/deserialize: {0}")]
+    ProtocolError(#[from] ant_protocol::Error),
 }
 
 /// Errors that can occur during the get operation.

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -6,7 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::{client::PutError, networking::NetworkError};
 use futures::stream::{FuturesUnordered, StreamExt};
+use libp2p::PeerId;
 use std::future::Future;
 
 pub(crate) async fn process_tasks_with_max_concurrency<I, R>(tasks: I, batch_size: usize) -> Vec<R>
@@ -34,4 +36,24 @@ where
     }
 
     results
+}
+
+pub(crate) async fn process_request_tasks_expect_majority_succeeds<I>(
+    total_tasks: usize,
+    tasks: I,
+) -> Result<(), PutError>
+where
+    I: IntoIterator,
+    I::Item: Future<Output = Result<Option<PeerId>, NetworkError>> + Send,
+{
+    let tasks_results = process_tasks_with_max_concurrency(tasks, total_tasks).await;
+
+    // return error only when not having enough OK responses.
+    if tasks_results.iter().filter(|res| res.is_ok()).count() <= total_tasks / 2 {
+        // Just return the first error
+        if let Some(Err(res_err)) = tasks_results.iter().find(|res| res.is_err()) {
+            return Err(PutError::NetworkError(res_err.clone()));
+        }
+    }
+    Ok(())
 }

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -293,6 +293,29 @@ impl NetworkDriver {
                     },
                 );
             }
+            NetworkTask::Request {
+                peer_id,
+                addresses,
+                req,
+                resp,
+            } => {
+                // Add the peer addresses to our cache before sending a request.
+                for addr in &addresses.0 {
+                    self.swarm.add_peer_address(peer_id, addr.clone());
+                }
+
+                let req_id = self.req().send_request(&peer_id, req.clone());
+
+                self.pending_tasks.insert_query(
+                    req_id,
+                    NetworkTask::Request {
+                        peer_id,
+                        addresses,
+                        req,
+                        resp,
+                    },
+                );
+            }
         }
     }
 }

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use ant_protocol::messages::{CmdResponse, QueryResponse, Response};
+use ant_protocol::messages::{QueryResponse, Response};
 use libp2p::kad::{Event as KadEvent, ProgressStep, QueryId, QueryResult, QueryStats};
 use libp2p::request_response::{Event as ReqEvent, Message, OutboundRequestId};
 use libp2p::swarm::SwarmEvent;
@@ -117,9 +117,18 @@ impl NetworkDriver {
             }) => self
                 .pending_tasks
                 .update_get_quote(request_id, quote, peer_address)?,
-            Response::Cmd(CmdResponse::UploadRecord(resp))
-            | Response::Cmd(CmdResponse::PaymentNotification(resp)) => {
-                self.pending_tasks.update_request(request_id, resp)?
+            Response::Query(QueryResponse::UploadRecord {
+                result,
+                peer_address,
+                record_addr,
+            })
+            | Response::Query(QueryResponse::PaymentNotification {
+                result,
+                peer_address,
+                record_addr,
+            }) => {
+                self.pending_tasks
+                    .update_request(request_id, result, peer_address, record_addr)?
             }
             _ => warn!("Unsupported response of request({request_id:?}): {response:?}"),
         }

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -297,8 +297,6 @@ impl TaskHandler {
         &mut self,
         id: OutboundRequestId,
         request_res: Result<bool, ant_protocol::error::Error>,
-        _peer_address: NetworkAddress,
-        _record_addr: NetworkAddress,
     ) -> Result<(), TaskHandlerError> {
         let (resp, peer, _addresses) =
             self.requests
@@ -307,13 +305,13 @@ impl TaskHandler {
                     "OutboundRequestId {id:?}"
                 )))?;
         trace!("OutboundRequestId({id}): got request response {request_res:?} from peer {peer:?}");
-        let result = if request_res.is_err() {
-            None
+        let result = if let Err(err) = request_res {
+            Err(NetworkError::PutRecordError(format!("{err:?}")))
         } else {
-            Some(peer)
+            Ok(Some(peer))
         };
 
-        resp.send(Ok(result))
+        resp.send(result)
             .map_err(|_| TaskHandlerError::NetworkClientDropped)?;
 
         Ok(())

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -296,7 +296,9 @@ impl TaskHandler {
     pub fn update_request(
         &mut self,
         id: OutboundRequestId,
-        request_res: Result<(), ant_protocol::error::Error>,
+        request_res: Result<bool, ant_protocol::error::Error>,
+        _peer_address: NetworkAddress,
+        _record_addr: NetworkAddress,
     ) -> Result<(), TaskHandlerError> {
         let (resp, peer, _addresses) =
             self.requests

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::networking::OneShotTaskResult;
+use crate::networking::{common::Addresses, OneShotTaskResult};
 use ant_evm::PaymentQuote;
-use ant_protocol::NetworkAddress;
+use ant_protocol::{messages::Request, NetworkAddress};
 use libp2p::{
     kad::{PeerInfo, Quorum, Record},
     PeerId,
@@ -58,5 +58,13 @@ pub(super) enum NetworkTask {
         data_size: usize,
         #[debug(skip)]
         resp: OneShotTaskResult<Option<(PeerInfo, PaymentQuote)>>,
+    },
+    /// cf [`crate::driver::task_handler::TaskHandler::update_request`]
+    Request {
+        peer_id: PeerId,
+        addresses: Addresses,
+        req: Request,
+        #[debug(skip)]
+        resp: OneShotTaskResult<Option<PeerId>>,
     },
 }

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -275,6 +275,23 @@ impl Network {
         addresses: Addresses,
         req: Request,
     ) -> Result<Option<PeerId>, NetworkError> {
+        let result = self
+            .send_request_once(peer_id, addresses.clone(), req.clone())
+            .await;
+        if result.is_ok() {
+            return result;
+        }
+
+        // Re-send the request once
+        self.send_request_once(peer_id, addresses, req).await
+    }
+
+    async fn send_request_once(
+        &self,
+        peer_id: PeerId,
+        addresses: Addresses,
+        req: Request,
+    ) -> Result<Option<PeerId>, NetworkError> {
         let (tx, rx) = oneshot::channel();
         let task = NetworkTask::Request {
             peer_id,

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use utils::multiaddr_is_global;
 
 // re-export the types our API exposes to avoid dependency version conflicts
 pub use ant_evm::PaymentQuote;
-pub use ant_protocol::NetworkAddress;
+pub use ant_protocol::{messages::Request, NetworkAddress};
 pub use config::{RetryStrategy, Strategy};
 pub use libp2p::kad::PeerInfo;
 pub use libp2p::{
@@ -28,6 +28,7 @@ pub use libp2p::{
 };
 
 // internal needs
+use crate::networking::common::Addresses;
 use ant_protocol::CLOSE_GROUP_SIZE;
 use driver::NetworkDriver;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -258,6 +259,27 @@ impl Network {
             peer,
             data_type,
             data_size,
+            resp: tx,
+        };
+        self.task_sender
+            .send(task)
+            .await
+            .map_err(|_| NetworkError::NetworkDriverOffline)?;
+        rx.await?
+    }
+
+    /// Send a Request message to a node, and waiting for the response.
+    pub async fn send_request(
+        &self,
+        peer_id: PeerId,
+        addresses: Addresses,
+        req: Request,
+    ) -> Result<Option<PeerId>, NetworkError> {
+        let (tx, rx) = oneshot::channel();
+        let task = NetworkTask::Request {
+            peer_id,
+            addresses,
+            req,
             resp: tx,
         };
         self.task_sender

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }
 futures = "~0.3.13"
-libp2p = { version = "0.55.0", features = [
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = [
     "tokio",
     "tcp",
     "noise",

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
 evmlib = { path = "../evmlib", version = "0.4.0" }
-libp2p = { version = "0.55.0", features = ["identify", "kad"] }
+libp2p = { git = "https://github.com/maqi/rust-libp2p.git", branch = "lift_up_max_request_msg_size", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Description

To overcome the `quoting expiration` issue that encountered when having slow connection or having huge file or complex folder to upload, it is decided to separate payment (quote, smart_contract transaction, payment notification) and upload (real record) 
- a client quote and pay, then only notify selected payees about the payment first
- client then take whatever time required/willing to to upload correspondent record
- node keep such payment notification as an expectation list as long time as possible, and accept the upload it record is expected.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
