### PR TITLE
feat: scratchpad and pointers in cli

### DIFF
--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -41,6 +41,17 @@ ant [OPTIONS] <COMMAND>
 
 [Reference : Vault](#vault-operations)
 
+### Scratchpad
+- `scratchpad generate-key [--overwrite]`
+- `scratchpad cost <name>`
+- `scratchpad create <name> <data> [--max-fee-per-gas <value>]`
+- `scratchpad share <name>`
+- `scratchpad get <name> [--secret-key] [--hex]`
+- `scratchpad edit <name> <data> [--secret-key]`
+- `scratchpad list`
+
+[Reference : Scratchpad](#scratchpad-operations)
+
 ### Wallet
 - `wallet create [--no-password] [--password <password>]`
 - `wallet import <private_key> [--no-password] [--password <password>]`
@@ -327,6 +338,79 @@ Analyze an address to get the address type, and visualize the content.
 analyze <address>
 ```
 
+### Scratchpad Operations
+
+#### Generate a new scratchpad key
+```
+scratchpad generate-key [--overwrite]
+```
+Generate a new general scratchpad key from which all your scratchpad keys can be derived.
+
+The following flag can be applied:
+`--overwrite` (Optional) Warning: overwriting the existing key will result in loss of access to any existing scratchpads
+
+#### Get a cost estimate for creating a scratchpad
+```
+scratchpad cost <name>
+```
+Gets a cost estimate for creating a scratchpad on the network.
+
+Expected values:
+- `<name>`: The name of the scratchpad
+
+#### Create a new scratchpad
+```
+scratchpad create <name> <data> [--max-fee-per-gas <value>]
+```
+Create a new scratchpad with the given name and data.
+
+Expected values:
+- `<name>`: The name of the scratchpad
+- `<data>`: The data to store in the scratchpad (Up to 4MB)
+
+The following flag can be applied:
+`--max-fee-per-gas <value>` (Optional) Specify the maximum fee per gas
+
+#### Share a scratchpad
+```
+scratchpad share <name>
+```
+Share a scratchpad secret key with someone else. Sharing this key means that the other party will have permanent read and write access to the scratchpad.
+
+Expected values:
+- `<name>`: The name of the scratchpad
+
+#### Get a scratchpad
+```
+scratchpad get <name> [--secret-key] [--hex]
+```
+Get the contents of an existing scratchpad from the network.
+
+Expected values:
+- `<name>`: The name of the scratchpad
+
+The following flags can be applied:
+`--secret-key` (Optional) Indicate that this is an external scratchpad secret key (Use when interacting with a shared scratchpad)
+`--hex` (Optional) Display the data as a hex string instead of raw bytes
+
+#### Edit a scratchpad
+```
+scratchpad edit <name> <data> [--secret-key]
+```
+Edit the contents of an existing scratchpad.
+
+Expected values:
+- `<name>`: The name of the scratchpad
+- `<data>`: The new data to store in the scratchpad (Up to 4MB)
+
+The following flag can be applied:
+`--secret-key` (Optional) Indicate that this is an external scratchpad secret key (Use when interacting with a shared scratchpad)
+
+#### List scratchpads
+```
+scratchpad list
+```
+List owned scratchpads.
 
 ## Error Handling
 If you encounter any errors while using the CLI, you can use the `--log-output-dest` and `--log-format` options to specify logging details. This can help with debugging and understanding the behavior of the CLI.

--- a/ant-cli/src/access/keys.rs
+++ b/ant-cli/src/access/keys.rs
@@ -8,8 +8,9 @@
 
 use crate::wallet::load_wallet_private_key;
 use autonomi::client::register::SecretKey as RegisterSecretKey;
+use autonomi::client::scratchpad::SecretKey as ScratchpadSecretKey;
 use autonomi::client::vault::VaultSecretKey;
-use autonomi::{Network, Wallet};
+use autonomi::{Client, Network, Wallet};
 use color_eyre::eyre::{eyre, Context, Result};
 use color_eyre::Section;
 use std::env;
@@ -18,8 +19,10 @@ use std::path::PathBuf;
 
 const SECRET_KEY_ENV: &str = "SECRET_KEY";
 const REGISTER_SIGNING_KEY_ENV: &str = "REGISTER_SIGNING_KEY";
-
 const REGISTER_SIGNING_KEY_FILE: &str = "register_signing_key";
+
+const SCRATCHPAD_SIGNING_KEY_ENV: &str = "SCRATCHPAD_SIGNING_KEY";
+const SCRATCHPAD_SIGNING_KEY_FILE: &str = "scratchpad_signing_key";
 
 /// EVM wallet
 pub fn load_evm_wallet_from_env(evm_network: &Network) -> Result<Wallet> {
@@ -90,5 +93,66 @@ pub fn get_register_signing_key_path() -> Result<PathBuf> {
     let dir = super::data_dir::get_client_data_dir_path()
         .wrap_err("Could not access directory for register signing key")?;
     let file_path = dir.join(REGISTER_SIGNING_KEY_FILE);
+    Ok(file_path)
+}
+
+// --------- Scratchpad keys ----------
+
+pub fn get_scratchpad_signing_key_path() -> Result<PathBuf> {
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err("Could not access directory for scratchpad signing key")?;
+    let file_path = dir.join(SCRATCHPAD_SIGNING_KEY_FILE);
+    Ok(file_path)
+}
+
+pub fn get_scratchpad_general_signing_key() -> Result<ScratchpadSecretKey> {
+    // try env var first
+    let why_env_failed = match env::var(SCRATCHPAD_SIGNING_KEY_ENV) {
+        Ok(key) => return parse_scratchpad_signing_key(&key),
+        Err(e) => e,
+    };
+
+    // try from data dir
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err(format!("Failed to obtain scratchpad signing key from env var: {why_env_failed}, reading from disk also failed as couldn't access data dir"))
+        .with_suggestion(|| format!("make sure you've provided the {SCRATCHPAD_SIGNING_KEY_ENV} env var"))
+        .with_suggestion(|| "you can generate a new secret key with the `scratchpad generate-key` subcommand")?;
+
+    // load the key from file
+    let key_path = dir.join(SCRATCHPAD_SIGNING_KEY_FILE);
+    let key_hex = fs::read_to_string(&key_path)
+        .wrap_err("Failed to read secret key from file")
+        .with_suggestion(|| format!("make sure you've provided the {SCRATCHPAD_SIGNING_KEY_ENV} env var or have the key in a file at {key_path:?}"))
+        .with_suggestion(|| "you can generate a new secret key with the `scratchpad generate-key` subcommand")?;
+
+    // parse the key
+    let key = parse_scratchpad_signing_key(&key_hex)?;
+    Ok(key)
+}
+
+pub fn get_scratchpad_signing_key(name: &str) -> Result<ScratchpadSecretKey> {
+    let key = get_scratchpad_general_signing_key()?;
+
+    // derive the key using the same logic as registers
+    let key_for_name = Client::register_key_from_name(&key, name);
+    Ok(key_for_name)
+}
+
+pub fn parse_scratchpad_signing_key(key_hex: &str) -> Result<ScratchpadSecretKey> {
+    ScratchpadSecretKey::from_hex(key_hex)
+        .wrap_err("Failed to parse scratchpad signing key")
+        .with_suggestion(|| {
+            "the scratchpad signing key should be a hex encoded string of a bls secret key"
+        })
+        .with_suggestion(|| {
+            "you can generate a new secret key with the `scratchpad generate-key` subcommand"
+        })
+}
+
+pub fn create_scratchpad_signing_key_file(key: ScratchpadSecretKey) -> Result<PathBuf> {
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err("Could not access directory to write key to")?;
+    let file_path = dir.join(SCRATCHPAD_SIGNING_KEY_FILE);
+    fs::write(&file_path, key.to_hex()).wrap_err("Could not write key to file")?;
     Ok(file_path)
 }

--- a/ant-cli/src/access/keys.rs
+++ b/ant-cli/src/access/keys.rs
@@ -24,6 +24,9 @@ const REGISTER_SIGNING_KEY_FILE: &str = "register_signing_key";
 const SCRATCHPAD_SIGNING_KEY_ENV: &str = "SCRATCHPAD_SIGNING_KEY";
 const SCRATCHPAD_SIGNING_KEY_FILE: &str = "scratchpad_signing_key";
 
+const POINTER_SIGNING_KEY_ENV: &str = "POINTER_SIGNING_KEY";
+const POINTER_SIGNING_KEY_FILE: &str = "pointer_signing_key";
+
 /// EVM wallet
 pub fn load_evm_wallet_from_env(evm_network: &Network) -> Result<Wallet> {
     let secret_key =
@@ -153,6 +156,67 @@ pub fn create_scratchpad_signing_key_file(key: ScratchpadSecretKey) -> Result<Pa
     let dir = super::data_dir::get_client_data_dir_path()
         .wrap_err("Could not access directory to write key to")?;
     let file_path = dir.join(SCRATCHPAD_SIGNING_KEY_FILE);
+    fs::write(&file_path, key.to_hex()).wrap_err("Could not write key to file")?;
+    Ok(file_path)
+}
+
+// --------- Pointer keys ----------
+
+pub fn get_pointer_signing_key_path() -> Result<PathBuf> {
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err("Could not access directory for pointer signing key")?;
+    let file_path = dir.join(POINTER_SIGNING_KEY_FILE);
+    Ok(file_path)
+}
+
+pub fn get_pointer_general_signing_key() -> Result<ScratchpadSecretKey> {
+    // try env var first
+    let why_env_failed = match env::var(POINTER_SIGNING_KEY_ENV) {
+        Ok(key) => return parse_pointer_signing_key(&key),
+        Err(e) => e,
+    };
+
+    // try from data dir
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err(format!("Failed to obtain pointer signing key from env var: {why_env_failed}, reading from disk also failed as couldn't access data dir"))
+        .with_suggestion(|| format!("make sure you've provided the {POINTER_SIGNING_KEY_ENV} env var"))
+        .with_suggestion(|| "you can generate a new secret key with the `pointer generate-key` subcommand")?;
+
+    // load the key from file
+    let key_path = dir.join(POINTER_SIGNING_KEY_FILE);
+    let key_hex = fs::read_to_string(&key_path)
+        .wrap_err("Failed to read secret key from file")
+        .with_suggestion(|| format!("make sure you've provided the {POINTER_SIGNING_KEY_ENV} env var or have the key in a file at {key_path:?}"))
+        .with_suggestion(|| "you can generate a new secret key with the `pointer generate-key` subcommand")?;
+
+    // parse the key
+    let key = parse_pointer_signing_key(&key_hex)?;
+    Ok(key)
+}
+
+pub fn get_pointer_signing_key(name: &str) -> Result<ScratchpadSecretKey> {
+    let key = get_pointer_general_signing_key()?;
+
+    // derive the key using the same logic as registers
+    let key_for_name = Client::register_key_from_name(&key, name);
+    Ok(key_for_name)
+}
+
+pub fn parse_pointer_signing_key(key_hex: &str) -> Result<ScratchpadSecretKey> {
+    ScratchpadSecretKey::from_hex(key_hex)
+        .wrap_err("Failed to parse pointer signing key")
+        .with_suggestion(|| {
+            "the pointer signing key should be a hex encoded string of a bls secret key"
+        })
+        .with_suggestion(|| {
+            "you can generate a new secret key with the `pointer generate-key` subcommand"
+        })
+}
+
+pub fn create_pointer_signing_key_file(key: ScratchpadSecretKey) -> Result<PathBuf> {
+    let dir = super::data_dir::get_client_data_dir_path()
+        .wrap_err("Could not access directory to write key to")?;
+    let file_path = dir.join(POINTER_SIGNING_KEY_FILE);
     fs::write(&file_path, key.to_hex()).wrap_err("Could not write key to file")?;
     Ok(file_path)
 }

--- a/ant-cli/src/commands/pointer.rs
+++ b/ant-cli/src/commands/pointer.rs
@@ -1,0 +1,294 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::actions::NetworkContext;
+use crate::wallet::load_wallet;
+use autonomi::client::pointer::PointerTarget;
+use autonomi::client::pointer::SecretKey as PointerSecretKey;
+use autonomi::ChunkAddress;
+use autonomi::Client;
+use autonomi::GraphEntryAddress;
+use autonomi::PointerAddress;
+use autonomi::ScratchpadAddress;
+use autonomi::TransactionConfig;
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::Context;
+use color_eyre::eyre::Result;
+use color_eyre::Section;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TargetDataType {
+    /// Graph entry address
+    GraphEntry,
+    /// Scratchpad address
+    Scratchpad,
+    /// Pointer address
+    Pointer,
+    /// Chunk address
+    Chunk,
+    /// Auto-detect the type of the target
+    #[default]
+    Auto,
+}
+
+pub fn parse_target_data_type(s: &str) -> Result<TargetDataType> {
+    match s {
+        "graph" => Ok(TargetDataType::GraphEntry),
+        "scratchpad" => Ok(TargetDataType::Scratchpad),
+        "pointer" => Ok(TargetDataType::Pointer),
+        "chunk" => Ok(TargetDataType::Chunk),
+        "auto" => Ok(TargetDataType::Auto),
+        _ => Err(eyre!("Invalid target data type: {s}")),
+    }
+}
+
+/// Generates a new general pointer key
+///
+/// # Arguments
+/// * `overwrite` - If true, overwrites existing key if it exists
+pub fn generate_key(overwrite: bool) -> Result<()> {
+    let key_path = crate::keys::get_pointer_signing_key_path()?;
+    if key_path.exists() && !overwrite {
+        error!("Pointer key already exists at: {key_path:?}");
+        return Err(eyre!("Pointer key already exists at: {}", key_path.display()))
+            .with_suggestion(|| "if you want to overwrite the existing key, run the command with the --overwrite flag")
+            .with_warning(|| "overwriting the existing key might result in loss of access to any existing pointers created using that key");
+    }
+
+    let key = PointerSecretKey::random();
+    let path = crate::keys::create_pointer_signing_key_file(key)
+        .wrap_err("Failed to create new pointer key")?;
+    info!("Created new pointer key at: {path:?}");
+    println!("✅ Created new pointer key at: {}", path.display());
+    Ok(())
+}
+
+/// Estimates the cost to create a pointer
+///
+/// # Arguments
+/// * `name` - Name of the pointer
+/// * `network_context` - Network context for the operation
+pub async fn cost(name: String, network_context: NetworkContext) -> Result<()> {
+    let key = crate::keys::get_pointer_signing_key(&name)
+        .wrap_err("The pointer key is required to perform this action")?;
+    let client = crate::actions::connect_to_network(network_context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let cost = client
+        .pointer_cost(&key.public_key())
+        .await
+        .wrap_err("Failed to get cost for pointer")?;
+    info!("Estimated cost to create a pointer with name {name}: {cost}");
+    println!("✅ The estimated cost to create a pointer with name {name} is: {cost}");
+    Ok(())
+}
+
+/// Creates a new pointer
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the pointer
+/// * `target` - Target address as a string to store in the pointer
+/// * `target_data_type` - The type of the target data
+/// * `max_fee_per_gas` - Optional maximum fee per gas
+pub async fn create(
+    context: NetworkContext,
+    name: String,
+    target: String,
+    target_data_type: TargetDataType,
+    max_fee_per_gas: Option<u128>,
+) -> Result<()> {
+    let pointer_key = crate::keys::get_pointer_signing_key(&name)
+        .wrap_err("The pointer key is required to perform this action")?;
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let target = pointer_target_from_hex(&target, target_data_type, &client).await?;
+    let mut wallet = load_wallet(client.evm_network())?;
+
+    if let Some(max_fee_per_gas) = max_fee_per_gas {
+        wallet.set_transaction_config(TransactionConfig::new(max_fee_per_gas))
+    }
+
+    println!("Creating pointer with name: {name}");
+    info!("Creating pointer with name: {name}");
+
+    let (cost, address) = client
+        .pointer_create(&pointer_key, target, wallet.into())
+        .await
+        .wrap_err("Failed to create pointer")?;
+
+    println!("✅ Pointer created at address: {address}");
+    println!("With name: {name}");
+    info!("Pointer created at address: {address} with name: {name}");
+    println!("Total cost: {cost} AttoTokens");
+
+    crate::user_data::write_local_pointer(address, &name)
+        .wrap_err("Failed to save pointer to local user data")
+        .with_suggestion(|| "Local user data saves the pointer address above to disk (for the pointer list command), without it you need to keep track of the address yourself")?;
+    info!("Saved pointer to local user data");
+
+    Ok(())
+}
+
+async fn pointer_target_from_hex(
+    target: &str,
+    target_data_type: TargetDataType,
+    client: &Client,
+) -> Result<PointerTarget> {
+    match target_data_type {
+        TargetDataType::GraphEntry => {
+            let graph = GraphEntryAddress::from_hex(target)
+                .map_err(|_| eyre!("Failed to parse graph entry address from hex"))?;
+            Ok(PointerTarget::GraphEntryAddress(graph))
+        }
+        TargetDataType::Scratchpad => {
+            let scratchpad = ScratchpadAddress::from_hex(target)
+                .map_err(|_| eyre!("Failed to parse scratchpad address from hex"))?;
+            Ok(PointerTarget::ScratchpadAddress(scratchpad))
+        }
+        TargetDataType::Pointer => {
+            let pointer = PointerAddress::from_hex(target)
+                .map_err(|_| eyre!("Failed to parse pointer address from hex"))?;
+            Ok(PointerTarget::PointerAddress(pointer))
+        }
+        TargetDataType::Chunk => {
+            let chunk = ChunkAddress::from_hex(target)
+                .map_err(|_| eyre!("Failed to parse chunk address from hex"))?;
+            Ok(PointerTarget::ChunkAddress(chunk))
+        }
+        TargetDataType::Auto => {
+            println!("Auto-detecting target data type by fetching from network...");
+            let target_data_type = client
+                .analyze_address_type(target, false)
+                .await
+                .wrap_err(eyre!("Failed to auto-detect target data type"))
+                .with_suggestion(|| {
+                    "If you know the type of the target data, you can use the -t flag to specify it"
+                })?;
+            println!("Auto-detected target data type to be: {target_data_type:?}");
+            Ok(target_data_type)
+        }
+    }
+}
+
+/// Display information to share a pointer
+///
+/// # Arguments
+/// * `name` - Name of the pointer to share
+pub fn share(name: String) -> Result<()> {
+    let pointer_key = crate::keys::get_pointer_signing_key(&name)
+        .wrap_err("The pointer key is required to perform this action")?;
+
+    let hex = pointer_key.to_hex();
+    println!("Share this secret key with the recipient: {hex}");
+    println!("The recipient can use this key to read and write to the pointer");
+    println!("The recipient can use the following command to get the pointer: `ant pointer get --secret-key {hex}`");
+    Ok(())
+}
+
+/// Gets the target from an existing pointer on the network
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the pointer to load
+/// * `secret_key` - Whether this is an imported secret_key
+pub async fn get(context: NetworkContext, name: String, secret_key: bool) -> Result<()> {
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let pointer_key = if secret_key {
+        PointerSecretKey::from_hex(&name).wrap_err("Failed to parse secret key from hex")?
+    } else {
+        crate::keys::get_pointer_signing_key(&name)
+            .wrap_err("The pointer key is required to perform this action")?
+    };
+
+    println!("Retrieving pointer from network...");
+    let address = PointerAddress::new(pointer_key.public_key());
+    let pointer = client
+        .pointer_get(&address)
+        .await
+        .wrap_err("Failed to retrieve pointer from network")?;
+
+    println!("✅ Successfully loaded pointer:");
+    println!("Address: {}", address.to_hex());
+    println!("Counter: {}", pointer.counter());
+    println!("Target: {:?}", pointer.target());
+
+    Ok(())
+}
+
+/// Edits the target of an existing pointer
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the pointer to edit
+/// * `secret_key` - Whether this is an imported secret_key
+/// * `target` - The new target to store in the pointer
+/// * `target_data_type` - The type of the target data
+pub async fn edit(
+    context: NetworkContext,
+    name: String,
+    secret_key: bool,
+    target: String,
+    target_data_type: TargetDataType,
+) -> Result<()> {
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let pointer_key = if secret_key {
+        PointerSecretKey::from_hex(&name).wrap_err("Failed to parse secret key from hex")?
+    } else {
+        crate::keys::get_pointer_signing_key(&name)
+            .wrap_err("The pointer key is required to perform this action")?
+    };
+
+    let target = pointer_target_from_hex(&target, target_data_type, &client).await?;
+
+    println!("Updating pointer target...");
+    info!("Updating pointer target");
+
+    client
+        .pointer_update(&pointer_key, target)
+        .await
+        .wrap_err("Failed to update pointer")?;
+
+    println!("✅ Pointer updated");
+    if secret_key {
+        println!("With secret key: {}", pointer_key.to_hex());
+    } else {
+        println!("With name: {name}");
+    }
+    info!("Pointer updated");
+
+    if !secret_key {
+        let addr = PointerAddress::new(pointer_key.public_key());
+        crate::user_data::write_local_pointer(addr, &name)
+            .wrap_err("Failed to save pointer to local user data")
+            .with_suggestion(|| "Local user data saves the pointer address above to disk (for the pointer list command), without it you need remember the name yourself")?;
+        info!("Saved pointer to local user data");
+    }
+
+    Ok(())
+}
+
+/// Lists all previous pointers
+pub fn list() -> Result<()> {
+    println!("Retrieving local pointer data...");
+    let pointers = crate::user_data::get_local_pointers()?;
+    println!("✅ You have {} pointer(s):", pointers.len());
+    for (name, address) in pointers {
+        println!("{name} - {address}");
+    }
+    Ok(())
+}

--- a/ant-cli/src/commands/scratchpad.rs
+++ b/ant-cli/src/commands/scratchpad.rs
@@ -1,0 +1,222 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::actions::NetworkContext;
+use crate::wallet::load_wallet;
+use autonomi::client::scratchpad::SecretKey as ScratchpadSecretKey;
+use autonomi::Bytes;
+use autonomi::ScratchpadAddress;
+use autonomi::TransactionConfig;
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::Context;
+use color_eyre::eyre::Result;
+use color_eyre::Section;
+
+/// Generates a new general scratchpad key
+///
+/// # Arguments
+/// * `overwrite` - If true, overwrites existing key if it exists
+pub fn generate_key(overwrite: bool) -> Result<()> {
+    // check if the key already exists
+    let key_path = crate::keys::get_scratchpad_signing_key_path()?;
+    if key_path.exists() && !overwrite {
+        error!("Scratchpad key already exists at: {key_path:?}");
+        return Err(eyre!("Scratchpad key already exists at: {}", key_path.display()))
+            .with_suggestion(|| "if you want to overwrite the existing key, run the command with the --overwrite flag")
+            .with_warning(|| "overwriting the existing key might result in loss of access to any existing scratchpads created using that key");
+    }
+
+    // generate and write a new key to file
+    let key = ScratchpadSecretKey::random();
+    let path = crate::keys::create_scratchpad_signing_key_file(key)
+        .wrap_err("Failed to create new scratchpad key")?;
+    info!("Created new scratchpad key at: {path:?}");
+    println!("✅ Created new scratchpad key at: {}", path.display());
+    Ok(())
+}
+
+/// Estimates the cost to create a scratchpad
+///
+/// # Arguments
+/// * `name` - Name of the scratchpad
+/// * `network_context` - Network context for the operation
+pub async fn cost(name: String, network_context: NetworkContext) -> Result<()> {
+    let key = crate::keys::get_scratchpad_signing_key(&name)
+        .wrap_err("The scratchpad key is required to perform this action")?;
+    let client = crate::actions::connect_to_network(network_context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let cost = client
+        .scratchpad_cost(&key.public_key())
+        .await
+        .wrap_err("Failed to get cost for scratchpad")?;
+    info!("Estimated cost to create a scratchpad with name {name}: {cost}");
+    println!("✅ The estimated cost to create a scratchpad with name {name} is: {cost}");
+    Ok(())
+}
+
+/// Creates a new scratchpad
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the scratchpad
+/// * `data` - Data to store in the scratchpad
+/// * `max_fee_per_gas` - Optional maximum fee per gas
+pub async fn create(
+    context: NetworkContext,
+    name: String,
+    data: String,
+    max_fee_per_gas: Option<u128>,
+) -> Result<()> {
+    let scratchpad_key = crate::keys::get_scratchpad_signing_key(&name)
+        .wrap_err("The scratchpad key is required to perform this action")?;
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let mut wallet = load_wallet(client.evm_network())?;
+
+    if let Some(max_fee_per_gas) = max_fee_per_gas {
+        wallet.set_transaction_config(TransactionConfig::new(max_fee_per_gas))
+    }
+
+    println!("Creating scratchpad with name: {name}");
+    info!("Creating scratchpad with name: {name}");
+
+    let bytes = Bytes::from(data);
+    let (cost, address) = client
+        .scratchpad_create(&scratchpad_key, Default::default(), &bytes, wallet.into())
+        .await
+        .wrap_err("Failed to create scratchpad")?;
+
+    println!("✅ Scratchpad created at address: {address}");
+    println!("With name: {name}");
+    info!("Scratchpad created at address: {address} with name: {name}");
+    println!("Total cost: {cost} AttoTokens");
+
+    crate::user_data::write_local_scratchpad(address, &name)
+        .wrap_err("Failed to save scratchpad to local user data")
+        .with_suggestion(|| "Local user data saves the scratchpad address above to disk (for the scratchpad list command), without it you need to keep track of the address yourself")?;
+    info!("Saved scratchpad to local user data");
+
+    Ok(())
+}
+
+/// Display information to share a scratchpad
+///
+/// # Arguments
+/// * `name` - Name of the scratchpad to share
+pub fn share(name: String) -> Result<()> {
+    let scratchpad_key = crate::keys::get_scratchpad_signing_key(&name)
+        .wrap_err("The scratchpad key is required to perform this action")?;
+
+    let hex = scratchpad_key.to_hex();
+    println!("Share this secret key with the recipient: {hex}");
+    println!("The recipient can use this key to read and write to the scratchpad");
+    println!("The recipient can use the following command to get the scratchpad: `ant scratchpad get --secret-key {hex}`");
+    Ok(())
+}
+
+/// Gets the data from an existing scratchpad on the network
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the scratchpad to load
+/// * `secret_key` - Whether this is an imported secret_key
+pub async fn get(context: NetworkContext, name: String, secret_key: bool, hex: bool) -> Result<()> {
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let scratchpad_key = if secret_key {
+        // If secret_key is true, we expect the name to be a hex-encoded secret key
+        ScratchpadSecretKey::from_hex(&name).wrap_err("Failed to parse secret key from hex")?
+    } else {
+        crate::keys::get_scratchpad_signing_key(&name)
+            .wrap_err("The scratchpad key is required to perform this action")?
+    };
+
+    println!("Retrieving scratchpad from network...");
+    let address = ScratchpadAddress::new(scratchpad_key.public_key());
+    let scratchpad = client
+        .scratchpad_get(&address)
+        .await
+        .wrap_err("Failed to retrieve scratchpad from network")?;
+
+    let data = scratchpad
+        .decrypt_data(&scratchpad_key)
+        .wrap_err("Failed to decrypt scratchpad data")?;
+
+    println!("✅ Successfully loaded scratchpad:");
+    println!("Address: {}", address.to_hex());
+    println!("Counter: {}", scratchpad.counter());
+    if hex {
+        println!("Data in hex: {}", hex::encode(data));
+    } else {
+        println!("Data: {}", String::from_utf8_lossy(&data));
+    }
+
+    Ok(())
+}
+
+/// Edits the contents of an existing scratchpad
+///
+/// # Arguments
+/// * `context` - Network context for the operation
+/// * `name` - Name of the scratchpad to edit
+/// * `secret_key` - Whether this is an imported secret_key
+/// * `data` - The new data to store in the scratchpad
+pub async fn edit(
+    context: NetworkContext,
+    name: String,
+    secret_key: bool,
+    data: String,
+) -> Result<()> {
+    let client = crate::actions::connect_to_network(context)
+        .await
+        .map_err(|(err, _)| err)?;
+
+    let scratchpad_key = if secret_key {
+        // If secret_key is true, we expect the name to be a hex-encoded secret key
+        ScratchpadSecretKey::from_hex(&name).wrap_err("Failed to parse secret key from hex")?
+    } else {
+        crate::keys::get_scratchpad_signing_key(&name)
+            .wrap_err("The scratchpad key is required to perform this action")?
+    };
+
+    println!("Updating scratchpad data...");
+    info!("Updating scratchpad data");
+
+    let bytes = Bytes::from(data);
+    client
+        .scratchpad_update(&scratchpad_key, Default::default(), &bytes)
+        .await
+        .wrap_err("Failed to update scratchpad")?;
+
+    println!("✅ Scratchpad updated");
+    if secret_key {
+        println!("With secret key: {}", scratchpad_key.to_hex());
+    } else {
+        println!("With name: {name}");
+    }
+    info!("Scratchpad updated");
+
+    Ok(())
+}
+
+/// Lists all previous scratchpads
+pub fn list() -> Result<()> {
+    println!("Retrieving local scratchpad data...");
+    let scratchpads = crate::user_data::get_local_scratchpads()?;
+    println!("✅ You have {} scratchpad(s):", scratchpads.len());
+    for (name, address) in scratchpads {
+        println!("{name} - {address}");
+    }
+    Ok(())
+}

--- a/ant-cli/src/commands/scratchpad.rs
+++ b/ant-cli/src/commands/scratchpad.rs
@@ -207,6 +207,14 @@ pub async fn edit(
     }
     info!("Scratchpad updated");
 
+    if !secret_key {
+        let addr = ScratchpadAddress::new(scratchpad_key.public_key());
+        crate::user_data::write_local_scratchpad(addr, &name)
+            .wrap_err("Failed to save scratchpad to local user data")
+            .with_suggestion(|| "Local user data saves the scratchpad address above to disk (for the scratchpad list command), without it you need remember the name yourself")?;
+        info!("Saved scratchpad to local user data");
+    }
+
     Ok(())
 }
 

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -112,7 +112,7 @@ fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
         register_addresses: _,
     } = net_user_data;
 
-    let mut endangered_key_type = String::new();
+    let mut endangered_key_types = Vec::new();
 
     // check local register key if it differs from one in the vault
     let net_register_key = register_key.clone();
@@ -123,7 +123,7 @@ fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
         && net_register_key.is_some()
         && net_register_key != local_register_key
     {
-        endangered_key_type = "register key".to_string();
+        endangered_key_types.push("register key".to_string());
     }
 
     // check local scratchpad key if it differs from one in the vault
@@ -135,7 +135,7 @@ fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
         && net_scratchpad_key.is_some()
         && net_scratchpad_key != local_scratchpad_key
     {
-        endangered_key_type.push_str(" scratchpad key");
+        endangered_key_types.push("scratchpad key".to_string());
     }
 
     // check local pointer key if it differs from one in the vault
@@ -147,11 +147,12 @@ fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
         && net_pointer_key.is_some()
         && net_pointer_key != local_pointer_key
     {
-        endangered_key_type.push_str(" pointer key");
+        endangered_key_types.push("pointer key".to_string());
     }
 
-    if !endangered_key_type.is_empty() {
-        return Err(eyre!("The {endangered_key_type} in the vault do not match the local {endangered_key_type}, aborting sync to prevent loss of current keys")
+    if !endangered_key_types.is_empty() {
+        let endangered_key_types = endangered_key_types.join(", ");
+        return Err(eyre!("The {endangered_key_types} in the vault do not match the local {endangered_key_types}, aborting sync to prevent loss of current keys")
             .with_suggestion(|| "You can overwrite the data in the vault with the local data by providing the `force` flag")
             .with_suggestion(|| "Or you can overwrite the local data with the data in the vault by using the `load` command")
         );

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -8,6 +8,7 @@
 
 use crate::actions::NetworkContext;
 use crate::wallet::load_wallet;
+use autonomi::vault::UserData;
 use autonomi::TransactionConfig;
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
@@ -82,20 +83,7 @@ pub async fn sync(force: bool, network_context: NetworkContext) -> Result<()> {
             .wrap_err("Failed to fetch vault from network")
             .with_suggestion(|| "Make sure you have already created a vault on the network")?;
 
-        // prevent loss of local register key if it differs from one in the vault
-        let net_register_key = net_user_data.register_key.clone();
-        let local_register_key = crate::access::keys::get_register_signing_key()
-            .map(|k| k.to_hex())
-            .ok();
-        if local_register_key.is_some()
-            && net_register_key.is_some()
-            && net_register_key != local_register_key
-        {
-            return Err(eyre!("The register key in the vault does not match the local register key, aborting sync to prevent loss of current register key")
-                .with_suggestion(|| "You can overwrite the data in the vault with the local data by providing the `force` flag")
-                .with_suggestion(|| "Or you can overwrite the local data with the data in the vault by using the `load` command")
-            );
-        }
+        prevent_loss_of_keys(&net_user_data)?;
 
         println!("Syncing vault with local user data...");
         crate::user_data::write_local_user_data(&net_user_data)?;
@@ -111,6 +99,64 @@ pub async fn sync(force: bool, network_context: NetworkContext) -> Result<()> {
     println!("✅ Successfully synced vault");
     println!("Vault contains:");
     local_user_data.display_stats();
+    Ok(())
+}
+
+fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
+    let UserData {
+        register_key,
+        scratchpad_key,
+        pointer_key,
+        file_archives: _,
+        private_file_archives: _,
+        register_addresses: _,
+    } = net_user_data;
+
+    let mut endangered_key_type = String::new();
+
+    // check local register key if it differs from one in the vault
+    let net_register_key = register_key.clone();
+    let local_register_key = crate::access::keys::get_register_signing_key()
+        .map(|k| k.to_hex())
+        .ok();
+    if local_register_key.is_some()
+        && net_register_key.is_some()
+        && net_register_key != local_register_key
+    {
+        endangered_key_type = "register key".to_string();
+    }
+
+    // check local scratchpad key if it differs from one in the vault
+    let net_scratchpad_key = scratchpad_key.clone();
+    let local_scratchpad_key = crate::access::keys::get_scratchpad_general_signing_key()
+        .map(|k| k.to_hex())
+        .ok();
+    if local_scratchpad_key.is_some()
+        && net_scratchpad_key.is_some()
+        && net_scratchpad_key != local_scratchpad_key
+    {
+        endangered_key_type.push_str(" scratchpad key");
+    }
+
+    // check local pointer key if it differs from one in the vault
+    let net_pointer_key = pointer_key.clone();
+    let local_pointer_key = crate::access::keys::get_pointer_general_signing_key()
+        .map(|k| k.to_hex())
+        .ok();
+    if local_pointer_key.is_some()
+        && net_pointer_key.is_some()
+        && net_pointer_key != local_pointer_key
+    {
+        endangered_key_type.push_str(" pointer key");
+    }
+
+    if !endangered_key_type.is_empty() {
+        return Err(eyre!("The {endangered_key_type} in the vault do not match the local {endangered_key_type}, aborting sync to prevent loss of current keys")
+            .with_suggestion(|| "You can overwrite the data in the vault with the local data by providing the `force` flag")
+            .with_suggestion(|| "Or you can overwrite the local data with the data in the vault by using the `load` command")
+        );
+    }
+
     Ok(())
 }
 

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -209,7 +209,7 @@ impl Client {
                 error!("Failed to put record - chunk {address:?} to the network: {err}")
             })
             .map_err(|err| PutError::Network {
-                address: address.clone(),
+                address: Box::new(address.clone()),
                 network_error: err.clone(),
                 payment: Some(payment_proofs),
             })?;
@@ -351,7 +351,7 @@ impl Client {
             .map_err(|err| {
                 let receipt = HashMap::from_iter([(*chunk.name(), (payment, price))]);
                 PutError::Network {
-                    address: NetworkAddress::from(*chunk.address()),
+                    address: Box::new(NetworkAddress::from(*chunk.address())),
                     network_error: err,
                     payment: Some(receipt),
                 }

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -168,7 +168,7 @@ impl Client {
             })
             .map_err(|err| {
                 GraphError::PutError(PutError::Network {
-                    address: NetworkAddress::from(address),
+                    address: Box::new(NetworkAddress::from(address)),
                     network_error: err.clone(),
                     payment: Some(payment_proofs.clone()),
                 })

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -19,7 +19,7 @@ use ant_protocol::{
     storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind},
     NetworkAddress,
 };
-use bls::{PublicKey, SecretKey};
+pub use bls::{PublicKey, SecretKey};
 use tracing::{debug, error, trace};
 
 use crate::networking::NetworkError;
@@ -190,7 +190,7 @@ impl Client {
             })
             .map_err(|err| {
                 PointerError::PutError(PutError::Network {
-                    address: NetworkAddress::from(address),
+                    address: Box::new(NetworkAddress::from(address)),
                     network_error: err,
                     payment: Some(payment_proofs),
                 })
@@ -273,7 +273,7 @@ impl Client {
             })
             .map_err(|err| {
                 PointerError::PutError(PutError::Network {
-                    address: NetworkAddress::from(address),
+                    address: Box::new(NetworkAddress::from(address)),
                     network_error: err,
                     payment: None,
                 })

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -240,7 +240,7 @@ impl Client {
             })
             .map_err(|err| {
                 ScratchpadError::PutError(PutError::Network {
-                    address: NetworkAddress::from(*address),
+                    address: Box::new(NetworkAddress::from(*address)),
                     network_error: err.clone(),
                     payment: Some(payment_proofs),
                 })
@@ -330,7 +330,7 @@ impl Client {
             })
             .map_err(|err| {
                 ScratchpadError::PutError(PutError::Network {
-                    address: NetworkAddress::from(address),
+                    address: Box::new(NetworkAddress::from(address)),
                     network_error: err,
                     payment: None,
                 })

--- a/autonomi/src/client/high_level/vault/user_data.rs
+++ b/autonomi/src/client/high_level/vault/user_data.rs
@@ -27,6 +27,7 @@ pub static USER_DATA_VAULT_CONTENT_IDENTIFIER: LazyLock<VaultContentType> =
 
 pub type RegisterSecretKeyHex = String;
 pub type ScratchpadSecretKeyHex = String;
+pub type PointerSecretKeyHex = String;
 
 /// UserData is stored in Vaults and contains most of a user's private data:
 /// It allows users to keep track of only the key to their User Data Vault
@@ -48,6 +49,10 @@ pub struct UserData {
     #[serde(default)]
     // This makes the field optional to support old versions without that field
     pub scratchpad_key: Option<ScratchpadSecretKeyHex>,
+    /// Pointer key
+    #[serde(default)]
+    // This makes the field optional to support old versions without that field
+    pub pointer_key: Option<PointerSecretKeyHex>,
 }
 
 /// Errors that can occur during the get operation.
@@ -67,20 +72,6 @@ impl UserData {
     /// Create a new empty UserData
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Set the register key
-    /// Returns Some(old register key) if it was already set and was different from the new one
-    pub fn set_register_key(
-        &mut self,
-        register_key: RegisterSecretKeyHex,
-    ) -> Option<RegisterSecretKeyHex> {
-        let mut old_key = self.register_key.clone();
-        if old_key == Some(register_key.clone()) {
-            old_key = None;
-        }
-        self.register_key = Some(register_key);
-        old_key
     }
 
     /// Add a register. Returning `Option::Some` with the old name if the register was already in the set.
@@ -252,6 +243,7 @@ mod tests {
             register_addresses: v1_data.register_addresses.clone(),
             register_key: Some("test_key".to_string()),
             scratchpad_key: Some("test_scratchpad_key".to_string()),
+            pointer_key: Some("test_pointer_key".to_string()),
         };
 
         let serialized = rmp_serde::to_vec(&current_data).unwrap();

--- a/autonomi/src/client/high_level/vault/user_data.rs
+++ b/autonomi/src/client/high_level/vault/user_data.rs
@@ -26,6 +26,7 @@ pub static USER_DATA_VAULT_CONTENT_IDENTIFIER: LazyLock<VaultContentType> =
     LazyLock::new(|| app_name_to_vault_content_type("UserData"));
 
 pub type RegisterSecretKeyHex = String;
+pub type ScratchpadSecretKeyHex = String;
 
 /// UserData is stored in Vaults and contains most of a user's private data:
 /// It allows users to keep track of only the key to their User Data Vault
@@ -43,6 +44,10 @@ pub struct UserData {
     #[serde(default)]
     // This makes the field optional to support old versions without that field
     pub register_key: Option<RegisterSecretKeyHex>,
+    /// Scratchpads key
+    #[serde(default)]
+    // This makes the field optional to support old versions without that field
+    pub scratchpad_key: Option<ScratchpadSecretKeyHex>,
 }
 
 /// Errors that can occur during the get operation.
@@ -246,6 +251,7 @@ mod tests {
             private_file_archives: v1_data.private_file_archives.clone(),
             register_addresses: v1_data.register_addresses.clone(),
             register_key: Some("test_key".to_string()),
+            scratchpad_key: Some("test_scratchpad_key".to_string()),
         };
 
         let serialized = rmp_serde::to_vec(&current_data).unwrap();

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -136,7 +136,7 @@ pub enum PutError {
     PayeesMissing,
     #[error("A network error occurred for {address}: {network_error}")]
     Network {
-        address: NetworkAddress,
+        address: Box<NetworkAddress>,
         network_error: NetworkError,
         /// if a payment was made, it will be returned here so it can be reused
         payment: Option<Receipt>,

--- a/autonomi/src/client/put_error_state.rs
+++ b/autonomi/src/client/put_error_state.rs
@@ -48,7 +48,7 @@ impl ChunkBatchUploadState {
                 network_error,
                 payment,
             } => {
-                let chunk_addr = match address {
+                let chunk_addr = match *address {
                     NetworkAddress::ChunkAddress(chunk_addr) => chunk_addr,
                     _ => {
                         error!("Skip unexpected non-chunk address: {address:?}");


### PR DESCRIPTION
WARNING! Please merge to `main` after #2896 as it is based atop it!

Adds Scratchpad and Pointers to the CLI:

```
Operations related to scratchpad management

Usage: ant scratchpad [OPTIONS] <COMMAND>

Commands:
  generate-key  Generate a new general scratchpad key from which all your scratchpad keys can be
                derived (using their names)
  cost          Estimate cost to create a scratchpad
  create        Create a new scratchpad
  share         Share a scratchpad secret key with someone else. Sharing this key means that the
                other party will have permanent read and write access to the scratchpad
  get           Get the contents of an existing scratchpad from the network
  edit          Edit the contents of an existing scratchpad
  list          List owned scratchpads
  help          Print this message or the help of the given subcommand(s)
```

```
Operations related to pointer management

Usage: ant pointer [OPTIONS] <COMMAND>

Commands:
  generate-key  Generate a new general pointer key from which all your pointer keys can be derived
                (using their names)
  cost          Estimate cost to create a pointer
  create        Create a new pointer
  share         Share a pointer secret key with someone else. Sharing this key means that the other
                party will have permanent read and write access to the pointer
  get           Get the target of an existing pointer from the network
  edit          Edit the target of an existing pointer
  list          List owned pointers
  help          Print this message or the help of the given subcommand(s)
```