### PR TITLE
feat: add timeout option for NAT-detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "ant-protocol",
  "ant-releases",
  "ant-service-management",
+ "anyhow",
  "assert_cmd",
  "assert_fs",
  "assert_matches",

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1.43", features = ["full"] }
 tracing = { version = "~0.1.26" }
 tonic = { version = "0.6.2" }
 uuid = { version = "1.5.0", features = ["v4"] }
+anyhow = "1.0.98"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 nix = { version = "0.27.1", features = ["fs", "user"] }


### PR DESCRIPTION
### Description
adds a 3 min timeout functionality for NAT detection operation, and sets relay option as default, if nat detection is not successful. 