### PR TITLE
feat(cli): batch entire quote-pay-upload flow to overcome quote expiracy

### DIFF
--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -36,6 +36,7 @@ bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
+evmlib = { path = "../evmlib", version = "0.4.0" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -7,21 +7,19 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::archive_public::{ArchiveAddress, PublicArchive};
-use super::{DownloadError, FileCostError, Metadata, UploadError};
+use super::{CombinedChunks, DownloadError, FileCostError, Metadata, UploadError};
 use crate::client::high_level::files::{
-    get_relative_file_path_from_abs_file_and_folder_path, FILE_UPLOAD_BATCH_SIZE,
+    get_relative_file_path_from_abs_file_and_folder_path, FILE_ENCRYPT_BATCH_SIZE,
 };
 use crate::client::payment::PaymentOption;
+use crate::client::Client;
 use crate::client::{high_level::data::DataAddress, utils::process_tasks_with_max_concurrency};
-use crate::client::{Client, PutError};
 use crate::self_encryption::encrypt;
 use crate::AttoTokens;
-use ant_protocol::storage::{Chunk, DataTypes};
 use bytes::Bytes;
 use std::path::PathBuf;
 use std::time;
 use std::time::{Duration, SystemTime};
-use xor_name::XorName;
 
 impl Client {
     /// Download file from network to local file system
@@ -71,7 +69,6 @@ impl Client {
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PublicArchive), UploadError> {
         info!("Uploading directory: {dir_path:?}");
-        let start = tokio::time::Instant::now();
 
         let mut encryption_tasks = vec![];
 
@@ -112,11 +109,6 @@ impl Client {
 
                 chunks.push(data_map_chunk);
 
-                let xor_names: Vec<_> = chunks
-                    .iter()
-                    .map(|chunk| (*chunk.name(), chunk.size()))
-                    .collect();
-
                 let metadata = metadata_from_entry(&entry);
 
                 let relative_path =
@@ -124,30 +116,27 @@ impl Client {
 
                 Ok((
                     file_path.to_string_lossy().to_string(),
-                    xor_names,
                     chunks,
                     (relative_path, DataAddress::new(data_address), metadata),
                 ))
             });
         }
 
-        let mut combined_xor_names: Vec<(XorName, usize)> = vec![];
-        let mut combined_chunks: Vec<((String, DataAddress), Vec<Chunk>)> = vec![];
+        let mut combined_chunks: CombinedChunks = vec![];
         let mut public_archive = PublicArchive::new();
 
         let encryption_results =
-            process_tasks_with_max_concurrency(encryption_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
+            process_tasks_with_max_concurrency(encryption_tasks, *FILE_ENCRYPT_BATCH_SIZE).await;
 
         for encryption_result in encryption_results {
             match encryption_result {
-                Ok((file_path, xor_names, chunks, file_data)) => {
+                Ok((file_path, chunks, file_data)) => {
                     info!("Successfully encrypted file: {file_path:?}");
                     #[cfg(feature = "loud")]
                     println!("Successfully encrypted file: {file_path:?}");
 
-                    combined_xor_names.extend(xor_names);
                     let (relative_path, data_address, file_metadata) = file_data;
-                    combined_chunks.push(((file_path, data_address), chunks));
+                    combined_chunks.push(((file_path, Some(data_address)), chunks));
                     public_archive.add_file(relative_path, data_address, file_metadata);
                 }
                 Err(err_msg) => {
@@ -156,77 +145,7 @@ impl Client {
             }
         }
 
-        info!("Quoting for {} chunks..", combined_xor_names.len());
-        #[cfg(feature = "loud")]
-        println!("Quoting for {} chunks..", combined_xor_names.len());
-
-        let (receipt, skipped_payments_amount) = self
-            .pay_for_content_addrs(
-                DataTypes::Chunk,
-                combined_xor_names.into_iter(),
-                payment_option,
-            )
-            .await
-            .inspect_err(|err| error!("Error paying for data: {err:?}"))
-            .map_err(PutError::from)?;
-
-        info!("{skipped_payments_amount} chunks were free");
-
-        let files_to_upload_amount = combined_chunks.len();
-
-        let mut upload_tasks = vec![];
-
-        for ((name, data_address), chunks) in combined_chunks {
-            let receipt_clone = receipt.clone();
-
-            upload_tasks.push(async move {
-                info!("Uploading file: {name} ({} chunks)..", chunks.len());
-                #[cfg(feature = "loud")]
-                println!("Uploading file: {name} ({} chunks)..", chunks.len());
-
-                match self
-                    .chunk_batch_upload(chunks.iter().collect(), &receipt_clone)
-                    .await
-                {
-                    Ok(()) => {
-                        info!(
-                            "Successfully uploaded {name} ({} chunks) to: {}",
-                            chunks.len(),
-                            hex::encode(data_address.xorname())
-                        );
-                        #[cfg(feature = "loud")]
-                        println!(
-                            "Successfully uploaded {name} ({} chunks) to: {}",
-                            chunks.len(),
-                            hex::encode(data_address.xorname())
-                        );
-
-                        (name, Ok(chunks.len()))
-                    }
-                    Err(err) => (name, Err(UploadError::from(err))),
-                }
-            });
-        }
-
-        let uploads =
-            process_tasks_with_max_concurrency(upload_tasks, *FILE_UPLOAD_BATCH_SIZE).await;
-
-        info!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        #[cfg(feature = "loud")]
-        println!(
-            "Upload of {} files completed in {:?}",
-            files_to_upload_amount,
-            start.elapsed()
-        );
-
-        let total_cost = self
-            .process_upload_results(uploads, receipt, skipped_payments_amount)
-            .await?;
+        let total_cost = self.pay_and_upload(payment_option, combined_chunks).await?;
 
         Ok((total_cost, public_archive))
     }

--- a/autonomi/src/client/high_level/files/fs_shared.rs
+++ b/autonomi/src/client/high_level/files/fs_shared.rs
@@ -1,57 +1,201 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::CombinedChunks;
+use crate::client::high_level::data::DataAddress;
+use crate::client::payment::PaymentOption;
 use crate::client::payment::Receipt;
-use crate::client::{ClientEvent, UploadSummary};
+use crate::client::{ClientEvent, PutError, UploadSummary};
 use crate::files::UploadError;
 use crate::Client;
 use ant_evm::{Amount, AttoTokens};
+use ant_protocol::storage::{Chunk, DataTypes};
+use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;
+use std::sync::LazyLock;
+
+type AggregatedChunks = Vec<((String, Option<DataAddress>, usize, usize), Chunk)>;
+
+/// Number of batch size of an entire quote-pay-upload flow to process.
+/// Suggested to be multiples of `MAX_TRANSFERS_PER_TRANSACTION  / 3` (records-payouts-per-transaction).
+///
+/// Can be overridden by the `UPLOAD_FLOW_BATCH_SIZE` environment variable.
+static UPLOAD_FLOW_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("UPLOAD_FLOW_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(MAX_TRANSFERS_PER_TRANSACTION / 3);
+    info!("Upload flow batch size: {}", batch_size);
+    batch_size
+});
 
 impl Client {
-    pub(crate) async fn process_upload_results(
+    /// Returns total tokens spent or the first encountered upload error
+    async fn calculate_total_cost(
         &self,
-        uploads: Vec<(String, Result<usize, UploadError>)>,
-        receipt: Receipt,
-        skipped_payments_amount: usize,
-    ) -> Result<AttoTokens, UploadError> {
-        let mut total_chunks_uploaded = 0;
-        let mut last_err: Option<UploadError> = None;
+        total_chunks: usize,
+        payment_receipts: Vec<Receipt>,
+        free_chunks_counts: Vec<usize>,
+    ) -> AttoTokens {
+        // Calculate total tokens spent across all receipts
+        let total_tokens: Amount = payment_receipts
+            .into_iter()
+            .flat_map(|receipt| receipt.into_values().map(|(_, cost)| cost.as_atto()))
+            .sum();
 
-        for (name, result) in uploads {
-            match result {
-                Ok(chunks_uploaded) => {
-                    total_chunks_uploaded += chunks_uploaded;
-                }
-                Err(err) => {
-                    error!("Error uploading file {name}: {err:?}");
-                    #[cfg(feature = "loud")]
-                    println!("Error uploading file {name}: {err:?}");
+        let total_free_chunks = free_chunks_counts.iter().sum::<usize>();
 
-                    last_err = Some(err);
-                }
-            }
-        }
-
-        // todo: bundle the errors together in a new error type
-        // Throw an error if not all files were uploaded successfully
-        if let Some(err) = last_err {
-            return Err(err);
-        }
-
-        let tokens_spent = receipt
-            .values()
-            .map(|(_, cost)| cost.as_atto())
-            .sum::<Amount>();
-
-        // Reporting
-        if let Some(channel) = self.client_event_sender.as_ref() {
+        // Send completion event if channel exists
+        if let Some(sender) = &self.client_event_sender {
             let summary = UploadSummary {
-                records_paid: total_chunks_uploaded.saturating_sub(skipped_payments_amount),
-                records_already_paid: skipped_payments_amount,
-                tokens_spent,
+                records_paid: total_chunks.saturating_sub(total_free_chunks),
+                records_already_paid: total_free_chunks,
+                tokens_spent: total_tokens,
             };
-            if let Err(err) = channel.send(ClientEvent::UploadComplete(summary)).await {
-                error!("Failed to send client event: {err:?}");
+
+            if let Err(err) = sender.send(ClientEvent::UploadComplete(summary)).await {
+                error!("Failed to send upload completion event: {err:?}");
             }
         }
 
-        Ok(AttoTokens::from_atto(tokens_spent))
+        AttoTokens::from_atto(total_tokens)
+    }
+
+    /// Processes file uploads with payment in batches
+    /// Returns total cost of uploads or error if any upload fails
+    pub(crate) async fn pay_and_upload(
+        &self,
+        payment_option: PaymentOption,
+        combined_chunks: CombinedChunks,
+    ) -> Result<AttoTokens, UploadError> {
+        let start = tokio::time::Instant::now();
+        let total_files = combined_chunks.len();
+        let mut receipts = Vec::new();
+        let mut free_chunks_counts = Vec::new();
+
+        // Process all combined chunks in batches.
+        // zip the file infos together for the better batch progressing print out.
+        let mut aggregated_chunks = vec![];
+        for ((file_name, data_address), chunks) in combined_chunks {
+            let total = chunks.len();
+            for (i, chunk) in chunks.into_iter().enumerate() {
+                aggregated_chunks.push(((file_name.clone(), data_address, i, total), chunk));
+            }
+        }
+
+        info!(
+            "Processing total {} chunks of {total_files} files",
+            aggregated_chunks.len()
+        );
+        #[cfg(feature = "loud")]
+        println!(
+            "Processing total {} chunks of {total_files} files",
+            aggregated_chunks.len()
+        );
+
+        let total_chunks = aggregated_chunks.len();
+
+        // Process all chunks for this file in batches
+        while !aggregated_chunks.is_empty() {
+            self.process_chunk_batch(
+                &mut aggregated_chunks,
+                &mut receipts,
+                &mut free_chunks_counts,
+                payment_option.clone(),
+            )
+            .await?;
+        }
+
+        info!(
+            "Upload of {total_files} files completed in {:?}",
+            start.elapsed()
+        );
+        #[cfg(feature = "loud")]
+        println!(
+            "Upload of {total_files} files completed in {:?}",
+            start.elapsed()
+        );
+
+        Ok(self
+            .calculate_total_cost(total_chunks, receipts, free_chunks_counts)
+            .await)
+    }
+
+    /// Processes a single batch of chunks (quote -> pay -> upload)
+    /// Returns error if any chunk in batch fails to upload
+    #[allow(clippy::too_many_arguments)]
+    async fn process_chunk_batch(
+        &self,
+        remaining_chunks: &mut AggregatedChunks,
+        receipts: &mut Vec<Receipt>,
+        free_chunks_counts: &mut Vec<usize>,
+        payment_option: PaymentOption,
+    ) -> Result<(), UploadError> {
+        // Take next batch of chunks (up to UPLOAD_FLOW_BATCH_SIZE)
+        let batch: Vec<_> = remaining_chunks
+            .drain(..std::cmp::min(remaining_chunks.len(), *UPLOAD_FLOW_BATCH_SIZE))
+            .collect();
+
+        // Prepare payment info for batch
+        let payment_info: Vec<_> = batch
+            .iter()
+            .map(|(_, chunk)| (*chunk.name(), chunk.size()))
+            .collect();
+
+        info!("Processing batch of {} chunks", batch.len());
+        #[cfg(feature = "loud")]
+        println!("Processing batch of {} chunks", batch.len());
+
+        let mut file_infos = vec![];
+        let mut batch_chunks = vec![];
+
+        for (chunk_info, chunk) in batch {
+            file_infos.push(chunk_info);
+            batch_chunks.push(chunk);
+        }
+
+        for (file_name, data_addr, i, total) in file_infos.iter() {
+            info!(
+                "Processing chunk ({}/{total}) of {file_name:?} at {data_addr:?}",
+                i + 1
+            );
+            #[cfg(feature = "loud")]
+            println!(
+                "Processing chunk ({}/{total}) of {file_name:?} at {data_addr:?}",
+                i + 1
+            );
+        }
+
+        // Process payment for this batch
+        let (receipt, free_chunks) = self
+            .pay_for_content_addrs(DataTypes::Chunk, payment_info.into_iter(), payment_option)
+            .await
+            .inspect_err(|err| error!("Payment failed: {err:?}"))
+            .map_err(PutError::from)?;
+
+        if free_chunks > 0 {
+            info!(
+                "{free_chunks} chunks were free in this batch {}",
+                batch_chunks.len()
+            );
+            #[cfg(feature = "loud")]
+            println!(
+                "{free_chunks} chunks were free in this batch {}",
+                batch_chunks.len()
+            );
+        }
+
+        // Upload all chunks in batch with retries
+        self.chunk_batch_upload(batch_chunks.iter().collect(), &receipt)
+            .await?;
+
+        receipts.push(receipt);
+        free_chunks_counts.push(free_chunks);
+
+        Ok(())
     }
 }

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -105,6 +105,9 @@ impl Client {
         let futures: Vec<_> = content_addrs
             .into_iter()
             .map(|(content_addr, data_size)| {
+                info!("Quoting for {content_addr:?} ..");
+                #[cfg(feature = "loud")]
+                println!("Quoting for {content_addr:?} ..");
                 fetch_store_quote(
                     &self.network,
                     content_addr,


### PR DESCRIPTION
### Description

The current quote all, pay all, then upload all flow put user in a higher risk in wasting extra fund when have to carry out re-upload due to in-middle failure,
especially for user with poor connection to upload big files or directory containing many files.

This PR change to batch entire quote-pay-upload flow, with a rolling window on chunks level.
It also brings in extra benefits of:
* quote expire issue is no longer a hurdle
* small files got combined together to be processed, so that saving transaction fees
* more user friendly progressing print out
* no more concern of gas_fee payment failure due to multiple transactions, as discussed at [here](https://github.com/maidsafe/autonomi/pull/2945#issuecomment-2900413588)

Changes to the environment settings:

*  FILE_ENCRYPT_BATCH_SIZE : newly added, default to num_of_thread_parallism * 8
*  FILE_UPLOAD_BATCH_SIZE : no longer effective for most cases, only used within Vault upload.
*  UPLOAD_FLOW_BATCH_SIZE: newly added, default to MAX_TRANSFERS_PER_TRANSACTION / 3 . Suggested to be multiples of the value (records-payouts-per-transaction).

The work is to replace https://github.com/maidsafe/autonomi/pull/2944, and will also resolve the `quote expire` issue mostly.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
