### PR TITLE
fix(client): add target peers address to libp2p before `put_record_to`

### DIFF
--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::networking::PeerInfo;
 use crate::{
     client::{
         payment::{PaymentOption, Receipt},
@@ -178,7 +179,10 @@ impl Client {
         let payees = proof
             .payees()
             .iter()
-            .map(|(peer_id, _addrs)| *peer_id)
+            .map(|(peer_id, addrs)| PeerInfo {
+                peer_id: *peer_id,
+                addrs: addrs.clone(),
+            })
             .collect();
 
         let record = Record {
@@ -312,7 +316,10 @@ impl Client {
         let storing_nodes: Vec<_> = payment
             .payees()
             .iter()
-            .map(|(peer_id, _addrs)| *peer_id)
+            .map(|(peer_id, addrs)| PeerInfo {
+                peer_id: *peer_id,
+                addrs: addrs.clone(),
+            })
             .collect();
 
         if storing_nodes.is_empty() {

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -25,7 +25,7 @@ use ant_protocol::{
 use bls::PublicKey;
 use libp2p::kad::Record;
 
-use crate::networking::NetworkError;
+use crate::networking::{NetworkError, PeerInfo};
 pub use crate::SecretKey;
 pub use ant_protocol::storage::{GraphContent, GraphEntry, GraphEntryAddress};
 
@@ -140,7 +140,10 @@ impl Client {
         let payees = proof
             .payees()
             .iter()
-            .map(|(peer_id, _addrs)| *peer_id)
+            .map(|(peer_id, addrs)| PeerInfo {
+                peer_id: *peer_id,
+                addrs: addrs.clone(),
+            })
             .collect();
 
         let record = Record {

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -13,7 +13,7 @@ use crate::client::{
     quote::CostError,
     Client, GetError, PutError,
 };
-use crate::networking::{PeerId, Record};
+use crate::networking::{PeerId, PeerInfo, Record};
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
 use ant_protocol::{
     storage::{try_deserialize_record, try_serialize_record, DataTypes, RecordHeader, RecordKind},
@@ -147,7 +147,10 @@ impl Client {
                 proof
                     .payees()
                     .iter()
-                    .map(|(peer_id, _addrs)| *peer_id)
+                    .map(|(peer_id, addrs)| PeerInfo {
+                        peer_id: *peer_id,
+                        addrs: addrs.clone(),
+                    })
                     .collect(),
             );
             let record = Record {

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -17,7 +17,7 @@ use ant_protocol::{
 use libp2p::kad::Record;
 
 use crate::client::{GetError, PutError};
-use crate::networking::NetworkError;
+use crate::networking::{NetworkError, PeerInfo};
 pub use crate::Bytes;
 pub use ant_protocol::storage::{Scratchpad, ScratchpadAddress};
 pub use bls::{PublicKey, SecretKey, Signature};
@@ -194,7 +194,10 @@ impl Client {
                 proof
                     .payees()
                     .iter()
-                    .map(|(peer_id, _addrs)| *peer_id)
+                    .map(|(peer_id, addrs)| PeerInfo {
+                        peer_id: *peer_id,
+                        addrs: addrs.clone(),
+                    })
                     .collect(),
             );
             let record = Record {

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -55,8 +55,8 @@ pub const KAD_ALPHA: NonZeroUsize = NonZeroUsize::new(3).expect("KAD_ALPHA must 
 /// Libp2p defaults to 5 minutes, we use 1 hour.
 const RESEND_IDENTIFY_INVERVAL: Duration = Duration::from_secs(3600); // todo: taken over from ant-networking. Why 1 hour?
 /// Size of the LRU cache for peers and their addresses.
-/// Libp2p defaults to 100, we use 10k.
-const PEER_CACHE_SIZE: usize = 10_000;
+/// Libp2p defaults to 100, we use 2k.
+const PEER_CACHE_SIZE: usize = 2_000;
 
 /// Driver for the Autonomi Client Network
 ///

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -45,7 +45,7 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         record: Record,
         /// Empty vec results in regular store to peers closest to record address
-        to: Vec<PeerId>,
+        to: Vec<PeerInfo>,
         quorum: Quorum,
         #[debug(skip)]
         resp: OneShotTaskResult<()>,

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -185,7 +185,7 @@ impl Network {
     pub async fn put_record(
         &self,
         record: Record,
-        to: Vec<PeerId>,
+        to: Vec<PeerInfo>,
         quorum: Quorum,
     ) -> Result<(), NetworkError> {
         let (tx, rx) = oneshot::channel();

--- a/autonomi/src/networking/retries.rs
+++ b/autonomi/src/networking/retries.rs
@@ -10,7 +10,7 @@ use ant_evm::PaymentQuote;
 use ant_protocol::{NetworkAddress, PrettyPrintRecordKey};
 
 use super::{Network, RetryStrategy};
-use super::{NetworkError, PeerId, PeerInfo, Record, Strategy};
+use super::{NetworkError, PeerInfo, Record, Strategy};
 use tokio::time::sleep;
 
 impl Network {
@@ -18,7 +18,7 @@ impl Network {
     pub async fn put_record_with_retries(
         &self,
         record: Record,
-        to: Vec<PeerId>,
+        to: Vec<PeerInfo>,
         strategy: &Strategy,
     ) -> Result<(), NetworkError> {
         let addr = PrettyPrintRecordKey::from(&record.key).into_owned();


### PR DESCRIPTION
Adds the target nodes' known addresses into libp2p, before putting records.

Close https://github.com/maidsafe/autonomi/pull/2979