### PR TITLE
feat(client): upload record shall always using put_record_to

### DIFF
--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -189,17 +189,15 @@ impl Client {
         let total_cost = *price;
 
         let net_addr = NetworkAddress::from(*address);
-        let (record, payees) = if let Some(proof) = proof {
-            let payees = Some(
-                proof
-                    .payees()
-                    .iter()
-                    .map(|(peer_id, addrs)| PeerInfo {
-                        peer_id: *peer_id,
-                        addrs: addrs.clone(),
-                    })
-                    .collect(),
-            );
+        let (record, target_nodes) = if let Some(proof) = proof {
+            let payees = proof
+                .payees()
+                .iter()
+                .map(|(peer_id, addrs)| PeerInfo {
+                    peer_id: *peer_id,
+                    addrs: addrs.clone(),
+                })
+                .collect();
             let record = Record {
                 key: net_addr.to_record_key(),
                 value: try_serialize_record(
@@ -224,13 +222,22 @@ impl Client {
                 publisher: None,
                 expires: None,
             };
-            (record, None)
+            let target_nodes = self
+                .network
+                .get_closest_peers_with_retries(net_addr.clone())
+                .await
+                .map_err(|e| PutError::Network {
+                    address: net_addr,
+                    network_error: e,
+                    payment: None,
+                })?;
+            (record, target_nodes)
         };
 
         // store the scratchpad on the network
-        debug!("Storing scratchpad at address {address:?} to the network");
-
-        let target_nodes = payees.unwrap_or_default();
+        debug!(
+            "Storing scratchpad at address {address:?} to the network on nodes {target_nodes:?}"
+        );
 
         self.network
             .put_record_with_retries(record, target_nodes, &self.config.scratchpad)
@@ -311,8 +318,9 @@ impl Client {
         Self::scratchpad_verify(&scratchpad)?;
 
         // prepare the record to be stored
+        let net_addr = NetworkAddress::from(address);
         let record = Record {
-            key: NetworkAddress::from(address).to_record_key(),
+            key: net_addr.to_record_key(),
             value: try_serialize_record(&scratchpad, RecordKind::DataOnly(DataTypes::Scratchpad))
                 .map_err(|_| ScratchpadError::Serialization)?
                 .to_vec(),
@@ -321,9 +329,21 @@ impl Client {
         };
 
         // store the scratchpad on the network
-        debug!("Updating scratchpad at address {address:?} to the network");
+        let target_nodes = self
+            .network
+            .get_closest_peers_with_retries(net_addr.clone())
+            .await
+            .map_err(|e| PutError::Network {
+                address: net_addr,
+                network_error: e,
+                payment: None,
+            })?;
+        debug!(
+            "Updating scratchpad at address {address:?} to the network on nodes {target_nodes:?}"
+        );
+
         self.network
-            .put_record_with_retries(record, Default::default(), &self.config.scratchpad)
+            .put_record_with_retries(record, target_nodes, &self.config.scratchpad)
             .await
             .inspect_err(|err| {
                 error!("Failed to update scratchpad at address {address:?} to the network: {err}")

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -236,19 +236,13 @@ impl NetworkDriver {
                 resp,
             } => {
                 let query_id = if to.is_empty() {
-                    match self.kad().put_record(record.clone(), quorum) {
-                        Ok(id) => id,
-                        Err(e) => {
-                            let k = PrettyPrintRecordKey::from(&record.key);
-                            warn!("Put record failed immediately for {k:?}: {e}");
-                            if let Err(e) =
-                                resp.send(Err(NetworkError::PutRecordError(e.to_string())))
-                            {
-                                error!("Error sending put record response: {e:?}");
-                            }
-                            return;
-                        }
+                    let _pretty_key = PrettyPrintRecordKey::from(&record.key);
+                    let error_str =
+                        "Target holders of record {_pretty_key:?} shall be provided".to_string();
+                    if let Err(e) = resp.send(Err(NetworkError::PutRecordError(error_str))) {
+                        error!("Error sending put record response: {e:?}");
                     }
+                    return;
                 } else {
                     for peer_info in &to {
                         // Add the peer addresses to our cache before sending a query.


### PR DESCRIPTION
### Description

upload record shall always using `put_record_to` instead of `put_record`, to:
* achieve a better controllable quality of service (during non-chunk data update)
* achieve future support of RBS

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
