### PR TITLE
fix(client): avoid confusing output of private upload

### DIFF
--- a/autonomi/src/client/high_level/files/fs_shared.rs
+++ b/autonomi/src/client/high_level/files/fs_shared.rs
@@ -158,16 +158,20 @@ impl Client {
             batch_chunks.push(chunk);
         }
 
-        for (file_name, data_addr, i, total) in file_infos.iter() {
-            info!(
-                "Processing chunk ({}/{total}) of {file_name:?} at {data_addr:?}",
-                i + 1
-            );
+        for (file_name, file_addr, i, total) in file_infos.iter() {
+            // File won't have address info if uploaded as private,
+            // hence using different output messaging to avoid confusion.
+            let output_str = if let Some(addr) = file_addr {
+                format!(
+                    "Processing chunk ({}/{total}) of {file_name:?} at {addr:?}",
+                    i + 1
+                )
+            } else {
+                format!("Processing chunk ({}/{total}) of {file_name:?}", i + 1)
+            };
+            info!("{output_str}");
             #[cfg(feature = "loud")]
-            println!(
-                "Processing chunk ({}/{total}) of {file_name:?} at {data_addr:?}",
-                i + 1
-            );
+            println!("{output_str}");
         }
 
         // Process payment for this batch


### PR DESCRIPTION
### Description

File uploaded as private will have no `address` info.
Hence a progress output message reformating is necessary to avoid confusion.


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
