### PR TITLE
feat: support network id from 0-255

### DIFF
--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -39,25 +39,25 @@ pub async fn connect_to_network_with_config(
 ) -> Result<Client, ExitCodeError> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.enable_steady_tick(Duration::from_millis(120));
-    progress_bar.set_message("Connecting to The Autonomi Network...");
+    progress_bar.set_message("Connecting to the Autonomi network...");
     let new_style = progress_bar.style().tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈🔗");
     progress_bar.set_style(new_style);
 
     let res = match network_context.network_id.as_u8() {
         LOCAL_NETWORK_ID => {
-            progress_bar.set_message("Connecting to a local Autonomi Network...");
+            progress_bar.set_message("Connecting to a local Autonomi network...");
             Client::init_local().await
         }
         MAIN_NETWORK_ID => {
-            progress_bar.set_message("Connecting to The Autonomi Network...");
+            progress_bar.set_message("Connecting to the Autonomi network...");
             Client::init().await
         }
         ALPHA_NETWORK_ID => {
-            progress_bar.set_message("Connecting to the Alpha Autonomi Network...");
+            progress_bar.set_message("Connecting to the alpha Autonomi network...");
             Client::init_alpha().await
         }
         _ => {
-            progress_bar.set_message("Connecting to a custom Autonomi Network...");
+            progress_bar.set_message("Connecting to a custom Autonomi network...");
             let evm_network = get_evm_network(
                 network_context.peers.local,
                 Some(network_context.network_id.as_u8()),
@@ -80,9 +80,9 @@ pub async fn connect_to_network_with_config(
 
     match res {
         Ok(client) => {
-            info!("Connected to the Network");
+            info!("Connected to the network");
             progress_bar.finish_with_message(format!(
-                "Connected to the {:?} Network",
+                "Connected to the {:?} network",
                 network_context.network_id
             ));
             let client = client.with_strategy(operating_strategy);
@@ -91,7 +91,7 @@ pub async fn connect_to_network_with_config(
         Err(e) => {
             error!("Failed to connect to the network: {e}");
             progress_bar.finish_with_message(format!(
-                "Failed to connect to the {:?} Network",
+                "Failed to connect to the {:?} network",
                 network_context.network_id
             ));
             let exit_code = connect_error_exit_code(&e);

--- a/ant-cli/src/actions/connect.rs
+++ b/ant-cli/src/actions/connect.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::exit_code::{connect_error_exit_code, evm_util_error_exit_code, ExitCodeError};
-use crate::opt::NetworkId;
+use crate::opt::{NetworkId, ALPHA_NETWORK_ID, LOCAL_NETWORK_ID, MAIN_NETWORK_ID};
 use autonomi::client::config::ClientOperatingStrategy;
 use autonomi::{get_evm_network, Client, ClientConfig, InitialPeersConfig};
 use color_eyre::eyre::eyre;
@@ -43,24 +43,24 @@ pub async fn connect_to_network_with_config(
     let new_style = progress_bar.style().tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈🔗");
     progress_bar.set_style(new_style);
 
-    let res = match network_context.network_id {
-        NetworkId::Local => {
+    let res = match network_context.network_id.as_u8() {
+        LOCAL_NETWORK_ID => {
             progress_bar.set_message("Connecting to a local Autonomi Network...");
             Client::init_local().await
         }
-        NetworkId::Main => {
+        MAIN_NETWORK_ID => {
             progress_bar.set_message("Connecting to The Autonomi Network...");
             Client::init().await
         }
-        NetworkId::Alpha => {
+        ALPHA_NETWORK_ID => {
             progress_bar.set_message("Connecting to the Alpha Autonomi Network...");
             Client::init_alpha().await
         }
-        NetworkId::Custom => {
+        _ => {
             progress_bar.set_message("Connecting to a custom Autonomi Network...");
             let evm_network = get_evm_network(
                 network_context.peers.local,
-                Some(network_context.network_id as u8),
+                Some(network_context.network_id.as_u8()),
             )
             .map_err(|err| {
                 let exit_code = evm_util_error_exit_code(&err);
@@ -71,7 +71,7 @@ pub async fn connect_to_network_with_config(
                 init_peers_config: network_context.peers,
                 evm_network,
                 strategy: operating_strategy.clone(),
-                network_id: Some(network_context.network_id as u8),
+                network_id: Some(network_context.network_id.as_u8()),
             };
 
             Client::init_with_config(config).await

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -243,7 +243,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
     let cmd = opt.command;
 
     let network_context = if opt.alpha {
-        NetworkContext::new(opt.peers, NetworkId::Alpha)
+        NetworkContext::new(opt.peers, NetworkId::alpha())
     } else {
         NetworkContext::new(opt.peers, opt.network_id)
     };

--- a/ant-cli/src/commands/wallet.rs
+++ b/ant-cli/src/commands/wallet.rs
@@ -84,7 +84,7 @@ pub fn export() -> Result<()> {
 pub async fn balance(network_context: NetworkContext) -> Result<()> {
     let network = get_evm_network(
         network_context.peers.local,
-        Some(network_context.network_id as u8),
+        Some(network_context.network_id.as_u8()),
     )?;
     let wallet = crate::wallet::load_wallet(&network)?;
 

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -27,8 +27,7 @@ use color_eyre::Result;
 use ant_logging::metrics::init_metrics;
 use ant_logging::{LogBuilder, LogFormat, ReloadHandle, WorkerGuard};
 use autonomi::version;
-use opt::NetworkId;
-use opt::Opt;
+use opt::{NetworkId, Opt};
 use tracing::Level;
 
 #[tokio::main]
@@ -72,9 +71,7 @@ async fn main() -> Result<()> {
     let _log_guards = init_logging_and_metrics(&opt)?;
     if opt.peers.local {
         tokio::spawn(init_metrics(std::process::id()));
-
-        // --local flag overrides the network ID
-        opt.network_id = NetworkId::Local;
+        opt.network_id = NetworkId::local();
     }
 
     info!("\"{}\"", std::env::args().collect::<Vec<_>>().join(" "));

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -88,7 +88,8 @@ impl NetworkDriver {
                 self.pending_tasks.update_closest_peers(id, res)?;
             }
             QueryResult::GetRecord(res) => {
-                trace!("GetRecord: {:?}", res);
+                // The result here is not logged because it can produce megabytes of text.
+                trace!("GetRecord event occurred");
                 self.pending_tasks.update_get_record(id, res)?;
             }
             QueryResult::PutRecord(res) => {


### PR DESCRIPTION
- 75c6aa7d8 **feat: support network id from 0-255**

  There was a bit of a misunderstanding in the way the `NetworkId` was implemented. It was reserving
  the values 0, 1, and 2, for local, main, and alpha networks, respectively, then assigning 3 for any
  other 'custom' network.

  We change it here such that 0, 1, and 2 are reserved as above, but custom networks are permitted to
  be between 3 and 255.

- a2b85174e **chore: standardise autonomi usage in connection messages**

  Our network is called 'Autonomi', not 'the Autonomi Network', and therefore only 'Autonomi' should
  be capitalised to denote it as a proper noun.

  The words 'alpha', 'local', and 'custom' are variants of Autonomi networks, so they should not be
  capitalised.

  Other usages of the word 'network' being capitalised were changed because 'network' is not a proper
  noun in that context.

- ad9ecd27f **chore: do not log result for `GetRecord`**

  Writing the result was causing excessive logging for `file download` commands.