### PR TITLE
On quorum error try get records

### DIFF
--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -189,6 +189,7 @@ impl Network {
         quorum: Quorum,
     ) -> Result<(), NetworkError> {
         let (tx, rx) = oneshot::channel();
+        let network_address = NetworkAddress::from(&record.key);
         let task = NetworkTask::PutRecord {
             record,
             to,
@@ -199,7 +200,19 @@ impl Network {
             .send(task)
             .await
             .map_err(|_| NetworkError::NetworkDriverOffline)?;
-        rx.await?
+
+        let res = rx.await?;
+
+        // In poor network conditions PutRecordQuorumFailed is unreliable.
+        // To eliminate false positives, we do a manual record existence check after the put.
+        if let Err(NetworkError::PutRecordQuorumFailed(_, _)) = res {
+            match self.get_record_and_holders(network_address, quorum).await {
+                Ok((Some(_), _)) => return Ok(()),
+                _ => return res,
+            }
+        }
+
+        res
     }
 
     /// Get the closest peers to an address on the Network


### PR DESCRIPTION
Don't trust PutRecordQuorumFailed error on PutRecordTo as it is not reliable. Introduce a manual get record check to verify the put. This will NOT slow down the upload throughput, and it will be more reliable. 

The issue with the PutRecordQuorumFailed errors being thrown comes from increasing the CHUNK_UPLOAD_BATCH_SIZE. The error is thrown even though the put can still have been successful.

I suggest we replace #2992 by this PR. What do you think @mickvandijke?