### PR TITLE
feat: early return `GetRecord` request in CLN if quorum is met

### DIFF
--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -12,7 +12,7 @@ mod task_handler;
 
 use std::{num::NonZeroUsize, time::Duration};
 
-use crate::networking::interface::NetworkTask;
+use crate::networking::interface::{Command, NetworkTask};
 use crate::networking::NetworkError;
 use ant_protocol::version::{IDENTIFY_CLIENT_VERSION_STR, IDENTIFY_PROTOCOL_STR};
 use ant_protocol::PrettyPrintRecordKey;
@@ -71,6 +71,8 @@ pub(crate) struct NetworkDriver {
     swarm: Swarm<AutonomiClientBehaviour>,
     /// can receive tasks from the [`crate::Network`]
     task_receiver: mpsc::Receiver<NetworkTask>,
+    /// can receive commands from the [`crate::driver::task_handler::TaskHandler`]
+    cmd_receiver: mpsc::Receiver<Command>,
     /// pending tasks currently awaiting swarm events to progress
     /// this is an opaque struct that can only be mutated by the module were [`crate::driver::task_handler::TaskHandler`] is defined
     pending_tasks: TaskHandler,
@@ -155,10 +157,15 @@ impl NetworkDriver {
         let swarm_config = libp2p::swarm::Config::with_tokio_executor();
         let swarm = Swarm::new(transport, behaviour, peer_id, swarm_config);
 
+        let (cmd_sender, cmd_receiver) = mpsc::channel(1);
+
+        let task_handler = TaskHandler::new(cmd_sender);
+
         Self {
             swarm,
             task_receiver,
-            pending_tasks: Default::default(),
+            cmd_receiver,
+            pending_tasks: task_handler,
         }
     }
 
@@ -175,10 +182,19 @@ impl NetworkDriver {
                             break;
                         }
                     }
-                }
+                },
+                cmd = self.cmd_receiver.recv() => {
+                    match cmd {
+                        Some(cmd) => self.process_cmd(cmd),
+                        None => {
+                            info!("Command receiver closed, exiting");
+                            break;
+                        }
+                    }
+                },
                 // swarm events
                 swarm_event = self.swarm.select_next_some() => {
-                    if let Err(e) = self.process_swarm_event(swarm_event) {
+                    if let Err(e) = self.process_swarm_event(swarm_event).await {
                         error!("Error processing swarm event: {e}");
                     }
                 }
@@ -298,6 +314,17 @@ impl NetworkDriver {
                         resp,
                     },
                 );
+            }
+        }
+    }
+
+    /// Process commands.
+    fn process_cmd(&mut self, cmd: Command) {
+        match cmd {
+            Command::TerminateQuery(query_id) => {
+                if let Some(mut query) = self.kad().query_mut(&query_id) {
+                    query.finish();
+                }
             }
         }
     }

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -9,6 +9,7 @@
 use crate::networking::OneShotTaskResult;
 use ant_evm::PaymentQuote;
 use ant_protocol::NetworkAddress;
+use libp2p::kad::QueryId;
 use libp2p::{
     kad::{PeerInfo, Quorum, Record},
     PeerId,
@@ -59,4 +60,11 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         resp: OneShotTaskResult<Option<(PeerInfo, PaymentQuote)>>,
     },
+}
+
+/// Commands that can be sent to the network driver to control ongoing operations.
+#[derive(Debug)]
+pub(super) enum Command {
+    /// Terminate an ongoing query.
+    TerminateQuery(QueryId),
 }

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -97,6 +97,11 @@ pub enum NetworkError {
     SplitRecord(HashMap<PeerId, Record>),
     #[error("Get record timed out, peers found holding the record at timeout: {0:?}")]
     GetRecordTimeout(Vec<PeerId>),
+    #[error("Failed to get enough holders for the get record request. Expected: {expected_holders}, got: {got_holders}")]
+    GetRecordQuorumFailed {
+        got_holders: usize,
+        expected_holders: usize,
+    },
 
     /// Invalid retry strategy
     #[error("Invalid retry strategy, check your config or use the default")]

--- a/autonomi/src/networking/utils.rs
+++ b/autonomi/src/networking/utils.rs
@@ -1,6 +1,7 @@
 use crate::Multiaddr;
+use ant_protocol::CLOSE_GROUP_SIZE;
+use libp2p::kad::Quorum;
 use libp2p::multiaddr::Protocol;
-
 // @anselme: this is a duplicate function from ant_networking, wasn't sure where to place it
 
 /// Verifies if `Multiaddr` contains IPv4 address that is not global.
@@ -19,4 +20,21 @@ pub(crate) fn multiaddr_is_global(multiaddr: &Multiaddr) -> bool {
         }
         _ => false,
     })
+}
+
+/// Majority of a given group (i.e. > 1/2).
+pub const fn close_group_majority() -> usize {
+    // Calculate the majority of the close group size by dividing it by 2 and adding 1.
+    // This ensures that the majority is always greater than half.
+    CLOSE_GROUP_SIZE / 2 + 1
+}
+
+/// Get the value of the provided `Quorum` as usize.
+pub fn get_quorum_amount(quorum: &Quorum) -> usize {
+    match quorum {
+        Quorum::Majority => close_group_majority(),
+        Quorum::All => CLOSE_GROUP_SIZE,
+        Quorum::N(v) => v.get(),
+        Quorum::One => 1,
+    }
 }


### PR DESCRIPTION
CLN did not really do anything with the `GetRecord` quorum. This change will make it early return a record and its holders if the specified quorum is met.

CLN download speed is now faster on average compared to `stable`.

TODO:
- [x] Gracefully end the `GetRecord` internal Kad query when early returning.