### PR TITLE
chore: disable nightly test runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,6 @@
 name: Nightly -- Full Network Tests
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Right now this test suite fails consistently and the failures are not being actively investigated, so we will disable the scheduled run.

The `workflow_dispatch` will be retained to enable it to be kicked off manually.