### PR TITLE
--no-archive flag for ant client

### DIFF
--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -17,7 +17,7 @@ ant [OPTIONS] <COMMAND>
 
 ### File
 - `file cost <file>`
-- `file upload <file> [--public]`
+- `file upload <file> [--public] [--no-archive]`
 - `file download <addr> <dest_file>`
 - `file list`
 
@@ -155,15 +155,16 @@ Expected value:
 
 #### Upload a file
 ```
-file upload <file> [--public]
+file upload <file> [--public] [--no-archive]
 ```
 Uploads a file to the network.
 
 Expected value: 
 - `<file>`: File path (accessible by current user)
 
-The following flag can be added:
-`--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+The following flags can be added:
+- `--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+- `--no-archive` (Optional) Skip creating local archive after upload. Only upload files without saving archive information
 
 #### Download a file
 ```

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -70,6 +70,9 @@ pub enum FileCmd {
         /// Upload the file as public. Everyone can see public data on the Network.
         #[arg(short, long)]
         public: bool,
+        /// Skip creating local archive after upload. Only upload files without saving archive information.
+        #[arg(long)]
+        no_archive: bool,
         /// Optional: Specify the maximum fee per gas in u128.
         #[arg(long)]
         max_fee_per_gas: Option<u128>,
@@ -258,10 +261,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Upload {
                 file,
                 public,
+                no_archive,
                 max_fee_per_gas,
             } => {
                 if let Err((err, exit_code)) =
-                    file::upload(&file, public, network_context, max_fee_per_gas).await
+                    file::upload(&file, public, no_archive, network_context, max_fee_per_gas).await
                 {
                     eprintln!("{err:?}");
                     std::process::exit(exit_code);

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -42,6 +42,7 @@ pub async fn cost(file: &str, network_context: NetworkContext) -> Result<()> {
 pub async fn upload(
     file: &str,
     public: bool,
+    no_archive: bool,
     network_context: NetworkContext,
     max_fee_per_gas: Option<u128>,
 ) -> Result<(), ExitCodeError> {
@@ -80,97 +81,102 @@ pub async fn upload(
 
     // upload dir
     let local_addr;
-    let archive = if public {
-        let result = client.dir_upload_public(dir_path, payment.clone()).await;
-        match result {
-            Ok((_cost, xor_name)) => {
-                local_addr = xor_name.to_hex();
-                local_addr.clone()
-            }
-            Err(UploadError::PutError(PutError::Batch(upload_state))) => {
-                let res = cached_payments::save_payment(file, &upload_state);
-                println!("Cached payment to local disk for {file}: {res:?}");
-                let exit_code =
-                    upload_exit_code(&UploadError::PutError(PutError::Batch(Default::default())));
-                return Err((
-                    eyre!(UploadError::PutError(PutError::Batch(upload_state)))
-                        .wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
-            Err(err) => {
-                let exit_code = upload_exit_code(&err);
-                return Err((
-                    eyre!(err).wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
+    let archive = if no_archive {
+        // Only upload file content, don't create or upload archive
+        if public {
+            let (cost, _archive) = client.dir_content_upload_public(dir_path, payment.clone()).await
+                .map_err(|err| {
+                    let exit_code = upload_exit_code(&err);
+                    (eyre!(err).wrap_err("Failed to upload file content"), exit_code)
+                })?;
+            
+            println!("Files uploaded successfully. Total cost: {} AttoTokens", cost);
+            info!("Files uploaded successfully. Cost: {cost}");
+            local_addr = "content-only-upload".to_string();
+            local_addr.clone()
+        } else {
+            let (cost, _archive) = client.dir_content_upload(dir_path, payment).await
+                .map_err(|err| {
+                    let exit_code = upload_exit_code(&err);
+                    (eyre!(err).wrap_err("Failed to upload file content"), exit_code)
+                })?;
+            
+            println!("Files uploaded successfully. Total cost: {} AttoTokens", cost);
+            info!("Files uploaded successfully. Cost: {cost}");
+            local_addr = "content-only-upload".to_string();
+            local_addr.clone()
         }
     } else {
-        let result = client.dir_upload(dir_path, payment).await;
-        match result {
-            Ok((_cost, private_data_access)) => {
-                local_addr = private_data_access.address();
-                private_data_access.to_hex()
-            }
-            Err(UploadError::PutError(PutError::Batch(upload_state))) => {
-                let res = crate::access::cached_payments::save_payment(file, &upload_state);
-                println!("Cached payment to local disk for {file}: {res:?}");
-                let exit_code =
-                    upload_exit_code(&UploadError::PutError(PutError::Batch(Default::default())));
-                return Err((
-                    eyre!(UploadError::PutError(PutError::Batch(upload_state)))
-                        .wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
-            Err(err) => {
-                let exit_code = upload_exit_code(&err);
-                return Err((
-                    eyre!(err).wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
+        // Traditional upload with archive creation and upload
+        if public {
+            let (_cost, xor_name) = client.dir_upload_public(dir_path, payment.clone()).await
+                .map_err(|err| {
+                    let exit_code = upload_exit_code(&err);
+                    (eyre!(err).wrap_err("Failed to upload file"), exit_code)
+                })?;
+            
+            local_addr = xor_name.to_hex();
+            local_addr.clone()
+        } else {
+            let (_cost, private_data_access) = client.dir_upload(dir_path, payment).await
+                .map_err(|err| {
+                    let exit_code = upload_exit_code(&err);
+                    (eyre!(err).wrap_err("Failed to upload file"), exit_code)
+                })?;
+            
+            local_addr = private_data_access.address();
+            private_data_access.to_hex()
         }
     };
 
-    // wait for upload to complete
+    // wait for upload to complete and get summary
     if let Err(e) = upload_completed_tx.send(()) {
         error!("Failed to send upload completed event: {e:?}");
         eprintln!("Failed to send upload completed event: {e:?}");
     }
 
-    // get summary
-    let summary = upload_summary_thread
-        .await
-        .map_err(|err| (eyre!(err), IO_ERROR))?;
-    if summary.records_paid == 0 {
-        println!("All chunks already exist on the network.");
+    if !no_archive {
+        // get summary only for traditional uploads
+        let summary = upload_summary_thread
+            .await
+            .map_err(|err| (eyre!(err), IO_ERROR))?;
+        if summary.records_paid == 0 {
+            println!("All chunks already exist on the network.");
+        } else {
+            println!("Successfully uploaded: {file}");
+            println!("At address: {local_addr}");
+            info!("Successfully uploaded: {file} at address: {local_addr}");
+            println!("Number of chunks uploaded: {}", summary.records_paid);
+            println!(
+                "Number of chunks already paid/uploaded: {}",
+                summary.records_already_paid
+            );
+            println!("Total cost: {} AttoTokens", summary.tokens_spent);
+        }
+        info!("Summary for upload of file {file} at {local_addr:?}: {summary:?}");
     } else {
-        println!("Successfully uploaded: {file}");
-        println!("At address: {local_addr}");
-        info!("Successfully uploaded: {file} at address: {local_addr}");
-        println!("Number of chunks uploaded: {}", summary.records_paid);
-        println!(
-            "Number of chunks already paid/uploaded: {}",
-            summary.records_already_paid
-        );
-        println!("Total cost: {} AttoTokens", summary.tokens_spent);
+        // For no-archive uploads, we already printed the cost and don't have an archive address
+        println!("Content-only upload completed: {file}");
+        info!("Content-only upload completed: {file}");
     }
-    info!("Summary for upload of file {file} at {local_addr:?}: {summary:?}");
 
-    // save to local user data
-    let writer = if public {
-        crate::user_data::write_local_public_file_archive(archive, &name)
+    // save to local user data (skip if no_archive is true)
+    if !no_archive {
+        let writer = if public {
+            crate::user_data::write_local_public_file_archive(archive, &name)
+        } else {
+            crate::user_data::write_local_private_file_archive(archive, local_addr, &name)
+        };
+        writer
+            .wrap_err("Failed to save file to local user data")
+            .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
+            .map_err(|err| (err, IO_ERROR))?;
+
+        info!("Saved file to local user data");
     } else {
-        crate::user_data::write_local_private_file_archive(archive, local_addr, &name)
-    };
-    writer
-        .wrap_err("Failed to save file to local user data")
-        .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
-        .map_err(|err| (err, IO_ERROR))?;
-
-    info!("Saved file to local user data");
+        info!("Skipped saving file to local user data (no-archive mode)");
+        println!("Archive creation skipped. File uploaded but no local archive saved.");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Since I'm doing single file uploads repeatedly atm (uploading friends themes, background images, JS Webcomponents I want to include in other WebApps, ...) where I always just use the datamap and the chunks of the file but never the archive I created this mod for me and from what I hear there's multiple people out there who would like this feature too.

Archives have their place and are good for folder upload/download/syncing ... but if I just want an object or content online on autonomi there is absolutely no reason to create and upload an archive too.

### Related Issue

only general complaints / usability issues around not being able to upload content without creating the archive with the ant client

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I've tested locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have tried to add commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- feat
- fix
- docs
- style
- refactor
- perf
- test
- build
- ci
- chore
- revert
-->