### PR TITLE
making no-archive the default and adding the --archive / -a flag 

### DIFF
--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -17,7 +17,7 @@ ant [OPTIONS] <COMMAND>
 
 ### File
 - `file cost <file>`
-- `file upload <file> [--public]`
+- `file upload <file> [--public] [--archive]`
 - `file download <addr> <dest_file>`
 - `file list`
 
@@ -155,15 +155,16 @@ Expected value:
 
 #### Upload a file
 ```
-file upload <file> [--public]
+file upload <file> [--public] [--archive]
 ```
 Uploads a file to the network.
 
 Expected value: 
 - `<file>`: File path (accessible by current user)
 
-The following flag can be added:
-`--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+The following flags can be added:
+- `--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+- `--archive` (Optional) Create and upload archive after file upload. This enables traditional archive functionality.
 
 #### Download a file
 ```

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -70,6 +70,13 @@ pub enum FileCmd {
         /// Upload the file as public. Everyone can see public data on the Network.
         #[arg(short, long)]
         public: bool,
+        /// Create and upload archive after file upload. This enables traditional archive functionality.
+        /// The archive preserves directory structure, filenames, and metadata of uploaded folders.
+        /// This ensures the original folder structure and file naming are maintained after download.
+        /// Without this flag, all files are uploaded as individual objects, losing filenames, metadata, and directory structure.
+        /// Using this option incurs additional costs.
+        #[arg(short, long)]
+        archive: bool,
         /// Optional: Specify the maximum fee per gas in u128.
         #[arg(long)]
         max_fee_per_gas: Option<u128>,
@@ -258,10 +265,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Upload {
                 file,
                 public,
+                archive,
                 max_fee_per_gas,
             } => {
                 if let Err((err, exit_code)) =
-                    file::upload(&file, public, network_context, max_fee_per_gas).await
+                    file::upload(&file, public, archive, network_context,  max_fee_per_gas).await
                 {
                     eprintln!("{err:?}");
                     std::process::exit(exit_code);


### PR DESCRIPTION
### Description

Since I'm doing single file uploads repeatedly atm (uploading friends themes, background images, JS Webcomponents I want to include in other WebApps, ...) where I always just use the datamap and the chunks of the file but never the archive I created this mod for me and from what I hear there's multiple people out there who would like this feature too.

Archives have their place and are good for folder upload/download/syncing ... but if I just want an object or content online on autonomi there is absolutely no reason to create and upload an archive too.

---

side note: I tested downloading a file from raw datamap and the client already supports it - so there doesn't seem to be a breaking change on the other side that would prevent changing default behavior imho

### Related Issue

only general complaints / usability issues around not being able to upload content without creating the archive with the ant client

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I've tested locally with my changes.
- [x] I have updated the documentation accordingly.
- [x] I have tried to add commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- feat
- fix
- docs
- style
- refactor
- perf
- test
- build
- ci
- chore
- revert
-->