### PR TITLE
feat: no archive flag for cli and default to that for single file upload

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -150,7 +150,7 @@ jobs:
         if: always()
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
+        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_file
         env:
           ANT_LOG: "v"
         timeout-minutes: 2

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -267,7 +267,7 @@ jobs:
         shell: pwsh
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources
+        run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources/downloaded_file2
         env:
           ANT_LOG: "v"
         timeout-minutes: 5
@@ -1175,7 +1175,7 @@ jobs:
         shell: bash
 
       - name: File Download
-        run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources > ./download_output 2>&1
+        run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources/downloaded_file > ./download_output 2>&1
         env:
           ANT_LOG: "v"
         timeout-minutes: 5

--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -17,7 +17,7 @@ ant [OPTIONS] <COMMAND>
 
 ### File
 - `file cost <file>`
-- `file upload <file> [--public]`
+- `file upload <file> [--public] [--no-archive]`
 - `file download <addr> <dest_file>`
 - `file list`
 
@@ -155,15 +155,16 @@ Expected value:
 
 #### Upload a file
 ```
-file upload <file> [--public]
+file upload <file> [--public] [--no-archive]
 ```
 Uploads a file to the network.
 
 Expected value: 
 - `<file>`: File path (accessible by current user)
 
-The following flag can be added:
-`--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+The following flags can be added:
+- `--public` (Optional) Specifying this will make this file publicly available to anyone on the network
+- `--no-archive` (Optional) Skip creating local archive after upload. Only upload files without saving archive information
 
 #### Download a file
 ```

--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -164,7 +164,7 @@ Expected value:
 
 The following flags can be added:
 - `--public` (Optional) Specifying this will make this file publicly available to anyone on the network
-- `--no-archive` (Optional) Skip creating local archive after upload. Only upload files without saving archive information
+- `--no-archive` (Optional) Skip creating local archive after upload. Only upload files without saving archive information. Note that --no-archive is the default behaviour for single file uploads (folk can still upload a single file as an archive by putting it in a directory)
 
 #### Download a file
 ```

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -70,6 +70,12 @@ pub enum FileCmd {
         /// Upload the file as public. Everyone can see public data on the Network.
         #[arg(short, long)]
         public: bool,
+        /// Skip creating an archive after uploading a directory.
+        /// When uploading a directory, files are normally grouped into an archive for easier management.
+        /// This flag uploads the files individually without creating the archive metadata.
+        /// Note: This option only affects directory uploads - single file uploads never create archives.
+        #[arg(long)]
+        no_archive: bool,
         /// Optional: Specify the maximum fee per gas in u128.
         #[arg(long)]
         max_fee_per_gas: Option<u128>,
@@ -258,10 +264,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Upload {
                 file,
                 public,
+                no_archive,
                 max_fee_per_gas,
             } => {
                 if let Err((err, exit_code)) =
-                    file::upload(&file, public, network_context, max_fee_per_gas).await
+                    file::upload(&file, public, no_archive, network_context, max_fee_per_gas).await
                 {
                     eprintln!("{err:?}");
                     std::process::exit(exit_code);

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -82,6 +82,7 @@ pub async fn upload(
         .unwrap_or(file.to_string());
 
     // upload dir
+    let not_single_file = !dir_path.is_file();
     let (archive_addr, local_addr) =
         match upload_dir(&client, dir_path, public, no_archive, payment).await {
             Ok((a, l)) => (a, l),
@@ -131,7 +132,7 @@ pub async fn upload(
     info!("Summary for upload of file {file} at {local_addr:?}: {summary:?}");
 
     // save archive to local user data
-    if !no_archive {
+    if !no_archive && not_single_file {
         let writer = if public {
             crate::user_data::write_local_public_file_archive(archive_addr, &name)
         } else {
@@ -168,7 +169,7 @@ async fn upload_dir(
             addrs.push(addr.to_hex());
         }
 
-        if no_archive || !is_single_file {
+        if no_archive || is_single_file {
             if addrs.len() > MAX_ADDRESSES_TO_PRINT {
                 Ok(("no-archive".to_string(), "multiple addresses".to_string()))
             } else {
@@ -191,7 +192,7 @@ async fn upload_dir(
             addrs.push(private_datamap.to_hex());
         }
 
-        if no_archive || !is_single_file {
+        if no_archive || is_single_file {
             if addrs.len() > MAX_ADDRESSES_TO_PRINT {
                 Ok(("no-archive".to_string(), "multiple addresses".to_string()))
             } else {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -148,7 +148,10 @@ pub async fn upload(
     Ok(())
 }
 
-/// Uploads a directory to the network and prints the content and addresses. Returns the archive address and the address to access the data.
+/// Uploads a file or directory to the network and prints the content and addresses.
+/// Single files are uploaded without an archive, directories are uploaded with an archive.
+/// The no_archive argument can be used to skip the archive upload.
+/// Returns the archive address if any and the address to access the data.
 async fn upload_dir(
     client: &Client,
     dir_path: PathBuf,

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -16,10 +16,12 @@ use autonomi::client::payment::PaymentOption;
 use autonomi::client::PutError;
 use autonomi::files::UploadError;
 use autonomi::networking::{Quorum, RetryStrategy};
-use autonomi::{ClientOperatingStrategy, TransactionConfig};
+use autonomi::{Client, ClientOperatingStrategy, TransactionConfig};
 use color_eyre::eyre::{eyre, Context, Result};
 use color_eyre::Section;
 use std::path::PathBuf;
+
+const MAX_ADDRESSES_TO_PRINT: usize = 3;
 
 pub async fn cost(file: &str, network_context: NetworkContext) -> Result<()> {
     let client = crate::actions::connect_to_network(network_context)
@@ -42,6 +44,7 @@ pub async fn cost(file: &str, network_context: NetworkContext) -> Result<()> {
 pub async fn upload(
     file: &str,
     public: bool,
+    no_archive: bool,
     network_context: NetworkContext,
     max_fee_per_gas: Option<u128>,
 ) -> Result<(), ExitCodeError> {
@@ -79,14 +82,9 @@ pub async fn upload(
         .unwrap_or(file.to_string());
 
     // upload dir
-    let local_addr;
-    let archive = if public {
-        let result = client.dir_upload_public(dir_path, payment.clone()).await;
-        match result {
-            Ok((_cost, xor_name)) => {
-                local_addr = xor_name.to_hex();
-                local_addr.clone()
-            }
+    let (archive_addr, local_addr) =
+        match upload_dir(&client, dir_path, public, no_archive, payment).await {
+            Ok((a, l)) => (a, l),
             Err(UploadError::PutError(PutError::Batch(upload_state))) => {
                 let res = cached_payments::save_payment(file, &upload_state);
                 println!("Cached payment to local disk for {file}: {res:?}");
@@ -105,34 +103,7 @@ pub async fn upload(
                     exit_code,
                 ));
             }
-        }
-    } else {
-        let result = client.dir_upload(dir_path, payment).await;
-        match result {
-            Ok((_cost, private_data_access)) => {
-                local_addr = private_data_access.address();
-                private_data_access.to_hex()
-            }
-            Err(UploadError::PutError(PutError::Batch(upload_state))) => {
-                let res = crate::access::cached_payments::save_payment(file, &upload_state);
-                println!("Cached payment to local disk for {file}: {res:?}");
-                let exit_code =
-                    upload_exit_code(&UploadError::PutError(PutError::Batch(Default::default())));
-                return Err((
-                    eyre!(UploadError::PutError(PutError::Batch(upload_state)))
-                        .wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
-            Err(err) => {
-                let exit_code = upload_exit_code(&err);
-                return Err((
-                    eyre!(err).wrap_err("Failed to upload file".to_string()),
-                    exit_code,
-                ));
-            }
-        }
-    };
+        };
 
     // wait for upload to complete
     if let Err(e) = upload_completed_tx.send(()) {
@@ -159,20 +130,80 @@ pub async fn upload(
     }
     info!("Summary for upload of file {file} at {local_addr:?}: {summary:?}");
 
-    // save to local user data
-    let writer = if public {
-        crate::user_data::write_local_public_file_archive(archive, &name)
-    } else {
-        crate::user_data::write_local_private_file_archive(archive, local_addr, &name)
-    };
-    writer
-        .wrap_err("Failed to save file to local user data")
-        .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
-        .map_err(|err| (err, IO_ERROR))?;
-
-    info!("Saved file to local user data");
+    // save archive to local user data
+    if !no_archive {
+        let writer = if public {
+            crate::user_data::write_local_public_file_archive(archive_addr, &name)
+        } else {
+            crate::user_data::write_local_private_file_archive(archive_addr, local_addr, &name)
+        };
+        writer
+            .wrap_err("Failed to save file to local user data")
+            .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
+            .map_err(|err| (err, IO_ERROR))?;
+        info!("Saved file to local user data");
+    }
 
     Ok(())
+}
+
+/// Uploads a directory to the network and prints the content and addresses. Returns the archive address and the address to access the data.
+async fn upload_dir(
+    client: &Client,
+    dir_path: PathBuf,
+    public: bool,
+    no_archive: bool,
+    payment_option: PaymentOption,
+) -> Result<(String, String), UploadError> {
+    let is_single_file = dir_path.is_file();
+
+    if public {
+        let (_, public_archive) = client
+            .dir_content_upload_public(dir_path, payment_option.clone())
+            .await?;
+
+        let mut addrs = vec![];
+        for (file_path, addr, _meta) in public_archive.iter() {
+            println!("  - {file_path:?}: {:?}", addr.to_hex());
+            addrs.push(addr.to_hex());
+        }
+
+        if no_archive || !is_single_file {
+            if addrs.len() > MAX_ADDRESSES_TO_PRINT {
+                Ok(("no-archive".to_string(), "multiple addresses".to_string()))
+            } else {
+                Ok(("no-archive".to_string(), addrs.join(", ")))
+            }
+        } else {
+            let (_, addr) = client
+                .archive_put_public(&public_archive, payment_option.clone())
+                .await?;
+            Ok((addr.to_hex(), addr.to_hex()))
+        }
+    } else {
+        let (_, private_archive) = client
+            .dir_content_upload(dir_path, payment_option.clone())
+            .await?;
+
+        let mut addrs = vec![];
+        for (file_path, private_datamap, _meta) in private_archive.iter() {
+            println!("  - {file_path:?}: {:?}", private_datamap.to_hex());
+            addrs.push(private_datamap.to_hex());
+        }
+
+        if no_archive || !is_single_file {
+            if addrs.len() > MAX_ADDRESSES_TO_PRINT {
+                Ok(("no-archive".to_string(), "multiple addresses".to_string()))
+            } else {
+                Ok(("no-archive".to_string(), addrs.join(", ")))
+            }
+        } else {
+            let (_, private_datamap) = client
+                .archive_put(&private_archive, payment_option.clone())
+                .await?;
+            Ok((private_datamap.to_hex(), private_datamap.address()))
+        }
+    }
 }
 
 pub async fn download(


### PR DESCRIPTION
Based on the excellent suggestions by @rid-dim here:
- https://github.com/maidsafe/autonomi/pull/3010
- https://github.com/maidsafe/autonomi/pull/3011

This PR:
- adds the `--no-archive` flag as excellently suggested by @rid-dim
- but keep archives as the default for directories so upload and download commands stay symmetric
- single file uploads never generate `archive` (user can only put single file in a directory to have an archive, if really wanted)