### PR TITLE
chore(network): move ConnectionClosed logging to debug level

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -833,8 +833,14 @@ jobs:
           fi
 
       - name: Wait for nodes to discover each other
-        run: sleep 20
+        run: sleep 30
         timeout-minutes: 1
+
+      - name: Verify the routing tables of the nodes
+        run: cargo test --release -p ant-node --test verify_routing_table -- --nocapture
+        env:
+          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
+        timeout-minutes: 5
 
       - name: Verify the location of the data on the network
         run: cargo test --release -p ant-node --test verify_data_location -- --nocapture
@@ -843,12 +849,6 @@ jobs:
           ANT_LOG: "all"
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25
-
-      - name: Verify the routing tables of the nodes
-        run: cargo test --release -p ant-node --test verify_routing_table -- --nocapture
-        env:
-          CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-        timeout-minutes: 5
 
       # Sleep for a while to allow restarted nodes can be detected by others
       - name: Sleep a while

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -296,13 +296,21 @@ impl SwarmDriver {
                 error,
             } => {
                 event_string = "OutgoingConnErrWithoutPeerId";
+
                 warn!("OutgoingConnectionError on {connection_id:?} - {error:?}");
+
                 let remote_peer = "";
-                for error_str in dial_error_to_str(&error) {
-                    error!(
-                        "Node {:?} Remote {remote_peer:?} - Outgoing Connection Error - {error_str:?}",
-                        self.self_peer_id,
-                    );
+                for (error_str, level) in dial_error_to_str(&error) {
+                    match level {
+                        tracing::Level::ERROR => error!(
+                            "Node {:?} Remote {remote_peer:?} - Outgoing Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                        _ => debug!(
+                            "Node {:?} Remote {remote_peer:?} - Outgoing Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                    }
                 }
 
                 self.record_connection_metrics();
@@ -320,11 +328,18 @@ impl SwarmDriver {
             } => {
                 event_string = "OutgoingConnErr";
                 warn!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
-                for error_str in dial_error_to_str(&error) {
-                    error!(
-                        "Node {:?} Remote {failed_peer_id:?} - Outgoing Connection Error - {error_str:?}",
-                        self.self_peer_id,
-                    );
+
+                for (error_str, level) in dial_error_to_str(&error) {
+                    match level {
+                        tracing::Level::ERROR => error!(
+                            "Node {:?} Remote {failed_peer_id:?} - Outgoing Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                        _ => debug!(
+                            "Node {:?} Remote {failed_peer_id:?} - Outgoing Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                    }
                 }
 
                 let connection_details = self.live_connected_peers.remove(&connection_id);
@@ -474,11 +489,17 @@ impl SwarmDriver {
                         None => String::new(),
                     };
                     error!("IncomingConnectionError Valid from local_addr {local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
-                    error!(
-                        "Node {:?} Remote {remote_peer_id} - Incoming Connection Error - {:?}",
-                        self.self_peer_id,
-                        listen_error_to_str(&error)
-                    );
+                    let (error_str, level) = listen_error_to_str(&error);
+                    match level {
+                        tracing::Level::ERROR => error!(
+                            "Node {:?} Remote {remote_peer_id} - Incoming Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                        _ => debug!(
+                            "Node {:?} Remote {remote_peer_id} - Incoming Connection Error - {error_str:?}",
+                            self.self_peer_id,
+                        ),
+                    }
                 } else {
                     debug!("IncomingConnectionError InValid from local_addr {local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
                 }

--- a/ant-networking/src/event/swarm.rs
+++ b/ant-networking/src/event/swarm.rs
@@ -56,8 +56,7 @@ impl SwarmDriver {
                     metrics_recorder.record(&(*event));
                 }
                 event_string = "relay_client_event";
-
-                info!(?event, "relay client event");
+                debug!("relay client event: {event:?}");
 
                 if let libp2p::relay::client::Event::ReservationReqAccepted {
                     relay_peer_id,
@@ -297,7 +296,7 @@ impl SwarmDriver {
             } => {
                 event_string = "OutgoingConnErrWithoutPeerId";
 
-                warn!("OutgoingConnectionError on {connection_id:?} - {error:?}");
+                debug!("OutgoingConnectionError on {connection_id:?} - {error:?}");
 
                 let remote_peer = "";
                 for (error_str, level) in dial_error_to_str(&error) {
@@ -327,7 +326,7 @@ impl SwarmDriver {
                 connection_id,
             } => {
                 event_string = "OutgoingConnErr";
-                warn!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
+                debug!("OutgoingConnectionError to {failed_peer_id:?} on {connection_id:?} - {error:?}");
 
                 for (error_str, level) in dial_error_to_str(&error) {
                     match level {
@@ -352,14 +351,14 @@ impl SwarmDriver {
                 );
 
                 // we need to decide if this was a critical error and if we should report it to the Issue tracker
-                let is_critical_error = match error {
+                let is_critical_error = match &error {
                     DialError::Transport(errors) => {
                         // as it's an outgoing error, if it's transport based we can assume it is _our_ fault
                         //
                         // (eg, could not get a port for a tcp connection)
                         // so we default to it not being a real issue
                         // unless there are _specific_ errors (connection refused eg)
-                        error!("Dial errors len : {:?}", errors.len());
+                        debug!("Dial errors len : {:?} on {connection_id:?}", errors.len());
                         let mut there_is_a_serious_issue = false;
                         // Libp2p throws errors for all the listen addr (including private) of the remote peer even
                         // though we try to dial just the global/public addr. This would mean that we get
@@ -371,15 +370,15 @@ impl SwarmDriver {
                         for (_addr, err) in errors {
                             match err {
                                 TransportError::MultiaddrNotSupported(addr) => {
-                                    warn!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
+                                    debug!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
                                     #[cfg(feature = "loud")]
                                     {
-                                        warn!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
+                                        debug!("OutgoingConnectionError: Transport::MultiaddrNotSupported {addr:?}. This can be ignored if the peer has atleast one global address.");
                                         println!("If this was your bootstrap peer, restart your node with a supported multiaddr");
                                     }
                                 }
                                 TransportError::Other(err) => {
-                                    error!("OutgoingConnectionError: Transport::Other {err:?}");
+                                    debug!("OutgoingConnectionError: Transport::Other {err:?}");
 
                                     all_multiaddr_not_supported = false;
                                     let problematic_errors = [
@@ -391,7 +390,7 @@ impl SwarmDriver {
                                     if self.initial_bootstrap.is_bootstrap_peer(&failed_peer_id)
                                         && !self.initial_bootstrap.has_terminated()
                                     {
-                                        warn!("OutgoingConnectionError: On bootstrap peer {failed_peer_id:?}, while still in bootstrap mode, ignoring");
+                                        debug!("OutgoingConnectionError: On bootstrap peer {failed_peer_id:?}, while still in bootstrap mode, ignoring");
                                         there_is_a_serious_issue = false;
                                     } else {
                                         // It is really difficult to match this error, due to being eg:
@@ -402,7 +401,7 @@ impl SwarmDriver {
                                             .iter()
                                             .any(|err| error_msg.contains(err))
                                         {
-                                            warn!("Problematic error encountered: {error_msg}");
+                                            debug!("Problematic error encountered: {error_msg}");
                                             there_is_a_serious_issue = true;
                                         }
                                     }
@@ -410,7 +409,7 @@ impl SwarmDriver {
                             }
                         }
                         if all_multiaddr_not_supported {
-                            warn!("All multiaddrs had MultiaddrNotSupported error for {failed_peer_id:?}. Marking it as a serious issue.");
+                            debug!("All multiaddrs had MultiaddrNotSupported error for {failed_peer_id:?}. Marking it as a serious issue.");
                             there_is_a_serious_issue = true;
                         }
                         there_is_a_serious_issue
@@ -418,43 +417,43 @@ impl SwarmDriver {
                     DialError::NoAddresses => {
                         // We provided no address, and while we can't really blame the peer
                         // we also can't connect, so we opt to cleanup...
-                        warn!("OutgoingConnectionError: No address provided");
+                        debug!("OutgoingConnectionError: No address provided");
                         true
                     }
                     DialError::Aborted => {
                         // not their fault
-                        warn!("OutgoingConnectionError: Aborted");
+                        debug!("OutgoingConnectionError: Aborted");
                         false
                     }
                     DialError::DialPeerConditionFalse(_) => {
                         // we could not dial due to an internal condition, so not their issue
-                        warn!("OutgoingConnectionError: DialPeerConditionFalse");
+                        debug!("OutgoingConnectionError: DialPeerConditionFalse");
                         false
                     }
                     DialError::LocalPeerId { endpoint, .. } => {
                         // This is actually _us_ So we should remove this from the RT
-                        error!(
+                        debug!(
                             "OutgoingConnectionError: LocalPeerId: {}",
-                            endpoint_str(&endpoint)
+                            endpoint_str(endpoint)
                         );
                         true
                     }
                     DialError::WrongPeerId { obtained, endpoint } => {
                         // The peer id we attempted to dial was not the one we expected
                         // cleanup
-                        error!("OutgoingConnectionError: WrongPeerId: obtained: {obtained:?}, endpoint: {endpoint:?}");
+                        debug!("OutgoingConnectionError: WrongPeerId: obtained: {obtained:?}, endpoint: {endpoint:?}");
                         true
                     }
                     DialError::Denied { cause } => {
                         // The peer denied our connection
                         // cleanup
-                        error!("OutgoingConnectionError: Denied: {cause:?}");
+                        debug!("OutgoingConnectionError: Denied: {cause:?}");
                         true
                     }
                 };
 
                 if is_critical_error {
-                    warn!("Outgoing Connection error to {failed_peer_id:?} is considered as critical. Marking it as an issue.");
+                    warn!("Outgoing Connection error to {failed_peer_id:?} is considered as critical. Marking it as an issue. Error: {error:?}");
                     self.record_node_issue(failed_peer_id, NodeIssue::ConnectionIssue);
 
                     if let (Some((_, failed_addr, _)), Some(bootstrap_cache)) =
@@ -483,14 +482,13 @@ impl SwarmDriver {
                 // And since we don't do anything critical with this event, the order and time of processing is
                 // not critical.
 
-                if self.is_incoming_connection_error_valid(connection_id, &send_back_addr) {
-                    let remote_peer_id = match multiaddr_get_peer_id(&send_back_addr) {
-                        Some(peer_id) => format!("{peer_id:?}"),
-                        None => String::new(),
-                    };
-                    error!("IncomingConnectionError Valid from local_addr {local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
-                    let (error_str, level) = listen_error_to_str(&error);
-                    match level {
+                let remote_peer_id = match multiaddr_get_peer_id(&send_back_addr) {
+                    Some(peer_id) => format!("{peer_id:?}"),
+                    None => String::new(),
+                };
+                debug!("IncomingConnectionError Valid from local_addr {local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
+                let (error_str, level) = listen_error_to_str(&error);
+                match level {
                         tracing::Level::ERROR => error!(
                             "Node {:?} Remote {remote_peer_id} - Incoming Connection Error - {error_str:?}",
                             self.self_peer_id,
@@ -500,9 +498,6 @@ impl SwarmDriver {
                             self.self_peer_id,
                         ),
                     }
-                } else {
-                    debug!("IncomingConnectionError InValid from local_addr {local_addr:?}, send_back_addr {send_back_addr:?} on {connection_id:?} with error {error:?}");
-                }
 
                 #[cfg(feature = "open-metrics")]
                 if let Some(relay_manager) = self.relay_manager.as_mut() {
@@ -521,7 +516,7 @@ impl SwarmDriver {
             }
             SwarmEvent::NewExternalAddrCandidate { address } => {
                 event_string = "NewExternalAddrCandidate";
-                info!(?address, "new external address candidate");
+                debug!(?address, "new external address candidate");
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 event_string = "ExternalAddrConfirmed";
@@ -669,6 +664,7 @@ impl SwarmDriver {
     // Do not log IncomingConnectionError if the the send_back_addr is the same on the adjacent established connections.
     //
     // We either check by IP address or by `/p2p/<peer_id>` for relayed nodes.
+    #[allow(dead_code)]
     fn is_incoming_connection_error_valid(&self, id: ConnectionId, addr: &Multiaddr) -> bool {
         let Ok(id) = format!("{id}").parse::<usize>() else {
             return true;

--- a/ant-node/tests/verify_routing_table.rs
+++ b/ant-node/tests/verify_routing_table.rs
@@ -24,9 +24,9 @@ use std::{
 use tonic::Request;
 use tracing::{error, info, trace};
 
-/// Sleep for sometime for the nodes for discover each other before verification
+/// Sleep for sometime for the nodes to discover each other before verification
 /// Also can be set through the env variable of the same name.
-const SLEEP_BEFORE_VERIFICATION: Duration = Duration::from_secs(5);
+const SLEEP_BEFORE_VERIFICATION: Duration = Duration::from_secs(30);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn verify_routing_table() -> Result<()> {


### PR DESCRIPTION
- Do not log `ConnectionClosed` as an error msg.
- Reduce the logging level for connection errors (and other misc) from `warn/error` to `debug`. We still log the errors from `dial_error_to_str` & `listen_error_to_str` at the `Level::Error`. Thus, we're just avoiding double logging here. And here is the reasoning:
	- Old connection_error logs: Contained `connection id` and was useful to track errors from various peers. BUT to correlate the `connection id`, the other events like `ConnectionEstablished` / `IncomingConnection` etc were logged at `DEBUG` level. Thus this log line at ERROR level is kinda redundant.
	- New connection_error logs: These don't contain `connection_id` but are used instead to track errors src/dst in our internal dashboard. These are already in `ERROR` level. The loss of usable information would be just from the error string, like `TransportError::Other`, at which point we'd need connection ids to correlate, so we can always change the log level if we want to dig deeper. 