### PR TITLE
retry strategy for ant file upload

### DIFF
--- a/ant-cli/README.md
+++ b/ant-cli/README.md
@@ -17,7 +17,7 @@ ant [OPTIONS] <COMMAND>
 
 ### File
 - `file cost <file>`
-- `file upload <file> [--public] [--no-archive]`
+- `file upload <file> [--public] [--no-archive] [--retry-failed]`
 - `file download <addr> <dest_file>`
 - `file list`
 
@@ -166,7 +166,7 @@ Expected value:
 
 #### Upload a file
 ```
-file upload <file> [--public] [--no-archive]
+file upload <file> [--public] [--no-archive] [--retry-failed]
 ```
 Uploads a file to the network.
 
@@ -176,6 +176,13 @@ Expected value:
 The following flags can be added:
 - `--public` (Optional) Specifying this will make this file publicly available to anyone on the network
 - `--no-archive` (Optional) Skip creating local archive after upload. Only upload files without saving archive information. Note that --no-archive is the default behaviour for single file uploads (folk can still upload a single file as an archive by putting it in a directory)
+- `--retry-failed` (Optional) Automatically retry failed uploads after a 1-minute pause. This is particularly useful for handling gas fee errors when the network base fee exceeds your --max-fee-per-gas setting. The retry mechanism works at the batch level, so only failed chunks are retried, not the entire file upload process.
+
+Example usage with retry functionality:
+```
+ant file upload myfile.txt --public --retry-failed --max-fee-per-gas 10000000
+```
+This will upload the file publicly and automatically retry if the base fee is higher than arbitrums minimum gas fee, showing detailed error messages with current gas prices. Using these settings ensures your data goes up at minimum cost (but depending on current blockchain fees and the amount of data this might take a while)
 
 #### Download a file
 ```

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -93,6 +93,10 @@ pub enum FileCmd {
         /// Note: This option only affects directory uploads - single file uploads never create archives.
         #[arg(long)]
         no_archive: bool,
+        /// Retry failed uploads automatically after 1 minute pause.
+        /// This will persistently retry any failed chunks until all data is successfully uploaded.
+        #[arg(long)]
+        retry_failed: bool,
         #[command(flatten)]
         transaction_opt: TransactionOpt,
     },
@@ -421,6 +425,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 file,
                 public,
                 no_archive,
+                retry_failed,
                 transaction_opt,
             } => {
                 if let Err((err, exit_code)) = file::upload(
@@ -429,6 +434,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                     no_archive,
                     network_context,
                     transaction_opt.max_fee_per_gas,
+                    retry_failed,
                 )
                 .await
                 {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -172,7 +172,7 @@ async fn upload_dir(
     let is_single_file = dir_path.is_file();
 
     if public {
-        let (_, public_archive) = client
+        let (_, public_archive, _cost) = client
             .dir_upload_public(dir_path, payment_option.clone())
             .await?;
 
@@ -195,7 +195,7 @@ async fn upload_dir(
             Ok((addr.to_hex(), addr.to_hex()))
         }
     } else {
-        let (_, private_archive) = client
+        let (_, private_archive, _cost) = client
             .dir_upload(dir_path, payment_option.clone())
             .await?;
 

--- a/autonomi/examples/put_and_dir_upload.rs
+++ b/autonomi/examples/put_and_dir_upload.rs
@@ -19,9 +19,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _data_fetched = client.data_get_public(&data_addr).await?;
 
     // Put and fetch directory from local file system.
-    let (_cost, dir_addr) = client
-        .dir_upload_public("files/to/upload".into(), wallet.into())
+    let (_file_addrs, archive, _cost) = client
+        .dir_upload_public("files/to/upload".into(), (&wallet).into())
         .await?;
+    
+    // Upload the archive to get the address
+    let (_archive_cost, dir_addr) = client
+        .archive_put_public(&archive, (&wallet).into())
+        .await?;
+    
     client
         .dir_download_public(&dir_addr, "files/downloaded".into())
         .await?;

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -58,6 +58,7 @@ impl Client {
         Ok(())
     }
 
+
     /// Uploads a directory of files to the network as private data.
     ///
     /// # Arguments
@@ -76,11 +77,11 @@ impl Client {
     /// # let client = Client::init().await?;
     /// let dir_path = PathBuf::from("/path/to/directory");
     /// let payment = PaymentOption::default();
-    /// let (addresses, archive) = client.dir_content_upload(dir_path, payment).await?;
+    /// let (addresses, archive) = client.dir_upload(dir_path, payment).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn dir_content_upload(
+    pub async fn dir_upload(
         &self,
         dir_path: PathBuf,
         payment_option: PaymentOption,
@@ -102,43 +103,6 @@ impl Client {
 
         debug!(
             "Uploaded directory in {:?}: {} files, {} tokens spent",
-            start.elapsed(),
-            data_addrs.len(),
-            tokens_spent
-        );
-        Ok((data_addrs, private_archive))
-    }
-
-    /// Uploads a directory of files to the network as private data with retry functionality.
-    ///
-    /// # Arguments
-    /// * `dir_path` - Path to the directory to upload
-    /// * `payment_option` - Payment option for the upload
-    ///
-    /// # Returns
-    /// * `Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError>` - The private data addresses and private archive
-    pub async fn dir_content_upload_with_retry(
-        &self,
-        dir_path: PathBuf,
-        payment_option: PaymentOption,
-    ) -> Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError> {
-        info!("Uploading directory as private data with retry: {dir_path:?}");
-        let start = Instant::now();
-
-        // Generate chunks from directory
-        let (chunks, private_archive) = self.dir_to_private_archive(dir_path.clone()).await?;
-
-        // Upload chunks with retry
-        let tokens_spent = self.pay_and_upload_with_retry(payment_option, chunks).await?;
-
-        // Create data addresses map
-        let mut data_addrs = HashMap::new();
-        for (path, addr, _meta) in private_archive.iter() {
-            data_addrs.insert(path.clone(), addr.clone());
-        }
-
-        debug!(
-            "Uploaded directory with retry in {:?}: {} files, {} tokens spent",
             start.elapsed(),
             data_addrs.len(),
             tokens_spent

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -25,6 +25,7 @@ use crate::{AttoTokens, Client};
 use bytes::Bytes;
 use std::path::PathBuf;
 use std::time::Instant;
+use std::collections::HashMap;
 
 impl Client {
     /// Download a private file from network to local file system
@@ -57,16 +58,99 @@ impl Client {
         Ok(())
     }
 
-    /// Upload the content of all files in a directory to the network.
-    /// The directory is recursively walked and each file is uploaded to the network.
+    /// Uploads a directory of files to the network as private data.
     ///
-    /// The data maps of these (private) files are not uploaded but returned within the [`PrivateArchive`] return type.
+    /// # Arguments
+    /// * `dir_path` - Path to the directory to upload
+    /// * `payment_option` - Payment option for the upload
+    ///
+    /// # Returns
+    /// * `Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError>` - The private data addresses and private archive
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use autonomi::{Client, PaymentOption};
+    /// # use std::path::PathBuf;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = Client::init().await?;
+    /// let dir_path = PathBuf::from("/path/to/directory");
+    /// let payment = PaymentOption::default();
+    /// let (addresses, archive) = client.dir_content_upload(dir_path, payment).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn dir_content_upload(
         &self,
         dir_path: PathBuf,
         payment_option: PaymentOption,
-    ) -> Result<(AttoTokens, PrivateArchive), UploadError> {
-        info!("Uploading directory as private: {dir_path:?}");
+    ) -> Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError> {
+        info!("Uploading directory as private data: {dir_path:?}");
+        let start = Instant::now();
+
+        // Generate chunks from directory
+        let (chunks, private_archive) = self.dir_to_private_archive(dir_path.clone()).await?;
+
+        // Upload chunks
+        let tokens_spent = self.pay_and_upload(payment_option, chunks).await?;
+
+        // Create data addresses map
+        let mut data_addrs = HashMap::new();
+        for (path, addr, _meta) in private_archive.iter() {
+            data_addrs.insert(path.clone(), addr.clone());
+        }
+
+        debug!(
+            "Uploaded directory in {:?}: {} files, {} tokens spent",
+            start.elapsed(),
+            data_addrs.len(),
+            tokens_spent
+        );
+        Ok((data_addrs, private_archive))
+    }
+
+    /// Uploads a directory of files to the network as private data with retry functionality.
+    ///
+    /// # Arguments
+    /// * `dir_path` - Path to the directory to upload
+    /// * `payment_option` - Payment option for the upload
+    ///
+    /// # Returns
+    /// * `Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError>` - The private data addresses and private archive
+    pub async fn dir_content_upload_with_retry(
+        &self,
+        dir_path: PathBuf,
+        payment_option: PaymentOption,
+    ) -> Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError> {
+        info!("Uploading directory as private data with retry: {dir_path:?}");
+        let start = Instant::now();
+
+        // Generate chunks from directory
+        let (chunks, private_archive) = self.dir_to_private_archive(dir_path.clone()).await?;
+
+        // Upload chunks with retry
+        let tokens_spent = self.pay_and_upload_with_retry(payment_option, chunks).await?;
+
+        // Create data addresses map
+        let mut data_addrs = HashMap::new();
+        for (path, addr, _meta) in private_archive.iter() {
+            data_addrs.insert(path.clone(), addr.clone());
+        }
+
+        debug!(
+            "Uploaded directory with retry in {:?}: {} files, {} tokens spent",
+            start.elapsed(),
+            data_addrs.len(),
+            tokens_spent
+        );
+        Ok((data_addrs, private_archive))
+    }
+
+    /// Convert a directory to chunks and create a private archive
+    async fn dir_to_private_archive(
+        &self,
+        dir_path: PathBuf,
+    ) -> Result<(CombinedChunks, PrivateArchive), UploadError> {
         let mut encryption_tasks = vec![];
 
         for entry in walkdir::WalkDir::new(&dir_path) {
@@ -138,28 +222,7 @@ impl Client {
             }
         }
 
-        let total_cost = self.pay_and_upload(payment_option, combined_chunks).await?;
-
-        Ok((total_cost, private_archive))
-    }
-
-    /// Same as [`Client::dir_content_upload`] but also uploads the archive (privately) to the network.
-    ///
-    /// Returns the [`PrivateArchiveDataMap`] allowing the private archive to be downloaded from the network.
-    pub async fn dir_upload(
-        &self,
-        dir_path: PathBuf,
-        payment_option: PaymentOption,
-    ) -> Result<(AttoTokens, PrivateArchiveDataMap), UploadError> {
-        let (cost1, archive) = self
-            .dir_content_upload(dir_path, payment_option.clone())
-            .await?;
-        let (cost2, archive_addr) = self.archive_put(&archive, payment_option).await?;
-        let total_cost = cost1.checked_add(cost2).unwrap_or_else(|| {
-            error!("Total cost overflowed: {cost1:?} + {cost2:?}");
-            cost1
-        });
-        Ok((total_cost, archive_addr))
+        Ok((combined_chunks, private_archive))
     }
 
     /// Upload the content of a private file to the network.

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -66,7 +66,7 @@ impl Client {
     /// * `payment_option` - Payment option for the upload
     ///
     /// # Returns
-    /// * `Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError>` - The private data addresses and private archive
+    /// * `Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive, AttoTokens), UploadError>` - The private data addresses, private archive, and total cost
     ///
     /// # Example
     /// ```no_run
@@ -77,7 +77,7 @@ impl Client {
     /// # let client = Client::init().await?;
     /// let dir_path = PathBuf::from("/path/to/directory");
     /// let payment = PaymentOption::default();
-    /// let (addresses, archive) = client.dir_upload(dir_path, payment).await?;
+    /// let (addresses, archive, cost) = client.dir_upload(dir_path, payment).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -85,7 +85,7 @@ impl Client {
         &self,
         dir_path: PathBuf,
         payment_option: PaymentOption,
-    ) -> Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive), UploadError> {
+    ) -> Result<(HashMap<PathBuf, DataMapChunk>, PrivateArchive, AttoTokens), UploadError> {
         info!("Uploading directory as private data: {dir_path:?}");
         let start = Instant::now();
 
@@ -107,7 +107,7 @@ impl Client {
             data_addrs.len(),
             tokens_spent
         );
-        Ok((data_addrs, private_archive))
+        Ok((data_addrs, private_archive, tokens_spent))
     }
 
     /// Convert a directory to chunks and create a private archive

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -66,7 +66,7 @@ impl Client {
     /// * `payment_option` - Payment option for the upload
     ///
     /// # Returns
-    /// * `Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError>` - The public data addresses and public archive
+    /// * `Result<(HashMap<PathBuf, DataAddress>, PublicArchive, AttoTokens), UploadError>` - The public data addresses, public archive, and total cost
     ///
     /// # Example
     /// ```no_run
@@ -77,7 +77,7 @@ impl Client {
     /// # let client = Client::init().await?;
     /// let dir_path = PathBuf::from("/path/to/directory");
     /// let payment = PaymentOption::default();
-    /// let (addresses, archive) = client.dir_upload_public(dir_path, payment).await?;
+    /// let (addresses, archive, cost) = client.dir_upload_public(dir_path, payment).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -85,7 +85,7 @@ impl Client {
         &self,
         dir_path: PathBuf,
         payment_option: PaymentOption,
-    ) -> Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError> {
+    ) -> Result<(HashMap<PathBuf, DataAddress>, PublicArchive, AttoTokens), UploadError> {
         info!("Uploading directory as public data: {dir_path:?}");
         let start = Instant::now();
 
@@ -107,7 +107,7 @@ impl Client {
             data_addrs.len(),
             tokens_spent
         );
-        Ok((data_addrs, public_archive))
+        Ok((data_addrs, public_archive, tokens_spent))
     }
 
     /// Convert a directory to chunks and create a public archive

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -66,7 +66,7 @@ impl Client {
     /// * `payment_option` - Payment option for the upload
     ///
     /// # Returns
-    /// * `Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError>` - The data addresses and public archive
+    /// * `Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError>` - The public data addresses and public archive
     ///
     /// # Example
     /// ```no_run
@@ -77,11 +77,11 @@ impl Client {
     /// # let client = Client::init().await?;
     /// let dir_path = PathBuf::from("/path/to/directory");
     /// let payment = PaymentOption::default();
-    /// let (addresses, archive) = client.dir_content_upload_public(dir_path, payment).await?;
+    /// let (addresses, archive) = client.dir_upload_public(dir_path, payment).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn dir_content_upload_public(
+    pub async fn dir_upload_public(
         &self,
         dir_path: PathBuf,
         payment_option: PaymentOption,
@@ -103,43 +103,6 @@ impl Client {
 
         debug!(
             "Uploaded directory in {:?}: {} files, {} tokens spent",
-            start.elapsed(),
-            data_addrs.len(),
-            tokens_spent
-        );
-        Ok((data_addrs, public_archive))
-    }
-
-    /// Uploads a directory of files to the network as public data with retry functionality.
-    ///
-    /// # Arguments
-    /// * `dir_path` - Path to the directory to upload
-    /// * `payment_option` - Payment option for the upload
-    ///
-    /// # Returns
-    /// * `Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError>` - The data addresses and public archive
-    pub async fn dir_content_upload_public_with_retry(
-        &self,
-        dir_path: PathBuf,
-        payment_option: PaymentOption,
-    ) -> Result<(HashMap<PathBuf, DataAddress>, PublicArchive), UploadError> {
-        info!("Uploading directory as public data with retry: {dir_path:?}");
-        let start = Instant::now();
-
-        // Generate chunks from directory
-        let (chunks, public_archive) = self.dir_to_public_archive(dir_path.clone()).await?;
-
-        // Upload chunks with retry
-        let tokens_spent = self.pay_and_upload_with_retry(payment_option, chunks).await?;
-
-        // Create data addresses map
-        let mut data_addrs = HashMap::new();
-        for (path, addr, _meta) in public_archive.iter() {
-            data_addrs.insert(path.clone(), *addr);
-        }
-
-        debug!(
-            "Uploaded directory with retry in {:?}: {} files, {} tokens spent",
             start.elapsed(),
             data_addrs.len(),
             tokens_spent

--- a/autonomi/src/client/high_level/files/fs_shared.rs
+++ b/autonomi/src/client/high_level/files/fs_shared.rs
@@ -68,22 +68,12 @@ impl Client {
     }
 
     /// Processes file uploads with payment in batches
-    /// Returns total cost of uploads or error if any upload fails
     pub(crate) async fn pay_and_upload(
         &self,
         payment_option: PaymentOption,
         combined_chunks: CombinedChunks,
     ) -> Result<AttoTokens, UploadError> {
-        self.pay_and_upload_internal(payment_option, combined_chunks, false).await
-    }
-
-    /// Processes file uploads with payment in batches, with retry on failure
-    pub(crate) async fn pay_and_upload_with_retry(
-        &self,
-        payment_option: PaymentOption,
-        combined_chunks: CombinedChunks,
-    ) -> Result<AttoTokens, UploadError> {
-        self.pay_and_upload_internal(payment_option, combined_chunks, true).await
+        self.pay_and_upload_internal(payment_option, combined_chunks, self.retry_failed).await
     }
 
     /// Internal method that handles the actual upload logic with optional retry

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -93,6 +93,8 @@ pub struct Client {
     evm_network: EvmNetwork,
     /// The configuration for operations on the client.
     config: ClientOperatingStrategy,
+    /// Whether to retry failed uploads automatically.
+    retry_failed: bool,
 }
 
 /// Error returned by [`Client::init`].
@@ -269,12 +271,19 @@ impl Client {
             client_event_sender: None,
             evm_network: config.evm_network,
             config: config.strategy,
+            retry_failed: false,
         })
     }
 
     /// Set the `ClientOperatingStrategy` for the client.
     pub fn with_strategy(mut self, strategy: ClientOperatingStrategy) -> Self {
         self.config = strategy;
+        self
+    }
+
+    /// Set whether to retry failed uploads automatically.
+    pub fn with_retry_failed(mut self, retry_failed: bool) -> Self {
+        self.retry_failed = retry_failed;
         self
     }
 
@@ -288,12 +297,13 @@ impl Client {
         client_event_receiver
     }
 
+    /// Get the evm network.
     pub fn evm_network(&self) -> &EvmNetwork {
         &self.evm_network
     }
 }
 
-/// Events that can be broadcasted by the client.
+/// Events that can be sent by the client.
 #[derive(Debug, Clone)]
 pub enum ClientEvent {
     UploadComplete(UploadSummary),

--- a/autonomi/src/client/utils.rs
+++ b/autonomi/src/client/utils.rs
@@ -8,6 +8,8 @@
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::future::Future;
+use crate::client::PutError;
+use crate::files::UploadError;
 
 pub(crate) async fn process_tasks_with_max_concurrency<I, R>(tasks: I, batch_size: usize) -> Vec<R>
 where
@@ -34,4 +36,119 @@ where
     }
 
     results
+}
+
+/// Extracts gas fee values from an error message string.
+/// 
+/// Looks for patterns like "maxFeePerGas: <value>, baseFee: <value>" in the error string
+/// and returns the extracted values as a tuple of (max_fee, base_fee) strings.
+/// 
+/// # Arguments
+/// * `err_str` - The error string to parse
+/// 
+/// # Returns
+/// * `Some((max_fee, base_fee))` if both values are found
+/// * `None` if the pattern is not found or values cannot be extracted
+pub(crate) fn extract_gas_values(err_str: &str) -> Option<(String, String)> {
+    // Look for pattern: "maxFeePerGas: <value>, baseFee: <value>"
+    if let Some(max_fee_start) = err_str.find("maxFeePerGas: ") {
+        let max_fee_str = &err_str[max_fee_start + 14..];
+        if let Some(comma_pos) = max_fee_str.find(',') {
+            let max_fee = &max_fee_str[..comma_pos];
+            
+            if let Some(base_fee_start) = err_str.find("baseFee: ") {
+                let base_fee_str = &err_str[base_fee_start + 9..];
+                // Find the end of the base fee value (could be end of string or another delimiter)
+                let base_fee = base_fee_str.split(|c: char| !c.is_numeric()).next()?;
+                
+                return Some((max_fee.to_string(), base_fee.to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// Formats an upload error into a user-friendly error message.
+/// 
+/// This function analyzes the error type and returns an appropriate error message
+/// with helpful information for the user.
+/// 
+/// # Arguments
+/// * `err` - The upload error to format
+/// 
+/// # Returns
+/// A formatted error message string with emojis and helpful suggestions
+pub(crate) fn format_upload_error(err: &UploadError) -> String {
+    let err_str = format!("{err:?}");
+    
+    if err_str.contains("max fee per gas less than block base fee") {
+        if let Some((max_fee, base_fee)) = extract_gas_values(&err_str) {
+            format!(
+                "❌ Gas fee too low!\n💰 Your max fee per gas: {} wei\n📈 Network base fee: {} wei\n💡 Increase your --max-fee-per-gas if you want the upload to be executed faster",
+                max_fee, base_fee
+            )
+        } else {
+            "💸 Gas fee too low - current base fee exceeds your setting".to_string()
+        }
+    } else if err_str.contains("insufficient funds") {
+        "💰 Insufficient funds for transaction".to_string()
+    } else if let UploadError::PutError(PutError::Batch(ref upload_state)) = err {
+        format!("❌ Upload batch failed: {} chunks failed", upload_state.failed.len())
+    } else {
+        "❌ Upload error occurred".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::ChunkBatchUploadState;
+
+    #[test]
+    fn test_extract_gas_values() {
+        // Test successful extraction
+        let err_str = "Error: max fee per gas less than block base fee: maxFeePerGas: 1000000000, baseFee: 2000000000";
+        let result = extract_gas_values(err_str);
+        assert_eq!(result, Some(("1000000000".to_string(), "2000000000".to_string())));
+
+        // Test with additional text after baseFee
+        let err_str = "maxFeePerGas: 500, baseFee: 1000 (retry later)";
+        let result = extract_gas_values(err_str);
+        assert_eq!(result, Some(("500".to_string(), "1000".to_string())));
+
+        // Test missing maxFeePerGas
+        let err_str = "baseFee: 1000";
+        let result = extract_gas_values(err_str);
+        assert_eq!(result, None);
+
+        // Test missing baseFee
+        let err_str = "maxFeePerGas: 500";
+        let result = extract_gas_values(err_str);
+        assert_eq!(result, None);
+
+        // Test empty string
+        let err_str = "";
+        let result = extract_gas_values(err_str);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_format_upload_error() {
+        // Test batch error
+        let mut batch_state = ChunkBatchUploadState::default();
+        // Create dummy chunk addresses using XorName
+        let chunk_addr1 = ant_protocol::storage::ChunkAddress::new(xor_name::XorName([1; 32]));
+        let chunk_addr2 = ant_protocol::storage::ChunkAddress::new(xor_name::XorName([2; 32]));
+        batch_state.failed.push((chunk_addr1, "test error".to_string()));
+        batch_state.failed.push((chunk_addr2, "test error 2".to_string()));
+        let batch_err = UploadError::PutError(PutError::Batch(batch_state));
+        let err_msg = format_upload_error(&batch_err);
+        assert_eq!(err_msg, "❌ Upload batch failed: 2 chunks failed");
+        
+        // Test generic error (we can't easily construct the exact Network error)
+        // So we'll test with a simpler error case
+        let generic_err = UploadError::PutError(PutError::Batch(ChunkBatchUploadState::default()));
+        let err_msg = format_upload_error(&generic_err);
+        assert_eq!(err_msg, "❌ Upload batch failed: 0 chunks failed");
+    }
 }

--- a/autonomi/src/python.rs
+++ b/autonomi/src/python.rs
@@ -559,7 +559,7 @@ impl PyClient {
 
         future_into_py(py, async move {
             let (cost, archive) = client
-                .dir_content_upload(dir_path, payment.inner)
+                .dir_upload(dir_path, payment.inner)
                 .await
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to upload directory: {e}")))?;
             Ok((cost.to_string(), PyPrivateArchive { inner: archive }))

--- a/autonomi/tests/address.rs
+++ b/autonomi/tests/address.rs
@@ -130,7 +130,8 @@ async fn test_data_addresses_use() -> Result<()> {
     // put private dir
     let payment_option = PaymentOption::from(&wallet);
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_, archive, _) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_, archive_datamap) = client.archive_put(&archive, payment_option.clone()).await?;
     let archive_datamap_addr = archive_datamap.to_hex();
     println!("Private Archive (DataMap): {archive_datamap_addr}");
 
@@ -139,8 +140,11 @@ async fn test_data_addresses_use() -> Result<()> {
 
     // put public dir
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_addr) = client
+    let (_, archive, _) = client
         .dir_upload_public(path, payment_option.clone())
+        .await?;
+    let (_, archive_addr) = client
+        .archive_put_public(&archive, payment_option.clone())
         .await?;
     let archive_addr_str = archive_addr.to_hex();
     println!("Public Archive (XorName): {archive_addr_str}");

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -213,7 +213,8 @@ async fn test_analyze_private_dir() -> Result<()> {
     let payment_option = PaymentOption::from(&wallet);
 
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_data_addrs, archive, _cost) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_, archive_datamap) = client.archive_put(&archive, payment_option.clone()).await?;
     let archive_datamap_addr = archive_datamap.to_hex();
     println!("Private Archive (DataMap): {archive_datamap_addr}");
 
@@ -237,7 +238,8 @@ async fn test_analyze_public_dir() -> Result<()> {
     let payment_option = PaymentOption::from(&wallet);
 
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_addr) = client.dir_upload_public(path, payment_option).await?;
+    let (_data_addrs, archive, _cost) = client.dir_upload_public(path, payment_option.clone()).await?;
+    let (_, archive_addr) = client.archive_put_public(&archive, payment_option).await?;
     let archive_addr_str = archive_addr.to_hex();
     println!("Public Archive (XorName): {archive_addr_str}");
 

--- a/autonomi/tests/files.rs
+++ b/autonomi/tests/files.rs
@@ -30,7 +30,7 @@ async fn dir_upload_download() -> Result<()> {
     let client = Client::init_local().await?;
     let wallet = get_funded_wallet();
 
-    let (_cost, addr) = client
+    let (_, addr) = client
         .dir_upload_public("tests/file/test_dir".into(), wallet.into())
         .await?;
 
@@ -86,7 +86,7 @@ async fn file_into_vault() -> Result<()> {
     let wallet = get_funded_wallet();
     let client_sk = bls::SecretKey::random();
 
-    let (_cost, addr) = client
+    let (_, addr) = client
         .dir_upload_public("tests/file/test_dir".into(), wallet.clone().into())
         .await?;
     sleep(Duration::from_secs(2)).await;
@@ -125,7 +125,7 @@ async fn file_advanced_use() -> Result<()> {
 
     // upload a directory
     let (cost, mut archive) = client
-        .dir_content_upload("tests/file/test_dir/dir_a".into(), payment_option.clone())
+        .dir_upload("tests/file/test_dir/dir_a".into(), payment_option.clone())
         .await?;
     println!("cost to upload private directory: {cost:?}");
     println!("archive: {archive:#?}");

--- a/autonomi/tests/files.rs
+++ b/autonomi/tests/files.rs
@@ -30,8 +30,11 @@ async fn dir_upload_download() -> Result<()> {
     let client = Client::init_local().await?;
     let wallet = get_funded_wallet();
 
+    let (_, archive, _) = client
+        .dir_upload_public("tests/file/test_dir".into(), wallet.clone().into())
+        .await?;
     let (_, addr) = client
-        .dir_upload_public("tests/file/test_dir".into(), wallet.into())
+        .archive_put_public(&archive, wallet.into())
         .await?;
 
     sleep(Duration::from_secs(10)).await;
@@ -86,8 +89,11 @@ async fn file_into_vault() -> Result<()> {
     let wallet = get_funded_wallet();
     let client_sk = bls::SecretKey::random();
 
-    let (_, addr) = client
+    let (_, archive, _) = client
         .dir_upload_public("tests/file/test_dir".into(), wallet.clone().into())
+        .await?;
+    let (_, addr) = client
+        .archive_put_public(&archive, wallet.clone().into())
         .await?;
     sleep(Duration::from_secs(2)).await;
 
@@ -124,7 +130,7 @@ async fn file_advanced_use() -> Result<()> {
     let payment_option = PaymentOption::Wallet(wallet);
 
     // upload a directory
-    let (cost, mut archive) = client
+    let (_, mut archive, cost) = client
         .dir_upload("tests/file/test_dir/dir_a".into(), payment_option.clone())
         .await?;
     println!("cost to upload private directory: {cost:?}");

--- a/nodejs/src/lib.rs
+++ b/nodejs/src/lib.rs
@@ -587,7 +587,7 @@ impl Client {
 
         let (cost, archive) = self
             .0
-            .dir_content_upload(dir_path, payment_option.0.clone())
+            .dir_upload(dir_path, payment_option.0.clone())
             .await
             .map_err(map_error)?;
 
@@ -678,7 +678,7 @@ impl Client {
 
         let (cost, archive) = self
             .0
-            .dir_content_upload_public(dir_path, payment_option.0.clone())
+            .dir_upload_public(dir_path, payment_option.0.clone())
             .await
             .map_err(map_error)?;
 


### PR DESCRIPTION
### Description

as mentioned in discord I am running a modified ant client that does retry (once a minute) on upload-fails and just repeats the failed batch resulting in reliable and resilient uploads without wasting eth on high fees or time on restarting the upload from scratch on fail. It works really well and makes uploading to main suddenly a really good experience. 

this is a significantly cleaner version than the one I used before ... so maybe this could be used for basing a mod yourself on it. To me it still somehow looks like changes on too many places that look too similar but it really might be because of the architecture of the file upload ... not sure. I'm sure you're more qualified to judge and create a retrying client based on these ideas or decide to push it back due to priorities.

I tested with different combination of flags and it works for me pretty well (but I'm sure your tests are more complete than mine ;-) )

---

fee error:

> ⚠️  ❌ Gas fee too low!
💰 Your max fee per gas: 1000 wei
📈 Network base fee: 10000000 wei
💡 Increase your --max-fee-per-gas if you want the upload to be executed faster. Retrying after 1 minute pause...

chunk proof error:

> ⚠️  ❌ Upload batch failed: 1 chunks failed. Retrying after 1 minute pause...
🔄 Retrying upload...
....
Paying for 1 chunks..
Chunk payments of 1 chunks completed. 31 chunks were free / already paid for
35 chunks were free in this batch 32


### Related Issue

Fixes #3026 .

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
