### PR TITLE
feat: avoid printing progress when verbose is minimal

### DIFF
--- a/ant-node-manager/src/cmd/node.rs
+++ b/ant-node-manager/src/cmd/node.rs
@@ -170,6 +170,7 @@ pub async fn balance(
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
         false,
+        verbosity,
     )
     .await?;
 
@@ -209,6 +210,7 @@ pub async fn remove(
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
         false,
+        verbosity,
     )
     .await?;
 
@@ -295,6 +297,7 @@ pub async fn start(
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
         false,
+        verbosity,
     )
     .await?;
 
@@ -390,6 +393,7 @@ pub async fn stop(
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
         false,
+        verbosity,
     )
     .await?;
 
@@ -472,6 +476,7 @@ pub async fn upgrade(
         &ServiceController {},
         verbosity != VerbosityLevel::Minimal,
         false,
+        verbosity,
     )
     .await?;
 

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -388,6 +388,7 @@ pub async fn status_report(
         service_control,
         !output_json,
         is_local_network,
+        VerbosityLevel::Normal,
     )
     .await?;
 
@@ -556,25 +557,29 @@ pub async fn refresh_node_registry(
     service_control: &dyn ServiceControl,
     full_refresh: bool,
     is_local_network: bool,
+    verbosity: VerbosityLevel,
 ) -> Result<()> {
     // This message is useful for users, but needs to be suppressed when a JSON output is
     // requested.
 
     info!("Refreshing the node registry");
-
-    let total_nodes = node_registry.nodes.len() as u64;
-    // Create a progress bar
-    let pb = ProgressBar::new(total_nodes);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{msg} {spinner:.green} [{bar:40.cyan/blue}] ({percent}%)")
-            .unwrap_or_else(|_e| {
-                // Fallback to default style if template fails
-                ProgressStyle::default_bar()
-            })
-            .progress_chars("#>-"),
-    );
-    pb.set_message("Refreshing the node registry");
+    let pb = if verbosity != VerbosityLevel::Minimal {
+        let total_nodes = node_registry.nodes.len() as u64;
+        let pb = ProgressBar::new(total_nodes);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} {spinner:.green} [{bar:40.cyan/blue}] ({percent}%)")
+                .unwrap_or_else(|_e| {
+                    // Fallback to default style if template fails
+                    ProgressStyle::default_bar()
+                })
+                .progress_chars("#>-"),
+        );
+        pb.set_message("Refreshing the node registry");
+        Some(pb)
+    } else {
+        None
+    };
 
     // Main processing loop
     for node in &mut node_registry.nodes {
@@ -646,9 +651,15 @@ pub async fn refresh_node_registry(
                 }
             }
         }
-        pb.inc(1);
+
+        if let Some(ref pb) = pb {
+            pb.inc(1);
+        }
     }
-    pb.finish_and_clear();
+
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
+    }
 
     info!("Node registry refresh complete!");
 

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -167,6 +167,7 @@ impl Status<'_> {
             &ServiceController {},
             false,
             true,
+            ant_node_manager::VerbosityLevel::Minimal,
         )
         .await?;
         node_registry.save()?;


### PR DESCRIPTION
Progress bar reflects on node-launchpad, Add support to remove progress bar from displaying on LP.