### PR TITLE
docs: clarify timestamps in file Metadata are UTC (see #2983)

### DIFF
--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -53,7 +53,7 @@ pub static FILE_ENCRYPT_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     batch_size
 });
 
-/// Metadata for a file in an archive. Time values are UNIX timestamps.
+/// Metadata for a file in an archive. Time values are UNIX timestamps (UTC).
 ///
 /// The recommended way to create a new [`Metadata`] is to use [`Metadata::new_with_size`].
 ///
@@ -62,9 +62,9 @@ pub static FILE_ENCRYPT_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
 /// The [`Metadata::empty`] method creates a new [`Metadata`] filled with 0s. Use this if you don't want to reveal any metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Metadata {
-    /// File creation time on local file system. See [`std::fs::Metadata::created`] for details per OS.
+    /// File creation time on local file system as UTC. See [`std::fs::Metadata::created`] for details per OS.
     pub created: u64,
-    /// Last file modification time taken from local file system. See [`std::fs::Metadata::modified`] for details per OS.
+    /// Last file modification time taken from local file system as UTC. See [`std::fs::Metadata::modified`] for details per OS.
     pub modified: u64,
     /// File size in bytes
     pub size: u64,


### PR DESCRIPTION
### Description

Update docs to state file Metadata timestamps use UTC.

### Related Issue

Fixes #2983

### Type of Change

Please mark the types of changes made in this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

### Checklist

Please ensure all of the following tasks have been completed:

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for commit messages.
- [ ] I have verified my commit messages with [commitlint](https://commitlint.js.org/#/).

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
