### PR TITLE
feat: archive universal path naming

### DIFF
--- a/autonomi/src/client/high_level/files/archive_private.rs
+++ b/autonomi/src/client/high_level/files/archive_private.rs
@@ -13,6 +13,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::Metadata;
+use crate::files::normalize_path;
 use crate::{
     client::{
         data_types::chunk::DataMapChunk, high_level::files::RenameError, payment::PaymentOption,
@@ -22,8 +24,6 @@ use crate::{
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-
-use super::Metadata;
 
 /// Private archive data map, allowing access to the [`PrivateArchive`] data.
 pub type PrivateArchiveDataMap = DataMapChunk;
@@ -77,8 +77,13 @@ impl PrivateArchive {
 
     /// Add a file to a local archive. Note that this does not upload the archive to the network.
     pub fn add_file(&mut self, path: PathBuf, data_map: DataMapChunk, meta: Metadata) {
-        self.map.insert(path.clone(), (data_map, meta));
-        debug!("Added a new file to the archive, path: {:?}", path);
+        // Normalize the path to use forward slashes
+        let normalized_path = normalize_path(path.clone());
+        self.map.insert(normalized_path.clone(), (data_map, meta));
+        debug!(
+            "Added a new file to the archive, path: {:?}",
+            normalized_path
+        );
     }
 
     /// List all files in the archive

--- a/autonomi/src/client/high_level/files/archive_public.rs
+++ b/autonomi/src/client/high_level/files/archive_public.rs
@@ -15,6 +15,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::Metadata;
+use crate::files::normalize_path;
 use crate::{
     client::{
         high_level::{data::DataAddress, files::RenameError},
@@ -23,8 +25,6 @@ use crate::{
     },
     Client,
 };
-
-use super::Metadata;
 
 /// The address of a public archive on the network. Points to an [`PublicArchive`].
 pub type ArchiveAddress = DataAddress;
@@ -78,8 +78,13 @@ impl PublicArchive {
     /// Add a file to a local archive
     /// Note that this does not upload the archive to the network
     pub fn add_file(&mut self, path: PathBuf, data_addr: DataAddress, meta: Metadata) {
-        self.map.insert(path.clone(), (data_addr, meta));
-        debug!("Added a new file to the archive, path: {:?}", path);
+        // Normalize the path to use forward slashes
+        let normalized_path = normalize_path(path.clone());
+        self.map.insert(normalized_path.clone(), (data_addr, meta));
+        debug!(
+            "Added a new file to the archive, path: {:?}",
+            normalized_path
+        );
     }
 
     /// List all files in the archive
@@ -212,10 +217,9 @@ impl Client {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use std::str::FromStr;
     use xor_name::XorName;
-
-    use super::*;
 
     #[test]
     fn compatibility() {

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -114,6 +114,9 @@ impl Client {
                 let relative_path =
                     get_relative_file_path_from_abs_file_and_folder_path(&file_path, &dir_path);
 
+                println!("File path: {file_path:?}");
+                println!("Relative path: {relative_path:?}");
+
                 Ok((
                     file_path.to_string_lossy().to_string(),
                     chunks,
@@ -220,6 +223,7 @@ impl Client {
             content_addrs.extend(addrs);
 
             let metadata = metadata_from_entry(&entry);
+
             archive.add_file(path, DataAddress::new(map_xor_name), metadata);
         }
 

--- a/autonomi/tests/files.rs
+++ b/autonomi/tests/files.rs
@@ -177,3 +177,41 @@ async fn file_advanced_use() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[serial]
+async fn archives_use_paths_with_forward_slashes() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test(
+        "archives_use_paths_with_forward_slashes",
+        false,
+    );
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let (_cost, pub_archive) = client
+        .dir_content_upload_public("tests/file/test_dir".into(), (&wallet).into())
+        .await?;
+
+    for (path, _metadata) in pub_archive.files() {
+        // The path should not contain any backslashes
+        assert!(
+            !path.to_string_lossy().contains(r"\"),
+            "Path in archive contains backslashes: {path:?}"
+        );
+    }
+
+    let (_cost, private_archive) = client
+        .dir_content_upload("tests/file/test_dir".into(), (&wallet).into())
+        .await?;
+
+    for (path, _metadata) in private_archive.files() {
+        // The path should not contain any backslashes
+        assert!(
+            !path.to_string_lossy().contains(r"\"),
+            "Path in archive contains backslashes: {path:?}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Always use `/` in paths stored in archives.

#### Relevant issue

https://github.com/maidsafe/autonomi/issues/3042