### PR TITLE
feat(client): extend libp2p::kad::OutboundSubstreams timeout

### DIFF
--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -53,6 +53,8 @@ const RESEND_IDENTIFY_INVERVAL: Duration = Duration::from_secs(3600); // todo: t
 /// Size of the LRU cache for peers and their addresses.
 /// Libp2p defaults to 100, we use 2k.
 const PEER_CACHE_SIZE: usize = 2_000;
+/// Client with poor connection requires a longer time to transmit large sized recrod to production network, via put_record_to
+const CLIENT_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(30);
 
 /// Driver for the Autonomi Client Network
 ///
@@ -156,7 +158,10 @@ impl NetworkDriver {
             .set_parallelism(KAD_ALPHA)
             .set_replication_factor(REPLICATION_FACTOR)
             .set_query_timeout(KAD_QUERY_TIMEOUT)
-            .set_periodic_bootstrap_interval(None);
+            .set_periodic_bootstrap_interval(None)
+            // Extend outbound_substreams timeout to allow client with poor connection
+            // still able to upload large sized record with higher success rate.
+            .set_substreams_timeout(CLIENT_SUBSTREAMS_TIMEOUT_S);
 
         // setup kad and autonomi requests as our behaviour
         let behaviour = AutonomiClientBehaviour {


### PR DESCRIPTION
### Description

Extend outbound_substreams timeout to allow client with poor connection still able to upload large sized record with higher success rate.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
