### PR TITLE
fix(client): remove client relay setup

### DIFF
--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -52,8 +52,6 @@ libp2p = { version = "0.56.0", features = [
     "cbor",
     "identify",
     "quic",
-    "relay",
-    "noise",
     "tcp",
     "yamux",
     "websocket",

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -20,7 +20,6 @@ use ant_protocol::{
     messages::{Query, Request, Response},
     version::REQ_RESPONSE_VERSION_STR,
 };
-use futures::future::Either;
 use libp2p::kad::store::MemoryStoreConfig;
 use libp2p::kad::NoKnownPeers;
 use libp2p::{
@@ -78,7 +77,6 @@ pub(crate) struct NetworkDriver {
 pub(crate) struct AutonomiClientBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub identify: libp2p::identify::Behaviour,
-    pub relay_client: libp2p::relay::client::Behaviour,
     pub request_response: request_response::cbor::Behaviour<Request, Response>,
 }
 
@@ -96,23 +94,6 @@ impl NetworkDriver {
         let transport_gen = QuicTransport::new(quic_config);
         let trans = transport_gen.map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
         let transport = trans.boxed();
-
-        let (relay_transport, relay_client_behaviour) = libp2p::relay::client::new(peer_id);
-        let relay_transport = relay_transport
-            .upgrade(libp2p::core::upgrade::Version::V1Lazy)
-            .authenticate(
-                libp2p::noise::Config::new(&keypair)
-                    .expect("Signing libp2p-noise static DH keypair failed."),
-            )
-            .multiplex(libp2p::yamux::Config::default())
-            .or_transport(transport);
-
-        let transport = relay_transport
-            .map(|either_output, _| match either_output {
-                Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-                Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-            })
-            .boxed();
 
         // identify behaviour
         let identify = {
@@ -171,7 +152,6 @@ impl NetworkDriver {
         // setup kad and autonomi requests as our behaviour
         let behaviour = AutonomiClientBehaviour {
             kademlia: libp2p::kad::Behaviour::with_config(peer_id, store, kad_cfg),
-            relay_client: relay_client_behaviour,
             identify,
             request_response,
         };


### PR DESCRIPTION
### Description

remove client relay setup, which supposed to be useless on client side.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
