### PR TITLE
Revert "feat(network): remove external address manager"

### DIFF
--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::networking::{
-    craft_valid_multiaddr_without_p2p,
+    multiaddr_get_port,
     network::connection_action_logging,
     relay_manager::{is_a_relayed_peer, RelayManager},
     Addresses, NetworkEvent,
@@ -356,6 +356,23 @@ fn does_the_peer_support_dnd(info: &Info) -> bool {
         }
     }
     false
+}
+
+/// Craft valid multiaddr like /ip4/68.183.39.80/udp/31055/quic-v1
+/// RelayManager::craft_relay_address for relayed addr. This is for non-relayed addr.
+fn craft_valid_multiaddr_without_p2p(addr: &Multiaddr) -> Option<Multiaddr> {
+    let mut new_multiaddr = Multiaddr::empty();
+    let ip = addr.iter().find_map(|p| match p {
+        Protocol::Ip4(addr) => Some(addr),
+        _ => None,
+    })?;
+    let port = multiaddr_get_port(addr)?;
+
+    new_multiaddr.push(Protocol::Ip4(ip));
+    new_multiaddr.push(Protocol::Udp(port));
+    new_multiaddr.push(Protocol::QuicV1);
+
+    Some(new_multiaddr)
 }
 
 /// Build a `Multiaddr` with the p2p protocol filtered out.

--- a/ant-node/src/networking/driver/event/swarm.rs
+++ b/ant-node/src/networking/driver/event/swarm.rs
@@ -8,15 +8,15 @@
 
 use super::SwarmDriver;
 use crate::networking::{
-    craft_valid_multiaddr_without_p2p,
     error::{dial_error_to_str, listen_error_to_str},
     interface::TerminateNodeReason,
-    multiaddr_is_global, NetworkEvent, NodeIssue, Result,
+    NetworkEvent, NodeIssue, Result,
 };
 use itertools::Itertools;
 #[cfg(feature = "open-metrics")]
 use libp2p::metrics::Recorder;
 use libp2p::{
+    core::ConnectedPoint,
     multiaddr::Protocol,
     swarm::{ConnectionId, DialError, SwarmEvent},
     Multiaddr, TransportError,
@@ -183,21 +183,14 @@ impl SwarmDriver {
                         if let Err(err) = self.sync_and_flush_cache() {
                             warn!("Failed to sync and flush cache during NewListenAddr: {err:?}");
                         }
+                    } else if let Some(external_address_manager) =
+                        self.external_address_manager.as_mut()
+                    {
+                        external_address_manager
+                            .on_new_listen_addr(address.clone(), &mut self.swarm);
                     } else {
-                        // only add our global addresses
-                        if multiaddr_is_global(&address) {
-                            if let Some(mut crafted_address) =
-                                craft_valid_multiaddr_without_p2p(&address)
-                            {
-                                crafted_address.push(Protocol::P2p(self.self_peer_id));
-                                info!("Adding listen address to external addresses: {crafted_address:?}");
-                                self.swarm.add_external_address(crafted_address);
-                            } else {
-                                error!("Listen address is ill formed {address:?}");
-                            }
-                        } else {
-                            warn!("Listen address is not global, ignoring: {address:?}");
-                        };
+                        // just for future reference.
+                        warn!("External address manager is not enabled for a public node. This should not happen.");
                     }
                 }
 
@@ -255,6 +248,13 @@ impl SwarmDriver {
                     &mut self.swarm,
                     self.peers_in_rt,
                 );
+
+                if let Some(external_address_manager) = self.external_address_manager.as_mut() {
+                    if let ConnectedPoint::Listener { local_addr, .. } = &endpoint {
+                        external_address_manager
+                            .on_established_incoming_connection(local_addr.clone());
+                    }
+                }
 
                 #[cfg(feature = "open-metrics")]
                 if let Some(relay_manager) = self.relay_manager.as_mut() {
@@ -507,6 +507,10 @@ impl SwarmDriver {
             SwarmEvent::NewExternalAddrCandidate { address } => {
                 event_string = "NewExternalAddrCandidate";
                 debug!("New external address candidate: {address:?}");
+                if let Some(external_address_manager) = self.external_address_manager.as_mut() {
+                    external_address_manager
+                        .add_external_address_candidate(address, &mut self.swarm);
+                }
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 event_string = "ExternalAddrConfirmed";
@@ -522,6 +526,9 @@ impl SwarmDriver {
             } => {
                 event_string = "ExpiredListenAddr";
                 info!("Listen address has expired. {listener_id:?} on {address:?}");
+                if let Some(external_address_manager) = self.external_address_manager.as_mut() {
+                    external_address_manager.on_expired_listen_addr(address, &self.swarm);
+                }
             }
             SwarmEvent::ListenerError { listener_id, error } => {
                 event_string = "ListenerError";

--- a/ant-node/src/networking/driver/mod.rs
+++ b/ant-node/src/networking/driver/mod.rs
@@ -21,6 +21,7 @@ use crate::networking::{
     circular_vec::CircularVec,
     driver::kad::U256,
     error::Result,
+    external_address::ExternalAddressManager,
     log_markers::Marker,
     relay_manager::RelayManager,
     replication_fetcher::ReplicationFetcher,
@@ -116,6 +117,7 @@ pub(crate) struct SwarmDriver {
     pub(crate) initial_bootstrap_trigger: InitialBootstrapTrigger,
     pub(crate) network_discovery: NetworkDiscovery,
     pub(crate) bootstrap_cache: Option<BootstrapCacheStore>,
+    pub(crate) external_address_manager: Option<ExternalAddressManager>,
     pub(crate) relay_manager: Option<RelayManager>,
     /// The peers that are using our relay service.
     pub(crate) connected_relay_clients: HashSet<PeerId>,

--- a/ant-node/src/networking/external_address.rs
+++ b/ant-node/src/networking/external_address.rs
@@ -1,0 +1,497 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::networking::{
+    driver::NodeBehaviour, multiaddr_get_ip, multiaddr_get_port, multiaddr_is_global,
+};
+use itertools::Itertools;
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId, Swarm};
+use std::{
+    collections::{HashMap, HashSet},
+    net::IpAddr,
+};
+
+/// The maximum number of reports before an candidate address is confirmed
+const MAX_REPORTS_BEFORE_CONFIRMATION: u8 = 3;
+/// The maximum number of reports for a confirmed address before switching to a new IP address
+const MAX_REPORTS_BEFORE_SWITCHING_IP: u8 = 10;
+/// The maximum number of confirmed addresses needed before switching to a new IP address
+const MAX_CONFIRMED_ADDRESSES_BEFORE_SWITCHING_IP: u8 = 5;
+/// The maximum number of candidates to store
+const MAX_CANDIDATES: usize = 50;
+
+/// To be deprecated in future. The external address that is advertised by the node is not used for dialing the peers
+/// anymore. But this whole struct exists for backwards compatibility with the old code.
+///
+/// Manages the external addresses of a Public node. For a relayed node, the RelayManager should deal with
+/// adding and removing external addresses. Also, we don't manage "local" addresses here.
+#[derive(Debug)]
+pub(crate) struct ExternalAddressManager {
+    /// All the external addresses of the node
+    address_states: Vec<ExternalAddressState>,
+    /// The current IP address of all the external addresses.
+    current_ip_address: Option<IpAddr>,
+    /// The peer id of the node
+    peer_id: PeerId,
+    // Port -> (ok, error) count
+    connection_stats: HashMap<u16, PortStats>,
+    // Bad ports
+    bad_ports: HashSet<u16>,
+}
+
+#[derive(Debug, Default)]
+struct PortStats {
+    ok: usize,
+    _error: usize,
+}
+
+impl ExternalAddressManager {
+    pub(crate) fn new(peer_id: PeerId) -> Self {
+        Self {
+            address_states: Vec::new(),
+            current_ip_address: None,
+            peer_id,
+            connection_stats: HashMap::new(),
+            bad_ports: HashSet::new(),
+        }
+    }
+
+    /// Get the list of candidate addresses
+    pub(crate) fn candidate_addresses(&self) -> Vec<&Multiaddr> {
+        self.address_states
+            .iter()
+            .filter_map(|state| {
+                if let ExternalAddressState::Candidate { address, .. } = state {
+                    Some(address)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Add an external address candidate to the manager.
+    /// If the address has been reported often enough, it is confirmed and added to the swarm.
+    /// If a new IP address has been reported often enough, then we switch to the new IP address and discard the old
+    /// external addresses.
+    pub(in crate::networking) fn add_external_address_candidate(
+        &mut self,
+        address: Multiaddr,
+        swarm: &mut Swarm<NodeBehaviour>,
+    ) {
+        if !multiaddr_is_global(&address) {
+            debug!("Address is not global, ignoring: {address:?}");
+            return;
+        }
+
+        let Some(address) = self.craft_external_address(&address) else {
+            debug!("Address is ill formed, not added to manager: {address:?}");
+            return;
+        };
+
+        let Some(port) = multiaddr_get_port(&address) else {
+            return;
+        };
+
+        if self.bad_ports.contains(&port) {
+            debug!("External address had problem earlier, ignoring: {address:?}");
+            return;
+        }
+
+        if let Some(state) = self
+            .address_states
+            .iter_mut()
+            .find(|state| state.multiaddr() == &address)
+        {
+            state.increment_reports();
+
+            if state.is_candidate() {
+                if state.num_reports() >= MAX_REPORTS_BEFORE_CONFIRMATION {
+                    // if the IP address of our confirmed address is the same as the new address, then add it
+                    let confirmed = if let Some(current_ip_address) = self.current_ip_address {
+                        current_ip_address == *state.ip_address()
+                    } else {
+                        true
+                    };
+
+                    if confirmed {
+                        debug!("External address confirmed, adding it to swarm: {address:?}");
+                        swarm.add_external_address(address.clone());
+                        *state = ExternalAddressState::Confirmed {
+                            address: address.clone(),
+                            num_reports: state.num_reports(),
+                            ip_address: *state.ip_address(),
+                        };
+
+                        Self::print_swarm_state(swarm);
+                        return;
+                    } else {
+                        debug!(
+                            "External address {address:?} is not confirmed due to mismatched IP address. Checking if we can switch to new IP."
+                        );
+                    }
+                }
+            } else {
+                if state.num_reports() < 10 {
+                    debug!("External address: {address:?} is already confirmed or a listener. Do nothing");
+                }
+
+                return;
+            }
+        }
+        // check if we need to update to new ip.
+        // TODO: Need to observe this
+        if let Some(current_ip_address) = self.current_ip_address {
+            let mut new_ip_map = HashMap::new();
+
+            for state in &self.address_states {
+                if let ExternalAddressState::Candidate {
+                    ip_address,
+                    num_reports,
+                    ..
+                } = state
+                {
+                    if current_ip_address != *ip_address
+                        && *num_reports >= MAX_REPORTS_BEFORE_SWITCHING_IP
+                    {
+                        *new_ip_map.entry(ip_address).or_insert(0) += 1;
+                    }
+                }
+            }
+
+            if let Some((&&new_ip, count)) = new_ip_map
+                .iter()
+                .sorted_by_key(|(_, count)| *count)
+                .next_back()
+            {
+                if *count >= MAX_CONFIRMED_ADDRESSES_BEFORE_SWITCHING_IP {
+                    info!("New IP map as count>= {MAX_CONFIRMED_ADDRESSES_BEFORE_SWITCHING_IP}: {new_ip_map:?}");
+                    self.switch_to_new_ip(new_ip, swarm);
+                    return;
+                }
+            }
+        }
+
+        if self.candidate_addresses().len() >= MAX_CANDIDATES {
+            debug!("Max candidates reached, not adding new candidate external address {address:?}");
+            return;
+        }
+
+        if self
+            .address_states
+            .iter()
+            .any(|state| state.multiaddr() == &address)
+        {
+            // incremented in the previous find().
+            debug!(
+                "External address {address:?} already exists in manager. Report count incremented."
+            );
+            return;
+        }
+
+        let Some(ip_address) = multiaddr_get_ip(&address) else {
+            return;
+        };
+        debug!("Added external address to manager: {address:?}");
+        self.address_states.push(ExternalAddressState::Candidate {
+            address,
+            num_reports: 0,
+            ip_address,
+        });
+    }
+
+    /// Adds a non-local listen-addr to the swarm and the manager.
+    /// If the IP address of the listen-addr is different from the current IP address, then we directly
+    /// switch to the new IP address.
+    pub(in crate::networking) fn on_new_listen_addr(
+        &mut self,
+        listen_addr: Multiaddr,
+        swarm: &mut Swarm<NodeBehaviour>,
+    ) {
+        // only add our global addresses
+        let address = if multiaddr_is_global(&listen_addr) {
+            let Some(address) = self.craft_external_address(&listen_addr) else {
+                error!("Listen address is ill formed, not added to manager: {listen_addr:?}");
+                return;
+            };
+            address
+        } else {
+            debug!("Listen address is not global, ignoring: {listen_addr:?}");
+            return;
+        };
+        let Some(ip_address) = multiaddr_get_ip(&address) else {
+            return;
+        };
+
+        // set the current IP address if it is not set
+        if self.current_ip_address.is_none() {
+            self.current_ip_address = Some(ip_address);
+        }
+
+        // Switch to new IP early.
+        if let Some(current_ip_address) = self.current_ip_address {
+            if current_ip_address != ip_address {
+                self.address_states.push(ExternalAddressState::Listener {
+                    address: address.clone(),
+                    ip_address,
+                });
+                // this will add it as external addr
+                self.switch_to_new_ip(ip_address, swarm);
+                return;
+            }
+        }
+
+        if let Some(state) = self
+            .address_states
+            .iter_mut()
+            .find(|state| state.multiaddr() == &address)
+        {
+            match state {
+                ExternalAddressState::Candidate { ip_address, .. } => {
+                    info!("Listen Addr was found as a candidate. Adding it as external to the swarm {address:?}");
+
+                    swarm.add_external_address(address.clone());
+                    *state = ExternalAddressState::Listener {
+                        address: address.clone(),
+                        ip_address: *ip_address,
+                    };
+
+                    Self::print_swarm_state(swarm);
+                    return;
+                }
+                ExternalAddressState::Confirmed { ip_address, .. } => {
+                    debug!("Listen address was found as confirmed. Changing it to Listener {address:?}.");
+                    *state = ExternalAddressState::Listener {
+                        address: address.clone(),
+                        ip_address: *ip_address,
+                    };
+                    return;
+                }
+                ExternalAddressState::Listener { .. } => {
+                    debug!("Listen address is already a listener {address:?}. Do nothing");
+                    return;
+                }
+            }
+        }
+
+        // if it is a new one, add it as a Listener
+        info!("Listen Addr was not found in the manager. Adding it as external to the swarm {address:?}");
+        self.address_states.push(ExternalAddressState::Listener {
+            address: address.clone(),
+            ip_address,
+        });
+        swarm.add_external_address(address);
+    }
+
+    /// Remove a listen-addr from the manager if expired.
+    pub(in crate::networking) fn on_expired_listen_addr(
+        &mut self,
+        listen_addr: Multiaddr,
+        swarm: &Swarm<NodeBehaviour>,
+    ) {
+        let address = if multiaddr_is_global(&listen_addr) {
+            let Some(address) = self.craft_external_address(&listen_addr) else {
+                error!("Listen address is ill formed, ignoring {listen_addr:?}");
+                return;
+            };
+            address
+        } else {
+            debug!("Listen address is not global, ignoring: {listen_addr:?}");
+            return;
+        };
+
+        self.address_states.retain(|state| {
+            if state.multiaddr() == &address {
+                debug!("Removing listen address from manager: {address:?}");
+                // Todo: should we call swarm.remove_listener()? or is it already removed? Confirm with the below debug.
+                Self::print_swarm_state(swarm);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    /// Reset the incoming connection errors for a port
+    pub(in crate::networking) fn on_established_incoming_connection(
+        &mut self,
+        on_address: Multiaddr,
+    ) {
+        let Some(port) = multiaddr_get_port(&on_address) else {
+            return;
+        };
+
+        let stats = self.connection_stats.entry(port).or_default();
+        stats.ok = stats.ok.saturating_add(1);
+    }
+
+    /// Switch to a new IP address. The old external addresses are removed and the new ones are added.
+    /// The new IP address is set as the current IP address.
+    fn switch_to_new_ip(&mut self, new_ip: IpAddr, swarm: &mut Swarm<NodeBehaviour>) {
+        info!("Switching to new IpAddr: {new_ip}");
+        self.current_ip_address = Some(new_ip);
+
+        // remove all the old confirmed addresses with different ip
+        let mut removed_addresses = Vec::new();
+        let mut to_remove_indices = Vec::new();
+        for (idx, state) in &mut self.address_states.iter().enumerate() {
+            if state.is_candidate() {
+                continue;
+            }
+
+            if state.ip_address() != &new_ip {
+                // todo: should we remove listener from swarm?
+                swarm.remove_external_address(state.multiaddr());
+                removed_addresses.push(state.multiaddr().clone());
+                to_remove_indices.push(idx);
+            }
+        }
+        for idx in to_remove_indices.iter().rev() {
+            let _ = self.address_states.remove(*idx);
+        }
+        info!("Removed addresses due to change of IP: {removed_addresses:?}");
+
+        // add the new confirmed addresses with new ip
+        for state in &mut self.address_states {
+            if state.ip_address() == &new_ip {
+                match state {
+                    ExternalAddressState::Candidate {
+                        address,
+                        num_reports,
+                        ip_address,
+                    } => {
+                        if *num_reports >= MAX_REPORTS_BEFORE_SWITCHING_IP {
+                            info!("Switching to new IP, adding confirmed address: {address:?}");
+                            swarm.add_external_address(address.clone());
+                            *state = ExternalAddressState::Confirmed {
+                                address: address.clone(),
+                                num_reports: *num_reports,
+                                ip_address: *ip_address,
+                            };
+                        }
+                    }
+
+                    ExternalAddressState::Listener { address, .. } => {
+                        info!("Switching to new IP, adding listen address as external address {address:?}");
+                        swarm.add_external_address(address.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Self::print_swarm_state(swarm);
+    }
+
+    /// Craft a proper address Ws or Quic address to avoid any ill formed addresses
+    /// Example:
+    /// /ip4/131.131.131.131/tcp/53620/ws/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5
+    /// /ip4/131.131.131.131/udp/53620/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5
+    fn craft_external_address(&self, given_address: &Multiaddr) -> Option<Multiaddr> {
+        let mut output_address = Multiaddr::empty();
+
+        let ip = given_address
+            .iter()
+            .find(|protocol| matches!(protocol, Protocol::Ip4(_)))?;
+        output_address.push(ip);
+
+        if let Some(ws_protocol) = given_address
+            .iter()
+            .find(|protocol| matches!(protocol, Protocol::Ws(_)))
+        {
+            let port = given_address
+                .iter()
+                .find(|protocol| matches!(protocol, Protocol::Tcp(_)))?;
+            output_address.push(port);
+            output_address.push(ws_protocol);
+        } else if given_address
+            .iter()
+            .any(|protocol| matches!(protocol, Protocol::QuicV1))
+        {
+            let port = given_address
+                .iter()
+                .find(|protocol| matches!(protocol, Protocol::Udp(_)))?;
+            output_address.push(port);
+            output_address.push(Protocol::QuicV1);
+        } else {
+            return None;
+        }
+
+        output_address.push(Protocol::P2p(self.peer_id));
+        Some(output_address)
+    }
+
+    fn print_swarm_state(swarm: &Swarm<NodeBehaviour>) {
+        let listen_addr = swarm.listeners().collect::<Vec<_>>();
+        let external_addr = swarm.external_addresses().collect::<Vec<_>>();
+        // Combined output to reduce cpu/disk usage.
+        info!("All External addresses: {external_addr:?}, and listen addresses: {listen_addr:?}");
+    }
+}
+
+#[derive(Debug)]
+enum ExternalAddressState {
+    Candidate {
+        address: Multiaddr,
+        num_reports: u8,
+        ip_address: IpAddr,
+    },
+    Confirmed {
+        address: Multiaddr,
+        num_reports: u8,
+        ip_address: IpAddr,
+    },
+    Listener {
+        address: Multiaddr,
+        ip_address: IpAddr,
+    },
+}
+
+impl ExternalAddressState {
+    fn multiaddr(&self) -> &Multiaddr {
+        match self {
+            Self::Candidate { address, .. } => address,
+            Self::Confirmed { address, .. } => address,
+            Self::Listener { address, .. } => address,
+        }
+    }
+
+    fn ip_address(&self) -> &IpAddr {
+        match self {
+            Self::Candidate { ip_address, .. } => ip_address,
+            Self::Confirmed { ip_address, .. } => ip_address,
+            Self::Listener { ip_address, .. } => ip_address,
+        }
+    }
+
+    fn increment_reports(&mut self) {
+        match self {
+            Self::Candidate { num_reports, .. } => *num_reports = num_reports.saturating_add(1),
+            Self::Confirmed { num_reports, .. } => *num_reports = num_reports.saturating_add(1),
+            Self::Listener { .. } => {}
+        }
+        if self.num_reports() < 10 {
+            debug!(
+                "Incrementing reports for address: {}, current reports: {}",
+                self.multiaddr(),
+                self.num_reports(),
+            );
+        }
+    }
+
+    fn num_reports(&self) -> u8 {
+        match self {
+            Self::Candidate { num_reports, .. } => *num_reports,
+            Self::Confirmed { num_reports, .. } => *num_reports,
+            Self::Listener { .. } => u8::MAX,
+        }
+    }
+
+    fn is_candidate(&self) -> bool {
+        matches!(self, Self::Candidate { .. })
+    }
+}

--- a/ant-node/src/networking/mod.rs
+++ b/ant-node/src/networking/mod.rs
@@ -13,6 +13,7 @@ mod bootstrap;
 mod circular_vec;
 mod driver;
 mod error;
+mod external_address;
 mod interface;
 mod log_markers;
 #[cfg(feature = "open-metrics")]
@@ -41,6 +42,7 @@ use libp2p::{
     multiaddr::Protocol,
     Multiaddr, PeerId,
 };
+use std::net::IpAddr;
 
 /// Sort the provided peers by their distance to the given `KBucketKey`.
 /// Return with the closest expected number of entries it has.
@@ -105,23 +107,6 @@ pub(crate) fn multiaddr_is_global(multiaddr: &Multiaddr) -> bool {
     })
 }
 
-/// Craft valid multiaddr like /ip4/68.183.39.80/udp/31055/quic-v1
-/// RelayManager::craft_relay_address for relayed addr. This is for non-relayed addr.
-pub(crate) fn craft_valid_multiaddr_without_p2p(addr: &Multiaddr) -> Option<Multiaddr> {
-    let mut new_multiaddr = Multiaddr::empty();
-    let ip = addr.iter().find_map(|p| match p {
-        Protocol::Ip4(addr) => Some(addr),
-        _ => None,
-    })?;
-    let port = multiaddr_get_port(addr)?;
-
-    new_multiaddr.push(Protocol::Ip4(ip));
-    new_multiaddr.push(Protocol::Udp(port));
-    new_multiaddr.push(Protocol::QuicV1);
-
-    Some(new_multiaddr)
-}
-
 /// Pop off the `/p2p/<peer_id>`. This mutates the `Multiaddr` and returns the `PeerId` if it exists.
 pub(crate) fn multiaddr_pop_p2p(multiaddr: &mut Multiaddr) -> Option<PeerId> {
     if let Some(Protocol::P2p(peer_id)) = multiaddr.iter().last() {
@@ -140,6 +125,15 @@ pub(crate) fn multiaddr_get_p2p(multiaddr: &Multiaddr) -> Option<PeerId> {
     } else {
         None
     }
+}
+
+/// Get the `IpAddr` from the `Multiaddr`
+pub(crate) fn multiaddr_get_ip(addr: &Multiaddr) -> Option<IpAddr> {
+    addr.iter().find_map(|p| match p {
+        Protocol::Ip4(addr) => Some(IpAddr::V4(addr)),
+        Protocol::Ip6(addr) => Some(IpAddr::V6(addr)),
+        _ => None,
+    })
 }
 
 pub(crate) fn multiaddr_get_port(addr: &Multiaddr) -> Option<u16> {


### PR DESCRIPTION
This reverts commit 14e8638052ea31e7b7066fe8e3402a62b59aa8b9.

Re-introduce the external address manager by reverting #3067.

Removing this component resulted in clients not always being able to correctly communicate with nodes using port forwarding.