### PR TITLE
Revert "fix(client): remove client relay setup"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned, and along with it, all the scratchpad versions, which can then be used for merge and
   conflict resolution.
 
-#### Removed
-
-- The client was configured to use relays. This should not be necessary and could adversely affect
-  performance.
-
 ### Network
 
 #### Fixed

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -52,6 +52,8 @@ libp2p = { version = "0.56.0", features = [
     "cbor",
     "identify",
     "quic",
+    "relay",
+    "noise",
     "tcp",
     "yamux",
     "websocket",

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -20,6 +20,7 @@ use ant_protocol::{
     messages::{Query, Request, Response},
     version::REQ_RESPONSE_VERSION_STR,
 };
+use futures::future::Either;
 use libp2p::kad::store::MemoryStoreConfig;
 use libp2p::kad::NoKnownPeers;
 use libp2p::{
@@ -77,6 +78,7 @@ pub(crate) struct NetworkDriver {
 pub(crate) struct AutonomiClientBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub identify: libp2p::identify::Behaviour,
+    pub relay_client: libp2p::relay::client::Behaviour,
     pub request_response: request_response::cbor::Behaviour<Request, Response>,
 }
 
@@ -94,6 +96,23 @@ impl NetworkDriver {
         let transport_gen = QuicTransport::new(quic_config);
         let trans = transport_gen.map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
         let transport = trans.boxed();
+
+        let (relay_transport, relay_client_behaviour) = libp2p::relay::client::new(peer_id);
+        let relay_transport = relay_transport
+            .upgrade(libp2p::core::upgrade::Version::V1Lazy)
+            .authenticate(
+                libp2p::noise::Config::new(&keypair)
+                    .expect("Signing libp2p-noise static DH keypair failed."),
+            )
+            .multiplex(libp2p::yamux::Config::default())
+            .or_transport(transport);
+
+        let transport = relay_transport
+            .map(|either_output, _| match either_output {
+                Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+                Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+            })
+            .boxed();
 
         // identify behaviour
         let identify = {
@@ -152,6 +171,7 @@ impl NetworkDriver {
         // setup kad and autonomi requests as our behaviour
         let behaviour = AutonomiClientBehaviour {
             kademlia: libp2p::kad::Behaviour::with_config(peer_id, store, kad_cfg),
+            relay_client: relay_client_behaviour,
             identify,
             request_response,
         };


### PR DESCRIPTION
This reverts commit 24f1adfc4cadf42c1663d14fdbb2a363ea8384de.

Without relaying being enabled on the client, any clients will not be able to route through relayed nodes.