### PR TITLE
feat(antctl): spawn evm-testnet as part of local testnet cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "dirs-next",
+ "evmlib",
  "indicatif",
  "libp2p",
  "libp2p-identity",
@@ -3283,7 +3284,6 @@ name = "evmlib"
 version = "0.4.2"
 dependencies = [
  "alloy",
- "dirs-next",
  "rand 0.8.5",
  "serde",
  "serde_with",

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -36,6 +36,7 @@ ant-logging = { path = "../ant-logging", version = "0.2.51" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.7" }
 ant-releases = { version = "0.4.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.15" }
+evmlib = { path = "../evmlib", version = "0.4.2" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"
@@ -49,6 +50,7 @@ rand = "0.8.5"
 semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 service-manager = "0.8.0"
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
@@ -56,6 +58,7 @@ tokio = { version = "1.43", features = ["full"] }
 tracing = { version = "~0.1.26" }
 tonic = { version = "0.6.2" }
 uuid = { version = "1.5.0", features = ["v4"] }
+which = "6.0.1"
 anyhow = "1.0.98"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -920,11 +920,10 @@ async fn main() -> Result<()> {
                 evm_network,
                 skip_validation: _,
             } => {
-                let evm_network = if let Some(evm_network) = evm_network {
-                    Some(evm_network.try_into()?)
-                } else {
-                    None
-                };
+                let evm_network = evm_network
+                    .unwrap_or(EvmNetworkCommand::EvmLocal)
+                    .try_into()?;
+
                 cmd::local::join(
                     build,
                     count,
@@ -963,11 +962,10 @@ async fn main() -> Result<()> {
                 evm_network,
                 skip_validation: _,
             } => {
-                let evm_network = if let Some(evm_network) = evm_network {
-                    Some(evm_network.try_into()?)
-                } else {
-                    None
-                };
+                let evm_network = evm_network
+                    .unwrap_or(EvmNetworkCommand::EvmLocal)
+                    .try_into()?;
+
                 cmd::local::run(
                     build,
                     clean,

--- a/ant-node-manager/src/local.rs
+++ b/ant-node-manager/src/local.rs
@@ -47,7 +47,7 @@ pub trait Launcher {
         node_port: Option<u16>,
         rpc_socket_addr: SocketAddr,
         rewards_address: RewardsAddress,
-        evm_network: Option<EvmNetwork>,
+        evm_network: EvmNetwork,
     ) -> Result<()>;
     fn wait(&self, delay: u64);
 }
@@ -70,7 +70,7 @@ impl Launcher for LocalSafeLauncher {
         node_port: Option<u16>,
         rpc_socket_addr: SocketAddr,
         rewards_address: RewardsAddress,
-        evm_network: Option<EvmNetwork>,
+        evm_network: EvmNetwork,
     ) -> Result<()> {
         let mut args = Vec::new();
 
@@ -100,17 +100,15 @@ impl Launcher for LocalSafeLauncher {
         args.push("--rewards-address".to_string());
         args.push(rewards_address.to_string());
 
-        if let Some(network) = evm_network {
-            args.push(format!("evm-{}", network.identifier()));
+        args.push(format!("evm-{}", evm_network.identifier()));
 
-            if let EvmNetwork::Custom(custom) = network {
-                args.push("--rpc-url".to_string());
-                args.push(custom.rpc_url_http.to_string());
-                args.push("--payment-token-address".to_string());
-                args.push(custom.payment_token_address.to_string());
-                args.push("--data-payments-address".to_string());
-                args.push(custom.data_payments_address.to_string());
-            }
+        if let EvmNetwork::Custom(custom) = evm_network {
+            args.push("--rpc-url".to_string());
+            args.push(custom.rpc_url_http.to_string());
+            args.push("--payment-token-address".to_string());
+            args.push(custom.payment_token_address.to_string());
+            args.push("--data-payments-address".to_string());
+            args.push(custom.data_payments_address.to_string());
         }
 
         Command::new(self.antnode_bin_path.clone())
@@ -131,6 +129,19 @@ impl Launcher for LocalSafeLauncher {
     }
 }
 
+/// Kill any running EVM testnet processes
+async fn kill_evm_testnet_processes(system: &mut System) {
+    // Look for anvil processes (which are used by evm-testnet)
+    for (pid, process) in system.processes() {
+        let process_name = process.name().to_lowercase();
+        if process_name.contains("anvil") || process_name.contains("evm-testnet") {
+            debug!("Killing EVM testnet process: {} ({})", process_name, pid);
+            process.kill();
+            println!("  {} Killed EVM testnet process ({})", "✓".green(), pid);
+        }
+    }
+}
+
 pub async fn kill_network(
     node_registry: NodeRegistryManager,
     keep_directories: bool,
@@ -146,6 +157,9 @@ pub async fn kill_network(
         debug!("Removed genesis data directory");
         std::fs::remove_dir_all(genesis_data_path)?;
     }
+
+    // Kill any running EVM testnet processes
+    kill_evm_testnet_processes(&mut system).await;
 
     for node in node_registry.nodes.read().await.iter() {
         let node = node.read().await;
@@ -200,7 +214,7 @@ pub struct LocalNetworkOptions {
     pub skip_validation: bool,
     pub log_format: Option<LogFormat>,
     pub rewards_address: RewardsAddress,
-    pub evm_network: Option<EvmNetwork>,
+    pub evm_network: EvmNetwork,
 }
 
 pub async fn run_network(
@@ -361,7 +375,7 @@ pub struct RunNodeOptions {
     pub number: u16,
     pub rpc_socket_addr: SocketAddr,
     pub rewards_address: RewardsAddress,
-    pub evm_network: Option<EvmNetwork>,
+    pub evm_network: EvmNetwork,
     pub version: String,
 }
 
@@ -399,7 +413,7 @@ pub async fn run_node(
         auto_restart: false,
         connected_peers,
         data_dir_path: node_info.data_path,
-        evm_network: run_options.evm_network.unwrap_or(EvmNetwork::ArbitrumOne),
+        evm_network: run_options.evm_network,
         relay: false,
         initial_peers_config: InitialPeersConfig {
             first: run_options.first,
@@ -506,6 +520,7 @@ mod tests {
         rpc::{NetworkInfo, NodeInfo, RecordAddress, RpcActions},
     };
     use async_trait::async_trait;
+    use evmlib::CustomNetwork;
     use libp2p_identity::PeerId;
     use mockall::mock;
     use mockall::predicate::*;
@@ -543,7 +558,11 @@ mod tests {
                 eq(None),
                 eq(rpc_socket_addr),
                 eq(rewards_address),
-                eq(None),
+                eq(EvmNetwork::Custom(CustomNetwork::new(
+                    "http://localhost:61611",
+                    "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+                    "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+                ))),
             )
             .times(1)
             .returning(|_, _, _, _, _, _, _| Ok(()));
@@ -591,7 +610,11 @@ mod tests {
                 number: 1,
                 rpc_socket_addr,
                 rewards_address,
-                evm_network: None,
+                evm_network: EvmNetwork::Custom(CustomNetwork::new(
+                    "http://localhost:61611",
+                    "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+                    "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+                )),
                 version: "0.100.12".to_string(),
             },
             &mock_launcher,

--- a/evm-testnet/README.md
+++ b/evm-testnet/README.md
@@ -18,7 +18,7 @@ Example output:
 *************************
 * Ethereum node started *
 *************************
-RPC URL: http://localhost:60093/
+RPC URL: http://localhost:61611/
 Payment token address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 Chunk payments address: 0x8464135c8F25Da09e49BC8782676a84730C318bC
 Deployer wallet private key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/evm-testnet/src/main.rs
+++ b/evm-testnet/src/main.rs
@@ -24,10 +24,6 @@ struct Args {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    start_node(args.genesis_wallet).await;
-}
-
-async fn start_node(genesis_wallet: Option<Address>) {
     let testnet = Testnet::new().await;
 
     println!("*************************");
@@ -35,17 +31,16 @@ async fn start_node(genesis_wallet: Option<Address>) {
     println!("*************************");
 
     // Transfer all gas and payment tokens to the genesis wallet.
-    if let Some(genesis) = genesis_wallet {
+    if let Some(genesis) = args.genesis_wallet {
         transfer_funds(&testnet, genesis).await;
     }
 
-    let testnet_data = TestnetData::new(&testnet, genesis_wallet).await;
-    testnet_data.save_csv();
+    let testnet_data = TestnetData::new(&testnet, args.genesis_wallet).await;
+
     testnet_data.print();
     keep_alive(testnet).await;
 
     println!("Ethereum node stopped.");
-    TestnetData::remove_csv();
 }
 
 async fn transfer_funds(testnet: &Testnet, genesis_wallet: Address) {
@@ -143,38 +138,5 @@ impl TestnetData {
         println!("SECRET_KEY=\"{}\"", self.deployer_wallet_private_key);
         println!("--------------");
         println!();
-    }
-
-    fn save_csv(&self) {
-        let csv_path = evmlib::utils::get_evm_testnet_csv_path()
-            .expect("Could not get data_dir to save evm testnet data");
-        let path = csv_path
-            .parent()
-            .expect("Could not get parent dir of csv_path");
-        if !path.exists() {
-            std::fs::create_dir_all(path).expect("Could not create safe directory");
-        }
-
-        let csv = format!(
-            "{},{},{},{}",
-            self.rpc_url,
-            self.payment_token_address,
-            self.data_payments_address,
-            self.deployer_wallet_private_key
-        );
-        std::fs::write(&csv_path, csv).expect("Could not write to evm_testnet_data.csv file");
-        println!("EVM testnet data saved to: {csv_path:?}");
-        println!("When running the Node or CLI in local mode, it will automatically use this network by loading the EVM Network's info from the CSV file.");
-        println!();
-    }
-
-    fn remove_csv() {
-        let csv_path = evmlib::utils::get_evm_testnet_csv_path()
-            .expect("Could not get data_dir to remove evm testnet data");
-        if csv_path.exists() {
-            std::fs::remove_file(&csv_path).expect("Could not remove evm_testnet_data.csv file");
-        } else {
-            eprintln!("No EVM testnet data CSV file found to remove");
-        }
     }
 }

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -13,7 +13,6 @@ external-signer = []
 
 [dependencies]
 alloy = { version = "0.15.6", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
-dirs-next = "~2.0.0"
 serde = "1"
 serde_with = { version = "3.11.0", features = ["macros"] }
 thiserror = "1.0"

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -67,7 +67,7 @@ pub struct CustomNetwork {
 }
 
 impl CustomNetwork {
-    fn new(rpc_url: &str, payment_token_addr: &str, data_payments_addr: &str) -> Self {
+    pub fn new(rpc_url: &str, payment_token_addr: &str, data_payments_addr: &str) -> Self {
         Self {
             rpc_url_http: reqwest::Url::parse(rpc_url).expect("Invalid RPC URL"),
             payment_token_address: Address::from_str(payment_token_addr)

--- a/evmlib/src/testnet.rs
+++ b/evmlib/src/testnet.rs
@@ -22,6 +22,8 @@ use alloy::providers::fillers::{
 use alloy::providers::{Identity, ProviderBuilder, RootProvider};
 use alloy::signers::local::PrivateKeySigner;
 
+const ANVIL_DEFAULT_PORT: u16 = 61611;
+
 pub struct Testnet {
     anvil: AnvilInstance,
     rpc_url: Url,
@@ -70,7 +72,7 @@ impl Testnet {
 pub fn start_node() -> (AnvilInstance, Url) {
     let host = std::env::var("ANVIL_IP_ADDR").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("ANVIL_PORT")
-        .unwrap_or(0.to_string())
+        .unwrap_or(ANVIL_DEFAULT_PORT.to_string())
         .parse::<u16>()
         .expect("Invalid port number");
 

--- a/evmlib/src/utils.rs
+++ b/evmlib/src/utils.rs
@@ -17,15 +17,11 @@ use alloy::providers::fillers::{
 };
 use alloy::providers::{Identity, ProviderBuilder, RootProvider};
 use alloy::transports::http::reqwest;
-use dirs_next::data_dir;
 use rand::Rng;
 use std::env;
-use std::path::PathBuf;
 
 const MAINNET_ID: u8 = 1;
 const ALPHANET_ID: u8 = 2;
-
-pub const EVM_TESTNET_CSV_FILENAME: &str = "evm_testnet_data.csv";
 
 /// environment variable to connect to a custom EVM network
 pub const RPC_URL: &str = "RPC_URL";
@@ -58,7 +54,7 @@ static EVM_NETWORK: OnceLock<Network> = OnceLock::new();
 /// Initialize the EVM Network.
 ///
 /// Try to obtain it first from environment variables. If that fails and `local` is true,
-/// try to get it from the local CSV file. Lastly, attempt to obtain it based on the network ID,
+/// try to get it from hardcoded values. Lastly, attempt to obtain it based on the network ID,
 /// where 1 is reserved for the mainnet, 2 is reserved for the alpha network, and any other value
 /// between 3 and 255 is reserved for testnets. In the case of a testnet, the network to use must
 /// be configured via the environment variables. We can't just default to Sepolia because sometimes
@@ -74,8 +70,7 @@ pub fn get_evm_network(local: bool, network_id: Option<u8>) -> Result<Network, E
 
     let res = match get_evm_network_from_env() {
         Ok(evm_network) => Ok(evm_network),
-        Err(_) if local => Ok(local_evm_network_from_csv()
-            .map_err(|e| Error::FailedToGetEvmNetwork(e.to_string()))?),
+        Err(_) if local => Ok(local_evm_network_hardcoded()),
         Err(_) => {
             if let Some(id) = network_id {
                 match id {
@@ -108,16 +103,6 @@ pub fn get_evm_network(local: bool, network_id: Option<u8>) -> Result<Network, E
     }
 
     res
-}
-
-pub fn get_evm_testnet_csv_path() -> Result<PathBuf, Error> {
-    let file = data_dir()
-        .ok_or(Error::FailedToGetEvmNetwork(
-            "failed to get data dir when fetching evm testnet CSV file".to_string(),
-        ))?
-        .join("autonomi")
-        .join(EVM_TESTNET_CSV_FILENAME);
-    Ok(file)
 }
 
 /// Get the `Network` from environment variables.
@@ -172,7 +157,7 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
             &evm_vars[2],
         )))
     } else if use_local_evm {
-        local_evm_network_from_csv()
+        Ok(local_evm_network_hardcoded())
     } else {
         error!("Failed to obtain the desired EVM network through environment variables");
         Err(Error::FailedToGetEvmNetwork(
@@ -181,33 +166,13 @@ fn get_evm_network_from_env() -> Result<Network, Error> {
     }
 }
 
-/// Get the `Network::Custom` from the local EVM testnet CSV file
-fn local_evm_network_from_csv() -> Result<Network, Error> {
-    // load the csv
-    let csv_path = get_evm_testnet_csv_path()?;
-
-    if !csv_path.exists() {
-        error!("evm data csv path does not exist {:?}", csv_path);
-        return Err(Error::FailedToGetEvmNetwork(format!(
-            "evm data csv path does not exist {csv_path:?}"
-        )));
-    }
-
-    let csv = std::fs::read_to_string(&csv_path).map_err(|_| {
-        Error::FailedToGetEvmNetwork(format!("failed to read evm testnet CSV file {csv_path:?}"))
-    })?;
-    let parts: Vec<&str> = csv.split(',').collect();
-    match parts.as_slice() {
-        [rpc_url, payment_token_address, chunk_payments_address, _] => Ok(Network::Custom(
-            CustomNetwork::new(rpc_url, payment_token_address, chunk_payments_address),
-        )),
-        _ => {
-            error!("Invalid data in evm testnet CSV file");
-            Err(Error::FailedToGetEvmNetwork(
-                "invalid data in evm testnet CSV file".to_string(),
-            ))
-        }
-    }
+/// Get the `Network::Custom` from the hardcoded values.
+fn local_evm_network_hardcoded() -> Network {
+    Network::Custom(CustomNetwork::new(
+        "http://localhost:61611",
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+    ))
 }
 
 #[allow(clippy::type_complexity)]


### PR DESCRIPTION
- Removes the `evm_testnet_data.csv` file and instead the values are hardcoded now.
- When `--build` is used, the `evm-testnet` binary is compiled and auto run for you. 