### PR TITLE
feat: verify bootstrap peers before adding to RT

### DIFF
--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -104,6 +104,7 @@ pub(crate) fn connect_error_exit_code(err: &ConnectError) -> i32 {
         ConnectError::TimedOut => 59,
         ConnectError::TimedOutWithIncompatibleProtocol(_, _) => 60,
         ConnectError::NoKnownPeers(_) => 51, // todo: uses duplicate exit code from `BootstrapError::NoBootstrapPeersFound`
+        ConnectError::BootstrapFailure(_) => 51, // todo: uses duplicate exit code from `BootstrapError::NoBootstrapPeersFound`
     }
 }
 

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -59,10 +59,10 @@ use tokio::sync::mpsc;
 pub const CONNECT_TIMEOUT_SECS: u64 = 10;
 
 const CLIENT_EVENT_CHANNEL_SIZE: usize = 100;
+const MAX_BOOTSTRAP_PEERS: usize = 50;
 
 // Amount of peers to confirm into our routing table before we consider the client ready.
 use crate::client::config::ClientOperatingStrategy;
-use crate::networking::bootstrap::BOOTSTRAP_MAX_REQUIRED_PEERS;
 use crate::networking::{
     bootstrap, multiaddr_is_global, Multiaddr, Network, NetworkAddress, NetworkError,
 };
@@ -266,7 +266,7 @@ impl Client {
 
         let initial_peers = match config
             .init_peers_config
-            .get_bootstrap_addr(None, Some(BOOTSTRAP_MAX_REQUIRED_PEERS as usize))
+            .get_bootstrap_addr(None, Some(MAX_BOOTSTRAP_PEERS))
             .await
         {
             Ok(peers) => peers,

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -259,14 +259,14 @@ impl Client {
 
         let initial_peers = match config
             .init_peers_config
-            .get_bootstrap_addr(None, None)
+            .get_bootstrap_addr(None, Some(25))
             .await
         {
             Ok(peers) => peers,
             Err(e) => return Err(e.into()),
         };
 
-        let network = Network::new(initial_peers)?;
+        let network = Network::new(initial_peers).await?;
 
         Ok(Self {
             network,

--- a/autonomi/src/networking/bootstrap.rs
+++ b/autonomi/src/networking/bootstrap.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::error;
 
-pub(crate) const BOOTSTRAP_MAX_REQUIRED_PEERS: u32 = 25;
+pub(crate) const BOOTSTRAP_MAX_REQUIRED_PEERS: u32 = 20;
 pub(crate) const BOOTSTRAP_MAX_DURATION_SECS: u64 = 30;
 
 /// Errors that can occur during network Bootstrap

--- a/autonomi/src/networking/bootstrap.rs
+++ b/autonomi/src/networking/bootstrap.rs
@@ -55,6 +55,10 @@ impl BootstrapManager {
         self.observers.push(observer);
     }
 
+    pub fn has_observers(&self) -> bool {
+        !self.observers.is_empty()
+    }
+
     pub fn add_connected_peer(&mut self, peer_id: PeerId) {
         self.connected_peers.insert(peer_id);
 

--- a/autonomi/src/networking/bootstrap.rs
+++ b/autonomi/src/networking/bootstrap.rs
@@ -1,0 +1,45 @@
+use crate::networking::PeerId;
+use std::collections::HashSet;
+use tokio::sync::oneshot;
+use tracing::error;
+
+pub(crate) const MAX_REQUIRED_PEERS: u32 = 25;
+pub(crate) const MAX_BOOTSTRAP_DURATION_SECS: u64 = 10;
+
+pub(crate) struct BootstrapManager {
+    connected_peers: HashSet<PeerId>,
+    observers: Vec<(oneshot::Sender<u32>, u32)>,
+}
+
+impl BootstrapManager {
+    pub fn new() -> Self {
+        Self {
+            connected_peers: Default::default(),
+            observers: Default::default(),
+        }
+    }
+
+    pub fn register_observer(&mut self, observer: (oneshot::Sender<u32>, u32)) {
+        self.observers.push(observer);
+    }
+
+    pub fn add_connected_peer(&mut self, peer_id: PeerId) {
+        self.connected_peers.insert(peer_id);
+
+        // Process observers and remove those whose conditions are met or that fail to send
+        let mut i = 0;
+        while i < self.observers.len() {
+            let required_peers = self.observers[i].1;
+            if self.connected_peers.len() >= required_peers as usize {
+                // Remove the observer and attempt to notify it
+                let (observer_callback, _) = self.observers.swap_remove(i);
+                if let Err(err) = observer_callback.send(self.connected_peers.len() as u32) {
+                    error!("Failed to send bootstrap result to observer: {err:?}");
+                }
+                // Don't increment i since we removed an element
+            } else {
+                i += 1;
+            }
+        }
+    }
+}

--- a/autonomi/src/networking/bootstrap.rs
+++ b/autonomi/src/networking/bootstrap.rs
@@ -5,7 +5,7 @@ use tokio::sync::oneshot;
 use tracing::error;
 
 pub(crate) const BOOTSTRAP_MAX_REQUIRED_PEERS: u32 = 25;
-pub(crate) const BOOTSTRAP_MAX_DURATION_SECS: u64 = 10;
+pub(crate) const BOOTSTRAP_MAX_DURATION_SECS: u64 = 30;
 
 /// Errors that can occur during network Bootstrap
 #[derive(Error, Debug, Clone)]

--- a/autonomi/src/networking/bootstrap.rs
+++ b/autonomi/src/networking/bootstrap.rs
@@ -1,10 +1,42 @@
 use crate::networking::PeerId;
 use std::collections::HashSet;
+use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::error;
 
-pub(crate) const MAX_REQUIRED_PEERS: u32 = 25;
-pub(crate) const MAX_BOOTSTRAP_DURATION_SECS: u64 = 10;
+pub(crate) const BOOTSTRAP_MAX_REQUIRED_PEERS: u32 = 25;
+pub(crate) const BOOTSTRAP_MAX_DURATION_SECS: u64 = 10;
+
+/// Errors that can occur during network Bootstrap
+#[derive(Error, Debug, Clone)]
+pub enum BootstrapError {
+    /// No initial contacts were provided
+    #[error("No initial contacts provided - at least one peer address is required")]
+    NoInitialContacts,
+
+    /// Failed to register bootstrap observer
+    #[error("Failed to register bootstrap observer: {reason}")]
+    BootstrapObserverRegistrationFailed { reason: String },
+
+    /// Failed to connect to initial peers
+    #[error("Failed to connect to initial peers: {reason}")]
+    PeerConnectionFailed { reason: String },
+
+    /// Bootstrap process timed out
+    #[error("Bootstrap timed out after {timeout_secs} seconds. Could not connect to {required_peers} peers in time")]
+    BootstrapTimeout {
+        timeout_secs: u64,
+        required_peers: u32,
+    },
+
+    /// Bootstrap observer channel was closed unexpectedly
+    #[error("Bootstrap observer was dropped before completion. This typically indicates a network driver issue")]
+    BootstrapObserverClosed,
+
+    /// Failed to trigger Kademlia bootstrap
+    #[error("Failed to trigger Kademlia bootstrap: {reason}")]
+    KademliaBootstrapFailed { reason: String },
+}
 
 pub(crate) struct BootstrapManager {
     connected_peers: HashSet<PeerId>,

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -180,6 +180,15 @@ impl NetworkDriver {
         peer_id: PeerId,
         info: libp2p::identify::Info,
     ) -> Result<(), NetworkDriverError> {
+        self.handle_bootstrap(peer_id, info);
+        Ok(())
+    }
+
+    fn handle_bootstrap(&mut self, peer_id: PeerId, info: libp2p::identify::Info) {
+        if !self.bootstrap_manager.has_observers() {
+            return;
+        }
+
         if info
             .protocols
             .contains(&StreamProtocol::new(KAD_STREAM_PROTOCOL_ID))
@@ -193,7 +202,5 @@ impl NetworkDriver {
                 self.bootstrap_manager.add_connected_peer(peer_id);
             }
         }
-
-        Ok(())
     }
 }

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -11,9 +11,10 @@ use ant_evm::PaymentQuote;
 use ant_protocol::NetworkAddress;
 use libp2p::{
     kad::{PeerInfo, Quorum, Record},
-    PeerId,
+    Multiaddr, PeerId,
 };
 use std::num::NonZeroUsize;
+use tokio::sync::oneshot;
 
 /// Task for the underlying network driver
 /// Sent by the [`crate::Network`], handled by the [`crate::driver::NetworkDriver`]
@@ -66,5 +67,21 @@ pub(super) enum NetworkTask {
         data_size: usize,
         #[debug(skip)]
         resp: OneShotTaskResult<Option<(PeerInfo, PaymentQuote)>>,
+    },
+    /// Connect to peers
+    ConnectToPeers {
+        peers: Vec<Multiaddr>,
+        #[debug(skip)]
+        resp: OneShotTaskResult<()>,
+    },
+    /// Register a bootstrap observer
+    RegisterBootstrapObserver {
+        required_peers: u32,
+        observer_callback: oneshot::Sender<u32>,
+    },
+    /// Trigger bootstrap process
+    TriggerBootstrap {
+        #[debug(skip)]
+        resp: OneShotTaskResult<()>,
     },
 }


### PR DESCRIPTION
Verifies that bootstrap peers actually support the kad protocol before adding them to the RT.

It dials the initial peers after running the network in the Client (during Client init) and it waits for their identity packets to be received. When we receive an identity packet that supports the kad protocol, we directly insert it into the RT. When we have added 20 peers to our RT, we fire a signal that the bootstrapping is complete.

The fix is quite big and I’m not happy about introducing so much code to the new CLN. So we should only see it is a temp patch until dealing with unsupported/missing protocol nodes is resolved on the libp2p end.

NOTE: Will be replaced by a new PR if tests prove to be successful: https://github.com/maidsafe/autonomi/pull/3129