### PR TITLE
fix: resolve failuring data_with_churn CI test

### DIFF
--- a/ant-node/src/networking/replication_fetcher.rs
+++ b/ant-node/src/networking/replication_fetcher.rs
@@ -464,7 +464,7 @@ impl ReplicationFetcher {
         if let Some(ref distance_range) = self.distance_range {
             new_incoming_keys.retain(|(addr, _record_type)| {
                 let distance = &self_address.distance(addr);
-                trace!(
+                debug!(
                     "Distance to target {addr:?} is {distance:?}, against range {distance_range:?}"
                 );
                 let mut is_in_range = distance <= distance_range;
@@ -472,9 +472,10 @@ impl ReplicationFetcher {
                 // but still supposed to be held by the closest group to us.
                 if !is_in_range && distance.0 - distance_range.0 < distance_range.0 {
                     closest_k_peers.sort_by_key(|key| key.distance(addr));
-                    let closest_group: HashSet<_> = closest_k_peers.iter().take(CLOSE_GROUP_SIZE).collect();
+                    let closest_group: HashSet<_> = closest_k_peers.iter().take(CLOSE_GROUP_SIZE + 2).collect();
                     if closest_group.contains(&self_address) {
-                        debug!("Record {addr:?} has a far distance but still among {CLOSE_GROUP_SIZE} closest within {} neighbourd.", closest_k_peers.len());
+                        debug!("Record {addr:?} has a far distance but still among {} closest within {} neighbourd.",
+                            CLOSE_GROUP_SIZE + 2, closest_k_peers.len());
                         is_in_range = true;
                     }
                 }
@@ -713,7 +714,7 @@ mod tests {
                 closest_k_peers_include_self.sort_by_key(|addr| key.distance(addr));
                 let closest_group: HashSet<_> = closest_k_peers_include_self
                     .iter()
-                    .take(CLOSE_GROUP_SIZE)
+                    .take(CLOSE_GROUP_SIZE + 2)
                     .collect();
                 if closest_group.contains(&self_address) {
                     in_range_keys += 1;

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -360,13 +360,13 @@ fn create_scratchpad_task(
                             error!("Failed to update ScratchPad at {addr:?}. Retrying ...");
                             if retries >= 3 {
                                 println!(
-                                    "Failed to update pointer at {addr:?} after 3 retries: {err}"
+                                    "Failed to update ScratchPad at {addr:?} after 3 retries: {err}"
                                 );
                                 error!(
-                                    "Failed to update pointer at {addr:?} after 3 retries: {err}"
+                                    "Failed to update ScratchPad at {addr:?} after 3 retries: {err}"
                                 );
                                 bail!(
-                                    "Failed to update pointer at {addr:?} after 3 retries: {err}"
+                                    "Failed to update ScratchPad at {addr:?} after 3 retries: {err}"
                                 );
                             }
                             retries += 1;

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -246,7 +246,10 @@ impl Network {
         quorum: Quorum,
     ) -> Result<(), NetworkError> {
         let key = PrettyPrintRecordKey::from(&record.key);
-        let total = NonZeroUsize::new(to.len()).ok_or(NetworkError::PutRecordMissingTargets)?;
+        // For data_type like ScratchPad, it is observed the holders will be 7
+        // which result in the expected_holders to be 4, and could result in false alert.
+        let candidates = std::cmp::min(CLOSE_GROUP_SIZE, to.len());
+        let total = NonZeroUsize::new(candidates).ok_or(NetworkError::PutRecordMissingTargets)?;
         let expected_holders = expected_holders(quorum, total);
 
         trace!(


### PR DESCRIPTION
### Description

resolvements of failuring data_with_churn CI test :
* fetched split Scratchpad records may contain same copies bearing the same counter value, they shall be de-duplicated
* expand the replication acceptance range (only for the records that falls in the middle range)
* holder candidates could be more than CLOSE_GROUP_SIZE (for example, 7 for ScratchPad datatype). For that, the expected_holders shall still be majority of CLOSE_GROUP_SIZE (i.e. 3)

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
