### PR TITLE
feat: rename vault functions to match the code standard

### DIFF
--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -56,7 +56,7 @@ pub async fn create(
     let local_user_data = crate::user_data::get_local_user_data()?;
     println!("Pushing to network vault...");
     let total_cost = client
-        .put_user_data_to_vault(&vault_sk, wallet.into(), local_user_data.clone())
+        .vault_put_user_data(&vault_sk, wallet.into(), local_user_data.clone())
         .await?;
 
     if total_cost.is_zero() {
@@ -86,7 +86,7 @@ pub async fn sync(force: bool, network_context: NetworkContext) -> Result<()> {
     } else {
         println!("Fetching vault from network...");
         let net_user_data = client
-            .get_user_data_from_vault(&vault_sk)
+            .vault_get_user_data(&vault_sk)
             .await
             .wrap_err("Failed to fetch vault from network")
             .with_suggestion(|| "Make sure you have already created a vault on the network")?;
@@ -100,7 +100,7 @@ pub async fn sync(force: bool, network_context: NetworkContext) -> Result<()> {
     println!("Pushing local user data to network vault...");
     let local_user_data = crate::user_data::get_local_user_data()?;
     client
-        .put_user_data_to_vault(&vault_sk, wallet.into(), local_user_data.clone())
+        .vault_put_user_data(&vault_sk, wallet.into(), local_user_data.clone())
         .await
         .with_suggestion(
             || "Make sure you have already created a vault on the network or try again",
@@ -181,7 +181,7 @@ pub async fn load(network_context: NetworkContext) -> Result<()> {
     let vault_sk = crate::keys::get_vault_secret_key()?;
 
     println!("Retrieving vault from network...");
-    let user_data = client.get_user_data_from_vault(&vault_sk).await?;
+    let user_data = client.vault_get_user_data(&vault_sk).await?;
     println!("Writing user data to disk...");
     crate::user_data::write_local_user_data(&user_data)?;
 

--- a/autonomi-nodejs/src/lib.rs
+++ b/autonomi-nodejs/src/lib.rs
@@ -787,9 +787,9 @@ impl Client {
 
     /// Get the user data from the vault
     #[napi]
-    pub async fn get_user_data_from_vault(&self, secret_key: &VaultSecretKey) -> Result<UserData> {
+    pub async fn vault_get_user_data(&self, secret_key: &VaultSecretKey) -> Result<UserData> {
         self.0
-            .get_user_data_from_vault(&secret_key.0)
+            .vault_get_user_data(&secret_key.0)
             .await
             .map(UserData)
             .map_err(map_error)
@@ -799,14 +799,14 @@ impl Client {
     ///
     /// Returns the total cost of the put operation
     #[napi]
-    pub async fn put_user_data_to_vault(
+    pub async fn vault_put_user_data(
         &self,
         secret_key: &VaultSecretKey,
         payment_option: &PaymentOption,
         user_data: &UserData,
     ) -> Result</* AttoTokens */ String> {
         self.0
-            .put_user_data_to_vault(&secret_key.0, payment_option.0.clone(), user_data.0.clone())
+            .vault_put_user_data(&secret_key.0, payment_option.0.clone(), user_data.0.clone())
             .await
             .map(|c| c.to_string())
             .map_err(map_error)
@@ -816,13 +816,13 @@ impl Client {
     ///
     /// Returns the content type of the bytes in the vault.
     #[napi]
-    pub async fn fetch_and_decrypt_vault(
+    pub async fn vault_get(
         &self,
         secret_key: &VaultSecretKey,
     ) -> Result</* (Bytes, VaultContentType) */ tuple_result::FetchAndDecryptVault> {
         let (data, content_type) = self
             .0
-            .fetch_and_decrypt_vault(&secret_key.0)
+            .vault_get(&secret_key.0)
             .await
             .map_err(map_error)?;
 
@@ -855,7 +855,7 @@ impl Client {
     /// It is recommended to use the hash of the app name or unique identifier as the content type.
 
     #[napi]
-    pub async fn write_bytes_to_vault(
+    pub async fn vault_put(
         &self,
         data: Buffer,
         payment_option: &PaymentOption,
@@ -865,7 +865,7 @@ impl Client {
         let data = Bytes::copy_from_slice(&data);
 
         self.0
-            .write_bytes_to_vault(
+            .vault_put(
                 data,
                 payment_option.0.clone(),
                 &secret_key.0,
@@ -874,6 +874,44 @@ impl Client {
             .await
             .map(|c| c.to_string())
             .map_err(map_error)
+    }
+
+    /// @deprecated Use `vault_get_user_data` instead. This function will be removed in a future version.
+    #[napi]
+    pub async fn get_user_data_from_vault(&self, secret_key: &VaultSecretKey) -> Result<UserData> {
+        self.vault_get_user_data(secret_key).await
+    }
+
+    /// @deprecated Use `vault_put_user_data` instead. This function will be removed in a future version.
+    #[napi]
+    pub async fn put_user_data_to_vault(
+        &self,
+        secret_key: &VaultSecretKey,
+        payment_option: &PaymentOption,
+        user_data: &UserData,
+    ) -> Result</* AttoTokens */ String> {
+        self.vault_put_user_data(secret_key, payment_option, user_data).await
+    }
+
+    /// @deprecated Use `vault_get` instead. This function will be removed in a future version.
+    #[napi]
+    pub async fn fetch_and_decrypt_vault(
+        &self,
+        secret_key: &VaultSecretKey,
+    ) -> Result</* (Bytes, VaultContentType) */ tuple_result::FetchAndDecryptVault> {
+        self.vault_get(secret_key).await
+    }
+
+    /// @deprecated Use `vault_put` instead. This function will be removed in a future version.
+    #[napi]
+    pub async fn write_bytes_to_vault(
+        &self,
+        data: Buffer,
+        payment_option: &PaymentOption,
+        secret_key: &VaultSecretKey,
+        content_type: &VaultContentType,
+    ) -> Result</* AttoTokens */ String> {
+        self.vault_put(data, payment_option, secret_key, content_type).await
     }
 
     // Registers

--- a/autonomi/README_PYTHON.md
+++ b/autonomi/README_PYTHON.md
@@ -171,10 +171,10 @@ Manage mutable encrypted data on the network.
     - Retrieve vault data
     - Returns (data, content_type)
 
-- `get_user_data_from_vault(key: VaultSecretKey) -> UserData`
+- `vault_get_user_data(key: VaultSecretKey) -> UserData`
     - Get user data from vault
 
-- `put_user_data_to_vault(key: VaultSecretKey, payment: PaymentOption, user_data: UserData) -> str`
+- `vault_put_user_data(key: VaultSecretKey, payment: PaymentOption, user_data: UserData) -> str`
     - Store user data in vault
     - Returns vault address
 

--- a/autonomi/python/examples/autonomi_vault.py
+++ b/autonomi/python/examples/autonomi_vault.py
@@ -1,0 +1,53 @@
+from autonomi_client import Client, Wallet, PaymentOption, VaultSecretKey, UserData
+
+def main():
+    # Initialize
+    private_key = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    peers = ["/ip4/127.0.0.1/tcp/12000"]
+    
+    try:
+        # Setup
+        wallet = Wallet(private_key)
+        client = Client.connect(peers)
+        payment = PaymentOption.wallet(wallet)
+        
+        # Create vault key
+        vault_key = VaultSecretKey.new()
+        print(f"Created vault key: {vault_key.to_hex()}")
+        
+        # Get vault cost
+        cost = client.vault_cost(vault_key)
+        print(f"Vault cost: {cost}")
+        
+        # Create user data
+        user_data = UserData()
+        
+        # Store some data in vault
+        data = b"Hello from vault!"
+        content_type = 1  # Custom content type
+        cost = client.write_bytes_to_vault(data, payment, vault_key, content_type)
+        print(f"Wrote data to vault, cost: {cost}")
+        
+        # Read data back
+        retrieved_data, retrieved_type = client.fetch_and_decrypt_vault(vault_key)
+        print(f"Retrieved data: {retrieved_data.decode()}")
+        print(f"Content type: {retrieved_type}")
+        
+        # Store user data
+        cost = client.vault_put_user_data(vault_key, payment, user_data)
+        print(f"Stored user data, cost: {cost}")
+        
+        # Get user data
+        retrieved_user_data = client.vault_get_user_data(vault_key)
+        print("File archives:", retrieved_user_data.file_archives())
+        print("Private file archives:", retrieved_user_data.private_file_archives())
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+    
+    print("All vault operations completed successfully!")
+    return 0
+
+if __name__ == "__main__":
+    exit(main()) 

--- a/autonomi/python/examples/basic.py
+++ b/autonomi/python/examples/basic.py
@@ -1,0 +1,64 @@
+from autonomi_client import Client, Wallet, VaultSecretKey, UserData
+
+def external_signer_example(client: Client, data: bytes):
+    # Get quotes for storing data
+    quotes, payments, free_chunks = client.get_quotes_for_data(data)
+    print(f"Got {len(quotes)} quotes for storing data")
+    print(f"Need to make {len(payments)} payments")
+    print(f"{len(free_chunks)} chunks are free")
+    
+    # Get raw quotes for specific addresses
+    addr = "0123456789abcdef"  # Example address
+    quotes, payments, free = client.get_quotes_for_content_addresses([addr])
+    print(f"Got quotes for address {addr}")
+
+def main():
+    # Connect to network
+    client = Client(["/ip4/127.0.0.1/tcp/12000"])
+    
+    # Create wallet
+    wallet = Wallet()
+    print(f"Wallet address: {wallet.address()}")
+    
+    # Upload public data
+    data = b"Hello World!"
+    addr = client.data_put_public(data, wallet)
+    print(f"Uploaded public data to: {addr}")
+    retrieved = client.data_get_public(addr)
+    print(f"Retrieved public data: {retrieved}")
+    
+    # Upload private data
+    private_access = client.data_put(b"Secret message", wallet)
+    print(f"Private data access: {private_access}")
+    private_data = client.data_get(private_access)
+    print(f"Retrieved private data: {private_data}")
+    
+    # Upload file/directory
+    file_addr = client.file_upload_public("./test_data", wallet)
+    print(f"Uploaded files to: {file_addr}")
+    client.file_download(file_addr, "./downloaded_data")
+    print("Downloaded files")
+    
+    # Vault operations
+    vault_key = VaultSecretKey.generate()
+    vault_cost = client.vault_cost(vault_key)
+    print(f"Vault creation cost: {vault_cost}")
+
+    user_data = UserData()
+    cost = client.vault_put_user_data(vault_key, wallet, user_data)
+    print(f"Stored user data, cost: {cost}")
+
+    retrieved_data = client.vault_get_user_data(vault_key)
+    print(f"Retrieved user data: {retrieved_data}")
+
+    # Private directory operations
+    private_dir_access = client.dir_upload("./test_data", wallet)
+    print(f"Uploaded private directory, access: {private_dir_access}")
+    client.dir_download(private_dir_access, "./downloaded_private")
+    print("Downloaded private directory")
+
+    # External signer example
+    external_signer_example(client, b"Test data")
+
+if __name__ == "__main__":
+    main() 

--- a/autonomi/src/client/high_level/vault/mod.rs
+++ b/autonomi/src/client/high_level/vault/mod.rs
@@ -74,7 +74,7 @@ impl Client {
     /// Retrieves and returns a decrypted vault if one exists.
     ///
     /// Returns the content type of the bytes in the vault.
-    pub async fn fetch_and_decrypt_vault(
+    pub async fn vault_get(
         &self,
         secret_key: &VaultSecretKey,
     ) -> Result<(Bytes, VaultContentType), VaultError> {
@@ -160,7 +160,7 @@ impl Client {
     /// Dynamically expand the vault capacity by paying for more space (Scratchpad) when needed.
     ///
     /// It is recommended to use the hash of the app name or unique identifier as the content type.
-    pub async fn write_bytes_to_vault(
+    pub async fn vault_put(
         &self,
         data: Bytes,
         payment_option: PaymentOption,
@@ -404,6 +404,27 @@ impl Client {
             content_type,
             has_end_reached,
         ))
+    }
+
+    /// @deprecated Use `vault_get` instead. This function will be removed in a future version.
+    #[deprecated(since = "0.2.0", note = "Use `vault_get` instead")]
+    pub async fn fetch_and_decrypt_vault(
+        &self,
+        secret_key: &VaultSecretKey,
+    ) -> Result<(Bytes, VaultContentType), VaultError> {
+        self.vault_get(secret_key).await
+    }
+
+    /// @deprecated Use `vault_put` instead. This function will be removed in a future version.
+    #[deprecated(since = "0.2.0", note = "Use `vault_put` instead")]
+    pub async fn write_bytes_to_vault(
+        &self,
+        data: Bytes,
+        payment_option: PaymentOption,
+        secret_key: &VaultSecretKey,
+        content_type: VaultContentType,
+    ) -> Result<AttoTokens, VaultError> {
+        self.vault_put(data, payment_option, secret_key, content_type).await
     }
 }
 

--- a/autonomi/src/client/high_level/vault/user_data.rs
+++ b/autonomi/src/client/high_level/vault/user_data.rs
@@ -174,11 +174,11 @@ impl UserData {
 
 impl Client {
     /// Get the user data from the vault
-    pub async fn get_user_data_from_vault(
+    pub async fn vault_get_user_data(
         &self,
         secret_key: &VaultSecretKey,
     ) -> Result<UserData, UserDataVaultError> {
-        let (bytes, content_type) = self.fetch_and_decrypt_vault(secret_key).await?;
+        let (bytes, content_type) = self.vault_get(secret_key).await?;
 
         if content_type != *USER_DATA_VAULT_CONTENT_IDENTIFIER {
             return Err(UserDataVaultError::UnsupportedVaultContentType(
@@ -196,7 +196,7 @@ impl Client {
     /// Put the user data to the vault
     ///
     /// Returns the total cost of the put operation
-    pub async fn put_user_data_to_vault(
+    pub async fn vault_put_user_data(
         &self,
         secret_key: &VaultSecretKey,
         payment_option: PaymentOption,
@@ -206,7 +206,7 @@ impl Client {
             UserDataVaultError::Serialization(format!("Failed to serialize user data: {e}"))
         })?;
         let total_cost = self
-            .write_bytes_to_vault(
+            .vault_put(
                 bytes,
                 payment_option,
                 secret_key,
@@ -214,6 +214,26 @@ impl Client {
             )
             .await?;
         Ok(total_cost)
+    }
+
+    /// @deprecated Use `vault_get_user_data` instead. This function will be removed in a future version.
+    #[deprecated(since = "0.2.0", note = "Use `vault_get_user_data` instead")]
+    pub async fn get_user_data_from_vault(
+        &self,
+        secret_key: &VaultSecretKey,
+    ) -> Result<UserData, UserDataVaultError> {
+        self.vault_get_user_data(secret_key).await
+    }
+
+    /// @deprecated Use `vault_put_user_data` instead. This function will be removed in a future version.
+    #[deprecated(since = "0.2.0", note = "Use `vault_put_user_data` instead")]
+    pub async fn put_user_data_to_vault(
+        &self,
+        secret_key: &VaultSecretKey,
+        payment_option: PaymentOption,
+        user_data: UserData,
+    ) -> Result<AttoTokens, UserDataVaultError> {
+        self.vault_put_user_data(secret_key, payment_option, user_data).await
     }
 }
 

--- a/autonomi/tests/external_signer.rs
+++ b/autonomi/tests/external_signer.rs
@@ -158,10 +158,10 @@ async fn external_signer_put() -> eyre::Result<()> {
     sleep(Duration::from_secs(5)).await;
 
     let _ = client
-        .put_user_data_to_vault(&vault_key, receipt.into(), user_data)
+        .vault_put_user_data(&vault_key, receipt.into(), user_data)
         .await?;
 
-    let fetched_user_data = client.get_user_data_from_vault(&vault_key).await?;
+    let fetched_user_data = client.vault_get_user_data(&vault_key).await?;
 
     let fetched_private_archive_access = fetched_user_data
         .private_file_archives

--- a/autonomi/tests/files.rs
+++ b/autonomi/tests/files.rs
@@ -95,13 +95,13 @@ async fn file_into_vault() -> Result<()> {
     let archive = client.archive_get_public(&addr).await?;
     let set_version = 0;
     client
-        .write_bytes_to_vault(archive.to_bytes()?, wallet.into(), &client_sk, set_version)
+        .vault_put(archive.to_bytes()?, wallet.into(), &client_sk, set_version)
         .await?;
 
     // now assert over the stored account packet
     let new_client = Client::init_local().await?;
 
-    let (ap, got_version) = new_client.fetch_and_decrypt_vault(&client_sk).await?;
+    let (ap, got_version) = new_client.vault_get(&client_sk).await?;
     assert_eq!(set_version, got_version);
     let ap_archive_fetched =
         autonomi::client::files::archive_public::PublicArchive::from_bytes(ap)?;

--- a/autonomi/tests/vault.rs
+++ b/autonomi/tests/vault.rs
@@ -43,7 +43,7 @@ async fn vault_expand() -> Result<()> {
     let original_content = gen_random_data(1024);
 
     let cost = client
-        .write_bytes_to_vault(
+        .vault_put(
             original_content.clone(),
             wallet.clone().into(),
             &main_key,
@@ -52,7 +52,7 @@ async fn vault_expand() -> Result<()> {
         .await?;
     println!("1KB Vault update cost: {cost}");
 
-    let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    let (fetched_content, fetched_content_type) = client.vault_get(&main_key).await?;
     println!("1KB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, original_content);
@@ -60,7 +60,7 @@ async fn vault_expand() -> Result<()> {
     // Update content to 2KB. Shall not incur any cost.
     let update_content_2_kb = gen_random_data(2 * 1024);
     let cost = client
-        .write_bytes_to_vault(
+        .vault_put(
             update_content_2_kb.clone(),
             wallet.clone().into(),
             &main_key,
@@ -70,7 +70,7 @@ async fn vault_expand() -> Result<()> {
     assert_eq!(cost, AttoTokens::zero());
     println!("2KB Vault update cost: {cost}");
 
-    let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    let (fetched_content, fetched_content_type) = client.vault_get(&main_key).await?;
     println!("2KB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, update_content_2_kb);
@@ -78,7 +78,7 @@ async fn vault_expand() -> Result<()> {
     // Update content to 10MB. Shall only incur cost paying two extra Scratchpad.
     let update_content_10_mb = gen_random_data(10 * 1024 * 1024);
     let cost = client
-        .write_bytes_to_vault(
+        .vault_put(
             update_content_10_mb.clone(),
             wallet.into(),
             &main_key,
@@ -91,7 +91,7 @@ async fn vault_expand() -> Result<()> {
     // Short break is required to avoid client choked by the last query round
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-    let (fetched_content, fetched_content_type) = client.fetch_and_decrypt_vault(&main_key).await?;
+    let (fetched_content, fetched_content_type) = client.vault_get(&main_key).await?;
     println!("10MB Vault fetched");
     assert_eq!(fetched_content_type, content_type);
     assert_eq!(fetched_content, update_content_10_mb);


### PR DESCRIPTION
Consistent Vault Function Naming Fixes #2995 
Updated vault functions to follow {datatype}_{action} naming pattern
New names:
fetch_and_decrypt_vault → vault_get
write_bytes_to_vault → vault_put
get_user_data_from_vault → vault_get_user_data
put_user_data_to_vault → vault_put_user_data
Added backward compatibility functions with deprecation warnings
Updated all references across CLI, Python bindings, Node.js bindings, and tests