### PR TITLE
test: self_encryption backward compatible test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -131,9 +131,9 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release --package autonomi --doc
 
-      - name: Run autonomi self_encryption backward_compatibility tests
+      - name: Run autonomi self_encryption backward_compatibility unit tests
         timeout-minutes: 25
-        run: cargo test --release backward_compatibility
+        run: cargo test --release test_self_encryption_backward_compatibility
 
       - name: Run bootstrap tests
         timeout-minutes: 25

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -131,6 +131,10 @@ jobs:
         timeout-minutes: 25
         run: cargo test --release --package autonomi --doc
 
+      - name: Run autonomi self_encryption backward_compatibility tests
+        timeout-minutes: 25
+        run: cargo test --release backward_compatibility
+
       - name: Run bootstrap tests
         timeout-minutes: 25
         run: cargo test --release --package ant-bootstrap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.22",
  "rmp-serde",
- "self_encryption",
+ "self_encryption 0.30.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1615,7 +1615,8 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rmp-serde",
- "self_encryption",
+ "self_encryption 0.30.0",
+ "self_encryption 0.31.0",
  "serde",
  "serial_test",
  "sha2",
@@ -8498,6 +8499,27 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
+ "tokio",
+ "xor_name",
+]
+
+[[package]]
+name = "self_encryption"
+version = "0.31.0"
+source = "git+https://github.com/maidsafe/self_encryption.git?branch=master#be94cb46afe060fdff6edad6766235214e9d4f89"
+dependencies = [
+ "aes",
+ "bincode",
+ "brotli",
+ "bytes",
+ "cbc",
+ "hex",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "xor_name",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.22",
  "rmp-serde",
- "self_encryption 0.30.0",
+ "self_encryption 0.32.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1616,7 +1616,7 @@ dependencies = [
  "rayon",
  "rmp-serde",
  "self_encryption 0.30.0",
- "self_encryption 0.31.0",
+ "self_encryption 0.32.0",
  "serde",
  "serial_test",
  "sha2",
@@ -8505,8 +8505,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.31.0"
-source = "git+https://github.com/maidsafe/self_encryption.git?branch=master#be94cb46afe060fdff6edad6766235214e9d4f89"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f865256fc2075a28be19d56944f68b552076088c5ccc072db0c8626599ca35b6"
 dependencies = [
  "aes",
  "bincode",

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -59,6 +59,7 @@ pub(crate) fn get_error_exit_code(err: &GetError) -> i32 {
         GetError::RecordNotFound => 33,
         GetError::RecordKindMismatch(_) => 34,
         GetError::Configuration(_) => 35,
+        GetError::UnrecognizedDataMap(_) => 31,
     }
 }
 

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -78,7 +78,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
 sha2 = "0.10"
-self_encryption = "~0.30.0"
+self_encryption = "~0.32.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 strum = { version = "0.26.2", features = ["derive"] }
 sysinfo = { version = "0.30.8", default-features = false, optional = true }

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -48,7 +48,7 @@ const POINTER_CREATION_RATIO_TO_CHURN: u32 = 11;
 const SCRATCHPAD_CREATION_RATIO_TO_CHURN: u32 = 9;
 const GRAPHENTRY_CREATION_RATIO_TO_CHURN: u32 = 7;
 
-static DATA_SIZE: LazyLock<usize> = LazyLock::new(|| *MAX_CHUNK_SIZE / 3);
+static DATA_SIZE: LazyLock<usize> = LazyLock::new(|| MAX_CHUNK_SIZE / 3);
 
 const CONTENT_QUERY_RATIO_TO_CHURN: u32 = 40;
 const MAX_NUM_OF_QUERY_ATTEMPTS: u8 = 5;

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -64,7 +64,7 @@ pyo3-async-runtimes = { version = "0.23", optional = true, features = ["tokio-ru
 rand = "0.8.5"
 rayon = "1.8.0"
 rmp-serde = "1.1.1"
-self_encryption = "~0.30.0"
+self_encryption = "~0.32.0"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sha2 = "0.10.6"
 thiserror = "1.0.23"
@@ -86,7 +86,7 @@ sha2 = "0.10.6"
 test-utils = { path = "../test-utils" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Older version of self_encryption for backward compatibility testing
-self_encryption_old = { package = "self_encryption", git = "https://github.com/maidsafe/self_encryption.git", branch = "master"}
+self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 
 [lints]
 workspace = true

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -85,6 +85,8 @@ sha2 = "0.10.6"
 # Removing the version field is a workaround.
 test-utils = { path = "../test-utils" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Older version of self_encryption for backward compatibility testing
+self_encryption_old = { package = "self_encryption", git = "https://github.com/maidsafe/self_encryption.git", branch = "master"}
 
 [lints]
 workspace = true

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -65,6 +65,8 @@ rand = "0.8.5"
 rayon = "1.8.0"
 rmp-serde = "1.1.1"
 self_encryption = "~0.32.0"
+# Older version of self_encryption for backward compatibility
+self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sha2 = "0.10.6"
 thiserror = "1.0.23"
@@ -85,8 +87,6 @@ sha2 = "0.10.6"
 # Removing the version field is a workaround.
 test-utils = { path = "../test-utils" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Older version of self_encryption for backward compatibility testing
-self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 
 [lints]
 workspace = true

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -28,7 +28,7 @@ use ant_protocol::{
 };
 use bytes::Bytes;
 use libp2p::kad::Record;
-use self_encryption::{DataMap, EncryptedChunk, decrypt_full_set};
+use self_encryption::{DataMap, EncryptedChunk, decrypt};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -527,7 +527,6 @@ impl Client {
                         println!("Fetching chunk {idx}/{total_chunks} [DONE]");
                         info!("Successfully fetched chunk {idx}/{total_chunks}({chunk_addr:?})");
                         Ok(EncryptedChunk {
-                            index: info.index,
                             content: chunk.value,
                         })
                     }
@@ -551,7 +550,7 @@ impl Client {
         println!("Successfully fetched all {total_chunks} encrypted chunks");
         debug!("Successfully fetched all {total_chunks} encrypted chunks");
 
-        let data = decrypt_full_set(data_map, &encrypted_chunks).map_err(|e| {
+        let data = decrypt(data_map, &encrypted_chunks).map_err(|e| {
             error!("Error decrypting encrypted_chunks: {e:?}");
             GetError::Decryption(crate::self_encryption::Error::SelfEncryption(e))
         })?;

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -470,16 +470,64 @@ impl Client {
         Ok(*chunk.address())
     }
 
-    #[allow(dead_code)]
-    /// Unpack a wrapped data map and fetch all bytes using self-encryption.
-    pub(crate) async fn fetch_from_data_map_chunk_old(
+    /// Generic function to unpack a wrapped data map and fetch all bytes using self-encryption.
+    /// This function automatically detects whether the data map is in the old format (DataMapLevel)
+    /// or new format (DataMap) and calls the appropriate handler for backward compatibility.
+    pub(crate) async fn fetch_from_data_map_chunk(
         &self,
         data_map_bytes: &Bytes,
     ) -> Result<Bytes, GetError> {
-        let mut data_map_level: DataMapLevel = rmp_serde::from_slice(data_map_bytes)
-            .map_err(GetError::InvalidDataMap)
-            .inspect_err(|err| error!("Error deserializing data map: {err:?}"))?;
+        debug!(
+            "Attempting to detect data map format from {} bytes",
+            data_map_bytes.len()
+        );
 
+        // Try to deserialize as new format (DataMap) first
+        let new_format_result = rmp_serde::from_slice::<DataMap>(data_map_bytes);
+        match new_format_result {
+            Ok(data_map) => {
+                info!(
+                    "Successfully detected new DataMap format with {} chunk infos",
+                    data_map.infos().len()
+                );
+                debug!("Using new format handler for DataMap");
+                self.fetch_from_data_map_chunk_new(data_map).await
+            }
+            Err(new_err) => {
+                debug!("Failed to deserialize as new DataMap format: {new_err:?}");
+
+                // If new format fails, try old format (DataMapLevel)
+                let old_format_result = rmp_serde::from_slice::<DataMapLevel>(data_map_bytes);
+                match old_format_result {
+                    Ok(data_map_level) => {
+                        info!("Successfully detected old DataMapLevel format");
+                        debug!("Using old format handler for DataMapLevel");
+                        self.fetch_from_data_map_chunk_old(data_map_level).await
+                    }
+                    Err(old_err) => {
+                        error!("Failed to deserialize data map as either format:");
+                        error!("  New format (DataMap) error: {new_err:?}");
+                        error!("  Old format (DataMapLevel) error: {old_err:?}");
+                        error!("  Data map bytes length: {}", data_map_bytes.len());
+                        error!(
+                            "  Data map bytes (first 100 bytes): {:?}",
+                            &data_map_bytes[..std::cmp::min(100, data_map_bytes.len())]
+                        );
+
+                        Err(GetError::UnrecognizedDataMap(format!(
+                            "Data map format not recognized. New format error: {new_err:?}, Old format error: {old_err:?}"
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Unpack a wrapped data map and fetch all bytes using self-encryption (old format).
+    async fn fetch_from_data_map_chunk_old(
+        &self,
+        mut data_map_level: DataMapLevel,
+    ) -> Result<Bytes, GetError> {
         loop {
             let data_map = match &data_map_level {
                 DataMapLevel::First(map) => map,
@@ -500,22 +548,17 @@ impl Client {
         }
     }
 
-    /// Unpack a wrapped data map and fetch all bytes using self-encryption.
-    pub(crate) async fn fetch_from_data_map_chunk(
+    // self_encryption now changed to always return a data_map pointing to the 3 datamap_chunks.
+    // Hence, the input data_map_bytes is actually the root_data_map pointing to that 3 datamap_chunks.
+    // The downloading work flow then shall be:
+    //   * fetch that 3 datamap_chunks first
+    //   * compose the real datamap of the file, from that 3 datamap_chunks
+    //   * repeat the above two steps if the recovered data_map contains chiled
+    //   * fetch the leftover content chunks to compose the file
+    async fn fetch_from_data_map_chunk_new(
         &self,
-        root_data_map_bytes: &Bytes,
+        root_data_map: DataMap,
     ) -> Result<Bytes, GetError> {
-        // self_encryption now changed to always return a data_map pointing to the 3 datamap_chunks.
-        // Hence, the input data_map_bytes is actually the root_data_map pointing to that 3 datamap_chunks.
-        // The downloading work flow then shall be:
-        //   * fetch that 3 datamap_chunks first
-        //   * compose the real datamap of the file, from that 3 datamap_chunks
-        //   * repeat the above two steps if the recovered data_map contains chiled
-        //   * fetch the leftover content chunks to compose the file
-        let root_data_map: DataMap = rmp_serde::from_slice(root_data_map_bytes)
-            .map_err(GetError::InvalidDataMap)
-            .inspect_err(|err| error!("Error deserializing data map: {err:?}"))?;
-
         let file_data_map = self.fetch_data_map(&root_data_map)?;
         debug!("Fetched file_data_map: {file_data_map:?}");
         let data_bytes = self.fetch_from_data_map(&file_data_map).await?;
@@ -524,11 +567,13 @@ impl Client {
 
     /// Fetch and decrypt file data_map from the root one using lazy evaluation.
     /// Chunks are only fetched from the network when actually needed by get_root_data_map.
-    pub(crate) fn fetch_data_map(&self, data_map: &DataMap) -> Result<DataMap, GetError> {
+    fn fetch_data_map(&self, data_map: &DataMap) -> Result<DataMap, GetError> {
         let total_chunks = data_map.infos().len();
         #[cfg(feature = "loud")]
-        println!("Setting up lazy chunk fetching for {total_chunks} chunks.");
-        debug!("Setting up lazy chunk fetching for data map {data_map:?}");
+        println!(
+            "Setting up lazy chunk fetching for {total_chunks} chunks of data_map {data_map:?}"
+        );
+        debug!("Setting up lazy chunk fetching for {total_chunks} chunks of data_map {data_map:?}");
 
         // Create a closure that fetches chunks on-demand
         let client = self.clone();
@@ -573,7 +618,7 @@ impl Client {
     }
 
     /// Fetch and decrypt all chunks in the data map.
-    pub(crate) async fn fetch_from_data_map(&self, data_map: &DataMap) -> Result<Bytes, GetError> {
+    async fn fetch_from_data_map(&self, data_map: &DataMap) -> Result<Bytes, GetError> {
         let total_chunks = data_map.infos().len();
         #[cfg(feature = "loud")]
         println!("Fetching {total_chunks} encrypted data chunks from network.");

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -167,6 +167,8 @@ pub enum GetError {
     RecordKindMismatch(RecordKind),
     #[error("Configuration error: {0}")]
     Configuration(String),
+    #[error("Unable to recogonize the so claimed DataMap: {0}")]
+    UnrecognizedDataMap(String),
 }
 
 impl Client {

--- a/autonomi/src/self_encryption.rs
+++ b/autonomi/src/self_encryption.rs
@@ -9,9 +9,9 @@
 use ant_protocol::storage::Chunk;
 use bytes::{BufMut, Bytes, BytesMut};
 use rayon::prelude::*;
-use self_encryption::{DataMap, MAX_CHUNK_SIZE};
+use self_encryption::DataMap;
+use self_encryption_old::DataMap as OldDataMap;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -22,13 +22,13 @@ pub enum Error {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) enum DataMapLevel {
+pub enum DataMapLevel {
     // Holds the data map to the source data.
-    First(DataMap),
+    First(OldDataMap),
     // Holds the data map of an _additional_ level of chunks
     // resulting from chunking up a previous level data map.
     // This happens when that previous level data map was too big to fit in a chunk itself.
-    Additional(DataMap),
+    Additional(OldDataMap),
 }
 
 pub fn encrypt(data: Bytes) -> Result<(Chunk, Vec<Chunk>), Error> {
@@ -44,74 +44,12 @@ pub fn encrypt(data: Bytes) -> Result<(Chunk, Vec<Chunk>), Error> {
     Ok((data_map_chunk, chunks))
 }
 
-pub fn encrypt_old(data: Bytes) -> Result<(Chunk, Vec<Chunk>), Error> {
-    let (data_map, chunks) = self_encryption::encrypt(data)?;
-    let (data_map_chunk, additional_chunks) = pack_data_map_old(data_map)?;
-
-    // Transform `EncryptedChunk` into `Chunk`
-    let chunks: Vec<Chunk> = chunks
-        .into_par_iter()
-        .map(|c| Chunk::new(c.content.clone()))
-        .chain(additional_chunks)
-        .collect();
-
-    Ok((data_map_chunk, chunks))
-}
-
 // Produces a chunk out of the first `DataMap`, which is validated for its size.
 // self-encryption now returns the root_data_map only, which points to the three datamap_chunks.
 // Hence guaranteed can be packed into one chunk.
 fn pack_data_map(data_map: DataMap) -> Result<Chunk, Error> {
     let chunk_content = wrap_data_map(&data_map)?;
     Ok(Chunk::new(chunk_content))
-}
-
-// Produces a chunk out of the first `DataMap`, which is validated for its size.
-// If the chunk is too big, it is self-encrypted and the resulting (additional level) `DataMap` is put into a chunk.
-// The above step is repeated as many times as required until the chunk size is valid.
-// In other words: If the chunk content is too big, it will be
-// self encrypted into additional chunks, and now we have a new `DataMap`
-// which points to all of those additional chunks.. and so on.
-fn pack_data_map_old(data_map: DataMap) -> Result<(Chunk, Vec<Chunk>), Error> {
-    let mut chunks = vec![];
-    let mut chunk_content = wrap_data_map_old(&DataMapLevel::First(data_map))?;
-
-    let (data_map_chunk, additional_chunks) = loop {
-        debug!("Max chunk size: {}", MAX_CHUNK_SIZE);
-        let chunk = Chunk::new(chunk_content);
-        // If datamap chunk is less than `MAX_CHUNK_SIZE` return it so it can be directly sent to the network.
-        if MAX_CHUNK_SIZE >= chunk.size() {
-            chunks.reverse();
-            // Returns the last datamap, and all the chunks produced.
-            break (chunk, chunks);
-        } else {
-            let mut bytes = BytesMut::with_capacity(MAX_CHUNK_SIZE).writer();
-            let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
-            chunk.serialize(&mut serialiser)?;
-            let serialized_chunk = bytes.into_inner().freeze();
-
-            let (data_map, next_encrypted_chunks) = self_encryption::encrypt(serialized_chunk)
-                .inspect_err(|err| error!("Failed to encrypt chunks: {err:?}"))?;
-            chunks = next_encrypted_chunks
-                .iter()
-                .map(|c| Chunk::new(c.content.clone())) // no need to encrypt what is self-encrypted
-                .chain(chunks)
-                .collect();
-            chunk_content = wrap_data_map_old(&DataMapLevel::Additional(data_map))?;
-        }
-    };
-
-    Ok((data_map_chunk, additional_chunks))
-}
-
-fn wrap_data_map_old(data_map: &DataMapLevel) -> Result<Bytes, rmp_serde::encode::Error> {
-    // we use an initial/starting size of 300 bytes as that's roughly the current size of a DataMapLevel instance.
-    let mut bytes = BytesMut::with_capacity(300).writer();
-    let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
-    data_map
-        .serialize(&mut serialiser)
-        .inspect_err(|err| error!("Failed to serialize data map: {err:?}"))?;
-    Ok(bytes.into_inner().freeze())
 }
 
 fn wrap_data_map(data_map: &DataMap) -> Result<Bytes, rmp_serde::encode::Error> {

--- a/autonomi/src/self_encryption.rs
+++ b/autonomi/src/self_encryption.rs
@@ -56,15 +56,15 @@ fn pack_data_map(data_map: DataMap) -> Result<(Chunk, Vec<Chunk>), Error> {
     let mut chunk_content = wrap_data_map(&DataMapLevel::First(data_map))?;
 
     let (data_map_chunk, additional_chunks) = loop {
-        debug!("Max chunk size: {}", *MAX_CHUNK_SIZE);
+        debug!("Max chunk size: {}", MAX_CHUNK_SIZE);
         let chunk = Chunk::new(chunk_content);
         // If datamap chunk is less than `MAX_CHUNK_SIZE` return it so it can be directly sent to the network.
-        if *MAX_CHUNK_SIZE >= chunk.size() {
+        if MAX_CHUNK_SIZE >= chunk.size() {
             chunks.reverse();
             // Returns the last datamap, and all the chunks produced.
             break (chunk, chunks);
         } else {
-            let mut bytes = BytesMut::with_capacity(*MAX_CHUNK_SIZE).writer();
+            let mut bytes = BytesMut::with_capacity(MAX_CHUNK_SIZE).writer();
             let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
             chunk.serialize(&mut serialiser)?;
             let serialized_chunk = bytes.into_inner().freeze();

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -81,8 +81,7 @@ async fn test_analyze_public_data() -> Result<()> {
 
     let analysis = client.analyze_address(&public_data_addr, true).await?;
     println!("Analysis: {analysis}");
-    // now data_map chunks are stored as normal Chunk
-    assert!(matches!(analysis, Analysis::Chunk(_)));
+    assert!(matches!(analysis, Analysis::DataMap { .. }));
     Ok(())
 }
 
@@ -243,8 +242,7 @@ async fn test_analyze_public_dir() -> Result<()> {
 
     let analysis = client.analyze_address(&archive_addr_str, true).await?;
     println!("Analysis: {analysis}");
-    // now data_map chunks are stored as normal Chunk
-    assert!(matches!(analysis, Analysis::Chunk(..)));
+    assert!(matches!(analysis, Analysis::PublicArchive { .. }));
 
     Ok(())
 }

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -81,7 +81,8 @@ async fn test_analyze_public_data() -> Result<()> {
 
     let analysis = client.analyze_address(&public_data_addr, true).await?;
     println!("Analysis: {analysis}");
-    assert!(matches!(analysis, Analysis::DataMap { .. }));
+    // now data_map chunks are stored as normal Chunk
+    assert!(matches!(analysis, Analysis::Chunk(_)));
     Ok(())
 }
 
@@ -242,7 +243,8 @@ async fn test_analyze_public_dir() -> Result<()> {
 
     let analysis = client.analyze_address(&archive_addr_str, true).await?;
     println!("Analysis: {analysis}");
-    assert!(matches!(analysis, Analysis::PublicArchive { .. }));
+    // now data_map chunks are stored as normal Chunk
+    assert!(matches!(analysis, Analysis::Chunk(..)));
 
     Ok(())
 }

--- a/autonomi/tests/backward_compatibility.rs
+++ b/autonomi/tests/backward_compatibility.rs
@@ -1,0 +1,60 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bytes::Bytes;
+use self_encryption::{encrypt, MAX_CHUNK_SIZE};
+use self_encryption_old::{decrypt as old_decrypt, ChunkInfo as OldChunkInfo, DataMap as OldDataMap, EncryptedChunk as OldEncryptedChunk};
+
+/// Test backward compatibility between old and new self_encryption versions
+/// 
+/// This test verifies that data encrypted with version (0.30.0) can be
+/// decrypted with the new version.
+#[test]
+fn test_self_encryption_backward_compatibility() -> Result<(), Box<dyn std::error::Error>> {
+    // Test 1: Encrypt with old version, decrypt with new version
+    // TODO: switch to this once new self_encryption released and integrated into autonomi
+    // test_old_encrypt_new_decrypt()?;
+    
+    // Test 2: Encrypt with new version, decrypt with old version 
+    // TODO: remove this once new self_encryption released and integrated into autonomi
+    test_new_encrypt_old_decrypt()?;
+    
+    Ok(())
+}
+
+/// Test encrypting data with new version and decrypting with old version
+fn test_new_encrypt_old_decrypt() -> Result<(), Box<dyn std::error::Error>> {
+    let content_size: usize = 20 * *MAX_CHUNK_SIZE + 100;
+    let mut content = vec![0u8; content_size];
+    for (i, c) in content.iter_mut().enumerate().take(content_size) {
+        *c = (i % 17) as u8;
+    }
+    let content_bytes = Bytes::from(content);
+
+    let (data_map, encrypted_chunks) = encrypt(content_bytes.clone())?;
+
+    // Convert new format of DataMap and EncryptedChunk into old
+    let chunk_identifiers: Vec<OldChunkInfo> = data_map.infos().iter().map(|ck_info| OldChunkInfo {
+        index: ck_info.index,
+        dst_hash: ck_info.dst_hash,
+        src_hash: ck_info.src_hash,
+        src_size: ck_info.src_size,
+    }).collect();
+    let old_data_map = OldDataMap {
+        chunk_identifiers,
+        child: None,
+    };
+    let old_encrypted_chunks: Vec<OldEncryptedChunk> = encrypted_chunks.iter().map(|enc| OldEncryptedChunk {
+        content: enc.content.clone(),
+    }).collect();
+
+    let decrypted_content = old_decrypt(&old_data_map, &old_encrypted_chunks)?;
+
+    assert_eq!(decrypted_content, content_bytes);
+    Ok(())
+}

--- a/autonomi/tests/backward_compatibility.rs
+++ b/autonomi/tests/backward_compatibility.rs
@@ -7,53 +7,55 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use bytes::Bytes;
-use self_encryption::{encrypt, MAX_CHUNK_SIZE};
-use self_encryption_old::{decrypt as old_decrypt, ChunkInfo as OldChunkInfo, DataMap as OldDataMap, EncryptedChunk as OldEncryptedChunk};
+use self_encryption::{ChunkInfo, DataMap, EncryptedChunk, MAX_CHUNK_SIZE, decrypt};
+use self_encryption_old::encrypt as old_encrypt;
 
 /// Test backward compatibility between old and new self_encryption versions
-/// 
+///
 /// This test verifies that data encrypted with version (0.30.0) can be
 /// decrypted with the new version.
 #[test]
 fn test_self_encryption_backward_compatibility() -> Result<(), Box<dyn std::error::Error>> {
-    // Test 1: Encrypt with old version, decrypt with new version
-    // TODO: switch to this once new self_encryption released and integrated into autonomi
-    // test_old_encrypt_new_decrypt()?;
-    
-    // Test 2: Encrypt with new version, decrypt with old version 
-    // TODO: remove this once new self_encryption released and integrated into autonomi
-    test_new_encrypt_old_decrypt()?;
-    
+    // Test 1 Encrypt with old version, decrypt with new version
+    test_old_encrypt_new_decrypt()?;
+
     Ok(())
 }
 
 /// Test encrypting data with new version and decrypting with old version
-fn test_new_encrypt_old_decrypt() -> Result<(), Box<dyn std::error::Error>> {
-    let content_size: usize = 20 * *MAX_CHUNK_SIZE + 100;
+fn test_old_encrypt_new_decrypt() -> Result<(), Box<dyn std::error::Error>> {
+    let content_size: usize = 20 * MAX_CHUNK_SIZE + 100;
     let mut content = vec![0u8; content_size];
     for (i, c) in content.iter_mut().enumerate().take(content_size) {
         *c = (i % 17) as u8;
     }
     let content_bytes = Bytes::from(content);
 
-    let (data_map, encrypted_chunks) = encrypt(content_bytes.clone())?;
+    let (old_data_map, old_encrypted_chunks) = old_encrypt(content_bytes.clone())?;
 
-    // Convert new format of DataMap and EncryptedChunk into old
-    let chunk_identifiers: Vec<OldChunkInfo> = data_map.infos().iter().map(|ck_info| OldChunkInfo {
-        index: ck_info.index,
-        dst_hash: ck_info.dst_hash,
-        src_hash: ck_info.src_hash,
-        src_size: ck_info.src_size,
-    }).collect();
-    let old_data_map = OldDataMap {
+    // Convert old format of DataMap and EncryptedChunk into new
+    let chunk_identifiers: Vec<ChunkInfo> = old_data_map
+        .infos()
+        .iter()
+        .map(|ck_info| ChunkInfo {
+            index: ck_info.index,
+            dst_hash: ck_info.dst_hash,
+            src_hash: ck_info.src_hash,
+            src_size: ck_info.src_size,
+        })
+        .collect();
+    let data_map = DataMap {
         chunk_identifiers,
         child: None,
     };
-    let old_encrypted_chunks: Vec<OldEncryptedChunk> = encrypted_chunks.iter().map(|enc| OldEncryptedChunk {
-        content: enc.content.clone(),
-    }).collect();
+    let encrypted_chunks: Vec<EncryptedChunk> = old_encrypted_chunks
+        .iter()
+        .map(|enc| EncryptedChunk {
+            content: enc.content.clone(),
+        })
+        .collect();
 
-    let decrypted_content = old_decrypt(&old_data_map, &old_encrypted_chunks)?;
+    let decrypted_content = decrypt(&data_map, &encrypted_chunks)?;
 
     assert_eq!(decrypted_content, content_bytes);
     Ok(())

--- a/autonomi/tests/backward_compatibility.rs
+++ b/autonomi/tests/backward_compatibility.rs
@@ -6,9 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use bytes::Bytes;
+use autonomi::self_encryption::DataMapLevel;
+use bytes::{BufMut, Bytes, BytesMut};
 use self_encryption::{ChunkInfo, DataMap, EncryptedChunk, MAX_CHUNK_SIZE, decrypt};
 use self_encryption_old::encrypt as old_encrypt;
+use serde::Serialize;
+use tracing::error;
 
 /// Test backward compatibility between old and new self_encryption versions
 ///
@@ -59,4 +62,99 @@ fn test_old_encrypt_new_decrypt() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(decrypted_content, content_bytes);
     Ok(())
+}
+
+/// Comprehensive E2E test for backward compatibility involving network operations.
+/// This test verifies that data encrypted with old self_encryption can be uploaded
+/// to the network and then downloaded and decrypted using the new self_encryption.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_backward_compatibility_e2e_network() -> Result<(), Box<dyn std::error::Error>> {
+    use ant_logging::LogBuilder;
+    use autonomi::client::payment::PaymentOption;
+    use autonomi::{Chunk, Client};
+    use test_utils::evm::get_funded_wallet;
+
+    // Initialize logging for the test
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test();
+
+    // Step 1: Setup client and payment (like test_analyze_chunk)
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+    let payment_option = PaymentOption::from(&wallet);
+
+    // Step 2: Generate test data and encrypt using old self_encryption way
+    let content_size: usize = 20 * MAX_CHUNK_SIZE + 100;
+    let mut content = vec![0u8; content_size];
+    for (i, c) in content.iter_mut().enumerate().take(content_size) {
+        *c = (i % 17) as u8;
+    }
+    let content_bytes = Bytes::from(content);
+
+    println!("Original content length: {} bytes", content_bytes.len());
+
+    // Use old self_encryption to generate data_map and chunks
+    let (old_data_map, old_encrypted_chunks) = old_encrypt(content_bytes.clone())?;
+
+    println!("Generated {} encrypted chunks", old_encrypted_chunks.len());
+    println!("Data map generated: {old_data_map:?}");
+
+    // Step 3: Pack the generated data_map using old methods to create data_map_bytes
+    let data_map_bytes = wrap_data_map_old(&DataMapLevel::First(old_data_map))?;
+    println!("Data map bytes length: {} bytes", data_map_bytes.len());
+
+    // Step 4: Upload all generated chunks to network (like test_analyze_chunk)
+    let chunks: Vec<Chunk> = old_encrypted_chunks
+        .iter()
+        .map(|enc| Chunk::new(enc.content.clone()))
+        .collect();
+    println!("Uploading {} encrypted chunks...", chunks.len());
+    let mut chunk_addresses = Vec::new();
+    for (i, chunk) in chunks.iter().enumerate() {
+        let (_cost, addr) = client.chunk_put(chunk, payment_option.clone()).await?;
+        chunk_addresses.push(addr);
+        println!(
+            "Uploaded chunk {}/{} to address: {}",
+            i + 1,
+            chunks.len(),
+            addr.to_hex()
+        );
+    }
+
+    // Step 5: Wait for data replication
+    println!("Waiting for data replication...");
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    // Step 6: Download the content back by calling fetch_from_data_map_chunk function
+    println!("Downloading and decrypting content using backward-compatible function...");
+    let decrypted_content = client.fetch_from_data_map_chunk(&data_map_bytes).await?;
+
+    println!(
+        "Downloaded content length: {} bytes",
+        decrypted_content.len()
+    );
+
+    // Step 7: Compare the fetched content with the original content
+    println!("Comparing original and downloaded content...");
+    assert_eq!(
+        decrypted_content, content_bytes,
+        "Downloaded content does not match original content"
+    );
+
+    println!("✅ Backward compatibility E2E network test: SUCCESS");
+    println!(
+        "Successfully uploaded data using old self_encryption format and downloaded/decrypted using new format"
+    );
+
+    Ok(())
+}
+
+fn wrap_data_map_old(data_map: &DataMapLevel) -> Result<Bytes, rmp_serde::encode::Error> {
+    // we use an initial/starting size of 300 bytes as that's roughly the current size of a DataMapLevel instance.
+    let mut bytes = BytesMut::with_capacity(300).writer();
+    let mut serialiser = rmp_serde::Serializer::new(&mut bytes);
+    data_map
+        .serialize(&mut serialiser)
+        .inspect_err(|err| error!("Failed to serialize data map: {err:?}"))?;
+    Ok(bytes.into_inner().freeze())
 }


### PR DESCRIPTION
### Description

* integrate newly released self_encryption
* backward compatible facility to support old data_map scheme
* self_encryption backward compatible unit test and e2e test

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
