### PR TITLE
fix(autonomi): retry failed chunks from the final / only batch

### DIFF
--- a/autonomi/src/client/high_level/data/helpers.rs
+++ b/autonomi/src/client/high_level/data/helpers.rs
@@ -260,14 +260,16 @@ impl Client {
         {
             Ok((receipt, free_chunks)) => (receipt, free_chunks),
             Err(err) if matches!(err, EvmWalletError(InsufficientTokensForQuotes(_, _))) => {
+                error!("Insufficient tokens: {err:?}. Returning immediately.");
                 return (vec![], vec![], 0, Some(PutError::from(err)));
             }
             Err(err) => {
                 return if retry_on_failure {
-                    info!("Quoting or payment error encountered, retry scheduled {err:?}");
+                    error!("Quoting or payment error encountered, retry scheduled {err:?}");
                     println!("Quoting or payment error encountered, retry scheduled.");
                     (batch, vec![], 0, None)
                 } else {
+                    error!("Quoting or payment error encountered, no retry scheduled {err:?}");
                     (vec![], vec![], 0, Some(PutError::from(err)))
                 };
             }


### PR DESCRIPTION
The exit condition of the while loop was not correct. It would exit if there was no new batch of chunks from the original batch schedule, but it didn't take into account any failed chunks. So if we had any failed chunks in the last batch or the first and only batch (usual for smaller files), they were just tossed and reported the upload as succeeded.

The fix also includes adding an early return for the insufficient tokens error as there is no point retrying in that case.