### PR TITLE
fix: store single file upload access locally

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -463,12 +463,27 @@ jobs:
 
           ./target/release/ant --log-output-dest data-dir --local file list 2>&1 > file_list.txt
 
-          NUM_OF_PUBLIC_FILES=`cat file_list.txt | grep "public" | grep -o '[0-9]\+'`
-          NUM_OF_PRIVATE_FILES=`cat file_list.txt | grep "private" | grep -o '[0-9]\+'`
+          # Extract and sum public file archive(s) and public file(s) counts
+          PUBLIC_ARCHIVES=`cat file_list.txt | grep "public file archive" | grep -o '[0-9]\+' | head -1`
+          PUBLIC_FILES=`cat file_list.txt | grep "public file(s)" | grep -o '[0-9]\+' | head -1`
+          NUM_OF_PUBLIC_FILES=$((${PUBLIC_ARCHIVES:-0} + ${PUBLIC_FILES:-0}))
+          
+          # Extract and sum private file archive(s) and private file(s) counts  
+          PRIVATE_ARCHIVES=`cat file_list.txt | grep "private file archive" | grep -o '[0-9]\+' | head -1`
+          PRIVATE_FILES=`cat file_list.txt | grep "private file(s)" | grep -o '[0-9]\+' | head -1`
+          NUM_OF_PRIVATE_FILES=$((${PRIVATE_ARCHIVES:-0} + ${PRIVATE_FILES:-0}))
+          
           ./target/release/ant --log-output-dest data-dir --local vault load 2>&1 > vault_data.txt
 
-          NUM_OF_PUBLIC_FILES_IN_VAULT=`cat vault_data.txt  | grep "public" | grep -o '[0-9]\+'`
-          NUM_OF_PRIVATE_FILES_IN_VAULT=`cat vault_data.txt| grep "private" | grep -o '[0-9]\+'`
+          # Extract and sum vault public file archive(s) and public file(s) counts
+          VAULT_PUBLIC_ARCHIVES=`cat vault_data.txt | grep "public file archive" | grep -o '[0-9]\+' | head -1`
+          VAULT_PUBLIC_FILES=`cat vault_data.txt | grep "public file(s)" | grep -o '[0-9]\+' | head -1`
+          NUM_OF_PUBLIC_FILES_IN_VAULT=$((${VAULT_PUBLIC_ARCHIVES:-0} + ${VAULT_PUBLIC_FILES:-0}))
+          
+          # Extract and sum vault private file archive(s) and private file(s) counts
+          VAULT_PRIVATE_ARCHIVES=`cat vault_data.txt | grep "private file archive" | grep -o '[0-9]\+' | head -1`
+          VAULT_PRIVATE_FILES=`cat vault_data.txt | grep "private file(s)" | grep -o '[0-9]\+' | head -1`
+          NUM_OF_PRIVATE_FILES_IN_VAULT=$((${VAULT_PRIVATE_ARCHIVES:-0} + ${VAULT_PRIVATE_FILES:-0}))
 
           echo "Total Num of local public files is $NUM_OF_PUBLIC_FILES and in vault is $NUM_OF_PUBLIC_FILES_IN_VAULT"
           echo "Total Num of local private files is $NUM_OF_PRIVATE_FILES and in vault is $NUM_OF_PRIVATE_FILES_IN_VAULT"
@@ -498,33 +513,49 @@ jobs:
         shell: python
         run: |
           import re
-          def find_number_before_word(file_name, search_word):
+          def find_number_before_phrase(file_name, search_phrase):
               """
-              Reads a file and finds the number immediately preceding a specified word in a line.
+              Reads a file and finds the number immediately preceding a specified phrase in a line.
 
               :param file_name: Name of the file to read.
-              :param search_word: Word to search for in the file.
-              :return: The number before the word as an integer, or None if not found.
+              :param search_phrase: Phrase to search for in the file.
+              :return: The number before the phrase as an integer, or 0 if not found.
               """
               try:
                   with open(file_name, 'r') as file:
                       for line in file:
-                          if search_word in line:
-                              match = re.search(r'(\d+)\s+' + re.escape(search_word), line)
+                          if search_phrase in line:
+                              match = re.search(r'(\d+)\s+' + re.escape(search_phrase), line)
                               if match:
                                   return int(match.group(1))  # Convert to integer
-                  return None  # Return None if no match is found
+                  return 0  # Return 0 if no match is found
               except FileNotFoundError:
                   print(f"Error: File '{file_name}' not found.")
-                  return None
-          NUM_OF_PUBLIC_FILES = find_number_before_word("file_list.txt", "public")
-          print("NUM_OF_PUBLIC_FILES:", NUM_OF_PUBLIC_FILES)
-          NUM_OF_PRIVATE_FILES = find_number_before_word("file_list.txt", "private")
-          print("NUM_OF_PRIVATE_FILES:", NUM_OF_PRIVATE_FILES)
-          NUM_OF_PUBLIC_FILES_IN_VAULT = find_number_before_word("vault_data.txt", "public")
-          print("NUM_OF_PUBLIC_FILES_IN_VAULT:", NUM_OF_PUBLIC_FILES_IN_VAULT)
-          NUM_OF_PRIVATE_FILES_IN_VAULT = find_number_before_word("vault_data.txt", "private")
-          print("NUM_OF_PRIVATE_FILES_IN_VAULT:", NUM_OF_PRIVATE_FILES_IN_VAULT)
+                  return 0
+
+          # Extract and sum public file archive(s) and public file(s) counts
+          public_archives = find_number_before_phrase("file_list.txt", "public file archive")
+          public_files = find_number_before_phrase("file_list.txt", "public file(s)")  
+          NUM_OF_PUBLIC_FILES = public_archives + public_files
+          print("NUM_OF_PUBLIC_FILES:", NUM_OF_PUBLIC_FILES, f"(archives: {public_archives}, files: {public_files})")
+          
+          # Extract and sum private file archive(s) and private file(s) counts
+          private_archives = find_number_before_phrase("file_list.txt", "private file archive")
+          private_files = find_number_before_phrase("file_list.txt", "private file(s)")
+          NUM_OF_PRIVATE_FILES = private_archives + private_files
+          print("NUM_OF_PRIVATE_FILES:", NUM_OF_PRIVATE_FILES, f"(archives: {private_archives}, files: {private_files})")
+          
+          # Extract and sum vault public file archive(s) and public file(s) counts  
+          vault_public_archives = find_number_before_phrase("vault_data.txt", "public file archive")
+          vault_public_files = find_number_before_phrase("vault_data.txt", "public file(s)")
+          NUM_OF_PUBLIC_FILES_IN_VAULT = vault_public_archives + vault_public_files
+          print("NUM_OF_PUBLIC_FILES_IN_VAULT:", NUM_OF_PUBLIC_FILES_IN_VAULT, f"(archives: {vault_public_archives}, files: {vault_public_files})")
+          
+          # Extract and sum vault private file archive(s) and private file(s) counts
+          vault_private_archives = find_number_before_phrase("vault_data.txt", "private file archive")
+          vault_private_files = find_number_before_phrase("vault_data.txt", "private file(s)")
+          NUM_OF_PRIVATE_FILES_IN_VAULT = vault_private_archives + vault_private_files
+          print("NUM_OF_PRIVATE_FILES_IN_VAULT:", NUM_OF_PRIVATE_FILES_IN_VAULT, f"(archives: {vault_private_archives}, files: {vault_private_files})")
 
           # Assertions
           assert NUM_OF_PUBLIC_FILES == NUM_OF_PUBLIC_FILES_IN_VAULT, f"Error: local data and vault in network dont match, Local public Files: {NUM_OF_PUBLIC_FILES} and vault public files: {NUM_OF_PUBLIC_FILES_IN_VAULT} are Not Equal"

--- a/ant-cli/src/access/user_data.rs
+++ b/ant-cli/src/access/user_data.rs
@@ -45,6 +45,8 @@ struct PublicFile {
 pub fn get_local_user_data() -> Result<UserData> {
     let file_archives = get_local_public_file_archives()?;
     let private_file_archives = get_local_private_file_archives()?;
+    let public_files = get_local_public_files()?;
+    let private_files = get_local_private_files()?;
     let registers = get_local_registers()?;
     let register_key = super::keys::get_register_signing_key()
         .map(|k| k.to_hex())
@@ -63,6 +65,8 @@ pub fn get_local_user_data() -> Result<UserData> {
         register_key,
         scratchpad_key,
         pointer_key,
+        public_files,
+        private_files,
     };
     Ok(user_data)
 }
@@ -169,6 +173,8 @@ pub fn write_local_user_data(user_data: &UserData) -> Result<()> {
         register_key,
         scratchpad_key,
         pointer_key,
+        public_files,
+        private_files,
     } = user_data;
 
     for (archive, name) in file_archives.iter() {
@@ -177,6 +183,14 @@ pub fn write_local_user_data(user_data: &UserData) -> Result<()> {
 
     for (archive, name) in private_file_archives.iter() {
         write_local_private_file_archive(archive.to_hex(), archive.address(), name)?;
+    }
+
+    for (data_address, name) in public_files.iter() {
+        write_local_public_file(data_address.to_hex(), name)?;
+    }
+
+    for (private_datamap, name) in private_files.iter() {
+        write_local_private_file(private_datamap.to_hex(), private_datamap.address(), name)?;
     }
 
     for (register, name) in register_addresses.iter() {

--- a/ant-cli/src/actions/download.rs
+++ b/ant-cli/src/actions/download.rs
@@ -24,9 +24,14 @@ pub async fn download(addr: &str, dest_path: &str, client: &Client) -> Result<()
         return download_public(addr, public_address, dest_path, client).await;
     }
 
-    let try_private_address = crate::user_data::get_local_private_archive_access(addr).ok();
-    if let Some(private_address) = try_private_address {
+    let try_local_private_archive = crate::user_data::get_local_private_archive_access(addr).ok();
+    if let Some(private_address) = try_local_private_archive {
         return download_private(addr, private_address, dest_path, client).await;
+    }
+
+    let try_local_private_file = crate::user_data::get_local_private_file_access(addr).ok();
+    if let Some(private_file_datamap) = try_local_private_file {
+        return download_from_datamap(addr, private_file_datamap, dest_path, client).await;
     }
 
     let try_datamap = DataMapChunk::from_hex(addr).ok();

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -145,15 +145,39 @@ pub async fn upload(
     // save archive to local user data
     if !no_archive && not_single_file {
         let writer = if public {
-            crate::user_data::write_local_public_file_archive(archive_addr, &name)
+            crate::user_data::write_local_public_file_archive(archive_addr.clone(), &name)
         } else {
-            crate::user_data::write_local_private_file_archive(archive_addr, local_addr, &name)
+            crate::user_data::write_local_private_file_archive(
+                archive_addr.clone(),
+                local_addr.clone(),
+                &name,
+            )
         };
         writer
             .wrap_err("Failed to save file to local user data")
             .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
             .map_err(|err| (err, IO_ERROR))?;
         info!("Saved file to local user data");
+    }
+
+    // save single private files to local user data
+    if !not_single_file && !public {
+        let writer = crate::user_data::write_local_private_file(archive_addr.clone(), local_addr.clone(), &name);
+        writer
+            .wrap_err("Failed to save private file to local user data")
+            .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
+            .map_err(|err| (err, IO_ERROR))?;
+        info!("Saved private file to local user data");
+    }
+
+    // save single public files to local user data
+    if !not_single_file && public {
+        let writer = crate::user_data::write_local_public_file(local_addr.to_owned(), &name);
+        writer
+            .wrap_err("Failed to save public file to local user data")
+            .with_suggestion(|| "Local user data saves the file address above to disk, without it you need to keep track of the address yourself")
+            .map_err(|err| (err, IO_ERROR))?;
+        info!("Saved public file to local user data");
     }
 
     Ok(())
@@ -209,6 +233,14 @@ async fn upload_dir(
         if no_archive || is_single_file {
             if addrs.len() > MAX_ADDRESSES_TO_PRINT {
                 Ok(("no-archive".to_string(), "multiple addresses".to_string()))
+            } else if is_single_file && addrs.len() == 1 {
+                // For single private files, return both full hex and short address
+                if let Some((_, private_datamap, _)) = private_archive.iter().next() {
+                    Ok((private_datamap.to_hex(), private_datamap.address()))
+                } else {
+                    // This should not happen given the conditions, but handle gracefully
+                    Ok(("no-archive".to_string(), addrs.join(", ")))
+                }
             } else {
                 Ok(("no-archive".to_string(), addrs.join(", ")))
             }
@@ -300,6 +332,24 @@ pub async fn list(network_context: NetworkContext, verbose: bool) -> Result<(), 
         }
     }
 
+    // get public files
+    println!();
+    let public_files = crate::user_data::get_local_public_files()
+        .wrap_err("Failed to get local public files")
+        .map_err(|err| (err, IO_ERROR))?;
+
+    println!("✅ You have {} public file(s):", public_files.len());
+    for (addr, name) in public_files {
+        println!("{}: {}", name, addr.to_hex());
+        if let (true, Some(client)) = (verbose, maybe_client.as_ref()) {
+            if let Ok(file_bytes) = client.data_get_public(&addr).await {
+                println!("  - File size: {} bytes", file_bytes.len());
+            } else {
+                println!("  - Not found on network");
+            }
+        }
+    }
+
     // get private file archives
     println!();
     let private_file_archives = crate::user_data::get_local_private_file_archives()
@@ -319,6 +369,24 @@ pub async fn list(network_context: NetworkContext, verbose: bool) -> Result<(), 
                 for (file_path, _data_addr, _meta) in private_archive.iter() {
                     println!("  - {file_path:?}");
                 }
+            } else {
+                println!("  - Not found on network");
+            }
+        }
+    }
+
+    // get private files
+    println!();
+    let private_files = crate::user_data::get_local_private_files()
+        .wrap_err("Failed to get local private files")
+        .map_err(|err| (err, IO_ERROR))?;
+
+    println!("✅ You have {} private file(s):", private_files.len());
+    for (addr, name) in private_files {
+        println!("{}: {}", name, addr.address());
+        if let (true, Some(client)) = (verbose, maybe_client.as_ref()) {
+            if let Ok(file_bytes) = client.data_get(&addr).await {
+                println!("  - File size: {} bytes", file_bytes.len());
             } else {
                 println!("  - Not found on network");
             }

--- a/ant-cli/src/commands/vault.rs
+++ b/ant-cli/src/commands/vault.rs
@@ -120,6 +120,8 @@ fn prevent_loss_of_keys(net_user_data: &UserData) -> Result<()> {
         file_archives: _,
         private_file_archives: _,
         register_addresses: _,
+        public_files: _,
+        private_files: _,
     } = net_user_data;
 
     let mut endangered_key_types = Vec::new();


### PR DESCRIPTION
Single file upload data addresses and private datamaps were not saved in the `user_data` folder like for multi-file uploads (archives).