### PR TITLE
using stream_encryption during CI

### DIFF
--- a/autonomi-nodejs/__test__/archive.spec.mjs
+++ b/autonomi-nodejs/__test__/archive.spec.mjs
@@ -225,7 +225,10 @@ test('private archive - upload and download directory', async (t) => {
   
   // Define source and destination directories
   const sourceDir = path.join('../autonomi', 'tests', 'file', 'test_dir');
-  const destDir = path.join(os.tmpdir());
+  // `os.tmpdir()` generates the same folder within private archive and public archive tests.
+  // To avoid streaming_decryptor flushing to the same file which pollutes the result,
+  // make them using individual destDir. 
+  const destDir = path.join(os.tmpdir(), 'private_archive');
   
   // Upload directory content
   const { cost, archive } = await client.dirContentUpload(sourceDir, paymentOption);
@@ -280,7 +283,10 @@ test('public archive - upload and download directory', async (t) => {
   
   // Define source and destination directories
   const sourceDir = path.join('../autonomi', 'tests', 'file', 'test_dir');
-  const destDir = os.tmpdir();
+  // `os.tmpdir()` generates the same folder within private archive and public archive tests.
+  // To avoid streaming_decryptor flushing to the same file which pollutes the result,
+  // make them using individual destDir. 
+  const destDir = path.join(os.tmpdir(), 'public_archive');
   
   // Upload directory content as public
   const { cost, addr: archive } = await client.dirContentUploadPublic(sourceDir, paymentOption);

--- a/autonomi/src/client/encryption.rs
+++ b/autonomi/src/client/encryption.rs
@@ -104,6 +104,12 @@ impl EncryptionStream {
                             // Chunk stream is done, check if we have the datamap
                             match datamap_receiver.try_recv() {
                                 Ok(datamap_chunk) => {
+                                    // The datamap_chunk shall be uploaded if as public
+                                    if self.is_public {
+                                        batch.push(datamap_chunk.0.clone());
+                                        progress.chunk_count += 1;
+                                    }
+
                                     // Transition to StreamDone state
                                     state_change = Some(EncryptionState::StreamDone((
                                         datamap_chunk,

--- a/autonomi/src/client/encryption.rs
+++ b/autonomi/src/client/encryption.rs
@@ -29,7 +29,7 @@ pub static IN_MEMORY_ENCRYPTION_MAX_SIZE: LazyLock<usize> = LazyLock::new(|| {
     let max_size = std::env::var("IN_MEMORY_ENCRYPTION_MAX_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(100_000_000);
+        .unwrap_or(50_000_000);
     info!(
         "IN_MEMORY_ENCRYPTION_MAX_SIZE (from that threshold, the file will be encrypted in a stream): {}",
         max_size


### PR DESCRIPTION
### Description

* lower IN_MEMORY_ENCRYPTION_MAX_SIZE to 50MB, so that stream_encryption will be used during CI tests (memory_check and upload_large_file)
* fixed a bug when upload public file using stream_encryption
* fixed a bug within the nodejs tests, that tests using stream_decryption flushing to same file, which pollutes the result

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
