### PR TITLE
fix(node): add and sync on the same thread

### DIFF
--- a/ant-node/src/networking/driver/event/swarm.rs
+++ b/ant-node/src/networking/driver/event/swarm.rs
@@ -182,18 +182,7 @@ impl SwarmDriver {
                         // all addresses are effectively external here...
                         // this is needed for Kad Mode::Server
                         self.swarm.add_external_address(address.clone());
-
-                        // If we are local, add our own address(es) to cache
-                        if let Some(bootstrap_cache) = self.bootstrap_cache.as_ref() {
-                            info!("Adding listen address to bootstrap cache (local): {address:?}");
-                            let bootstrap_cache = bootstrap_cache.clone();
-                            let address_clone = address.clone();
-                            #[allow(clippy::let_underscore_future)]
-                            let _ = tokio::spawn(async move {
-                                bootstrap_cache.add_addr(address_clone).await;
-                            });
-                        }
-                        if let Err(err) = self.sync_and_flush_cache() {
+                        if let Err(err) = self.add_sync_and_flush_cache(address.clone()) {
                             warn!("Failed to sync and flush cache during NewListenAddr: {err:?}");
                         }
                     } else if let Some(external_address_manager) =

--- a/ant-node/src/networking/driver/mod.rs
+++ b/ant-node/src/networking/driver/mod.rs
@@ -517,7 +517,7 @@ impl SwarmDriver {
     /// Sync and flush the bootstrap cache to disk.
     ///
     /// This function creates a new cache and saves the old one to disk.
-    pub(crate) fn sync_and_flush_cache(&mut self) -> Result<()> {
+    fn add_sync_and_flush_cache(&mut self, addr: Multiaddr) -> Result<()> {
         if let Some(bootstrap_cache) = self.bootstrap_cache.as_mut() {
             let config = bootstrap_cache.config().clone();
             let old_cache = bootstrap_cache.clone();
@@ -528,6 +528,7 @@ impl SwarmDriver {
                 // Save cache to disk.
                 #[allow(clippy::let_underscore_future)]
                 let _ = tokio::spawn(async move {
+                    old_cache.add_addr(addr).await;
                     if let Err(err) = old_cache.sync_and_flush_to_disk().await {
                         error!("Failed to save bootstrap cache: {err}");
                     }


### PR DESCRIPTION
- Prevent race condition on local network startup where adding the
  address to the bootstrap cache and syncing can sometimes lead to the
  address being added after write, instead of add -> write.