### PR TITLE
ci: provide tests for covering all file types

### DIFF
--- a/.github/workflows/files.yml
+++ b/.github/workflows/files.yml
@@ -1,0 +1,521 @@
+name: File Upload/Download Tests
+
+on:
+  merge_group:
+    branches: [ main ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  file_upload_download_tests:
+    name: "File Upload/Download Tests"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build binaries
+        run: cargo build --release --bin antnode --bin ant --bin antctl
+        timeout-minutes: 30
+
+      - name: Start a local network
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: start
+          enable-evm-testnet: true
+          node-path: target/release/antnode
+          build: true
+
+      - name: Check if ANT_PEERS and EVM_NETWORK are set
+        shell: bash
+        run: |
+          if [[ -z "$ANT_PEERS" ]]; then
+            echo "The ANT_PEERS variable has not been set"
+            exit 1
+          elif [[ -z "$EVM_NETWORK" ]]; then
+            echo "The EVM_NETWORK variable has not been set"
+            exit 1
+          else
+            echo "ANT_PEERS has been set to $ANT_PEERS"
+            echo "EVM_NETWORK has been set to $EVM_NETWORK"
+          fi
+
+      - name: Set secret key
+        shell: bash
+        run: echo "SECRET_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" >> $GITHUB_ENV
+
+      - name: Create base directory structure
+        shell: bash
+        run: mkdir -p test_upload test_download
+
+      - name: Upload and download test files
+        shell: bash
+        run: |
+          declare -a test_configs=(
+            "public_file|--public|file"
+            "public_file_no_archive|--public --no-archive|file" 
+            "public_dir|--public|dir"
+            "public_dir_no_archive|--public --no-archive|dir"
+            "private_file||file"
+            "private_file_no_archive|--no-archive|file"
+            "private_dir||dir"
+            "private_dir_no_archive|--no-archive|dir"
+          )
+          
+          declare -a passed_tests=()
+          declare -a failed_tests=()
+          
+          extract_address() {
+            local output_file="$1"
+            local address=""
+            
+            # Try to find "At address: <address>" format first
+            address=$(rg "At address: ([0-9a-f]+)" -o -r '$1' "$output_file" 2>/dev/null || true)
+            
+            # If not found, try to find "to: <address>" format (when content already exists)
+            if [[ -z "$address" ]]; then
+              address=$(rg "to: ([0-9a-f]+)" -o -r '$1' "$output_file" 2>/dev/null || true)
+            fi
+            
+            # If still not found, try quoted address format
+            if [[ -z "$address" ]]; then
+              address=$(rg '"([0-9a-f]{64})"' -o -r '$1' "$output_file" 2>/dev/null || true)
+            fi
+            
+            echo "$address"
+          }
+          
+          for config in "${test_configs[@]}"; do
+            IFS='|' read -r test_name upload_args test_type <<< "$config"
+            
+            if [[ "$test_type" == "dir" ]]; then
+              echo "============================================="
+              echo "🧪 Running test: $test_name $test_type"
+              echo "============================================="
+              
+              test_dir="test_upload/test_data_${test_name}"
+              mkdir -p "$test_dir/subdir1/subdir2"
+              
+              echo "Creating unique test data for $test_name..."
+              dd if=/dev/urandom of="$test_dir/file1_${test_name}.bin" bs=1M count=10 2>/dev/null || python3 -c "import os; open('$test_dir/file1_${test_name}.bin', 'wb').write(os.urandom(10*1024*1024))"
+              dd if=/dev/urandom of="$test_dir/subdir1/file2_${test_name}.bin" bs=1M count=8 2>/dev/null || python3 -c "import os; open('$test_dir/subdir1/file2_${test_name}.bin', 'wb').write(os.urandom(8*1024*1024))"
+              dd if=/dev/urandom of="$test_dir/subdir1/subdir2/file3_${test_name}.bin" bs=1M count=7 2>/dev/null || python3 -c "import os; open('$test_dir/subdir1/subdir2/file3_${test_name}.bin', 'wb').write(os.urandom(7*1024*1024))"
+              
+              find "$test_dir" -type f -exec ls -lh {} \;
+              echo "Running ant with args: $upload_args"
+              ./target/release/ant --local file upload "$test_dir" $upload_args 2>&1 | tee ./upload_output_${test_name}
+              
+              ADDRESS=$(extract_address "./upload_output_${test_name}")
+              echo "Directory address: $ADDRESS"
+              
+              if [[ -z "$ADDRESS" ]]; then
+                echo "❌ Failed to extract address for $test_name"
+                echo "Upload output:"
+                cat "./upload_output_${test_name}"
+                failed_tests+=("$test_name (dir) - address extraction failed")
+                continue
+              fi
+              
+              ./target/release/ant --local file download "$ADDRESS" "test_download/downloaded_content_${test_name}"
+              find test_download -type f -exec ls -lh {} \;
+              
+              if [[ "$upload_args" == *"--no-archive"* ]]; then
+                downloaded_files=$(find "test_download/downloaded_content_${test_name}" -type f 2>/dev/null | wc -l)
+                if [[ $downloaded_files -ge 1 ]]; then
+                  echo "✅ $test_name test passed: found $downloaded_files files"
+                  passed_tests+=("$test_name (dir, no-archive) - $downloaded_files files")
+                else
+                  echo "❌ $test_name test failed: no files found"
+                  failed_tests+=("$test_name (dir, no-archive) - no files found")
+                fi
+              else
+                if [[ -d "test_download/downloaded_content_${test_name}" ]] && [[ $(find "test_download/downloaded_content_${test_name}" -type f 2>/dev/null | wc -l) -gt 0 ]]; then
+                  echo "✅ $test_name test passed"
+                  passed_tests+=("$test_name (dir, archive)")
+                else
+                  echo "❌ $test_name test failed"
+                  ls -la "test_download/downloaded_content_${test_name}/" 2>/dev/null || echo "Downloaded directory not found"
+                  failed_tests+=("$test_name (dir, archive) - download failed")
+                fi
+              fi
+            else
+              for size in small medium; do
+                echo "============================================="
+                echo "🧪 Running test: $test_name $test_type ($size)"
+                echo "============================================="
+                
+                if [[ "$size" == "small" ]]; then
+                  file_size_mb=25
+                else
+                  file_size_mb=200
+                fi
+                
+                test_file="test_upload/${size}_${test_name}.bin"
+                echo "Creating unique ${size} test file for $test_name..."
+                dd if=/dev/urandom of="$test_file" bs=1M count=$file_size_mb 2>/dev/null || python3 -c "import os; open('$test_file', 'wb').write(os.urandom($file_size_mb*1024*1024))"
+
+                find test_upload -type f -exec ls -lh {} \;
+                echo "Running ant with args: $upload_args"
+                ./target/release/ant --log-output-dest=data-dir --local file upload "$test_file" $upload_args 2>&1 | tee ./${size}_upload_output_${test_name}
+                
+                ADDRESS=$(extract_address "./${size}_upload_output_${test_name}")
+                echo "${size} file address: $ADDRESS"
+                
+                if [[ -z "$ADDRESS" ]]; then
+                  echo "❌ Failed to extract address for $test_name ${size} file"
+                  echo "Upload output:"
+                  cat "./${size}_upload_output_${test_name}"
+                  failed_tests+=("$test_name ($size file) - address extraction failed")
+                  continue
+                fi
+                
+                ./target/release/ant --local file download "$ADDRESS" "test_download/downloaded_${size}_file_${test_name}"
+                find test_download -type f -exec ls -lh {} \;
+                
+                if [[ -f "test_download/downloaded_${size}_file_${test_name}" ]]; then
+                  original_size=$(stat -c%s "$test_file" 2>/dev/null || stat -f%z "$test_file")
+                  downloaded_size=$(stat -c%s "test_download/downloaded_${size}_file_${test_name}" 2>/dev/null || stat -f%z "test_download/downloaded_${size}_file_${test_name}")
+                  
+                  if [[ $original_size -eq $downloaded_size ]]; then
+                    echo "✅ $test_name ${size} file test passed: $downloaded_size bytes"
+                    passed_tests+=("$test_name ($size file) - $downloaded_size bytes")
+                  else
+                    echo "❌ $test_name ${size} file size mismatch - original: $original_size, downloaded: $downloaded_size"
+                    failed_tests+=("$test_name ($size file) - size mismatch")
+                  fi
+                else
+                  echo "❌ $test_name ${size} file download failed"
+                  failed_tests+=("$test_name ($size file) - download failed")
+                fi
+              done
+            fi
+            
+            echo "---"
+          done
+          
+          echo ""
+          echo "==============="
+          echo "🏁 TEST SUMMARY"
+          echo "==============="
+          
+          if [[ ${#passed_tests[@]} -gt 0 ]]; then
+            echo "✅ PASSED TESTS (${#passed_tests[@]}):"
+            for test in "${passed_tests[@]}"; do
+              echo "  • $test"
+            done
+          fi
+          
+          if [[ ${#failed_tests[@]} -gt 0 ]]; then
+            echo ""
+            echo "❌ FAILED TESTS (${#failed_tests[@]}):"
+            for test in "${failed_tests[@]}"; do
+              echo "  • $test"
+            done
+          fi
+          
+          echo ""
+          total_tests=$((${#passed_tests[@]} + ${#failed_tests[@]}))
+          echo "📊 RESULTS: ${#passed_tests[@]}/$total_tests tests passed"
+          
+          if [[ ${#failed_tests[@]} -gt 0 ]]; then
+            echo "❌ One or more tests failed"
+            exit 1
+          else
+            echo "🎉 All tests passed!"
+          fi
+        env:
+          ANT_LOG: "v"
+        timeout-minutes: 45
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: ant_test_logs_file_upload_download
+          build: true
+
+  file_upload_download_tests_windows:
+    name: "File Upload/Download Tests (Windows)"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build binaries
+        run: cargo build --release --bin antnode --bin ant --bin antctl
+        timeout-minutes: 30
+
+      - name: Install antctl
+        shell: pwsh
+        run: |
+          $destination = "$env:USERPROFILE\AppData\Local\Microsoft\WindowsApps"
+          Copy-Item "target\release\antctl.exe" -Destination $destination -Force
+          Write-Host "antctl installed to $destination"
+
+      - name: Start a local network
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: start
+          enable-evm-testnet: true
+          node-path: target/release/antnode.exe
+          build: true
+
+      - name: Check if ANT_PEERS and EVM_NETWORK are set
+        shell: pwsh
+        run: |
+          if (-not $env:ANT_PEERS) {
+            Write-Host "The ANT_PEERS variable has not been set"
+            exit 1
+          } elseif (-not $env:EVM_NETWORK) {
+            Write-Host "The EVM_NETWORK variable has not been set"
+            exit 1
+          } else {
+            Write-Host "ANT_PEERS has been set to $env:ANT_PEERS"
+            Write-Host "EVM_NETWORK has been set to $env:EVM_NETWORK"
+          }
+
+      - name: Set secret key
+        shell: pwsh
+        run: |
+          "SECRET_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Create base directory structure
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "test_upload"
+          New-Item -ItemType Directory -Force -Path "test_download"
+
+      - name: Upload and download test files
+        shell: pwsh
+        run: |
+          $testConfigs = @(
+            @{name="public_file"; args="--public"; type="file"},
+            @{name="public_file_no_archive"; args="--public --no-archive"; type="file"},
+            @{name="public_dir"; args="--public"; type="dir"},
+            @{name="public_dir_no_archive"; args="--public --no-archive"; type="dir"},
+            @{name="private_file"; args=""; type="file"},
+            @{name="private_file_no_archive"; args="--no-archive"; type="file"},
+            @{name="private_dir"; args=""; type="dir"},
+            @{name="private_dir_no_archive"; args="--no-archive"; type="dir"}
+          )
+          
+          $passedTests = @()
+          $failedTests = @()
+          
+          function Extract-Address {
+            param([string]$outputFile)
+            
+            if (-not (Test-Path $outputFile)) {
+              return ""
+            }
+            
+            $content = Get-Content $outputFile -Raw
+            
+            # Try to find "At address: <address>" format first
+            $match = [regex]::Match($content, "At address: ([0-9a-f]+)")
+            if ($match.Success) {
+              return $match.Groups[1].Value
+            }
+            
+            # Try to find "to: <address>" format (when content already exists)
+            $match = [regex]::Match($content, "to: ([0-9a-f]+)")
+            if ($match.Success) {
+              return $match.Groups[1].Value
+            }
+            
+            # Try quoted address format
+            $match = [regex]::Match($content, '"([0-9a-f]{64})"')
+            if ($match.Success) {
+              return $match.Groups[1].Value
+            }
+            
+            return ""
+          }
+          
+          function Create-RandomFile {
+            param([string]$filePath, [int]$sizeMB)
+            
+            $bytes = New-Object byte[] ($sizeMB * 1024 * 1024)
+            $rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+            $rng.GetBytes($bytes)
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+            $rng.Dispose()
+          }
+          
+          foreach ($config in $testConfigs) {
+            $testName = $config.name
+            $uploadArgs = $config.args
+            $testType = $config.type
+            
+            if ($testType -eq "dir") {
+              Write-Host "==================================="
+              Write-Host "🧪 Running test: $testName $testType"
+              Write-Host "==================================="
+              
+              $testDir = "test_upload\test_data_$testName"
+              New-Item -ItemType Directory -Force -Path "$testDir\subdir1\subdir2"
+              
+              Write-Host "Creating unique test data for $testName..."
+              Create-RandomFile "$testDir\file1_$testName.bin" 10
+              Create-RandomFile "$testDir\subdir1\file2_$testName.bin" 8
+              Create-RandomFile "$testDir\subdir1\subdir2\file3_$testName.bin" 7
+              
+              Write-Host "Running ant with args: $uploadArgs"
+              $uploadOutput = "upload_output_$testName"
+              if ($uploadArgs) {
+                & ".\target\release\ant.exe" --local file upload $testDir $uploadArgs.Split(' ') 2>&1 | Tee-Object -FilePath $uploadOutput
+              } else {
+                & ".\target\release\ant.exe" --local file upload $testDir 2>&1 | Tee-Object -FilePath $uploadOutput
+              }
+              
+              $address = Extract-Address $uploadOutput
+              Write-Host "Directory address: $address"
+              
+              if (-not $address) {
+                Write-Host "❌ Failed to extract address for $testName"
+                Write-Host "Upload output:"
+                Get-Content $uploadOutput
+                $failedTests += "$testName (dir) - address extraction failed"
+                continue
+              }
+              
+              & ".\target\release\ant.exe" --local file download $address "test_download\downloaded_content_$testName"
+              
+              Write-Host "Downloaded content:"
+              if (Test-Path "test_download\downloaded_content_$testName") {
+                Get-ChildItem "test_download\downloaded_content_$testName" -Recurse -File | ForEach-Object { 
+                  Write-Host "$($_.FullName) - $($_.Length) bytes"
+                }
+              }
+              
+              if ($uploadArgs -like "*--no-archive*") {
+                $downloadedFiles = @(Get-ChildItem "test_download\downloaded_content_$testName" -Recurse -File -ErrorAction SilentlyContinue)
+                if ($downloadedFiles.Count -ge 1) {
+                  Write-Host "✅ $testName test passed: found $($downloadedFiles.Count) files"
+                  $passedTests += "$testName (dir, no-archive) - $($downloadedFiles.Count) files"
+                } else {
+                  Write-Host "❌ $testName test failed: no files found"
+                  $failedTests += "$testName (dir, no-archive) - no files found"
+                }
+              } else {
+                $downloadedFiles = @(Get-ChildItem "test_download\downloaded_content_$testName" -Recurse -File -ErrorAction SilentlyContinue)
+                if ((Test-Path "test_download\downloaded_content_$testName") -and $downloadedFiles.Count -gt 0) {
+                  Write-Host "✅ $testName test passed"
+                  $passedTests += "$testName (dir, archive)"
+                } else {
+                  Write-Host "❌ $testName test failed"
+                  if (Test-Path "test_download\downloaded_content_$testName") {
+                    Get-ChildItem "test_download\downloaded_content_$testName"
+                  } else {
+                    Write-Host "Downloaded directory not found"
+                  }
+                  $failedTests += "$testName (dir, archive) - download failed"
+                }
+              }
+            } else {
+              foreach ($size in @("small", "medium")) {
+                Write-Host "==========================================="
+                Write-Host "🧪 Running test: $testName $testType ($size)"
+                Write-Host "==========================================="
+                
+                $fileSizeMB = if ($size -eq "small") { 25 } else { 200 }
+                
+                $testFile = "test_upload\${size}_$testName.bin"
+                Write-Host "Creating unique $size test file for $testName..."
+                Create-RandomFile $testFile $fileSizeMB
+                
+                Write-Host "Running ant with args: $uploadArgs"
+                $uploadOutput = "${size}_upload_output_$testName"
+                if ($uploadArgs) {
+                  & ".\target\release\ant.exe" --local file upload $testFile $uploadArgs.Split(' ') 2>&1 | Tee-Object -FilePath $uploadOutput
+                } else {
+                  & ".\target\release\ant.exe" --local file upload $testFile 2>&1 | Tee-Object -FilePath $uploadOutput
+                }
+                
+                $address = Extract-Address $uploadOutput
+                Write-Host "$size file address: $address"
+                
+                if (-not $address) {
+                  Write-Host "❌ Failed to extract address for $testName $size file"
+                  Write-Host "Upload output:"
+                  Get-Content $uploadOutput
+                  $failedTests += "$testName ($size file) - address extraction failed"
+                  continue
+                }
+                
+                & ".\target\release\ant.exe" --local file download $address "test_download\downloaded_${size}_file_$testName"
+                
+                if (Test-Path "test_download\downloaded_${size}_file_$testName") {
+                  $originalSize = (Get-Item $testFile).Length
+                  $downloadedSize = (Get-Item "test_download\downloaded_${size}_file_$testName").Length
+                  
+                  if ($originalSize -eq $downloadedSize) {
+                    Write-Host "✅ $testName $size file test passed: $downloadedSize bytes"
+                    $passedTests += "$testName ($size file) - $downloadedSize bytes"
+                  } else {
+                    Write-Host "❌ $testName $size file size mismatch - original: $originalSize, downloaded: $downloadedSize"
+                    $failedTests += "$testName ($size file) - size mismatch"
+                  }
+                } else {
+                  Write-Host "❌ $testName $size file download failed"
+                  $failedTests += "$testName ($size file) - download failed"
+                }
+              }
+            }
+            
+            Write-Host "---"
+          }
+          
+          Write-Host ""
+          Write-Host "==============="
+          Write-Host "🏁 TEST SUMMARY"
+          Write-Host "==============="
+          
+          if ($passedTests.Count -gt 0) {
+            Write-Host "✅ PASSED TESTS ($($passedTests.Count)):"
+            foreach ($test in $passedTests) {
+              Write-Host "  • $test"
+            }
+          }
+          
+          if ($failedTests.Count -gt 0) {
+            Write-Host ""
+            Write-Host "❌ FAILED TESTS ($($failedTests.Count)):"
+            foreach ($test in $failedTests) {
+              Write-Host "  • $test"
+            }
+          }
+          
+          Write-Host ""
+          $totalTests = $passedTests.Count + $failedTests.Count
+          Write-Host "📊 RESULTS: $($passedTests.Count)/$totalTests tests passed"
+          
+          if ($failedTests.Count -gt 0) {
+            Write-Host "❌ Some tests failed"
+            exit 1
+          } else {
+            Write-Host "🎉 All tests passed!"
+          }
+        env:
+          ANT_LOG: "v"
+        timeout-minutes: 45
+
+      - name: Stop the local network and upload logs
+        if: always()
+        uses: maidsafe/ant-local-testnet-action@main
+        with:
+          action: stop
+          log_file_prefix: ant_test_logs_file_upload_download_windows
+          build: true

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -1,11 +1,8 @@
 name: Memory Check
 
 on:
-  # tests must run for a PR to be valid and pass merge queue muster
-  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
-  # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [main]
   pull_request:
     branches: ["*"]
 
@@ -249,53 +246,6 @@ jobs:
             echo "Client average memory usage exceeded threshold: $client_avg_mem_limit_mb MB"
             exit 1
           fi
-
-      # Logging of handling time is on Trace level,
-      # meanwhile the local_network startup tool sets the logging level on Debug.
-      #
-      # - name: Check node swarm_driver handling statistics
-      #   shell: bash
-      #   # With the latest improvements, swarm_driver will be in high chance
-      #   # has no super long handling (longer than 1s).
-      #   # As the `rg` cmd will fail the shell directly if no entry find,
-      #   # hence not covering it.
-      #   # Be aware that if do need to looking for handlings longer than second, it shall be:
-      #   #   rg "SwarmCmd handled in [^m,µ,n]*s:" $NODE_DATA_PATH/*/logs/* --glob antnode.* -c --stats
-      #   run: |
-      #     num_of_times=$(
-      #       rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob antnode.* -c --stats |
-      #       rg "(\d+) matches" |
-      #       rg "\d+" -o
-      #     )
-      #     echo "Number of long cmd handling times: $num_of_times"
-      #     total_long_handling_ms=$(
-      #       rg "SwarmCmd handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob antnode.* -o --no-line-number --no-filename |
-      #       awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
-      #     )
-      #     echo "Total cmd long handling time is: $total_long_handling_ms ms"
-      #     average_handling_ms=$(($total_long_handling_ms/$(($num_of_times))))
-      #     echo "Average cmd long handling time is: $average_handling_ms ms"
-      #     total_long_handling=$(($total_long_handling_ms))
-      #     total_num_of_times=$(($num_of_times))
-      #     num_of_times=$(
-      #       rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob antnode.* -c --stats |
-      #       rg "(\d+) matches" |
-      #       rg "\d+" -o
-      #     )
-      #     echo "Number of long event handling times: $num_of_times"
-      #     total_long_handling_ms=$(
-      #       rg "SwarmEvent handled in [0-9.]+ms:" $NODE_DATA_PATH/*/logs/* --glob antnode.* -o --no-line-number --no-filename |
-      #       awk -F' |ms:' '{sum += $4} END {printf "%.0f\n", sum}'
-      #     )
-      #     echo "Total event long handling time is: $total_long_handling_ms ms"
-      #     average_handling_ms=$(($total_long_handling_ms/$(($num_of_times))))
-      #     echo "Average event long handling time is: $average_handling_ms ms"
-      #     total_long_handling=$(($total_long_handling_ms+$total_long_handling))
-      #     total_num_of_times=$(($num_of_times+$total_num_of_times))
-      #     average_handling_ms=$(($total_long_handling/$(($total_num_of_times))))
-      #     echo "Total swarm_driver long handling times is: $total_num_of_times"
-      #     echo "Total swarm_driver long handling duration is: $total_long_handling ms"
-      #     echo "Total average swarm_driver long handling duration is: $average_handling_ms ms"
 
       - name: Move restart_node log to the working directory
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,20 +1,13 @@
 name: Check before merge
 
 on:
-  # tests must run for a PR to be valid and pass merge queue muster
-  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
-  # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [ main, alpha*, beta*, rc* ]
+    branches: [ main ]
   pull_request:
     branches: [ "*" ]
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
-  WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
-  GENESIS_PK: 9377ab39708a59d02d09bfd3c9bc7548faab9e0c2a2700b9ac7d5c14f0842f0b4bb0df411b6abd3f1a92b9aa1ebf5c3d
-  GENESIS_SK: 5ec88891c1098a0fede5b98b07f8abc931d7247b7aa310d21ab430cc957f9f02
-  MAX_CHUNK_SIZE: 4194304
 
 jobs:
   build:
@@ -28,7 +21,6 @@ jobs:
         run: python --version
 
   cargo-udeps:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Unused dependency check
     runs-on: ubuntu-latest
     steps:
@@ -57,10 +49,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      # commitlint check removed - no longer enforcing conventional commits
 
   checks:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: various checks
     runs-on: ubuntu-latest
     steps:
@@ -72,9 +62,6 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
-
-      # Formatting check removed - no longer enforcing code formatting in CI
-      # Developers can still use `cargo fmt` locally
 
       - shell: bash
         run: cargo clippy --all-targets --all-features -- -Dwarnings
@@ -103,7 +90,6 @@ jobs:
           cargo clean
 
   unit:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -183,7 +169,6 @@ jobs:
           log_file_prefix: ant_test_logs_unit
 
   e2e:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -608,72 +593,7 @@ jobs:
           log_file_prefix: ant_test_logs_e2e
           build: true
 
-  # token_distribution_test:
-  #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-  #   name: token distribution test
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #     - uses: actions/checkout@v5
-
-  #     - name: Install Rust
-  #       uses: dtolnay/rust-toolchain@stable
-
-  #     - uses: Swatinem/rust-cache@v2
-
-  #     - name: Build binaries
-  #       run: cargo build --release --features=distribution --bin antnode
-  #       timeout-minutes: 35
-
-  #     - name: Build faucet binary
-  #       run: cargo build --release --features=distribution,gifting --bin faucet
-  #       timeout-minutes: 35
-
-  #     - name: Build testing executable
-  #       run: cargo test --release --features=distribution --no-run
-  #       env:
-  #         # only set the target dir for windows to bypass the linker issue.
-  #         # happens if we build the node manager via testnet action
-  #         CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-  #       timeout-minutes: 35
-
-  #     - name: Start a local network
-  #       uses: maidsafe/ant-local-testnet-action@main
-  #       with:
-  #         action: start
-  #         interval: 2000
-  #         node-path: target/release/antnode
-  #         faucet-path: target/release/faucet
-  #         build: true
-
-  #     - name: Check ANT_PEERS was set
-  #       shell: bash
-  #       run: |
-  #         if [[ -z "$ANT_PEERS" ]]; then
-  #           echo "The ANT_PEERS variable has not been set"
-  #           exit 1
-  #         else
-  #           echo "ANT_PEERS has been set to $ANT_PEERS"
-  #         fi
-
-  #     - name: execute token_distribution tests
-  #       run: cargo test --release --features=distribution token_distribution -- --nocapture --test-threads=1
-  #       env:
-  #         ANT_LOG: "all"
-  #         CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
-  #       timeout-minutes: 25
-
-  #     - name: Stop the local network and upload logs
-  #       if: always()
-  #       uses: maidsafe/ant-local-testnet-action@main
-  #       with:
-  #         action: stop
-  #         log_file_prefix: ant_logs_token_distribution
-
   churn:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Network churning tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -963,7 +883,6 @@ jobs:
           fi
 
   large_file_upload_test:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Large file upload
     runs-on: ubuntu-latest
     steps:
@@ -1111,218 +1030,3 @@ jobs:
           action: stop
           log_file_prefix: ant_test_logs_large_file_upload_no_ws
           build: true
-
-  # replication_bench_with_heavy_upload:
-  #   if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-  #   name: Replication bench with heavy upload
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     CLIENT_DATA_PATH: /home/runner/.local/share/autonomi/client
-
-  #   steps:
-  #     - uses: actions/checkout@v5
-
-  #     - name: Install Rust
-  #       uses: dtolnay/rust-toolchain@stable
-  #     - uses: Swatinem/rust-cache@v2
-
-  #     - name: install ripgrep
-  #       shell: bash
-  #       run: sudo apt-get install -y ripgrep
-
-  #     - name: Download materials to create two 300MB test_files to be uploaded by client
-  #       shell: bash
-  #       run: |
-  #         mkdir test_data_1
-  #         cd test_data_1
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safe-qiWithListeners-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safenode-qiWithListeners-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/Qi930/safenode_rpc_client-qiWithListeners-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/faucet-qilesssubs-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safe-qilesssubs-x86_64.tar.gz
-  #         ls -l
-  #         cd ..
-  #         tar -cvzf test_data_1.tar.gz test_data_1
-  #         mkdir test_data_2
-  #         cd test_data_2
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safenode-qilesssubs-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/QiSubdivisionBranch/safenode_rpc_client-qilesssubs-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/faucet-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safe-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safenode-DebugMem-x86_64.tar.gz
-  #         ls -l
-  #         cd ..
-  #         tar -cvzf test_data_2.tar.gz test_data_2
-  #         ls -l
-  #         mkdir test_data_3
-  #         cd test_data_3
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush/safenode_rpc_client-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/faucet-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safe-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safenode-DebugMem-x86_64.tar.gz
-  #         wget https://sn-node.s3.eu-west-2.amazonaws.com/joshuef/RemoveArtificalReplPush2/safenode_rpc_client-DebugMem-x86_64.tar.gz
-  #         ls -l
-  #         cd ..
-  #         tar -cvzf test_data_3.tar.gz test_data_3
-  #         ls -l
-  #         df
-
-  #     - name: Build binaries
-  #       run: cargo build --release --bin antnode --bin safe
-  #       timeout-minutes: 30
-
-  #     - name: Build faucet binary
-  #       run: cargo build --release --bin faucet --features gifting
-  #       timeout-minutes: 30
-
-  #     - name: Start a local network
-  #       uses: maidsafe/ant-local-testnet-action@main
-  #       with:
-  #         action: start
-  #         interval: 2000
-  #         node-path: target/release/antnode
-  #         faucet-path: target/release/faucet
-  #         build: true
-
-  #     - name: Check ANT_PEERS was set
-  #       shell: bash
-  #       run: |
-  #         if [[ -z "$ANT_PEERS" ]]; then
-  #           echo "The ANT_PEERS variable has not been set"
-  #           exit 1
-  #         else
-  #           echo "ANT_PEERS has been set to $ANT_PEERS"
-  #         fi
-
-  #     - name: Create and fund a wallet to pay for files storage
-  #       run: |
-  #         ./target/release/safe --log-output-dest=data-dir wallet create --no-password
-  #         ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
-  #         ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
-  #       env:
-  #         ANT_LOG: "all"
-  #       timeout-minutes: 5
-
-  #     - name: Start a client to upload first file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_1.tar.gz" --retry-strategy quick
-  #       env:
-  #         ANT_LOG: "all"
-  #       timeout-minutes: 5
-
-  #     - name: Ensure no leftover transactions and payment files
-  #       run: |
-  #         expected_transactions_files="1"
-  #         expected_payment_files="0"
-  #         pwd
-  #         ls $CLIENT_DATA_PATH/ -l
-  #         ls $CLIENT_DATA_PATH/wallet -l
-  #         ls $CLIENT_DATA_PATH/wallet/transactions -l
-  #         transaction_files=$(ls $CLIENT_DATA_PATH/wallet/transactions | wc -l)
-  #         echo "Find $transaction_files transaction files"
-  #         if [ $expected_transactions_files -lt $transaction_files ]; then
-  #           echo "Got too many transaction files leftover: $transaction_files"
-  #           exit 1
-  #         fi
-  #         ls $CLIENT_DATA_PATH/wallet/payments -l
-  #         payment_files=$(ls $CLIENT_DATA_PATH/wallet/payments | wc -l)
-  #         if [ $expected_payment_files -lt $payment_files ]; then
-  #           echo "Got too many payment files leftover: $payment_files"
-  #           exit 1
-  #         fi
-  #       env:
-  #         CLIENT_DATA_PATH: /home/runner/.local/share/autonomi/client
-  #       timeout-minutes: 10
-
-  #     - name: Wait for certain period
-  #       run: sleep 300
-  #       timeout-minutes: 6
-
-  #     - name: Use same client to upload second file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_2.tar.gz" --retry-strategy quick
-  #       env:
-  #         ANT_LOG: "all"
-  #       timeout-minutes: 10
-
-  #     - name: Ensure no leftover transactions and payment files
-  #       run: |
-  #         expected_transactions_files="1"
-  #         expected_payment_files="0"
-  #         pwd
-  #         ls $CLIENT_DATA_PATH/ -l
-  #         ls $CLIENT_DATA_PATH/wallet -l
-  #         ls $CLIENT_DATA_PATH/wallet/transactions -l
-  #         transaction_files=$(find $CLIENT_DATA_PATH/wallet/transactions -type f | wc -l)
-  #         if (( $(echo "$transaction_files > $expected_transactions_files" | bc -l) )); then
-  #           echo "Got too many transaction files leftover: $transaction_files when we expected $expected_transactions_files"
-  #           exit 1
-  #         fi
-  #         ls $CLIENT_DATA_PATH/wallet/payments -l
-  #         payment_files=$(find $CLIENT_DATA_PATH/wallet/payments -type f | wc -l)
-  #         if (( $(echo "$payment_files > $expected_payment_files" | bc -l) )); then
-  #           echo "Got too many payment files leftover: $payment_files"
-  #           exit 1
-  #         fi
-  #       env:
-  #         CLIENT_DATA_PATH: /home/runner/.local/share/autonomi/client
-  #       timeout-minutes: 10
-
-  #     - name: Wait for certain period
-  #       run: sleep 300
-  #       timeout-minutes: 6
-
-  #     # Start a different client to avoid local wallet slow down with more payments handled.
-  #     - name: Start a different client
-  #       run: |
-  #         pwd
-  #         mv $CLIENT_DATA_PATH $SAFE_DATA_PATH/client_first
-  #         ls -l $SAFE_DATA_PATH
-  #         ls -l $SAFE_DATA_PATH/client_first
-  #         mkdir $SAFE_DATA_PATH/client
-  #         ls -l $SAFE_DATA_PATH
-  #         mv $SAFE_DATA_PATH/client_first/logs $CLIENT_DATA_PATH/logs
-  #         ls -l $CLIENT_DATA_PATH
-  #         ./target/release/safe --log-output-dest=data-dir wallet create --no-password
-  #         ./target/release/faucet --log-output-dest=data-dir send 100000000 $(./target/release/safe --log-output-dest=data-dir wallet address | tail -n 1) | tail -n 1 > transfer_hex
-  #         ./target/release/safe --log-output-dest=data-dir wallet receive --file transfer_hex
-  #       env:
-  #         ANT_LOG: "all"
-  #         SAFE_DATA_PATH: /home/runner/.local/share/autonomi
-  #         CLIENT_DATA_PATH: /home/runner/.local/share/autonomi/client
-  #       timeout-minutes: 25
-
-  #     - name: Use second client to upload third file
-  #       run: ./target/release/safe --log-output-dest=data-dir files upload "./test_data_3.tar.gz" --retry-strategy quick
-  #       env:
-  #         ANT_LOG: "all"
-  #       timeout-minutes: 10
-
-  #     - name: Ensure no leftover transactions and payment files
-  #       run: |
-  #         expected_transactions_files="1"
-  #         expected_payment_files="0"
-  #         pwd
-  #         ls $CLIENT_DATA_PATH/ -l
-  #         ls $CLIENT_DATA_PATH/wallet -l
-  #         ls $CLIENT_DATA_PATH/wallet/transactions -l
-  #         transaction_files=$(ls $CLIENT_DATA_PATH/wallet/transactions | wc -l)
-  #         echo "Find $transaction_files transaction files"
-  #         if [ $expected_transactions_files -lt $transaction_files ]; then
-  #           echo "Got too many transaction files leftover: $transaction_files"
-  #           exit 1
-  #         fi
-  #         ls $CLIENT_DATA_PATH/wallet/payments -l
-  #         payment_files=$(ls $CLIENT_DATA_PATH/wallet/payments | wc -l)
-  #         if [ $expected_payment_files -lt $payment_files ]; then
-  #           echo "Got too many payment files leftover: $payment_files"
-  #           exit 1
-  #         fi
-  #       env:
-  #         CLIENT_DATA_PATH: /home/runner/.local/share/autonomi/client
-  #       timeout-minutes: 10
-
-  #     - name: Stop the local network and upload logs
-  #       if: always()
-  #       uses: maidsafe/ant-local-testnet-action@main
-  #       with:
-  #         action: stop
-  #         log_file_prefix: ant_test_logs_heavy_replicate_bench

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -755,7 +755,6 @@ jobs:
           fi
 
   verify_data_location_routing_table:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Verify data location and Routing Table
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/node_man_tests.yml
+++ b/.github/workflows/node_man_tests.yml
@@ -2,7 +2,7 @@ name: Node Manager Tests
 
 on:
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [main]
   pull_request:
     branches: ["*"]
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,11 +8,8 @@ permissions:
 on:
   # allow workflow to be used as part of other workflow
   workflow_call:
-  # tests must run for a PR to be valid and pass merge queue muster
-  # on main, we want to know that all commits are passing at a glance, any deviation should help bisecting errors
-  # the merge run checks should show on master and enable this clear test/passing history
   merge_group:
-    branches: [main, alpha*, beta*, rc*]
+    branches: [main]
   pull_request:
     branches: ["*"]
 defaults:

--- a/autonomi/tests/put.rs
+++ b/autonomi/tests/put.rs
@@ -11,7 +11,8 @@ use autonomi::Client;
 use eyre::Result;
 use test_utils::{evm::get_funded_wallet, gen_random_data};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
 async fn put() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test();
 


### PR DESCRIPTION
- b48339f5c **ci: provide tests for covering all file types**

  For both small and medium files:
  * public without archive
  * public with archive
  * public directory
  * public directory without archive
  * private without archive
  * private with archive
  * private directory
  * private directory without archive

  Where a small file is something between 1 to 50MB, and a medium file is between 50MB and 1GB.

  Since these are bit cumbersome to have in shell, it's arguable they could have been implemented as
  Rust tests for `autonomi`. However, things like the `--no-archive` flag is a feature of the CLI, not
  the `autonomi` API.

  I also chose to implement these as a separate job from the e2e test, and just leave that as
  something that deals with smaller cases for each feature.

- 9a9713d9c **chore: tidy some workflows**

  * Remove conditions for checking if there is a release. These are not necessary because releases are
    not triggered manually.
  * Remove large chunks of commented out jobs. These have typically been commented out for several
    months or longer.
  * Remove redundant branches from merge queue definitions.
  * Remove some superfluous comments.