### PR TITLE
chore(client): unify Pointer and Scratchpad split resolution approacch

### DIFF
--- a/autonomi/src/client/data_types/mod.rs
+++ b/autonomi/src/client/data_types/mod.rs
@@ -10,3 +10,88 @@ pub mod chunk;
 pub mod graph;
 pub mod pointer;
 pub mod scratchpad;
+
+use crate::networking::{PeerId, Record};
+use ant_protocol::NetworkAddress;
+use std::collections::HashMap;
+use tracing::{debug, error, warn};
+
+/// Resolve split records by selecting the highest counter.
+/// If multiple records share the highest counter but have different content,
+/// return a fork error constructed by the provided closure.
+/// If deserialization fails for any record, return the deserialization error.
+/// If no valid records remain, return a corrupt error constructed by the provided closure.
+pub(crate) fn resolve_split_records<T, E, FDeser, FCounter, FEqual, FFork, FCorrupt>(
+    result_map: HashMap<PeerId, Record>,
+    key: NetworkAddress,
+    deserialize: FDeser,
+    counter_of: FCounter,
+    same_content: FEqual,
+    fork_error: FFork,
+    corrupt_error: FCorrupt,
+) -> Result<T, E>
+where
+    T: Clone,
+    FDeser: Fn(Record) -> Result<T, E>,
+    FCounter: Fn(&T) -> u64,
+    FEqual: Fn(&T, &T) -> bool,
+    FFork: Fn(Vec<T>) -> E,
+    FCorrupt: Fn() -> E,
+{
+    debug!("Resolving split records at {key:?}");
+
+    // Deserialize all records; if any fails, propagate the error upstream
+    let mut items: Vec<T> = result_map
+        .into_values()
+        .map(deserialize)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if items.is_empty() {
+        error!("Got empty records map for {key:?}");
+        return Err(corrupt_error());
+    }
+
+    // Sort by counter then pick the max counter value
+    items.sort_by_key(|t| counter_of(t));
+    let max_counter = match items.last().map(&counter_of) {
+        Some(c) => c,
+        None => {
+            error!("No records left after sorting for {key:?}");
+            return Err(corrupt_error());
+        }
+    };
+
+    // Collect all with max counter
+    let latest: Vec<T> = items
+        .into_iter()
+        .filter(|t| counter_of(t) == max_counter)
+        .collect();
+
+    if latest.is_empty() {
+        error!("No latest records found for {key:?}");
+        return Err(corrupt_error());
+    }
+
+    // Deduplicate equal-content entries
+    let mut dedup_latest: Vec<T> = Vec::with_capacity(latest.len());
+    for item in latest.iter().cloned() {
+        if !dedup_latest
+            .iter()
+            .any(|existing| same_content(existing, &item))
+        {
+            dedup_latest.push(item);
+        }
+    }
+
+    match dedup_latest.as_slice() {
+        [one] => Ok(one.clone()),
+        [] => {
+            error!("No valid records remain after deduplication for {key:?}");
+            Err(corrupt_error())
+        }
+        _multi => {
+            warn!("Multiple conflicting records found at latest version for {key:?}");
+            Err(fork_error(latest))
+        }
+    }
+}

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -6,24 +6,26 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::collections::HashMap;
+use super::resolve_split_records;
 
-use crate::client::{
-    Client, GetError, PutError,
-    payment::{PayError, PaymentOption},
-    quote::CostError,
+use crate::{
+    client::{
+        Client, GetError, PutError,
+        payment::{PayError, PaymentOption},
+        quote::CostError,
+    },
+    networking::{NetworkError, PeerInfo, Record},
 };
-use crate::networking::{PeerId, PeerInfo, Record};
+
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
 use ant_protocol::{
     NetworkAddress,
     storage::{DataTypes, RecordHeader, RecordKind, try_deserialize_record, try_serialize_record},
 };
-pub use bls::{PublicKey, SecretKey};
 use tracing::{debug, error, trace};
 
-use crate::networking::NetworkError;
 pub use ant_protocol::storage::{Pointer, PointerAddress, PointerTarget};
+pub use bls::{PublicKey, SecretKey};
 
 /// Errors that can occur when dealing with Pointers
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +54,8 @@ pub enum PointerError {
         "Pointer cannot be updated as it does not exist, please create it first or wait for it to be created"
     )]
     CannotUpdateNewPointer,
+    #[error("Got multiple conflicting pointers with the latest version")]
+    Fork(Vec<Pointer>),
 }
 
 impl Client {
@@ -69,7 +73,19 @@ impl Client {
             Ok(None) => Err(GetError::RecordNotFound)?,
             Err(NetworkError::SplitRecord(result_map)) => {
                 warn!("Pointer at {key:?} is split, trying resolution");
-                select_highest_pointer_version(result_map, key)?
+                resolve_split_records(
+                    result_map,
+                    key.clone(),
+                    pointer_from_record,
+                    |p: &Pointer| p.counter(),
+                    |a: &Pointer, b: &Pointer| a == b,
+                    |multiples: Vec<Pointer>| PointerError::Fork(multiples),
+                    || {
+                        PointerError::Corrupt(format!(
+                            "Found multiple conflicting invalid pointers at {key:?}"
+                        ))
+                    },
+                )?
             }
             Err(err) => {
                 error!("Error fetching pointer: {err:?}");
@@ -340,35 +356,6 @@ impl Client {
         );
         debug!("Calculated the cost to create pointer of {key:?} is {total_cost}");
         Ok(total_cost)
-    }
-}
-
-/// Select the highest versioned pointer from a list of conflicting pointer records
-///
-/// If there are multiple conflicting pointers at the latest version, the first one is returned
-/// If there are no valid pointers, an error is returned
-fn select_highest_pointer_version(
-    result_map: HashMap<PeerId, Record>,
-    key: NetworkAddress,
-) -> Result<Pointer, PointerError> {
-    let highest_version = result_map
-        .into_iter()
-        .filter_map(|(peer, record)| match pointer_from_record(record) {
-            Ok(pointer) => Some(pointer),
-            Err(err) => {
-                warn!("Peer {peer:?} returned invalid pointer at {key} with error: {err}");
-                None
-            }
-        })
-        .max_by_key(|pointer| pointer.counter());
-
-    match highest_version {
-        Some(pointer) => Ok(pointer),
-        None => {
-            let msg = format!("Found multiple conflicting invalid pointers at {key}");
-            warn!("{msg}");
-            Err(PointerError::Corrupt(msg))
-        }
     }
 }
 


### PR DESCRIPTION
### Description

unify Pointer and Scratchpad split resolution approach:
* Resolve split records by selecting the highest counter.
* return a fork error If multiple records share the highest counter but have different content
* If deserialization fails for any record, return the deserialization error.
* If no valid records remain, return a corrupt error constructed by the provided closure.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
