### PR TITLE
fix(cli): re-enable ant cli logging

### DIFF
--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -90,15 +90,16 @@ async fn main() -> Result<()> {
 
 fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
     let logging_targets = vec![
+        // libs
         ("ant_bootstrap".to_string(), Level::INFO),
         ("ant_build_info".to_string(), Level::TRACE),
         ("ant_evm".to_string(), Level::TRACE),
-        ("autonomi_cli".to_string(), Level::TRACE),
         ("autonomi".to_string(), Level::TRACE),
         ("evmlib".to_string(), Level::TRACE),
         ("ant_logging".to_string(), Level::TRACE),
         ("ant_protocol".to_string(), Level::TRACE),
-        ("ant_cli".to_string(), Level::TRACE),
+        // bins
+        ("ant".to_string(), Level::TRACE),
     ];
     let mut log_builder = LogBuilder::new(logging_targets);
     log_builder.output_dest(opt.log_output_dest.clone());

--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -7,23 +7,25 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    LogFormat, LogOutputDest, appender,
+    appender,
     error::{Error, Result},
+    LogFormat, LogOutputDest,
 };
 use std::collections::BTreeMap;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_core::{Event, Level, Subscriber};
 use tracing_subscriber::{
-    Layer, Registry,
     filter::Targets,
     fmt::{
-        self as tracing_fmt, FmtContext, FormatEvent, FormatFields,
+        self as tracing_fmt,
         format::Writer,
         time::{FormatTime, SystemTime},
+        FmtContext, FormatEvent, FormatFields,
     },
     layer::Filter,
     registry::LookupSpan,
     reload::{self, Handle},
+    Layer, Registry,
 };
 
 const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
@@ -188,12 +190,12 @@ impl TracingLayers {
         default_logging_targets: Vec<(String, Level)>,
     ) -> Result<()> {
         use opentelemetry::{
+            sdk::{trace, Resource},
             KeyValue,
-            sdk::{Resource, trace},
         };
         use opentelemetry_otlp::WithExportConfig;
         use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
-        use rand::{Rng, distributions::Alphanumeric, thread_rng};
+        use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
         let service_name = std::env::var("OTLP_SERVICE_NAME").unwrap_or_else(|_| {
             let random_node_name: String = thread_rng()
@@ -265,7 +267,7 @@ fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> 
         if contains_keyword_all_sn_logs || contains_keyword_verbose_sn_logs {
             let mut t = BTreeMap::from_iter(vec![
                 // bins
-                ("autonomi_cli".to_string(), Level::TRACE),
+                ("ant".to_string(), Level::TRACE),
                 ("evm_testnet".to_string(), Level::TRACE),
                 ("antnode".to_string(), Level::TRACE),
                 ("antnode_rpc_client".to_string(), Level::TRACE),


### PR DESCRIPTION
### Description

 re-enable ant cli logging, which will bring back the logs like below:
```
[2025-08-25T12:53:18.066307Z INFO ant 80] "ant --log-output-dest=data-dir file download --disable-cache 9875177d76c9768edbabe048ad2b2846b8a9de0286bd5e1097813cc0dc75128f ./downloaded_file"
```

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
