### PR TITLE
Extend stream download coverage

### DIFF
--- a/.github/workflows/files.yml
+++ b/.github/workflows/files.yml
@@ -177,19 +177,38 @@ jobs:
                   continue
                 fi
                 
-                ./target/release/ant --local file download "$ADDRESS" "test_download/downloaded_${size}_file_${test_name}"
+                ./target/release/ant --local file download "$ADDRESS" "test_download/downloaded_${size}_file_${test_name}" 2>&1 | tee "./${size}_download_output_${test_name}"
                 find test_download -type f -exec ls -lh {} \;
+                
+                # Show download output to screen
+                echo "=== Download Output for ${size} file ==="
+                cat "./${size}_download_output_${test_name}"
+                echo "=== End Download Output ==="
+                
+                # Check for streaming download when file_size_mb is 200
+                streaming_check_passed=true
+                if [[ $file_size_mb -eq 200 ]]; then
+                  if ! grep -q "Streaming fetching" "./${size}_download_output_${test_name}"; then
+                    echo "⚠️  WARNING: streaming download not detected for 200MB file"
+                    streaming_check_passed=false
+                  else
+                    echo "✅ Streaming download detected for 200MB file"
+                  fi
+                fi
                 
                 if [[ -f "test_download/downloaded_${size}_file_${test_name}" ]]; then
                   original_size=$(stat -c%s "$test_file" 2>/dev/null || stat -f%z "$test_file")
                   downloaded_size=$(stat -c%s "test_download/downloaded_${size}_file_${test_name}" 2>/dev/null || stat -f%z "test_download/downloaded_${size}_file_${test_name}")
                   
-                  if [[ $original_size -eq $downloaded_size ]]; then
+                  if [[ $original_size -eq $downloaded_size ]] && [[ $streaming_check_passed == true ]]; then
                     echo "✅ $test_name ${size} file test passed: $downloaded_size bytes"
                     passed_tests+=("$test_name ($size file) - $downloaded_size bytes")
-                  else
+                  elif [[ $original_size -ne $downloaded_size ]]; then
                     echo "❌ $test_name ${size} file size mismatch - original: $original_size, downloaded: $downloaded_size"
                     failed_tests+=("$test_name ($size file) - size mismatch")
+                  elif [[ $streaming_check_passed == false ]]; then
+                    echo "❌ $test_name ${size} file test failed: streaming download not detected"
+                    failed_tests+=("$test_name ($size file) - streaming download not detected")
                   fi
                 else
                   echo "❌ $test_name ${size} file download failed"
@@ -455,18 +474,39 @@ jobs:
                   continue
                 }
                 
-                & ".\target\release\ant.exe" --local file download $address "test_download\downloaded_${size}_file_$testName"
+                $downloadOutput = "${size}_download_output_$testName"
+                & ".\target\release\ant.exe" --local file download $address "test_download\downloaded_${size}_file_$testName" 2>&1 | Tee-Object -FilePath $downloadOutput
+                
+                # Show download output to screen
+                Write-Host "=== Download Output for $size file ==="
+                Get-Content $downloadOutput
+                Write-Host "=== End Download Output ==="
+                
+                # Check for streaming download when fileSizeMB is 200
+                $streamingCheckPassed = $true
+                if ($fileSizeMB -eq 200) {
+                  $downloadContent = Get-Content $downloadOutput -Raw
+                  if ($downloadContent -notmatch "Streaming fetching") {
+                    Write-Host "⚠️  WARNING: streaming download not detected for 200MB file"
+                    $streamingCheckPassed = $false
+                  } else {
+                    Write-Host "✅ Streaming download detected for 200MB file"
+                  }
+                }
                 
                 if (Test-Path "test_download\downloaded_${size}_file_$testName") {
                   $originalSize = (Get-Item $testFile).Length
                   $downloadedSize = (Get-Item "test_download\downloaded_${size}_file_$testName").Length
                   
-                  if ($originalSize -eq $downloadedSize) {
+                  if (($originalSize -eq $downloadedSize) -and $streamingCheckPassed) {
                     Write-Host "✅ $testName $size file test passed: $downloadedSize bytes"
                     $passedTests += "$testName ($size file) - $downloadedSize bytes"
-                  } else {
+                  } elseif ($originalSize -ne $downloadedSize) {
                     Write-Host "❌ $testName $size file size mismatch - original: $originalSize, downloaded: $downloadedSize"
                     $failedTests += "$testName ($size file) - size mismatch"
+                  } elseif (-not $streamingCheckPassed) {
+                    Write-Host "❌ $testName $size file test failed: streaming download not detected"
+                    $failedTests += "$testName ($size file) - streaming download not detected"
                   }
                 } else {
                   Write-Host "❌ $testName $size file download failed"

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -60,6 +60,7 @@ pub(crate) fn get_error_exit_code(err: &GetError) -> i32 {
         GetError::RecordKindMismatch(_) => 34,
         GetError::Configuration(_) => 35,
         GetError::UnrecognizedDataMap(_) => 31,
+        GetError::TooLargeForMemory => 31,
     }
 }
 

--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -7,25 +7,23 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    appender,
+    LogFormat, LogOutputDest, appender,
     error::{Error, Result},
-    LogFormat, LogOutputDest,
 };
 use std::collections::BTreeMap;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_core::{Event, Level, Subscriber};
 use tracing_subscriber::{
+    Layer, Registry,
     filter::Targets,
     fmt::{
-        self as tracing_fmt,
+        self as tracing_fmt, FmtContext, FormatEvent, FormatFields,
         format::Writer,
         time::{FormatTime, SystemTime},
-        FmtContext, FormatEvent, FormatFields,
     },
     layer::Filter,
     registry::LookupSpan,
     reload::{self, Handle},
-    Layer, Registry,
 };
 
 const MAX_LOG_SIZE: usize = 20 * 1024 * 1024;
@@ -190,12 +188,12 @@ impl TracingLayers {
         default_logging_targets: Vec<(String, Level)>,
     ) -> Result<()> {
         use opentelemetry::{
-            sdk::{trace, Resource},
             KeyValue,
+            sdk::{Resource, trace},
         };
         use opentelemetry_otlp::WithExportConfig;
         use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
-        use rand::{distributions::Alphanumeric, thread_rng, Rng};
+        use rand::{Rng, distributions::Alphanumeric, thread_rng};
 
         let service_name = std::env::var("OTLP_SERVICE_NAME").unwrap_or_else(|_| {
             let random_node_name: String = thread_rng()

--- a/autonomi/src/client/high_level/data/public.rs
+++ b/autonomi/src/client/high_level/data/public.rs
@@ -38,6 +38,21 @@ impl Client {
         Ok(data)
     }
 
+    /// shall be used to replace the current data_get_public
+    ///
+    /// steaming_download will only be used when: `to_dest` is provided AND `target size is big enough (chunks.len()> 20)`
+    /// `Bytes` will only be returned when streaming_download not got used
+    pub async fn data_fetch_public(
+        &self,
+        addr: &DataAddress,
+        to_dest: Option<PathBuf>,
+    ) -> Result<Option<Bytes>, GetError> {
+        info!("Fetching data from Data Address: {addr:?}");
+        let datamap_chunk =
+            DataMapChunk(self.chunk_get(&ChunkAddress::new(*addr.xorname())).await?);
+        self.fetch_with_stream_opt(&datamap_chunk, to_dest).await
+    }
+
     /// Streamingly fetch a blob of data from the network
     pub async fn streaming_data_get_public(
         &self,

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use self_encryption::DataMap;
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -172,10 +173,18 @@ impl Client {
     /// Fetch
     pub(super) async fn stream_download_chunks_to_file(
         &self,
-        data_map_chunk: &DataMapChunk,
+        datamap_chunk: &DataMapChunk,
         to_dest: &Path,
     ) -> Result<(), DownloadError> {
-        let data_map = self.restore_data_map_from_chunk(data_map_chunk).await?;
+        let datamap = self.restore_data_map_from_chunk(datamap_chunk).await?;
+        self.stream_download_from_datamap(datamap, to_dest)
+    }
+
+    pub(crate) fn stream_download_from_datamap(
+        &self,
+        data_map: DataMap,
+        to_dest: &Path,
+    ) -> Result<(), DownloadError> {
         let total_chunks = data_map.infos().len();
 
         #[cfg(feature = "loud")]

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -179,8 +179,8 @@ impl Client {
         let total_chunks = data_map.infos().len();
 
         #[cfg(feature = "loud")]
-        println!("Fetching {total_chunks} chunks ...");
-        info!("Fetching {total_chunks} chunks ...");
+        println!("Streaming fetching {total_chunks} chunks to {to_dest:?} ...");
+        info!("Streaming fetching {total_chunks} chunks to {to_dest:?} ...");
 
         // Create parallel chunk fetcher for streaming decryption
         let client_clone = self.clone();

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -170,6 +170,8 @@ pub enum GetError {
     Configuration(String),
     #[error("Unable to recogonize the so claimed DataMap: {0}")]
     UnrecognizedDataMap(String),
+    #[error("DataMap pointing to a large file, shall not be handled in memory")]
+    TooLargeForMemory,
 }
 
 impl Client {

--- a/autonomi/tests/backward_compatibility.rs
+++ b/autonomi/tests/backward_compatibility.rs
@@ -84,7 +84,7 @@ async fn test_backward_compatibility_e2e_network() -> Result<(), Box<dyn std::er
     let payment_option = PaymentOption::from(&wallet);
 
     // Step 2: Generate test data and encrypt using old self_encryption way
-    let content_size: usize = 20 * MAX_CHUNK_SIZE + 100;
+    let content_size: usize = 15 * MAX_CHUNK_SIZE + 100;
     let mut content = vec![0u8; content_size];
     for (i, c) in content.iter_mut().enumerate().take(content_size) {
         *c = (i % 17) as u8;


### PR DESCRIPTION
### Description

* use stream download for private/public
* stream download usage checks during CI

Public API changes:
* `data_fetch_public` : newly added function call (shall eventually replace the existing `data_get_public`)
* `fetch_with_stream_opt` : newly added function call (shall eventually replace the existing `fetch_from_data_map_chunk`)
* `GetError::TooLargeForMemory` : newly added error entry
* `data` field of `Analysis::DataMap` and `Analysis::RawDataMap` : now changed to `Option<Bytes>`, instead of previous `Bytes`
* 'fetch_from_data_map_chunk` : now will raise error of `GetError::TooLargeForMemory` when the restored datamap points to a large sized file (`datamap.infos().len() > 20`)

Close https://github.com/maidsafe/autonomi/pull/3170
Close https://github.com/maidsafe/autonomi/pull/3171

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
