### PR TITLE
feat: cleanup api methods duplication

### DIFF
--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -64,6 +64,13 @@ pub(crate) fn get_error_exit_code(err: &GetError) -> i32 {
     }
 }
 
+pub(crate) fn get_download_error_exit_code(err: &autonomi::files::DownloadError) -> i32 {
+    match err {
+        autonomi::files::DownloadError::GetError(ge) => get_error_exit_code(ge),
+        autonomi::files::DownloadError::IoError(_) => IO_ERROR,
+    }
+}
+
 pub(crate) fn analysis_exit_code(err: &AnalysisError) -> i32 {
     match err {
         AnalysisError::UnrecognizedInput => 36,

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -69,6 +69,7 @@ self_encryption = { version = "0.33.0" }
 self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sha2 = "0.10.6"
+tempfile = "3.12.0"
 thiserror = "1.0.23"
 tokio = { version = "1.43.1", features = ["sync", "fs"] }
 tracing = { version = "~0.1.26" }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -69,7 +69,6 @@ self_encryption = { version = "0.33.0" }
 self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 sha2 = "0.10.6"
-tempfile = "3.12.0"
 thiserror = "1.0.23"
 tokio = { version = "1.43.1", features = ["sync", "fs"] }
 tracing = { version = "~0.1.26" }

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -9,7 +9,103 @@
 use crate::networking::{Quorum, RetryStrategy, Strategy};
 pub use ant_bootstrap::{BootstrapCacheConfig, InitialPeersConfig, error::Error as BootstrapError};
 use ant_evm::EvmNetwork;
-use std::num::NonZero;
+use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;
+use std::{num::NonZero, sync::LazyLock};
+
+/// Number of chunks to upload in parallel.
+///
+/// Can be overridden by the `CHUNK_UPLOAD_BATCH_SIZE` environment variable.
+pub(crate) static CHUNK_UPLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("CHUNK_UPLOAD_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    info!("Chunk upload batch size: {}", batch_size);
+    batch_size
+});
+
+/// Number of chunks to download in parallel.
+///
+/// Can be overridden by the `CHUNK_DOWNLOAD_BATCH_SIZE` environment variable.
+pub static CHUNK_DOWNLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("CHUNK_DOWNLOAD_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    info!("Chunk download batch size: {}", batch_size);
+    batch_size
+});
+
+/// Maximum number of chunks that we allow to download from a datamap in memory.
+/// This affects the maximum size of data downloaded with APIs such as [`crate::Client::data_get`]
+///
+/// Can be overridden by the `MAX_IN_MEMORY_DOWNLOAD_SIZE ` environment variable.
+pub static MAX_IN_MEMORY_DOWNLOAD_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let size = std::env::var("MAX_IN_MEMORY_DOWNLOAD_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20);
+    info!("Max in memory download size: {}", size);
+    size
+});
+
+/// Number of files to upload in parallel.
+///
+/// Can be overridden by the `FILE_UPLOAD_BATCH_SIZE` environment variable.
+pub static FILE_UPLOAD_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("FILE_UPLOAD_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    info!("File upload batch size: {}", batch_size);
+    batch_size
+});
+
+/// Number of files to encrypt in parallel.
+///
+/// Can be overridden by the `FILE_ENCRYPT_BATCH_SIZE` environment variable.
+pub static FILE_ENCRYPT_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("FILE_ENCRYPT_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+                * 8,
+        );
+    info!("File encryption batch size: {}", batch_size);
+    batch_size
+});
+
+/// Maximum size of a file to be encrypted in memory.
+///
+/// Can be overridden by the [`IN_MEMORY_ENCRYPTION_MAX_SIZE`] environment variable.
+/// The default is 100MB.
+pub static IN_MEMORY_ENCRYPTION_MAX_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let max_size = std::env::var("IN_MEMORY_ENCRYPTION_MAX_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50_000_000);
+    info!(
+        "IN_MEMORY_ENCRYPTION_MAX_SIZE (from that threshold, the file will be encrypted in a stream): {}",
+        max_size
+    );
+    max_size
+});
+
+/// Number of batch size of an entire quote-pay-upload flow to process.
+/// Suggested to be multiples of `MAX_TRANSFERS_PER_TRANSACTION  / 3` (records-payouts-per-transaction).
+///
+/// Can be overridden by the `UPLOAD_FLOW_BATCH_SIZE` environment variable.
+pub(crate) static UPLOAD_FLOW_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    let batch_size = std::env::var("UPLOAD_FLOW_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(MAX_TRANSFERS_PER_TRANSACTION / 3);
+    info!("Upload flow batch size: {}", batch_size);
+    batch_size
+});
 
 /// Configuration for the [`crate::Client`] which can be provided through: [`crate::Client::init_with_config`].
 #[derive(Debug, Clone, Default)]

--- a/autonomi/src/client/encryption.rs
+++ b/autonomi/src/client/encryption.rs
@@ -14,28 +14,11 @@ use ant_protocol::storage::Chunk;
 use bytes::Bytes;
 use self_encryption::MAX_CHUNK_SIZE;
 use std::path::PathBuf;
-use std::sync::LazyLock;
 use std::time::Instant;
 use tokio::sync::oneshot;
 
 use super::data::DataAddress;
-use super::files::FILE_ENCRYPT_BATCH_SIZE;
-
-/// Maximum size of a file to be encrypted in memory.
-///
-/// Can be overridden by the [`IN_MEMORY_ENCRYPTION_MAX_SIZE`] environment variable.
-/// The default is 100MB.
-pub static IN_MEMORY_ENCRYPTION_MAX_SIZE: LazyLock<usize> = LazyLock::new(|| {
-    let max_size = std::env::var("IN_MEMORY_ENCRYPTION_MAX_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(50_000_000);
-    info!(
-        "IN_MEMORY_ENCRYPTION_MAX_SIZE (from that threshold, the file will be encrypted in a stream): {}",
-        max_size
-    );
-    max_size
-});
+use crate::client::config::{FILE_ENCRYPT_BATCH_SIZE, IN_MEMORY_ENCRYPTION_MAX_SIZE};
 
 const STREAM_CHUNK_CHANNEL_CAPACITY: usize = 100;
 

--- a/autonomi/src/client/high_level/data/private.rs
+++ b/autonomi/src/client/high_level/data/private.rs
@@ -18,7 +18,8 @@ pub use crate::Bytes;
 pub use crate::client::data_types::chunk::DataMapChunk;
 
 impl Client {
-    /// Fetch a blob of (private) data from the network
+    /// Fetch a blob of (private) data from the network. In-memory only - fails for large files.
+    /// Use file_download for large files that need streaming.
     ///
     /// # Example
     ///
@@ -37,9 +38,20 @@ impl Client {
             "Fetching private data from datamap {:?}",
             data_map.0.address()
         );
-        let data = self.fetch_from_data_map_chunk(data_map).await?;
 
-        debug!("Successfully fetched a blob of private data from the network");
+        let mut datamap = self.restore_data_map_from_chunk(data_map).await?;
+        let chunk_count = datamap.infos().len();
+
+        if chunk_count > *crate::client::config::MAX_IN_MEMORY_DOWNLOAD_SIZE {
+            return Err(GetError::TooLargeForMemory);
+        }
+
+        datamap.child = None;
+        let data = self.fetch_from_data_map(&datamap).await?;
+        debug!(
+            "Successfully fetched private data ({} chunks) in-memory",
+            chunk_count
+        );
         Ok(data)
     }
 

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -16,24 +16,23 @@ use bytes::Bytes;
 use std::path::PathBuf;
 
 impl Client {
-    /// Download a private file from network to local file system
+    /// Download private file directly to filesystem. Always uses streaming.
     pub async fn file_download(
         &self,
-        data_access: &DataMapChunk,
+        data_map: &DataMapChunk,
         to_dest: PathBuf,
     ) -> Result<(), DownloadError> {
-        info!("Downloading file to {to_dest:?}");
+        info!("Downloading private file to {to_dest:?}");
 
         // Create parent directories if needed
         if let Some(parent) = to_dest.parent() {
             tokio::fs::create_dir_all(parent).await?;
-            debug!("Created parent directories for {to_dest:?}");
         }
 
-        self.stream_download_chunks_to_file(data_access, &to_dest)
-            .await?;
+        let datamap = self.restore_data_map_from_chunk(data_map).await?;
+        self.stream_download_from_datamap(datamap, &to_dest)?;
 
-        debug!("Downloaded file to {to_dest:?}");
+        debug!("Successfully downloaded private file to {to_dest:?}");
         Ok(())
     }
 

--- a/autonomi/src/client/high_level/vault/mod.rs
+++ b/autonomi/src/client/high_level/vault/mod.rs
@@ -12,8 +12,8 @@ pub mod user_data;
 pub use key::{VaultSecretKey, derive_vault_key};
 pub use user_data::UserData;
 
+use crate::client::config::FILE_UPLOAD_BATCH_SIZE;
 use crate::client::data_types::scratchpad::ScratchpadError;
-use crate::client::high_level::files::FILE_UPLOAD_BATCH_SIZE;
 use crate::client::key_derivation::{DerivationIndex, MainSecretKey};
 use crate::client::payment::PaymentOption;
 use crate::client::quote::CostError;

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -170,7 +170,11 @@ pub enum GetError {
     Configuration(String),
     #[error("Unable to recogonize the so claimed DataMap: {0}")]
     UnrecognizedDataMap(String),
-    #[error("DataMap pointing to a large file, shall not be handled in memory")]
+    /// When trying to download a file that is too large to be handled in memory
+    /// you can increase the [`crate::client::config::MAX_IN_MEMORY_DOWNLOAD_SIZE`] env var or use the streaming API.
+    #[error(
+        "DataMap points to a file too large to be handled in memory, you can increase the MAX_IN_MEMORY_DOWNLOAD_SIZE env var or use streaming to avoid this error."
+    )]
     TooLargeForMemory,
 }
 

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Client;
-use crate::client::data_types::chunk::CHUNK_UPLOAD_BATCH_SIZE;
+use crate::client::config::CHUNK_UPLOAD_BATCH_SIZE;
 use crate::client::utils::process_tasks_with_max_concurrency;
 use crate::networking::Network;
 use crate::networking::common::Addresses;

--- a/autonomi/tests/backward_compatibility.rs
+++ b/autonomi/tests/backward_compatibility.rs
@@ -125,10 +125,10 @@ async fn test_backward_compatibility_e2e_network() -> Result<(), Box<dyn std::er
     println!("Waiting for data replication...");
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    // Step 6: Download the content back by calling fetch_from_data_map_chunk function
+    // Step 6: Download the content back by calling data_get function
     println!("Downloading and decrypting content using backward-compatible function...");
     let data_map_chunk = DataMapChunk(Chunk::new(data_map_bytes));
-    let decrypted_content = client.fetch_from_data_map_chunk(&data_map_chunk).await?;
+    let decrypted_content = client.data_get(&data_map_chunk).await?;
 
     println!(
         "Downloaded content length: {} bytes",


### PR DESCRIPTION
Client Public API changes:
* `MAX_IN_MEMORY_DOWNLOAD_SIZE `: newly added const
* `fetch_from_data_map` : hidden from public
* `fetch_with_stream_opt` : removed
* `fetch_from_data_map_chunk`: removed
* `data_fetch_public` : removed
* `streaming_data_get_public` : removed
* `data_get` and `data_get_public` now will raise the `TooLargeForMemory` error when target blob is actually a large file (chunks.len() > MAX_IN_MEMORY_DOWNLOAD_SIZE)