### PR TITLE
feat(scratchpad_put)!: return receipt for secret-key–free updates

### DIFF
--- a/autonomi-nodejs/src/lib.rs
+++ b/autonomi-nodejs/src/lib.rs
@@ -359,7 +359,7 @@ impl Client {
         scratchpad: &Scratchpad,
         payment_option: &PaymentOption,
     ) -> Result</* (AttoTokens, ScratchpadAddress) */ tuple_result::ScratchpadPut> {
-        let (cost, addr) = self
+        let (cost, addr, _receipt) = self
             .0
             .scratchpad_put(scratchpad.0.clone(), payment_option.0.clone())
             .await

--- a/autonomi/src/python.rs
+++ b/autonomi/src/python.rs
@@ -505,7 +505,7 @@ impl PyClient {
         let payment = payment_option.inner.clone();
 
         future_into_py(py, async move {
-            let (cost, addr) = client
+            let (cost, addr, _receipt) = client
                 .scratchpad_put(scratchpad.inner, payment)
                 .await
                 .map_err(scratchpad_error_to_py_err)?;

--- a/autonomi/tests/address.rs
+++ b/autonomi/tests/address.rs
@@ -101,7 +101,7 @@ async fn test_data_addresses_use() -> Result<()> {
     let key = bls::SecretKey::random();
     let scratchpad = Scratchpad::new(&key, 0, &Bytes::from("Scratchpad content example"), 0);
     let payment_option = PaymentOption::from(&wallet);
-    let (_cost, addr) = client.scratchpad_put(scratchpad, payment_option).await?;
+    let (_cost, addr, _receipt) = client.scratchpad_put(scratchpad, payment_option).await?;
     let scratchpad_addr = addr.to_hex();
     println!("Scratchpad: {scratchpad_addr}");
     let scratchpad_bls_pubkey = key.public_key().to_hex();

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -158,7 +158,7 @@ async fn test_analyze_scratchpad() -> Result<()> {
 
     let key = bls::SecretKey::random();
     let scratchpad = Scratchpad::new(&key, 0, &Bytes::from("Scratchpad content example"), 0);
-    let (_cost, addr) = client
+    let (_cost, addr, _receipt) = client
         .scratchpad_put(scratchpad.clone(), payment_option)
         .await?;
     let scratchpad_addr = addr.to_hex();

--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -37,7 +37,7 @@ async fn scratchpad_put_manual() -> Result<()> {
 
     // put the scratchpad
     let payment_option = PaymentOption::from(&wallet);
-    let (cost, addr) = client
+    let (cost, addr, _receipt) = client
         .scratchpad_put(scratchpad.clone(), payment_option)
         .await?;
     assert_eq!(addr, *scratchpad.address());
@@ -59,7 +59,7 @@ async fn scratchpad_put_manual() -> Result<()> {
     let content2 = Bytes::from("Secure Access For Everyone");
     let scratchpad2 = Scratchpad::new(&key, 42, &content2, 1);
     let payment_option = PaymentOption::from(&wallet);
-    let (cost, _) = client
+    let (cost, _addr, _receipt) = client
         .scratchpad_put(scratchpad2.clone(), payment_option)
         .await?;
     assert_eq!(cost, AttoTokens::zero());


### PR DESCRIPTION
TL;DR: `scratchpad_put` now returns a `Receipt`; enables create+update without the address’s secret key.
Closes #3184.

Changes:
- Return `(AttoTokens, ScratchpadAddress, Receipt)` from `scratchpad_put`.
- Create: one-entry `Receipt`; Update: empty `Receipt`.

Breaking change: 2-tuple → 3-tuple.
Migration: `let (cost, addr, receipt) = scratchpad_put(...);`