### PR TITLE
fix(client): error out if imput dest path can not be used for streaming disk flush

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -987,6 +987,23 @@ jobs:
           echo "UPLOAD_ADDRESS=$UPLOAD_ADDRESS" >> $GITHUB_ENV
         shell: bash
 
+      - name: File Download Error Check
+        run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} . > ./error_output 2>&1
+        env:
+          ANT_LOG: "v"
+        timeout-minutes: 5
+        continue-on-error: true
+
+      - name: Verify expected error message
+        run: |
+          cat ./error_output
+          if ! grep -q "cannot be used for streaming disk flushing" ./error_output; then
+            echo "Expected error message 'cannot be used for streaming disk flushing' not found in output"
+            exit 1
+          fi
+          echo "Expected error message found in output"
+        shell: bash
+
       - name: File Download
         run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources/downloaded_file > ./download_output 2>&1
         env:


### PR DESCRIPTION
### Description

Carry out a check against the input dest file for streaming download.
In case the input dest file path cann't be used, error out properly.

```
ant file download ec3c02edd203c394f1b41148f9648755f9886533ab73ecf989ceb575b28806c5 .
```
will now generate following error directly:
```
Input destination path "." cannot be used for streaming disk flushing: Is a directory (os error 21)
This file could be uploaded without a metadata archive. A file name must be provided to download and save it.
```

### Related Issue

Fixes #3186

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
