### PR TITLE
feat: fix adding node in LP for windows

### DIFF
--- a/node-launchpad/.config/config.json5
+++ b/node-launchpad/.config/config.json5
@@ -20,6 +20,7 @@
       "<l>": {"StatusActions":"TriggerNodeLogs"},
       "<L>": {"StatusActions":"TriggerNodeLogs"},
       "<+>": {"StatusActions":"AddNode"},
+      "<Shift-+>": {"StatusActions":"AddNode"},
       "<->": {"StatusActions":"TriggerRemoveNode"},
 
       "up" : {"StatusActions":"PreviousTableItem"},

--- a/node-launchpad/src/app.rs
+++ b/node-launchpad/src/app.rs
@@ -204,12 +204,14 @@ impl App {
                     tui::Event::Render => action_tx.send(Action::Render)?,
                     tui::Event::Resize(x, y) => action_tx.send(Action::Resize(x, y))?,
                     tui::Event::Key(key) => {
+                        debug!("App received key event: {:?}", key);
                         if self.input_mode == InputMode::Navigation {
                             if let Some(keymap) = self.config.keybindings.get(&self.scene) {
                                 if let Some(action) = keymap.get(&vec![key]) {
                                     info!("Got action: {action:?}");
                                     action_tx.send(action.clone())?;
                                 } else {
+                                    debug!("Key {:?} not found in keymap for scene {:?}", key, self.scene);
                                     // If the key was not handled as a single key action,
                                     // then consider it for multi-key combinations.
                                     self.last_tick_key_events.push(key);
@@ -218,6 +220,8 @@ impl App {
                                     if let Some(action) = keymap.get(&self.last_tick_key_events) {
                                         info!("Got action: {action:?}");
                                         action_tx.send(action.clone())?;
+                                    } else if self.last_tick_key_events.len() > 1 {
+                                        debug!("Multi-key combination {:?} not found in keymap", self.last_tick_key_events);
                                     }
                                 }
                             };

--- a/node-launchpad/src/tui.rs
+++ b/node-launchpad/src/tui.rs
@@ -131,6 +131,7 @@ impl Tui {
                         match evt {
                           CrosstermEvent::Key(key) => {
                             if key.kind == KeyEventKind::Press {
+                              debug!("TUI received raw key event: {:?}", key);
                               _event_tx.send(Event::Key(key)).unwrap();
                             }
                           },


### PR DESCRIPTION
LP in windows is not able to add new nodes through the hotkey +, as most keyboards are 61% (Laptops, and other devices), LP reads it as shift, + which is making LP mark it as invalid input key. Add support to fix this, and add more debug logs to trace this from the logs. 