### PR TITLE
Various scratchpad improvements

### DIFF
--- a/autonomi/tests/scratchpad.rs
+++ b/autonomi/tests/scratchpad.rs
@@ -82,6 +82,63 @@ async fn scratchpad_put_manual() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn scratchpad_put_update_manual() -> Result<()> {
+    let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test();
+
+    let client = Client::init_local().await?;
+    let wallet = get_funded_wallet();
+
+    let key = bls::SecretKey::random();
+    let public_key = key.public_key();
+    let content = Bytes::from("Massive Array of Internet Disks");
+    let scratchpad = Scratchpad::new(&key, 42, &content, 0);
+
+    // estimate the cost of the scratchpad
+    let cost = client.scratchpad_cost(&public_key).await?;
+    println!("scratchpad cost: {cost}");
+
+    // put the scratchpad
+    let payment_option = PaymentOption::from(&wallet);
+    let (cost, addr) = client
+        .scratchpad_put(scratchpad.clone(), payment_option)
+        .await?;
+    assert_eq!(addr, *scratchpad.address());
+    println!("scratchpad put 1 cost: {cost}");
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is stored
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, scratchpad.clone());
+    println!("scratchpad got 1");
+
+    // check that the content is decrypted correctly
+    let got_content = got.decrypt_data(&key)?;
+    assert_eq!(got_content, content);
+
+    // try update scratchpad
+    let content2 = Bytes::from("Secure Access For Everyone");
+    let scratchpad2 = Scratchpad::new(&key, 42, &content2, 1);
+    client.scratchpad_put_update(scratchpad2.clone()).await?;
+
+    // wait for the scratchpad to be replicated
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // check that the scratchpad is updated
+    let got = client.scratchpad_get(&addr).await?;
+    assert_eq!(got, scratchpad2.clone());
+    println!("scratchpad got 2");
+
+    // check that the content is decrypted correctly
+    let got_content2 = got.decrypt_data(&key)?;
+    assert_eq!(got_content2, content2);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn scratchpad_put() -> Result<()> {
     let _log_appender_guard = LogBuilder::init_single_threaded_tokio_test();
 


### PR DESCRIPTION
PR including various improvements to scratchpad API:
- a new `scratchpad_put_update` method that allows the upload of custom scratchpads updates without payment as suggested by @oetyng (Thanks Ed! ❤️ )
- a fix in `scratchpad_update` which handles fork errors to allow for smooth fork resolution through a regular update