### PR TITLE
chore: remove outdated NetworkAddress::as_record_key function

### DIFF
--- a/ant-bootstrap/src/cache_store/mod.rs
+++ b/ant-bootstrap/src/cache_store/mod.rs
@@ -246,7 +246,7 @@ fn duration_with_variance(duration: Duration, variance: u32) -> Duration {
     let variance = duration.as_secs() as f64 * (variance as f64 / 100.0);
 
     let random_adjustment = Duration::from_secs(rand::thread_rng().gen_range(0..variance as u64));
-    if random_adjustment.as_secs() % 2 == 0 {
+    if random_adjustment.as_secs().is_multiple_of(2) {
         duration - random_adjustment
     } else {
         duration + random_adjustment

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -672,10 +672,9 @@ impl Node {
                     holder: Box::new(our_address.clone()),
                     key: Box::new(key.clone()),
                 });
-                let record_key = key.as_record_key();
+                let record_key = key.to_record_key();
 
-                if let Some(record_key) = record_key
-                    && let Ok(Some(record)) = network.get_local_record(&record_key).await
+                if let Ok(Some(record)) = network.get_local_record(&record_key).await
                 {
                     result = Ok((our_address, Bytes::from(record.value)));
                 }

--- a/ant-node/tests/data_with_churn.rs
+++ b/ant-node/tests/data_with_churn.rs
@@ -248,7 +248,7 @@ async fn data_availability_during_churn() -> Result<()> {
         }
 
         let failed = failures.read().await;
-        if start_time.elapsed().as_secs() % 10 == 0 {
+        if start_time.elapsed().as_secs().is_multiple_of(10) {
             println!(
                 "Current failures after {:?} ({}): {:?}",
                 start_time.elapsed(),

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -45,9 +45,9 @@ use self::storage::{ChunkAddress, GraphEntryAddress, PointerAddress, ScratchpadA
 pub use bytes::Bytes;
 
 use libp2p::{
-    Multiaddr, PeerId,
     kad::{KBucketDistance as Distance, KBucketKey as Key, RecordKey},
     multiaddr::Protocol,
+    Multiaddr, PeerId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -115,14 +115,6 @@ impl NetworkAddress {
             return Some(peer_id);
         }
         None
-    }
-
-    /// Try to return the represented `RecordKey`.
-    pub fn as_record_key(&self) -> Option<RecordKey> {
-        match self {
-            NetworkAddress::RecordKey(bytes) => Some(RecordKey::new(bytes)),
-            _ => None,
-        }
     }
 
     /// Return the convertable `RecordKey`.
@@ -392,9 +384,9 @@ impl std::fmt::Debug for PrettyPrintRecordKey<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        NetworkAddress, PeerId,
         messages::{Nonce, Query},
         storage::GraphEntryAddress,
+        NetworkAddress, PeerId,
     };
     use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
### Description

remove outdated NetworkAddress::as_record_key function

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
