### PR TITLE
fix: analyze for old datamap types

### DIFF
--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -674,8 +674,7 @@ impl Node {
                 });
                 let record_key = key.to_record_key();
 
-                if let Ok(Some(record)) = network.get_local_record(&record_key).await
-                {
+                if let Ok(Some(record)) = network.get_local_record(&record_key).await {
                     result = Ok((our_address, Bytes::from(record.value)));
                 }
 

--- a/ant-protocol/build.rs
+++ b/ant-protocol/build.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("./src/antnode_proto/antnode.proto")?;
+    tonic_build::configure()
+        .format(false)  // Disable rustfmt formatting
+        .compile(&["./src/antnode_proto/antnode.proto"], &["./src/antnode_proto"])?;
     Ok(())
 }

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -45,9 +45,9 @@ use self::storage::{ChunkAddress, GraphEntryAddress, PointerAddress, ScratchpadA
 pub use bytes::Bytes;
 
 use libp2p::{
+    Multiaddr, PeerId,
     kad::{KBucketDistance as Distance, KBucketKey as Key, RecordKey},
     multiaddr::Protocol,
-    Multiaddr, PeerId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -384,9 +384,9 @@ impl std::fmt::Debug for PrettyPrintRecordKey<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        NetworkAddress, PeerId,
         messages::{Nonce, Query},
         storage::GraphEntryAddress,
-        NetworkAddress, PeerId,
     };
     use serde::{Deserialize, Serialize};
 

--- a/ant-service-management/build.rs
+++ b/ant-service-management/build.rs
@@ -7,6 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("./src/antctl_proto/antctl.proto")?;
+    tonic_build::configure()
+        .format(false) // Disable rustfmt formatting
+        .compile(
+            &["./src/antctl_proto/antctl.proto"],
+            &["./src/antctl_proto"],
+        )?;
     Ok(())
 }

--- a/autonomi/src/client/high_level/data/helpers.rs
+++ b/autonomi/src/client/high_level/data/helpers.rs
@@ -253,11 +253,12 @@ impl Client {
             }
             Err(err) => {
                 return if retry_on_failure {
-                    error!("Quoting or payment error encountered, retry scheduled {err:?}");
-                    println!("Quoting or payment error encountered, retry scheduled.");
+                    error!("Quoting or payment error encountered, retry scheduled {err}");
+                    #[cfg(feature = "loud")]
+                    println!("Quoting or payment error encountered, retry scheduled: {err}.");
                     (batch, vec![], 0, None)
                 } else {
-                    error!("Quoting or payment error encountered, no retry scheduled {err:?}");
+                    error!("Quoting or payment error encountered, no retry scheduled {err}");
                     (vec![], vec![], 0, Some(PutError::from(err)))
                 };
             }

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -6,15 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::networking::interface::NetworkTask;
-use crate::networking::utils::get_quorum_amount;
 use crate::networking::NetworkError;
 use crate::networking::OneShotTaskResult;
+use crate::networking::interface::NetworkTask;
+use crate::networking::utils::get_quorum_amount;
 use ant_evm::PaymentQuote;
 use ant_protocol::{NetworkAddress, PrettyPrintRecordKey};
+use libp2p::PeerId;
 use libp2p::kad::{self, PeerInfo, QueryId, Quorum, Record};
 use libp2p::request_response::OutboundRequestId;
-use libp2p::PeerId;
 use std::collections::HashMap;
 use thiserror::Error;
 


### PR DESCRIPTION
Before trying `1fef204d8e5a44f487c59e5fe5061419bc20e23ed78f4e8bc7c4d2e04e5c19d1` would give:
```
🚨 Could not identify address type!
🚨 Please keep your secret key safe! Don't use it as a data address!
✅ Identified input as a: Secret Key
```

After fix:
```
PublicArchive stored at: 1fef204d8e5a44f487c59e5fe5061419bc20e23ed78f4e8bc7c4d2e04e5c19d1
PublicArchive with 1 files
PublicArchive {
    map: {
        "Alien 1979.mp4": (
            94f225f0620bafc65aa291c0b448921c225e4dc4723e423b0ab489ab1aafdf07,
            Metadata {
                created: 0,
                modified: 1746360762,
                size: 1554095557,
                extra: None,
            },
        ),
    },
}
```