### PR TITLE
feat(python): extend graphentry methods

### DIFF
--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -1,0 +1,65 @@
+name: python-bindings
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.12']  # bump/add versions later
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('autonomi/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            autonomi/.venv
+          key: ${{ runner.os }}-uv-${{ matrix.python }}-${{ hashFiles('autonomi/uv.lock', 'autonomi/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python }}-
+
+      - name: Build and test
+        shell: bash
+        working-directory: autonomi
+        run: |
+          uv venv
+          # create lockfile if absent
+          test -f uv.lock || uv lock
+          uv sync --locked
+          uv run python -V
+          uv run pip install -U maturin pytest
+          uv run maturin develop --uv
+          uv run pytest tests/python/test_bindings.py -q

--- a/autonomi/src/python.rs
+++ b/autonomi/src/python.rs
@@ -4141,6 +4141,29 @@ impl PyGraphEntry {
             inner: self.inner.address(),
         }
     }
+
+    /// Returns the content of the graph entry.
+    pub fn content(&self) -> [u8; 32] {
+        self.inner.content
+    }
+
+    /// Returns the parents' public keys.
+    pub fn parents(&self) -> Vec<PyPublicKey> {
+        self.inner
+            .parents
+            .iter()
+            .map(|&p| PyPublicKey { inner: p })
+            .collect()
+    }
+
+    /// Returns the descendants as (public_key, content) pairs.
+    pub fn descendants(&self) -> Vec<(PyPublicKey, [u8; 32])> {
+        self.inner
+            .descendants
+            .iter()
+            .map(|&(pk, c)| (PyPublicKey { inner: pk }, c))
+            .collect()
+    }
 }
 
 /// Scratchpad, a mutable space for encrypted data on the Network

--- a/autonomi/tests/python/test_bindings.py
+++ b/autonomi/tests/python/test_bindings.py
@@ -1,134 +1,159 @@
+import os
 import pytest
 from autonomi_client import *
 
+def _b32(b: bytes) -> bytes:
+    # Ensure exactly 32 bytes (Rust expects [u8; 32]).
+    assert len(b) == 32
+    return b
+
 def test_graph_entry_address():
-    # Create a random address from XOR
-    xor_hex = random_xor()
-    addr = GraphEntryAddress(xor_hex)
+    # Create a GraphEntry and verify its derived address and hex round-trip.
+    owner = SecretKey()
+    ge = GraphEntry(owner, [], _b32(os.urandom(32)), [])
+    addr = ge.address()
 
-    # Test hex representation
+    # Basic shape checks
+    assert isinstance(addr, GraphEntryAddress)
     assert isinstance(addr.hex, str)
-    assert len(addr.hex) == 64
-    assert addr.hex == xor_hex
+    assert len(addr.hex) == 96
 
-    # Test repr (round-trip) and equality
-    assert eval(repr(addr)) == addr
+    # Round-trip via from_hex (bindings expose from_hex, not a hex ctor)
+    addr2 = GraphEntryAddress.from_hex(addr.hex)
+    assert isinstance(addr2, GraphEntryAddress)
+    assert addr2.hex == addr.hex
 
-    # Create a graph entry address from a (random) public key
-    addr = GraphEntryAddress.from_owner(PublicKey.random())
+def test_graph_entry_methods_and_roundtrip():
+    # Exercise GraphEntry methods and ensure parents/descendants round-trip.
+    owner = SecretKey()
+    parents = [PublicKey.random() for _ in range(2)]
+    content = _b32(os.urandom(32))
+    descendants = [
+        (PublicKey.random(), _b32(os.urandom(32))),
+        (PublicKey.random(), _b32(os.urandom(32))),
+    ]
+
+    ge = GraphEntry(owner, parents, content, descendants)
+
+    # address()
+    addr = ge.address()
+    assert isinstance(addr, GraphEntryAddress)
+    assert isinstance(addr.hex, str) and len(addr.hex) == 96
+
+    # content()
+    assert ge.content() == content
+
+    # parents()
+    ps = ge.parents()
+    assert isinstance(ps, list) and all(isinstance(p, PublicKey) for p in ps)
+    assert [p.hex() for p in ps] == [p.hex() for p in parents]
+
+    # descendants()
+    ds = ge.descendants()
+    assert isinstance(ds, list)
+    for pk, h in ds:
+        assert isinstance(pk, PublicKey)
+        assert isinstance(h, (bytes, bytearray)) and len(h) == 32
+    assert [(pk.hex(), h) for pk, h in ds] == [(pk.hex(), h) for pk, h in descendants]
+
+    # Type/shape errors
+    with pytest.raises(Exception):
+        GraphEntry(owner, parents, os.urandom(31), descendants)  # bad content len
+    with pytest.raises(Exception):
+        GraphEntry(owner, parents, content, [(PublicKey.random(), b"x")])  # bad hash len
 
 def test_chunk_address():
-    # Create a random address from XOR
-    xor_hex = random_xor()
-    addr = ChunkAddress(xor_hex)
+    # Construct ChunkAddress from XorName and from content, validate hex.
+    xor = random_xor()                 # returns PyXorName
+    addr = ChunkAddress(xor)           # constructor expects PyXorName
 
-    # Test hex representation
+    # Hex is 64 chars and matches XorName hex
     assert isinstance(addr.hex, str)
     assert len(addr.hex) == 64
-    assert addr.hex == xor_hex
+    assert addr.hex == xor.as_hex()
 
-    # Test repr (round-trip) and equality
-    assert eval(repr(addr)) == addr
-
-    # Create a chunk address from some content
-    addr = ChunkAddress.from_content(b"test data")
+    # from_content factory should also work
+    addr2 = ChunkAddress.from_content(b"test data")
+    assert isinstance(addr2.hex, str) and len(addr2.hex) == 64
 
 def test_pointer_address():
-    # Create a random address from XOR
-    xor_hex = random_xor()
-    addr = PointerAddress(xor_hex)
+    # PointerAddress is derived from PublicKey; validate hex and round-trip.
+    pk = PublicKey.random()
+    addr = PointerAddress(pk)
 
-    # Test hex representation
     assert isinstance(addr.hex, str)
-    assert len(addr.hex) == 64
-    assert addr.hex == xor_hex
+    assert len(addr.hex) == 96
 
-    # Test repr (round-trip) and equality
-    assert eval(repr(addr)) == addr
-
-    # Create a pointer address from a (random) public key
-    addr = PointerAddress.from_owner(PublicKey.random())
+    # from_hex round-trip
+    addr2 = PointerAddress.from_hex(addr.hex)
+    assert addr2.hex == addr.hex
 
 def test_pointer_target_with_chunk_address():
-    # Create a chunk address
+    # Create a PointerTarget from a ChunkAddress and validate target hex.
     chunk_addr = ChunkAddress.from_content(b"test data for pointer target")
-    
-    # Create pointer target from chunk address
     target = PointerTarget.new_chunk(chunk_addr)
-    
-    # Verify the hex matches
     assert isinstance(target.hex, str)
     assert len(target.hex) == 64
 
 def test_pointer_creation():
-    xor_hex = random_xor()
-
-    # Create necessary components
+    # Construct a Pointer; check address() and target() shape.
     key = SecretKey()
     counter = 42
-    target = PointerTarget.new_chunk(ChunkAddress(xor_hex))
-    
-    # Create pointer
+    target = PointerTarget.new_chunk(ChunkAddress(random_xor()))
     pointer = Pointer(key, counter, target)
-    
-    # Verify pointer properties
-    assert isinstance(pointer.hex, str)
-    assert len(pointer.hex) == 64
-    
-    # Test network address
-    addr = pointer.address()
-    assert isinstance(addr, PointerAddress)
-    assert isinstance(addr.hex, str)
-    assert len(addr.hex) == 64
 
-    # Pointer should point to original XOR
-    assert pointer.target.hex == xor_hex
+    # Pointer has address()
+    paddr = pointer.address()
+    assert isinstance(paddr, PointerAddress)
+    assert isinstance(paddr.hex, str)
+    assert len(paddr.hex) == 96
+
+    # Target present and shaped correctly
+    assert isinstance(pointer.target.hex, str)
+    assert len(pointer.target.hex) == 64
 
 def test_pointer_target_creation():
-    # Test direct creation
-    test_data = b"test data for pointer target"
-    target = PointerTarget.new_chunk(ChunkAddress.from_content(test_data))
-    
-    # Verify hex
+    # Direct creation of PointerTarget from content-derived ChunkAddress.
+    target = PointerTarget.new_chunk(ChunkAddress.from_content(b"test data for pointer target"))
     assert isinstance(target.hex, str)
     assert len(target.hex) == 64
 
 def test_invalid_hex():
-    # Test invalid hex string for chunk address
-    with pytest.raises(ValueError):
-        ChunkAddress("invalid hex")
-    
-    # Test invalid hex string for pointer address
-    with pytest.raises(ValueError):
-        PointerAddress("invalid hex")
+    # Passing wrong Python types to ctors should raise TypeError in bindings.
+    with pytest.raises(TypeError):
+        ChunkAddress("invalid hex")     # expects PyXorName, not str
+    with pytest.raises(TypeError):
+        PointerAddress("invalid hex")   # expects PublicKey, not str
 
 def test_wallet():
-    network =  Network(True)
+    network = EVMNetwork(True)
     private_key = "0xdb1049e76a813c94be0df47ec3e20533ca676b1b9fef2ddbce9daa117e4da4aa"
     wallet = Wallet.new_from_private_key(network, private_key)
 
-    assert wallet.address() == '0x69D5BF2Bc42bca8782b8D2b4FdfF2b1Fa7644Fe7'
+    assert wallet.address() == "0x69D5BF2Bc42bca8782b8D2b4FdfF2b1Fa7644Fe7"
     assert wallet.network() == network
 
 def test_data_stream_types():
-    """Test that data stream classes can be instantiated and have expected methods"""
-    # Test that DataStream exists and can be imported
+    # Existence and minimal construction tests for data stream related types.
+    # DataStream class presence
     try:
         stream_class = DataStream
         assert hasattr(stream_class, '__name__')
         assert stream_class.__name__ == 'DataStream'
     except NameError:
         pytest.fail("DataStream class not found in autonomi_client module")
-    
-    # Test that DataMapChunk can be created (needed for data_stream)
-    data_map_hex = "0" * 64  # Mock hex string
+
+    # DataMapChunk.from_hex: exercise path and hex() method if it accepts dummy value
+    data_map_hex = "0" * 64
     try:
         data_map = DataMapChunk.from_hex(data_map_hex)
+        assert hasattr(data_map, "hex")
         assert data_map.hex() == data_map_hex
     except Exception:
-        pass  # Expected to fail with mock data, but class should exist
-    
-    # Test that DataAddress can be created (needed for data_stream_public)
-    xor_hex = random_xor()
-    data_addr = DataAddress(XorName(xor_hex))
+        # Acceptable with a mock hex; presence is primary goal
+        pass
+
+    # DataAddress should accept a XorName
+    data_addr = DataAddress(random_xor())
     assert isinstance(data_addr.hex, str)
+    assert len(data_addr.hex) == 64


### PR DESCRIPTION
This PR gives access to `GraphEntry` internals to Python users. A few tests assumed details that differ from the current bindings so they were updated. The Python bindings tests weren't previously covered in CI, so a workflow for that was added as well.

Changes
- Exposes `GraphEntry.content()`, `GraphEntry.parents()`, and `GraphEntry.descendants()` in PyO3 bindings.
- Adds tests for the extended `GraphEntry` api.
- Aligns existing tests with the current API surface to make them compile and pass.
- Adds cross-platform CI for Python bindings.

Test alignment details:
 - Assertions updated for `GraphEntryAddress.hex` and `PointerAddress.hex` having 96-char (48-byte) hex strings.
 - Replaced `repr`/`eval` round-trips with `from_hex(...)` round-trips where applicable.

Workflow:
- GitHub Actions workflow builds PyO3 with maturin, installs via uv, and runs pytest on Ubuntu, macOS, and Windows.
