### PR TITLE
fix(CI): avoid using rustfmt during CI build

### DIFF
--- a/ant-protocol/build.rs
+++ b/ant-protocol/build.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("./src/antnode_proto/antnode.proto")?;
+    tonic_build::configure()
+        .format(false)  // Disable rustfmt formatting
+        .compile(&["./src/antnode_proto/antnode.proto"], &["./src/antnode_proto"])?;
     Ok(())
 }

--- a/ant-service-management/build.rs
+++ b/ant-service-management/build.rs
@@ -7,6 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("./src/antctl_proto/antctl.proto")?;
+    tonic_build::configure()
+        .format(false) // Disable rustfmt formatting
+        .compile(
+            &["./src/antctl_proto/antctl.proto"],
+            &["./src/antctl_proto"],
+        )?;
     Ok(())
 }


### PR DESCRIPTION
### Description

As in the CI run https://github.com/maidsafe/autonomi/actions/runs/18001617538/job/51212016028?pr=3210
There is failure due to requiring using rustfmt during binary build.

This seems because of the tonic_build requires a fmt check by default, and it will be triggered when there is proto file related changes.

Hence raised this PR to make tonic_build NOT to use fmt check during build, to avoid the CI failures.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
