### PR TITLE
chore(release): stable release 2025.9.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,46 @@ on:
         description: Specify the chunk size in bytes. If not used, the current default is 1048576.
         type: number
         required: false
+      build-nat-detection:
+        description: Build nat-detection binary
+        type: boolean
+        required: false
+        default: true
+      build-node-launchpad:
+        description: Build node-launchpad binary
+        type: boolean
+        required: false
+        default: true
+      build-ant:
+        description: Build ant binary
+        type: boolean
+        required: false
+        default: true
+      build-antnode:
+        description: Build antnode binary
+        type: boolean
+        required: false
+        default: true
+      build-antctl:
+        description: Build antctl binary
+        type: boolean
+        required: false
+        default: true
+      build-antctld:
+        description: Build antctld binary
+        type: boolean
+        required: false
+        default: true
+      build-antnode-rpc-client:
+        description: Build antnode_rpc_client binary
+        type: boolean
+        required: false
+        default: true
+      build-evm-testnet:
+        description: Build evm-testnet binary
+        type: boolean
+        required: false
+        default: true
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/autonomi/actions/runs
@@ -53,7 +93,93 @@ jobs:
       - name: build release artifacts
         shell: bash
         run: |
+          export BUILD_NAT_DETECTION="${{ inputs.build-nat-detection }}"
+          export BUILD_NODE_LAUNCHPAD="${{ inputs.build-node-launchpad }}"
+          export BUILD_ANT="${{ inputs.build-ant }}"
+          export BUILD_ANTNODE="${{ inputs.build-antnode }}"
+          export BUILD_ANTCTL="${{ inputs.build-antctl }}"
+          export BUILD_ANTCTLD="${{ inputs.build-antctld }}"
+          export BUILD_ANTNODE_RPC_CLIENT="${{ inputs.build-antnode-rpc-client }}"
+          export BUILD_EVM_TESTNET="${{ inputs.build-evm-testnet }}"
+
           just build-release-artifacts "${{ matrix.target }}"
+
+      - name: Download previous binaries from S3
+        shell: bash
+        run: |
+          arch="${{ matrix.target }}"
+
+          get_version() {
+            local crate_dir=$1
+            grep "^version" < "$crate_dir/Cargo.toml" | head -n 1 | awk '{ print $3 }' | sed 's/"//g'
+          }
+
+          download_from_s3() {
+            local bin_name=$1
+            local crate_dir=$2
+            local s3_bucket=$3
+
+            version=$(get_version "$crate_dir")
+
+            if [[ "$arch" == *"windows"* ]]; then
+              archive_name="${bin_name}-${version}-${arch}.zip"
+              binary_name="${bin_name}.exe"
+            else
+              archive_name="${bin_name}-${version}-${arch}.tar.gz"
+              binary_name="${bin_name}"
+            fi
+
+            echo "Downloading ${archive_name} from S3..."
+            if ! curl -f -L -o "${archive_name}" "https://${s3_bucket}.s3.eu-west-2.amazonaws.com/${archive_name}"; then
+              echo "Failed to download ${archive_name}"
+              return 1
+            fi
+
+            temp_dir=$(mktemp -d)
+            if [[ "$arch" == *"windows"* ]]; then
+              unzip -q "${archive_name}" -d "$temp_dir"
+            else
+              tar -xzf "${archive_name}" -C "$temp_dir"
+            fi
+
+            cp "$temp_dir/${binary_name}" "artifacts/${binary_name}"
+            chmod +x "artifacts/${binary_name}"
+            rm -rf "$temp_dir" "${archive_name}"
+
+            echo "Downloaded ${bin_name} version ${version} from S3"
+          }
+
+          if [[ "${{ inputs.build-nat-detection }}" != "true" ]]; then
+            download_from_s3 "nat-detection" "nat-detection" "nat-detection"
+          fi
+
+          if [[ "${{ inputs.build-node-launchpad }}" != "true" ]]; then
+            download_from_s3 "node-launchpad" "node-launchpad" "node-launchpad"
+          fi
+
+          if [[ "${{ inputs.build-ant }}" != "true" ]]; then
+            download_from_s3 "ant" "ant-cli" "autonomi-cli"
+          fi
+
+          if [[ "${{ inputs.build-antnode }}" != "true" ]]; then
+            download_from_s3 "antnode" "ant-node" "antnode"
+          fi
+
+          if [[ "${{ inputs.build-antctl }}" != "true" ]]; then
+            download_from_s3 "antctl" "ant-node-manager" "antctl"
+          fi
+
+          if [[ "${{ inputs.build-antctld }}" != "true" ]]; then
+            download_from_s3 "antctld" "ant-node-manager" "antctl"
+          fi
+
+          if [[ "${{ inputs.build-antnode-rpc-client }}" != "true" ]]; then
+            download_from_s3 "antnode_rpc_client" "ant-node-rpc-client" "antnode-rpc-client"
+          fi
+
+          if [[ "${{ inputs.build-evm-testnet }}" != "true" ]]; then
+            download_from_s3 "evm-testnet" "evm-testnet" "evm-testnet"
+          fi
 
       - uses: actions/upload-artifact@main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2025-09-29
+
+### API
+
+#### Added
+
+- `DataStream` struct with streaming data access methods:
+  - `data_size()` returns the original data size
+  - `get_range(start, len)` decrypts and returns a specific byte range
+  - `range(range)` convenience method using Range syntax
+  - `range_from(start)` gets range from starting position to end
+  - `range_to(end)` gets range from beginning to end position
+  - `range_full()` gets the entire file content
+  - `range_inclusive(start, end)` gets an inclusive range
+- `data_stream(&DataMapChunk)` async method on `Client` for creating streaming access to private
+  data.
+- `data_stream_public(&DataAddress)` async method on `Client` for creating streaming access to
+  public data.
+- `scratchpad_put_update` async method for wallet-free scratchpad updates with caller-controlled
+  management.
+- `print_fork_analysis` function for detailed scratchpad fork error analysis and display.
+- `vault_expand_capacity` async method for expanding vault storage capacity.
+- `vault_claimed_capacity` async method for checking claimed vault capacity.
+- `vault_split_bytes` function for splitting bytes for vault storage.
+
+#### Changed
+
+- Client initialization now includes automatic network connectivity verification via
+  `wait_for_connectivity()` during the `init` process, improving reliability and error diagnostics.
+- Scratchpad error handling enhanced with fork resolution capabilities in update operations, solving
+  code duplication issues.
+- Vault function names updated for consistency:
+  - `fetch_and_decrypt_vault` → `vault_get` (deprecated function retained for compatibility)
+  - `write_bytes_to_vault` → `vault_put` (deprecated function retained for compatibility)
+  - `app_name_to_vault_content_type` → `vault_content_type_from_app_name` (deprecated function retained for compatibility)
+- Code organization improved by moving encryption and utility modules out of the client module to
+  top-level `self_encryption` and `utils` modules.
+
+#### Fixed
+
+- Analyze functionality now properly handles old datamap format types for backward compatibility.
+- Scratchpad fork display and resolution issues resolved across all API operations.
+- Streaming operations now validate destination paths before processing to prevent errors.
+
+### Language Bindings
+
+#### Added
+
+**Python:**
+- `GraphEntry` class methods for member access:
+  - `content()` returns the entry content
+  - `parents()` returns parent entry references
+  - `descendants()` returns descendant entry references
+- Data streaming bindings providing Python access to the new streaming data APIs.
+- Enhanced fork error display functionality for scratchpad operations with comprehensive error
+  details.
+- Comprehensive test coverage for all Python binding functionality including address format
+  validation.
+
+**Node.js:**
+- Updated vault operation support with new function names matching the renamed API standards.
+
+#### Fixed
+
+- Python binding tests updated to handle 96-character address hex format and proper `from_hex`
+  round-trip conversions.
+- `GraphEntry` bindings now properly expose all member access methods with correct error handling.
+
+### Ant Client
+
+#### Added
+
+- Enhanced scratchpad command functionality with improved fork error handling and resolution capabilities.
+- Better error reporting for scratchpad operations with detailed fork analysis output.
+
+#### Fixed
+
+- Scratchpad fork display and resolution functionality now works correctly across all client command
+  operations.
+- Get record operations now only perform early returns when unique content is received from
+  sufficient peers, improving data retrieval reliability.
+
+### Launchpad
+
+#### Fixed
+
+- Node storage size handling corrected for ARM v7 architecture devices.
+- Node addition process on Windows now functions properly without configuration conflicts.
+
 ## 2025-09-02
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault function names updated for consistency:
   - `fetch_and_decrypt_vault` → `vault_get` (deprecated function retained for compatibility)
   - `write_bytes_to_vault` → `vault_put` (deprecated function retained for compatibility)
-  - `app_name_to_vault_content_type` → `vault_content_type_from_app_name` (deprecated function retained for compatibility)
+  - `app_name_to_vault_content_type` → `vault_content_type_from_app_name` (deprecated function
+    retained for compatibility)
 - Code organization improved by moving encryption and utility modules out of the client module to
   top-level `self_encryption` and `utils` modules.
 
@@ -79,8 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- Enhanced scratchpad command functionality with improved fork error handling and resolution capabilities.
+- Enhanced `scratchpad` command functionality with improved fork error handling and resolution
+  capabilities.
 - Better error reporting for scratchpad operations with detailed fork analysis output.
+- The `download` command has improved error handling to immediately fail if the chosen download path
+  cannot be used.
 
 #### Fixed
 
@@ -88,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operations.
 - Get record operations now only perform early returns when unique content is received from
   sufficient peers, improving data retrieval reliability.
+- The `analyze` command now properly handles file references in the old datamap format.
 
 ### Launchpad
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.2.8-rc.1"
+version = "0.2.8"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.4.7-rc.1"
+version = "0.4.7"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.9-rc.1"
+version = "1.0.9"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1608,7 +1608,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.6.1-rc.1"
+version = "0.6.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "autonomi-nodejs"
-version = "0.2.1-rc.1"
+version = "0.2.1"
 dependencies = [
  "autonomi",
  "bytes",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.5.11-rc.1"
+version = "0.5.11"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.2.7"
+version = "0.2.8-rc.1"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.4.6"
+version = "0.4.7-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.8"
+version = "1.0.9-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1608,7 +1608,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.6.0"
+version = "0.6.1-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "autonomi-nodejs"
-version = "0.2.0"
+version = "0.2.1-rc.1"
 dependencies = [
  "autonomi",
  "bytes",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.5.10"
+version = "0.5.11-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Justfile
+++ b/Justfile
@@ -54,23 +54,41 @@ build-release-artifacts arch nightly="false":
 
   if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
     cargo binstall --no-confirm cross
-    cross build --release --target $arch --bin nat-detection $nightly_feature
-    cross build --release --target $arch --bin node-launchpad $nightly_feature
-    cross build --release --target $arch --bin ant $nightly_feature --features loud
-    cross build --release --target $arch --bin antnode $nightly_feature
-    cross build --release --target $arch --bin antctl $nightly_feature
-    cross build --release --target $arch --bin antctld $nightly_feature
-    cross build --release --target $arch --bin antnode_rpc_client $nightly_feature
-    cross build --release --target $arch --bin evm-testnet $nightly_feature
+    build_cmd="cross build --release --target $arch"
   else
-    cargo build --release --target $arch --bin nat-detection $nightly_feature
-    cargo build --release --target $arch --bin node-launchpad $nightly_feature
-    cargo build --release --target $arch --bin ant $nightly_feature --features loud
-    cargo build --release --target $arch --bin antnode $nightly_feature
-    cargo build --release --target $arch --bin antctl $nightly_feature
-    cargo build --release --target $arch --bin antctld $nightly_feature
-    cargo build --release --target $arch --bin antnode_rpc_client $nightly_feature
-    cargo build --release --target $arch --bin evm-testnet $nightly_feature
+    build_cmd="cargo build --release --target $arch"
+  fi
+
+  if [[ "${BUILD_NAT_DETECTION:-true}" == "true" ]]; then
+    $build_cmd --bin nat-detection $nightly_feature
+  fi
+
+  if [[ "${BUILD_NODE_LAUNCHPAD:-true}" == "true" ]]; then
+    $build_cmd --bin node-launchpad $nightly_feature
+  fi
+
+  if [[ "${BUILD_ANT:-true}" == "true" ]]; then
+    $build_cmd --bin ant $nightly_feature --features loud
+  fi
+
+  if [[ "${BUILD_ANTNODE:-true}" == "true" ]]; then
+    $build_cmd --bin antnode $nightly_feature
+  fi
+
+  if [[ "${BUILD_ANTCTL:-true}" == "true" ]]; then
+    $build_cmd --bin antctl $nightly_feature
+  fi
+
+  if [[ "${BUILD_ANTCTLD:-true}" == "true" ]]; then
+    $build_cmd --bin antctld $nightly_feature
+  fi
+
+  if [[ "${BUILD_ANTNODE_RPC_CLIENT:-true}" == "true" ]]; then
+    $build_cmd --bin antnode_rpc_client $nightly_feature
+  fi
+
+  if [[ "${BUILD_EVM_TESTNET:-true}" == "true" ]]; then
+    $build_cmd --bin evm-testnet $nightly_feature
   fi
 
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.7"
+version = "0.2.8-rc.1"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.8-rc.1"
+version = "0.2.8"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2025";
 pub const RELEASE_MONTH: &str = "9";
-pub const RELEASE_CYCLE: &str = "1";
-pub const RELEASE_CYCLE_COUNTER: &str = "2";
+pub const RELEASE_CYCLE: &str = "2";
+pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.4.7-rc.1"
+version = "0.4.7"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,7 +25,7 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-autonomi = { path = "../autonomi", version = "0.6.1-rc.1", features = ["loud"] }
+autonomi = { path = "../autonomi", version = "0.6.1", features = ["loud"] }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
 const-hex = "1.13.1"
@@ -53,7 +53,7 @@ tracing = { version = "~0.1.26" }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
+autonomi = { path = "../autonomi", version = "0.6.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.4.6"
+version = "0.4.7-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,7 +25,7 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-autonomi = { path = "../autonomi", version = "0.6.0", features = ["loud"] }
+autonomi = { path = "../autonomi", version = "0.6.1-rc.1", features = ["loud"] }
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
 const-hex = "1.13.1"
@@ -53,7 +53,7 @@ tracing = { version = "~0.1.26" }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.6.0" }
+autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -29,11 +29,11 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 ant-releases = { version = "0.4.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 evmlib = { path = "../evmlib", version = "0.4.3" }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -29,11 +29,11 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.7" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 ant-releases = { version = "0.4.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 evmlib = { path = "../evmlib", version = "0.4.3" }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,7 +19,7 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features=["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9", features=["rpc"] }
 ant-node = { path = "../ant-node", version = "0.4.4" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,7 +19,7 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8", features=["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features=["rpc"] }
 ant-node = { path = "../ant-node", version = "0.4.4" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -23,11 +23,11 @@ otlp = ["ant-logging/otlp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -102,10 +102,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.3" }
-autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
+autonomi = { path = "../autonomi", version = "0.6.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -23,11 +23,11 @@ otlp = ["ant-logging/otlp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.7" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -102,10 +102,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.8", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.3" }
-autonomi = { path = "../autonomi", version = "0.6.0" }
+autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.8"
+version = "1.0.9-rc.1"
 
 [features]
 default = []

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.9-rc.1"
+version = "1.0.9"
 
 [features]
 default = []

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/maidsafe/autonomi"
 version = "0.4.16"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/maidsafe/autonomi"
 version = "0.4.16"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.7" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "autonomi-nodejs"
-version = "0.2.0"
+version = "0.2.1-rc.1"
 description = "NodeJS bindings for the autonomi client"
 license = "GPL-3.0"
 
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.6.0" }
+autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "autonomi-nodejs"
-version = "0.2.1-rc.1"
+version = "0.2.1"
 description = "NodeJS bindings for the autonomi client"
 license = "GPL-3.0"
 
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.6.1-rc.1" }
+autonomi = { path = "../autonomi", version = "0.6.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/npm/darwin-arm64/package.json
+++ b/autonomi-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-arm64/package.json
+++ b/autonomi-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-arm64",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-x64/package.json
+++ b/autonomi-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-x64",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-x64/package.json
+++ b/autonomi-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-x64",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/linux-x64-gnu/package.json
+++ b/autonomi-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-linux-x64-gnu",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/linux-x64-gnu/package.json
+++ b/autonomi-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-linux-x64-gnu",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/win32-x64-msvc/package.json
+++ b/autonomi-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-win32-x64-msvc",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/win32-x64-msvc/package.json
+++ b/autonomi-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-win32-x64-msvc",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/package-lock.json
+++ b/autonomi-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withautonomi/autonomi",
-      "version": "0.6.1-rc.1",
+      "version": "0.6.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/autonomi-nodejs/package-lock.json
+++ b/autonomi-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withautonomi/autonomi",
-      "version": "0.6.0",
+      "version": "0.6.1-rc.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/autonomi-nodejs/package.json
+++ b/autonomi-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "description": "NodeJS bindings for Autonomi client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/autonomi-nodejs/package.json
+++ b/autonomi-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.6.1-rc.1",
+  "version": "0.6.1",
   "description": "NodeJS bindings for Autonomi client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.6.0"
+version = "0.6.1-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,9 +26,9 @@ extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.7" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.6.1-rc.1"
+version = "0.6.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,9 +26,9 @@ extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.5.11-rc.1"
+version = "0.5.11"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,11 +18,11 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-node-manager = { version = "0.13.3", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 ant-releases = { version = "0.4.1" }
 ant-service-management = { version = "0.4.16", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.5.10"
+version = "0.5.11-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,11 +18,11 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.7" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.8-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-node-manager = { version = "0.13.3", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.8" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.9-rc.1" }
 ant-releases = { version = "0.4.1" }
 ant-service-management = { version = "0.4.16", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -14,5 +14,5 @@
 # number for all the released binaries.
 release-year: 2025
 release-month: 9
-release-cycle: 1
-release-cycle-counter: 2
+release-cycle: 2
+release-cycle-counter: 1


### PR DESCRIPTION
    ==================
      Crate Versions
    ==================
    ant-bootstrap: 0.2.8
    ant-build-info: 0.1.29
    ant-cli: 0.4.7
    ant-evm: 0.1.17
    ant-logging: 0.2.52
    ant-metrics: 0.1.30
    ant-node: 0.4.4
    ant-node-manager: 0.13.3
    ant-node-rpc-client: 0.6.48
    ant-protocol: 1.0.9
    ant-service-management: 0.4.16
    ant-token-supplies: 0.1.67
    autonomi: 0.6.1
    evmlib: 0.4.3
    evm-testnet: 0.1.16
    nat-detection: 0.2.22
    node-launchpad: 0.5.11
    autonomi-nodejs: 0.2.1
    ant-node-nodejs: 0.1.5
    test-utils: 0.4.21
    ===================
      Binary Versions
    ===================
    ant: 0.4.7
    antctl: 0.13.3
    antctld: 0.13.3
    antnode: 0.4.4
    antnode_rpc_client: 0.6.48
    nat-detection: 0.2.22
    node-launchpad: 0.5.11