### PR TITLE
feat(autonomi): add get raw quote from peer

### DIFF
--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::networking::version::PackageVersion;
 use crate::Client;
 use crate::networking::NetworkError;
 use ant_protocol::NetworkAddress;
@@ -20,5 +21,9 @@ impl Client {
         self.network
             .get_closest_peers_with_retries(network_address.into())
             .await
+    }
+
+    pub async fn get_node_version(&self, peer: PeerInfo) -> Result<PackageVersion, String> {
+        self.network.get_node_version(peer).await
     }
 }

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -358,6 +358,16 @@ impl NetworkDriver {
                     },
                 );
             }
+            NetworkTask::GetVersion { peer, resp } => {
+                let req = Request::Query(Query::GetVersion(NetworkAddress::from(peer.peer_id)));
+
+                let req_id =
+                    self.req()
+                        .send_request_with_addresses(&peer.peer_id, req, peer.addrs.clone());
+
+                self.pending_tasks
+                    .insert_query(req_id, NetworkTask::GetVersion { peer, resp });
+            }
             NetworkTask::ConnectionsMade { resp } => {
                 // Send the current count of connections made
                 if let Err(e) = resp.send(Ok(self.connections_made)) {

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -183,7 +183,9 @@ impl NetworkDriver {
                 self.pending_tasks
                     .update_put_record_req(request_id, result)?;
             }
-
+            Response::Query(QueryResponse::GetVersion { peer: _, version }) => {
+                self.pending_tasks.update_get_version(request_id, version)?;
+            }
             _ => {
                 info!("Other request response event({request_id:?}): {response:?}");
                 // Unrecoganized req/rsp DM indicates peer is in an incorrect version

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -48,6 +48,7 @@ pub(crate) struct TaskHandler {
     >,
     get_record: HashMap<QueryId, (OneShotTaskResult<RecordAndHolders>, Quorum)>,
     get_record_accumulator: HashMap<QueryId, HashMap<PeerId, Record>>,
+    get_version: HashMap<OutboundRequestId, OneShotTaskResult<String>>,
 }
 
 impl TaskHandler {
@@ -59,6 +60,7 @@ impl TaskHandler {
             get_cost: Default::default(),
             get_record: Default::default(),
             get_record_accumulator: Default::default(),
+            get_version: Default::default(),
         }
     }
 
@@ -69,7 +71,9 @@ impl TaskHandler {
     }
 
     pub fn contains_query(&self, id: &OutboundRequestId) -> bool {
-        self.get_cost.contains_key(id) || self.put_record_req.contains_key(id)
+        self.get_cost.contains_key(id)
+            || self.put_record_req.contains_key(id)
+            || self.get_version.contains_key(id)
     }
 
     pub fn insert_task(&mut self, id: QueryId, task: NetworkTask) {
@@ -101,6 +105,9 @@ impl TaskHandler {
             }
             NetworkTask::PutRecordReq { resp, .. } => {
                 self.put_record_req.insert(id, resp);
+            }
+            NetworkTask::GetVersion { resp, .. } => {
+                self.get_version.insert(id, resp);
             }
             _ => {}
         }
@@ -375,6 +382,25 @@ impl TaskHandler {
                 Ok(())
             }
         }
+    }
+
+    pub fn update_get_version(
+        &mut self,
+        id: OutboundRequestId,
+        version: String,
+    ) -> Result<(), TaskHandlerError> {
+        let responder = self
+            .get_version
+            .remove(&id)
+            .ok_or(TaskHandlerError::UnknownQuery(format!(
+                "OutboundRequestId {id:?}"
+            )))?;
+
+        trace!("OutboundRequestId({id}): got version: {version}");
+        responder
+            .send(Ok(version))
+            .map_err(|_| TaskHandlerError::NetworkClientDropped)?;
+        Ok(())
     }
 
     pub fn terminate_query(

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -399,7 +399,7 @@ impl TaskHandler {
         trace!("OutboundRequestId({id}): got version: {version}");
         responder
             .send(Ok(version))
-            .map_err(|_| TaskHandlerError::NetworkClientDropped)?;
+            .map_err(|_| TaskHandlerError::NetworkClientDropped(format!("{id:?}")))?;
         Ok(())
     }
 

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -67,6 +67,12 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         resp: OneShotTaskResult<Option<(PeerInfo, PaymentQuote)>>,
     },
+    /// cf [`crate::driver::task_handler::TaskHandler::update_get_version`]
+    GetVersion {
+        peer: PeerInfo,
+        #[debug(skip)]
+        resp: OneShotTaskResult<String>,
+    },
     /// Get information about the amount of connections made
     ConnectionsMade {
         #[debug(skip)]

--- a/autonomi/src/networking/version.rs
+++ b/autonomi/src/networking/version.rs
@@ -177,8 +177,7 @@ mod tests {
             let parsed = PackageVersion::try_from(version_str.to_string()).unwrap();
             assert_eq!(
                 parsed, expected,
-                "Failed to parse version string: {}",
-                version_str
+                "Failed to parse version string: {version_str}"
             );
         }
     }

--- a/autonomi/src/networking/version.rs
+++ b/autonomi/src/networking/version.rs
@@ -1,0 +1,185 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PackageVersion {
+    /// Release year.
+    pub year: u16,
+    /// Release month.
+    pub month: u16,
+    /// Increments per month.
+    pub cycle: u16,
+    /// Increments per cycle.
+    pub cycle_counter: u16,
+}
+
+impl PackageVersion {
+    pub fn new(year: u16, month: u16, cycle: u16, cycle_counter: u16) -> Self {
+        PackageVersion {
+            year,
+            month,
+            cycle,
+            cycle_counter,
+        }
+    }
+
+    pub fn is_minimum(&self, other: &PackageVersion) -> bool {
+        (self.year, self.month, self.cycle, self.cycle_counter)
+            >= (other.year, other.month, other.cycle, other.cycle_counter)
+    }
+
+    pub fn is_maximum(&self, other: &PackageVersion) -> bool {
+        (self.year, self.month, self.cycle, self.cycle_counter)
+            <= (other.year, other.month, other.cycle, other.cycle_counter)
+    }
+
+    pub fn is_exact(&self, other: &PackageVersion) -> bool {
+        self.year == other.year
+            && self.month == other.month
+            && self.cycle == other.cycle
+            && self.cycle_counter == other.cycle_counter
+    }
+}
+
+impl TryFrom<String> for PackageVersion {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let parts: Vec<&str> = value.split('.').collect();
+        if parts.len() < 3 || parts.len() > 4 {
+            return Err(
+                "Invalid version format. Expected year.month.cycle[.cycle_counter]".to_string(),
+            );
+        }
+
+        let year = parts[0]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse year as u16".to_string())?;
+        let month = parts[1]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse month version as u16".to_string())?;
+        let cycle = parts[2]
+            .parse::<u16>()
+            .map_err(|_| "Failed to parse cycle version as u16".to_string())?;
+        let cycle_counter = if parts.len() == 4 {
+            parts[3]
+                .parse::<u16>()
+                .map_err(|_| "Failed to parse cycle counter version as u16".to_string())?
+        } else {
+            0
+        };
+
+        Ok(PackageVersion {
+            year,
+            month,
+            cycle,
+            cycle_counter,
+        })
+    }
+}
+
+impl Display for PackageVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}.{}.{}.{}",
+            self.year, self.month, self.cycle, self.cycle_counter
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_minimum() {
+        let version1 = PackageVersion::new(2023, 10, 2, 0);
+        let version2 = PackageVersion::new(2023, 11, 1, 0);
+        let version3 = PackageVersion::new(2023, 10, 3, 0);
+        let version4 = PackageVersion::new(2022, 10, 2, 0);
+        let version5 = PackageVersion::new(2023, 10, 2, 1);
+
+        assert!(version1.is_minimum(&version4));
+        assert!(!version1.is_minimum(&version2));
+        assert!(version1.is_minimum(&version1));
+        assert!(!version1.is_minimum(&version5));
+        assert!(version3.is_minimum(&version1));
+    }
+
+    #[test]
+    fn test_is_maximum() {
+        let version1 = PackageVersion::new(2023, 10, 2, 0);
+        let version2 = PackageVersion::new(2023, 11, 1, 0);
+        let version3 = PackageVersion::new(2023, 10, 1, 0);
+        let version4 = PackageVersion::new(2024, 1, 1, 0);
+        let version5 = PackageVersion::new(2023, 10, 2, 1);
+
+        assert!(version1.is_maximum(&version1));
+        assert!(!version1.is_maximum(&version3));
+        assert!(version1.is_maximum(&version2));
+        assert!(version1.is_maximum(&version4));
+        assert!(version1.is_maximum(&version5));
+    }
+
+    #[test]
+    fn test_is_exact() {
+        let version1 = PackageVersion::new(2023, 10, 2, 3);
+        let version2 = PackageVersion::new(2023, 10, 2, 3);
+        let version3 = PackageVersion::new(2023, 10, 3, 0);
+        assert!(version1.is_exact(&version2));
+        assert!(!version1.is_exact(&version3));
+    }
+
+    #[test]
+    fn test_try_from_valid_string() {
+        let version = PackageVersion::try_from("2023.10.2.1".to_string()).unwrap();
+        assert_eq!(version.year, 2023);
+        assert_eq!(version.month, 10);
+        assert_eq!(version.cycle, 2);
+        assert_eq!(version.cycle_counter, 1);
+    }
+
+    #[test]
+    fn test_try_from_valid_string_without_cycle_counter() {
+        let version = PackageVersion::try_from("2023.10.2".to_string()).unwrap();
+        assert_eq!(version.year, 2023);
+        assert_eq!(version.month, 10);
+        assert_eq!(version.cycle, 2);
+        assert_eq!(version.cycle_counter, 0);
+    }
+
+    #[test]
+    fn test_try_from_invalid_string() {
+        let result = PackageVersion::try_from("2023.10".to_string());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "Invalid version format. Expected year.month.cycle[.cycle_counter]"
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let version = PackageVersion::new(2023, 10, 2, 3);
+        assert_eq!(version.to_string(), "2023.10.2.3");
+    }
+
+    #[test]
+    fn test_version_parsing_from_node_response() {
+        // Test parsing various version strings that might come from nodes
+        let test_cases = vec![
+            ("2025.1.0.1", PackageVersion::new(2025, 1, 0, 1)),
+            ("2024.12.5.0", PackageVersion::new(2024, 12, 5, 0)),
+            ("2023.7.2", PackageVersion::new(2023, 7, 2, 0)),
+        ];
+
+        for (version_str, expected) in test_cases {
+            let parsed = PackageVersion::try_from(version_str.to_string()).unwrap();
+            assert_eq!(
+                parsed, expected,
+                "Failed to parse version string: {}",
+                version_str
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds a new public method `get_raw_quote_from_peer` to the autonomi client. Can also be used to get a reward address from a specific peer by grabbing it from the quote.

Can be merged after https://github.com/maidsafe/autonomi/pull/3182 is in.