### PR TITLE
fix(bootstrap_cache): push newer addresses to the front

### DIFF
--- a/ant-bootstrap/src/cache_store/mod.rs
+++ b/ant-bootstrap/src/cache_store/mod.rs
@@ -108,7 +108,7 @@ impl BootstrapCacheStore {
         ) {
             Ok(mut data) => {
                 while data.peers.len() > cfg.max_peers {
-                    data.peers.pop_front();
+                    data.peers.pop_back();
                 }
                 return Ok(data);
             }
@@ -126,7 +126,7 @@ impl BootstrapCacheStore {
                 warn!("Loaded cache data from older version, upgrading to latest version");
                 let mut data: CacheDataLatest = data.into();
                 while data.peers.len() > cfg.max_peers {
-                    data.peers.pop_front();
+                    data.peers.pop_back();
                 }
 
                 Ok(data)

--- a/ant-bootstrap/src/contacts.rs
+++ b/ant-bootstrap/src/contacts.rs
@@ -109,13 +109,8 @@ impl ContactsFetcher {
         self.ignore_peer_id = ignore_peer_id;
     }
 
-    /// Fetch the list of bootstrap addresses from all configured endpoints
+    /// Fetch the list of bootstrap multiaddrs from all configured endpoints
     pub async fn fetch_bootstrap_addresses(&self) -> Result<Vec<Multiaddr>> {
-        Ok(self.fetch_addrs().await?.into_iter().collect())
-    }
-
-    /// Fetch the list of multiaddrs from all configured endpoints
-    pub async fn fetch_addrs(&self) -> Result<Vec<Multiaddr>> {
         info!(
             "Starting peer fetcher from {} endpoints: {:?}",
             self.endpoints.len(),

--- a/ant-node-manager/src/cmd/nat_detection.rs
+++ b/ant-node-manager/src/cmd/nat_detection.rs
@@ -41,7 +41,7 @@ pub async fn run_nat_detection(
             contacts_fetcher.ignore_peer_id(true);
             contacts_fetcher.insert_endpoint(NAT_DETECTION_SERVERS_LIST_URL.parse()?);
 
-            let fetched = contacts_fetcher.fetch_addrs().await?;
+            let fetched = contacts_fetcher.fetch_bootstrap_addresses().await?;
             fetched
                 .choose_multiple(&mut rand::thread_rng(), 10)
                 .cloned()


### PR DESCRIPTION
- The newer addresses should be pushed to the front. This allows the clients to read the latest addresses rather than stale ones.