### PR TITLE
chore: roll back self_encryption to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
  "rayon",
  "rmp-serde",
  "self_encryption 0.30.0",
- "self_encryption 0.34.1",
+ "self_encryption 0.34.0",
  "serde",
  "serial_test",
  "sha2",
@@ -8674,9 +8674,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.34.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636a9d557a649b7c30068e270212eb42967384034de9fa8250fbbc55b65b43a7"
+checksum = "43f85a17897458dccae05b1339088f0efb4ac04333b9e749264fd437443ffd36"
 dependencies = [
  "aes",
  "bincode",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -64,7 +64,7 @@ pyo3-async-runtimes = { version = "0.23", optional = true, features = ["tokio-ru
 rand = "0.8.5"
 rayon = "1.8.0"
 rmp-serde = "1.1.1"
-self_encryption = { version = "0.34.1" }
+self_encryption = { version = "0.34.0" }
 # Older version of self_encryption for backward compatibility
 self_encryption_old = { package = "self_encryption", version = "0.30.0" }
 serde = { version = "1.0.133", features = ["derive", "rc"] }


### PR DESCRIPTION
### Description

roll back self_encryption to 0.34.0

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
