### PR TITLE
fix(CI): setup MAX_CHUNK_SIZE for backward_compatible test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -171,6 +171,8 @@ jobs:
   e2e:
     name: E2E tests
     runs-on: ${{ matrix.os }}
+    env:
+      MAX_CHUNK_SIZE: 4194304
     strategy:
       matrix:
         include:

--- a/autonomi/tests/streaming_download.rs
+++ b/autonomi/tests/streaming_download.rs
@@ -63,7 +63,7 @@ async fn test_streaming_large_blob() -> Result<()> {
     // init client
     let client = Client::init_local().await?;
     let wallet = get_funded_wallet();
-    let data = gen_random_data(1024 * 1024 * 50); // 50MB test data
+    let data = gen_random_data(1024 * 1024 * 100); // 100MB test data
 
     // put data
     let (_cost, data_addr) = client.data_put_public(data.clone(), wallet.into()).await?;
@@ -72,7 +72,7 @@ async fn test_streaming_large_blob() -> Result<()> {
     let get_result = client.data_get_public(&data_addr).await;
     assert!(
         get_result.is_err(),
-        "data_get_public should fail for 50MB file"
+        "data_get_public should fail for 100MB file"
     );
 
     // download data with stream - this should work for large files


### PR DESCRIPTION
### Description

MAX_CHUNK_SIZE still need to be setup for the test_backward_compatibility_e2e_network test.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
