### PR TITLE
refactor(autonomi): set SingleNode as default PaymentMode

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -83,9 +83,9 @@ pub enum FileCmd {
     Cost {
         /// The file to estimate cost for.
         file: String,
-        /// Disable single-node payment mode. By default, single-node payment pays only the highest
-        /// priced node with 3x that amount. This flag switches to paying 3 nodes individually,
-        /// which costs more in gas fees but less in upload tokens.
+        /// Use standard payment mode instead of single-node payment (default).
+        /// Standard mode pays 3 nodes individually, which costs more in gas fees.
+        /// Single-node payment (default) pays only one node with 3x that amount, saving gas fees.
         #[arg(long)]
         disable_single_node_payment: bool,
     },
@@ -108,9 +108,10 @@ pub enum FileCmd {
         #[arg(long)]
         #[clap(default_value = "0")]
         retry_failed: u64,
-        /// Disable single-node payment mode. By default, single-node payment pays only the highest
-        /// priced node with 3x that amount. Data is still stored on 5 nodes. This flag switches to
-        /// paying 3 nodes individually, which costs more in gas fees but less in upload tokens.
+        /// Use standard payment mode instead of single-node payment (default).
+        /// Standard mode pays 3 nodes individually, which costs more in gas fees.
+        /// Single-node payment (default) pays only one node with 3x that amount, saving gas fees.
+        /// Data is stored on 5 nodes regardless of payment mode.
         #[arg(long)]
         disable_single_node_payment: bool,
         #[command(flatten)]
@@ -459,7 +460,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             FileCmd::Cost {
                 file,
                 disable_single_node_payment,
-            } => file::cost(&file, network_context, !disable_single_node_payment).await,
+            } => file::cost(&file, network_context, disable_single_node_payment).await,
             FileCmd::Upload {
                 file,
                 public,
@@ -475,7 +476,7 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                     network_context,
                     transaction_opt.max_fee_per_gas,
                     retry_failed,
-                    !disable_single_node_payment,
+                    disable_single_node_payment,
                 )
                 .await
                 {

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -27,16 +27,18 @@ const MAX_ADDRESSES_TO_PRINT: usize = 3;
 pub async fn cost(
     file: &str,
     network_context: NetworkContext,
-    single_node_payment: bool,
+    use_standard_payment: bool,
 ) -> Result<()> {
     let mut client = crate::actions::connect_to_network(network_context)
         .await
         .map_err(|(err, _)| err)?;
 
-    // Configure payment mode
-    if single_node_payment {
-        client = client.with_payment_mode(PaymentMode::SingleNode);
-        println!("🎯 Using single node payment mode for cost estimation");
+    // Configure payment mode - default is SingleNode, only override if Standard is requested
+    if use_standard_payment {
+        client = client.with_payment_mode(PaymentMode::Standard);
+        println!("💳 Using standard payment mode (pays 3 nodes individually)");
+    } else {
+        println!("🎯 Using single node payment mode (default - saves gas fees)");
     }
 
     println!("Getting upload cost...");
@@ -59,7 +61,7 @@ pub async fn upload(
     network_context: NetworkContext,
     max_fee_per_gas_param: Option<MaxFeePerGasParam>,
     retry_failed: u64,
-    single_node_payment: bool,
+    use_standard_payment: bool,
 ) -> Result<(), ExitCodeError> {
     let config = ClientOperatingStrategy::new();
 
@@ -74,10 +76,12 @@ pub async fn upload(
         );
     }
 
-    // Configure payment mode
-    if single_node_payment {
-        client = client.with_payment_mode(PaymentMode::SingleNode);
-        println!("🎯 Using single node payment mode - saving gas fees");
+    // Configure payment mode - default is SingleNode, only override if Standard is requested
+    if use_standard_payment {
+        client = client.with_payment_mode(PaymentMode::Standard);
+        println!("💳 Using standard payment mode (pays 3 nodes individually)");
+    } else {
+        println!("🎯 Using single node payment mode (default - saves gas fees)");
     }
 
     let mut wallet = load_wallet(client.evm_network()).map_err(|err| (err, IO_ERROR))?;

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -282,7 +282,7 @@ impl Client {
             evm_network: config.evm_network,
             config: config.strategy,
             retry_failed: 0,
-            payment_mode: PaymentMode::Standard,
+            payment_mode: PaymentMode::default(),
         })
     }
 

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -23,10 +23,10 @@ use xor_name::XorName;
 /// Payment strategy for uploads
 #[derive(Debug, Clone, Copy, Default)]
 pub enum PaymentMode {
-    /// Default mode: Pay 3 nodes
-    #[default]
+    /// Pay 3 nodes
     Standard,
-    /// Alternative mode: Pay only the median priced node with 3x the quoted amount
+    /// Default mode: Pay only the median priced node with 3x the quoted amount
+    #[default]
     SingleNode,
 }
 

--- a/autonomi/tests/payment_modes.rs
+++ b/autonomi/tests/payment_modes.rs
@@ -37,9 +37,9 @@ async fn test_payment_modes_file_upload() -> Result<()> {
     thread_rng().fill_bytes(&mut single_data_vec);
     let single_data = Bytes::from(single_data_vec);
 
-    // Test 1: Standard payment mode (default)
+    // Test 1: Standard payment mode (explicitly set)
     println!("Testing Standard payment mode");
-    let client_standard = client.clone();
+    let client_standard = client.clone().with_payment_mode(PaymentMode::Standard);
     let (cost_standard, addr_standard) = client_standard
         .data_put_public(standard_data.clone(), payment_option.clone())
         .await?;
@@ -128,7 +128,7 @@ async fn test_payment_modes_cost_estimation() -> Result<()> {
 
     // Test 1: Upload small data with Standard mode
     println!("Testing small data upload with Standard mode");
-    let client_standard = client.clone();
+    let client_standard = client.clone().with_payment_mode(PaymentMode::Standard);
     let (small_cost_standard, addr_small_standard) = client_standard
         .data_put_public(small_data_standard.clone(), payment_option.clone())
         .await?;


### PR DESCRIPTION
Sets the default payment mode to `SingleNode`.