### PR TITLE
fix(bootstrap): abort cache sync task on drop 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "custom_debug",
  "dirs-next",
  "futures",
  "libp2p",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -15,6 +15,7 @@ ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }
+custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 futures = "0.3.30"
 libp2p = { version = "0.56.0", features = ["serde"] }


### PR DESCRIPTION
- The cache syncing task should be aborted when the `Bootstrap` struct is dropped, this allows us to initialize `Bootstrap` struct multiple times without causing alot of tasks trying to sync the cache.