### PR TITLE
fix(bootstrap): drive the dialing process via external loop

### DIFF
--- a/ant-bootstrap/src/config.rs
+++ b/ant-bootstrap/src/config.rs
@@ -29,7 +29,7 @@ const MIN_BOOTSTRAP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_BOOTSTRAP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(3 * 60 * 60);
 
 /// The max number of concurrent dials to be made during the initial bootstrap process.
-const CONCURRENT_DIALS: usize = 5;
+const CONCURRENT_DIALS: usize = 10;
 
 /// The max number of peers to be added before stopping the initial bootstrap process.
 const MAX_PEERS_BEFORE_TERMINATION: usize = 5;

--- a/ant-node/src/networking/driver/event/swarm.rs
+++ b/ant-node/src/networking/driver/event/swarm.rs
@@ -254,12 +254,8 @@ impl SwarmDriver {
                 event_string = "ConnectionEstablished";
                 debug!(%peer_id, num_established, ?concurrent_dial_errors, "ConnectionEstablished ({connection_id:?}) in {established_in:?}: {}", endpoint_str(&endpoint));
 
-                self.bootstrap.on_connection_established(
-                    &peer_id,
-                    &endpoint,
-                    &mut self.swarm,
-                    self.peers_in_rt,
-                );
+                self.bootstrap
+                    .on_connection_established(&peer_id, &endpoint);
 
                 if let Some(external_address_manager) = self.external_address_manager.as_mut()
                     && let ConnectedPoint::Listener { local_addr, .. } = &endpoint
@@ -337,11 +333,7 @@ impl SwarmDriver {
 
                 self.record_connection_metrics();
 
-                self.bootstrap.on_outgoing_connection_error(
-                    None,
-                    &mut self.swarm,
-                    self.peers_in_rt,
-                );
+                self.bootstrap.on_outgoing_connection_error(None);
             }
             SwarmEvent::OutgoingConnectionError {
                 peer_id: Some(failed_peer_id),
@@ -369,11 +361,8 @@ impl SwarmDriver {
                 let _ = self.live_connected_peers.remove(&connection_id);
                 self.record_connection_metrics();
 
-                self.bootstrap.on_outgoing_connection_error(
-                    Some(failed_peer_id),
-                    &mut self.swarm,
-                    self.peers_in_rt,
-                );
+                self.bootstrap
+                    .on_outgoing_connection_error(Some(failed_peer_id));
 
                 let mut redial = None;
                 // we need to decide if this was a critical error and if we should report it to the Issue tracker

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -77,12 +77,8 @@ impl NetworkDriver {
                     (peer_id, endpoint.get_remote_address().clone()),
                 );
                 self.connections_made += 1;
-                self.bootstrap.on_connection_established(
-                    &peer_id,
-                    &endpoint,
-                    &mut self.swarm,
-                    self.connections_made,
-                );
+                self.bootstrap
+                    .on_connection_established(&peer_id, &endpoint);
                 Ok(())
             }
             SwarmEvent::ConnectionClosed {
@@ -104,11 +100,7 @@ impl NetworkDriver {
             } => {
                 debug!("OutgoingConnectionError to {peer_id:?} on {connection_id:?} - {error:?}");
                 let _ = self.live_connected_peers.remove(&connection_id);
-                self.bootstrap.on_outgoing_connection_error(
-                    peer_id,
-                    &mut self.swarm,
-                    self.connections_made,
-                );
+                self.bootstrap.on_outgoing_connection_error(peer_id);
 
                 Ok(())
             }


### PR DESCRIPTION
- The dialing process prematurely stops if there are background async tasks that are still in flight. This means that the `Bootstrap` is not a "self-driving" struct, rather has to be driven by an external loop. This PR hence periodically drives the dialing process.