### PR TITLE
feat(bootstrap): split Bootstrap::new method into two

### DIFF
--- a/ant-bootstrap/src/bootstrap.rs
+++ b/ant-bootstrap/src/bootstrap.rs
@@ -80,9 +80,15 @@ pub struct Bootstrap {
 
 impl Bootstrap {
     /// Create a new Bootstrap manager with the given configuration.
-    /// Use `new_with_preloaded_addrs` to ensure that the struct contains at least MIN_INITIAL_ADDRS addresses immediately.
     ///
-    /// Must be called from a tokio runtime context.
+    /// This method does not preload addresses from cache or contacts endpoints. Addresses are fetched
+    /// lazily when `next_addr()` is called. This is suitable for nodes that run the swarm and can
+    /// wait for addresses to be fetched on-demand.
+    ///
+    /// For clients that need addresses populated before starting the libp2p driver, use
+    /// `new_with_preloaded_addrs()` instead.
+    ///
+    /// Must be called from a tokio runtime context (spawns internal tasks).
     pub fn new(config: BootstrapConfig) -> Result<Self> {
         let contacts_progress = Self::build_contacts_progress(&config)?;
 
@@ -151,7 +157,13 @@ impl Bootstrap {
         Ok(bootstrap)
     }
 
-    /// Create a new Bootstrap manager and ensure it has at least MIN_INITIAL_ADDRS addresses preloaded.
+    /// Create a new Bootstrap manager with addresses preloaded from cache and/or contacts endpoints.
+    ///
+    /// This method ensures the address queue has at least `MIN_INITIAL_ADDRS` addresses (or at least 1
+    /// if fewer are available) before returning. This is suitable for clients that need addresses
+    /// populated before starting the libp2p driver.
+    ///
+    /// For nodes that can fetch addresses on-demand via `next_addr()`, use `new()` instead.
     pub async fn new_with_preloaded_addrs(config: BootstrapConfig) -> Result<Self> {
         let mut bootstrap = Self::new(config)?;
 

--- a/ant-bootstrap/src/cache_store/mod.rs
+++ b/ant-bootstrap/src/cache_store/mod.rs
@@ -81,7 +81,7 @@ impl BootstrapCacheStore {
         if addr.iter().any(|p| matches!(p, Protocol::P2pCircuit)) {
             return;
         }
-        let Some(addr) = craft_valid_multiaddr(&addr, false) else {
+        let Some(addr) = craft_valid_multiaddr(&addr) else {
             return;
         };
         let peer_id = match addr.iter().find(|p| matches!(p, Protocol::P2p(_))) {
@@ -149,7 +149,7 @@ impl BootstrapCacheStore {
         }
 
         if self.data.read().await.peers.is_empty() {
-            info!("Cache is empty, skipping sync and flush to disk");
+            info!("No peers to write to disk, skipping sync to disk");
             return Ok(());
         }
 

--- a/ant-bootstrap/src/contacts_fetcher.rs
+++ b/ant-bootstrap/src/contacts_fetcher.rs
@@ -402,7 +402,7 @@ mod tests {
             .and(path("/"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_string("/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE\n/ip4/127.0.0.2/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"),
+                    .set_body_string("/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE\n/ip4/127.0.0.2/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"),
             )
             .mount(&mock_server)
             .await;
@@ -414,11 +414,11 @@ mod tests {
         assert_eq!(addrs.len(), 2);
 
         let addr1: Multiaddr =
-            "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
                 .parse()
                 .unwrap();
         let addr2: Multiaddr =
-            "/ip4/127.0.0.2/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
+            "/ip4/127.0.0.2/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
                 .parse()
                 .unwrap();
         assert!(addrs.iter().any(|p| p == &addr1));
@@ -441,7 +441,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/"))
             .respond_with(ResponseTemplate::new(200).set_body_string(
-                "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5",
+                "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5",
             ))
             .mount(&mock_server2)
             .await;
@@ -456,7 +456,7 @@ mod tests {
         assert_eq!(addrs.len(), 1);
 
         let addr: Multiaddr =
-            "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
                 .parse()
                 .unwrap();
         assert_eq!(addrs[0], addr);
@@ -497,7 +497,9 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("/ip4/127.0.0.1/tcp/8080"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("/ip4/127.0.0.1/udp/8080/quic-v1"),
+            )
             .mount(&mock_server)
             .await;
 
@@ -506,7 +508,7 @@ mod tests {
 
         let addrs = fetcher.fetch_bootstrap_addresses().await.unwrap();
 
-        let valid_addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        let valid_addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1".parse().unwrap();
         assert_eq!(addrs[0], valid_addr);
     }
 
@@ -535,7 +537,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_string("\n  \n/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5\n  \n"),
+                ResponseTemplate::new(200).set_body_string("\n  \n/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5\n  \n"),
             )
             .mount(&mock_server)
             .await;
@@ -547,7 +549,7 @@ mod tests {
         assert_eq!(addrs.len(), 1);
 
         let addr: Multiaddr =
-            "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
+            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
                 .parse()
                 .unwrap();
         assert_eq!(addrs[0], addr);

--- a/ant-bootstrap/src/contacts_fetcher.rs
+++ b/ant-bootstrap/src/contacts_fetcher.rs
@@ -48,8 +48,6 @@ pub struct ContactsFetcher {
     endpoints: Vec<Url>,
     /// Reqwest Client
     request_client: Client,
-    /// Ignore PeerId in the multiaddr if not present.
-    ignore_peer_id: bool,
 }
 
 impl ContactsFetcher {
@@ -68,7 +66,6 @@ impl ContactsFetcher {
             max_addrs: usize::MAX,
             endpoints,
             request_client,
-            ignore_peer_id: false,
         })
     }
 
@@ -105,10 +102,6 @@ impl ContactsFetcher {
         self.endpoints.push(endpoint);
     }
 
-    pub fn ignore_peer_id(&mut self, ignore_peer_id: bool) {
-        self.ignore_peer_id = ignore_peer_id;
-    }
-
     /// Fetch the list of bootstrap multiaddrs from all configured endpoints
     pub async fn fetch_bootstrap_addresses(&self) -> Result<Vec<Multiaddr>> {
         info!(
@@ -125,12 +118,7 @@ impl ContactsFetcher {
                     endpoint
                 );
                 (
-                    Self::fetch_from_endpoint(
-                        self.request_client.clone(),
-                        &endpoint,
-                        self.ignore_peer_id,
-                    )
-                    .await,
+                    Self::fetch_from_endpoint(self.request_client.clone(), &endpoint).await,
                     endpoint,
                 )
             })
@@ -175,11 +163,7 @@ impl ContactsFetcher {
     }
 
     /// Fetch the list of multiaddrs from a single endpoint
-    async fn fetch_from_endpoint(
-        request_client: Client,
-        endpoint: &Url,
-        ignore_peer_id: bool,
-    ) -> Result<Vec<Multiaddr>> {
+    async fn fetch_from_endpoint(request_client: Client, endpoint: &Url) -> Result<Vec<Multiaddr>> {
         let mut retries = 0;
 
         let bootstrap_addresses = loop {
@@ -194,7 +178,7 @@ impl ContactsFetcher {
                     if response.status().is_success() {
                         let text = response.text().await?;
 
-                        match Self::try_parse_response(&text, ignore_peer_id) {
+                        match Self::try_parse_response(&text) {
                             Ok(addrs) => break addrs,
                             Err(err) => {
                                 warn!("Failed to parse response with err: {err:?}");
@@ -239,7 +223,7 @@ impl ContactsFetcher {
     }
 
     /// Try to parse a response from an endpoint
-    fn try_parse_response(response: &str, ignore_peer_id: bool) -> Result<Vec<Multiaddr>> {
+    fn try_parse_response(response: &str) -> Result<Vec<Multiaddr>> {
         let cache_data = if let Ok(data) =
             serde_json::from_str::<super::cache_store::cache_data_v1::CacheData>(response)
         {
@@ -282,7 +266,7 @@ impl ContactsFetcher {
 
                 let bootstrap_addresses = response
                     .split('\n')
-                    .filter_map(|str| craft_valid_multiaddr_from_str(str, ignore_peer_id))
+                    .filter_map(craft_valid_multiaddr_from_str)
                     .collect::<Vec<_>>();
 
                 if bootstrap_addresses.is_empty() {
@@ -508,16 +492,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_multiaddr() {
+    async fn test_mutliaddr_without_peerid() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
             .and(path("/"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_string(
-                    "/ip4/127.0.0.1/tcp/8080\n/ip4/127.0.0.2/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5",
-                ),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_string("/ip4/127.0.0.1/tcp/8080"))
             .mount(&mock_server)
             .await;
 
@@ -525,10 +505,8 @@ mod tests {
         fetcher.endpoints = vec![mock_server.uri().parse().unwrap()];
 
         let addrs = fetcher.fetch_bootstrap_addresses().await.unwrap();
-        let valid_addr: Multiaddr =
-            "/ip4/127.0.0.2/tcp/8080/p2p/12D3KooWD2aV1f3qkhggzEFaJ24CEFYkSdZF5RKoMLpU6CwExYV5"
-                .parse()
-                .unwrap();
+
+        let valid_addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
         assert_eq!(addrs[0], valid_addr);
     }
 

--- a/ant-bootstrap/src/lib.rs
+++ b/ant-bootstrap/src/lib.rs
@@ -62,32 +62,13 @@ pub fn craft_valid_multiaddr(addr: &Multiaddr) -> Option<Multiaddr> {
 
     let udp = addr
         .iter()
-        .find(|protocol| matches!(protocol, Protocol::Udp(_)));
-    let tcp = addr
+        .find(|protocol| matches!(protocol, Protocol::Udp(_)))?;
+
+    output_address.push(udp);
+    let quic = addr
         .iter()
-        .find(|protocol| matches!(protocol, Protocol::Tcp(_)));
-
-    // UDP or TCP
-    if let Some(udp) = udp {
-        output_address.push(udp);
-        if let Some(quic) = addr
-            .iter()
-            .find(|protocol| matches!(protocol, Protocol::QuicV1))
-        {
-            output_address.push(quic);
-        }
-    } else if let Some(tcp) = tcp {
-        output_address.push(tcp);
-
-        if let Some(ws) = addr
-            .iter()
-            .find(|protocol| matches!(protocol, Protocol::Ws(_)))
-        {
-            output_address.push(ws);
-        }
-    } else {
-        return None;
-    }
+        .find(|protocol| matches!(protocol, Protocol::QuicV1))?;
+    output_address.push(quic);
 
     if let Some(peer_id) = peer_id {
         output_address.push(peer_id);
@@ -123,74 +104,135 @@ mod tests {
     use super::*;
     use libp2p::Multiaddr;
 
+    const VALID_PEER_ID: &str = "12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE";
+
     #[test]
-    fn test_transport_protocol_variants() {
-        let variants = [
-            (
-                "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
-                true,
-            ),
-            (
-                "/ip4/127.0.0.1/tcp/8080/ws/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
-                true,
-            ),
-            (
-                "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
-                true,
-            ),
-            ("/ip4/127.0.0.1/tcp/8080", false),
-            (
-                "/ip4/127.0.0.1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
-                false,
-            ),
-            (
-                "/ip4/127.0.0.1/wss/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE",
-                false,
-            ),
-        ];
+    fn craft_valid_multiaddr_accepts_udp_quic_v1_with_peer_id() {
+        let input = format!("/ip4/127.0.0.1/udp/8080/quic-v1/p2p/{VALID_PEER_ID}");
+        let addr: Multiaddr = input.parse().unwrap();
 
-        for (addr, should_be_valid) in variants {
-            let parsed: Multiaddr = addr.parse().unwrap();
-            let result = craft_valid_multiaddr(&parsed);
+        let result = craft_valid_multiaddr(&addr).expect("should accept udp/quic-v1 with peer id");
 
-            if should_be_valid {
-                let crafted = result.unwrap_or_else(|| panic!("Expected valid multiaddr: {addr}"));
-                assert_eq!(crafted.to_string(), parsed.to_string());
-            } else {
-                assert!(result.is_none(), "Expected invalid multiaddr: {addr}");
-            }
-        }
+        assert_eq!(result.to_string(), input);
     }
 
     #[test]
-    fn test_craft_valid_multiaddr_from_str() {
-        let valid = "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE";
-        assert!(craft_valid_multiaddr_from_str(valid).is_some());
+    fn craft_valid_multiaddr_accepts_udp_quic_v1_without_peer_id() {
+        let input = "/ip4/127.0.0.1/udp/8080/quic-v1";
+        let addr: Multiaddr = input.parse().unwrap();
 
-        let invalid = "not a multiaddr";
-        assert!(craft_valid_multiaddr_from_str(invalid).is_none());
+        let result =
+            craft_valid_multiaddr(&addr).expect("should accept udp/quic-v1 without peer id");
 
-        let missing_peer = "/ip4/127.0.0.1/tcp/8080";
-        assert!(craft_valid_multiaddr_from_str(missing_peer).is_none());
-        assert!(craft_valid_multiaddr_from_str(missing_peer).is_some());
+        assert_eq!(result.to_string(), input);
     }
 
     #[test]
-    fn test_craft_valid_multiaddr_ignore_peer_id() {
-        let addr_without_peer: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1".parse().unwrap();
-        assert!(craft_valid_multiaddr(&addr_without_peer).is_none());
-        assert!(craft_valid_multiaddr(&addr_without_peer).is_some());
+    fn craft_valid_multiaddr_rejects_tcp_transport() {
+        let input = format!("/ip4/127.0.0.1/tcp/8080/p2p/{VALID_PEER_ID}");
+        let addr: Multiaddr = input.parse().unwrap();
+
+        let result = craft_valid_multiaddr(&addr);
+
+        assert!(result.is_none(), "should reject tcp transport");
     }
 
     #[test]
-    fn test_multiaddr_get_peer_id() {
-        let addr_with_peer: Multiaddr =
-            "/ip4/127.0.0.1/udp/8080/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"
-                .parse()
-                .unwrap();
-        assert!(multiaddr_get_peer_id(&addr_with_peer).is_some());
+    fn craft_valid_multiaddr_rejects_tcp_with_websocket() {
+        let input = format!("/ip4/127.0.0.1/tcp/8080/ws/p2p/{VALID_PEER_ID}");
+        let addr: Multiaddr = input.parse().unwrap();
 
-        let addr_without_peer: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1".parse().unwrap();
-        assert!(multiaddr_get_peer_id(&addr_without_peer).is_none());
+        let result = craft_valid_multiaddr(&addr);
+
+        assert!(result.is_none(), "should reject tcp/ws transport");
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_rejects_udp_without_quic() {
+        let input = "/ip4/127.0.0.1/udp/8080";
+        let addr: Multiaddr = input.parse().unwrap();
+
+        let result = craft_valid_multiaddr(&addr);
+
+        assert!(result.is_none(), "should reject udp without quic-v1");
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_rejects_address_without_udp() {
+        let input = format!("/ip4/127.0.0.1/p2p/{VALID_PEER_ID}");
+        let addr: Multiaddr = input.parse().unwrap();
+
+        let result = craft_valid_multiaddr(&addr);
+
+        assert!(result.is_none(), "should reject address without udp");
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_rejects_address_without_ip() {
+        let input = format!("/udp/8080/quic-v1/p2p/{VALID_PEER_ID}");
+        let addr: Multiaddr = input.parse().unwrap();
+
+        let result = craft_valid_multiaddr(&addr);
+
+        assert!(result.is_none(), "should reject address without ip");
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_from_str_accepts_valid_address() {
+        let input = format!("/ip4/127.0.0.1/udp/8080/quic-v1/p2p/{VALID_PEER_ID}");
+
+        let result =
+            craft_valid_multiaddr_from_str(&input).expect("should parse valid address string");
+
+        assert_eq!(result.to_string(), input);
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_from_str_rejects_invalid_string() {
+        let result = craft_valid_multiaddr_from_str("not a multiaddr");
+
+        assert!(result.is_none(), "should reject invalid multiaddr string");
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_from_str_accepts_address_without_peer_id() {
+        let input = "/ip4/127.0.0.1/udp/8080/quic-v1";
+
+        let result = craft_valid_multiaddr_from_str(input)
+            .expect("should accept address string without peer id");
+
+        assert_eq!(result.to_string(), input);
+    }
+
+    #[test]
+    fn craft_valid_multiaddr_from_str_rejects_tcp_address() {
+        let input = format!("/ip4/127.0.0.1/tcp/8080/p2p/{VALID_PEER_ID}");
+
+        let result = craft_valid_multiaddr_from_str(&input);
+
+        assert!(result.is_none(), "should reject tcp address");
+    }
+
+    #[test]
+    fn multiaddr_get_peer_id_extracts_peer_id_when_present() {
+        let addr: Multiaddr = format!("/ip4/127.0.0.1/udp/8080/quic-v1/p2p/{VALID_PEER_ID}")
+            .parse()
+            .unwrap();
+
+        let peer_id = multiaddr_get_peer_id(&addr).expect("should extract peer id");
+
+        assert_eq!(peer_id.to_string(), VALID_PEER_ID);
+    }
+
+    #[test]
+    fn multiaddr_get_peer_id_returns_none_when_absent() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/udp/8080/quic-v1".parse().unwrap();
+
+        let result = multiaddr_get_peer_id(&addr);
+
+        assert!(
+            result.is_none(),
+            "should return None when peer id is absent"
+        );
     }
 }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -317,7 +317,7 @@ fn main() -> Result<()> {
 
     let bootstrap_config = BootstrapConfig::try_from(&opt.peers)?
         .with_backwards_compatible_writes(opt.write_older_cache_files);
-    let bootstrap = rt.block_on(Bootstrap::new(bootstrap_config))?;
+    let bootstrap = Bootstrap::new(bootstrap_config)?;
 
     let msg = format!(
         "Running {} v{}",

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -317,7 +317,7 @@ fn main() -> Result<()> {
 
     let bootstrap_config = BootstrapConfig::try_from(&opt.peers)?
         .with_backwards_compatible_writes(opt.write_older_cache_files);
-    let bootstrap = Bootstrap::new(bootstrap_config)?;
+    let bootstrap = rt.block_on(async { Bootstrap::new(bootstrap_config) })?;
 
     let msg = format!(
         "Running {} v{}",

--- a/ant-node/src/python.rs
+++ b/ant-node/src/python.rs
@@ -88,7 +88,6 @@ impl PyAntNode {
                 local,
                 ..Default::default()
             })
-            .await
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to initialise bootstrap: {e}")))?;
 
             let mut node_builder = NodeBuilder::new(

--- a/ant-node/src/spawn/node_spawner.rs
+++ b/ant-node/src/spawn/node_spawner.rs
@@ -139,7 +139,7 @@ async fn spawn_node(
 
     let bootstrap_config = bootstrap_config.unwrap_or_default();
     let local = bootstrap_config.local;
-    let bootstrap = Bootstrap::new(bootstrap_config).await?;
+    let bootstrap = Bootstrap::new(bootstrap_config)?;
 
     let mut node_builder = NodeBuilder::new(
         keypair,

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -275,7 +275,8 @@ impl Client {
             ant_protocol::version::set_network_id(network_id);
         }
 
-        let bootstrap = Bootstrap::new(config.bootstrap_config.clone()).await?;
+        let bootstrap =
+            Bootstrap::new_with_preloaded_addrs(config.bootstrap_config.clone()).await?;
         let network = Network::new(bootstrap)?;
 
         // Wait for the network to be ready with enough peers
@@ -295,7 +296,7 @@ impl Client {
             };
 
             // Retry the bootstrap and connection with cache disabled
-            let bootstrap_retry = Bootstrap::new(retry_config).await?;
+            let bootstrap_retry = Bootstrap::new_with_preloaded_addrs(retry_config).await?;
             let network_retry = Network::new(bootstrap_retry)?;
 
             // Wait for connectivity with the new bootstrap configuration
@@ -433,7 +434,7 @@ mod tests {
                 .parse()
                 .unwrap(),
         ];
-        let bootstrap = Bootstrap::new(
+        let bootstrap = Bootstrap::new_with_preloaded_addrs(
             BootstrapConfig::default()
                 .with_initial_peers(initial_peers)
                 .with_disable_cache_reading(true)


### PR DESCRIPTION
- Split the `async fn Bootstrap::new` method into two methods, where the `new` is made a "sync" method and `async fn new_with_preloaded_addrs` retains the same functionality as the old new method.
- The `new_with_preloaded_addrs` method is only required inside clients which tries to pre-populate its RT before starting the libp2p driver.
- Introduces `is_addr_queue_empty`, as it will be used by the reachability check implementation
- Deprecate `try_next_dial_addr` as it is just a copy of `next_addr` 