### PR TITLE
feat(ant): checking close group record holding status

### DIFF
--- a/ant-cli/src/commands/analyze.rs
+++ b/ant-cli/src/commands/analyze.rs
@@ -153,16 +153,22 @@ async fn print_closest_nodes(client: &autonomi::Client, addr: &str, verbose: boo
             .await
             .map_err(|e| color_eyre::eyre::eyre!("Failed to get closest peers: {e}"))?;
 
-    // Sort peers by peer_id for consistent output
+    // Sort peers by distance to target address
     let mut sorted_peers = peers;
-    sorted_peers.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
+    sorted_peers.sort_by_key(|peer| {
+        let peer_addr = NetworkAddress::from(peer.peer_id);
+        target_addr.distance(&peer_addr)
+    });
 
     println!("Found {} closest peers to {}:", sorted_peers.len(), addr);
     println!();
 
     // Check holding status for each peer
     for (i, peer) in sorted_peers.iter().enumerate() {
-        println!("{}. Peer ID: {}", i + 1, peer.peer_id);
+        let peer_addr = NetworkAddress::from(peer.peer_id);
+        let distance = target_addr.distance(&peer_addr);
+        
+        println!("{}. Peer ID: {} (distance: {distance:?}[{:?}])", i + 1, peer.peer_id, distance.ilog2());
         
         // Query the peer directly to check if it holds the record
         match client.get_record_from_peer(target_addr.clone(), peer.clone()).await {
@@ -181,6 +187,43 @@ async fn print_closest_nodes(client: &autonomi::Client, addr: &str, verbose: boo
             println!("   Addresses:");
             for addr in &peer.addrs {
                 println!("     - {addr}");
+            }
+        }
+        println!();
+    }
+
+    // Print 2-D distance matrix among sorted peers
+    println!("\n{}", "=".repeat(80));
+    println!("Distance Matrix Among Closest Peers:");
+    println!("{}", "=".repeat(80));
+    println!();
+
+    // Print header row with peer indices
+    print!("     ");
+    for i in 0..sorted_peers.len() {
+        print!("Peer {:2} ", i + 1);
+    }
+    println!();
+    print!("     ");
+    for _ in 0..sorted_peers.len() {
+        print!("{} ", "-".repeat(7));
+    }
+    println!();
+
+    // Print each row of the distance matrix
+    for (i, peer_i) in sorted_peers.iter().enumerate() {
+        print!("P{:2}  ", i + 1);
+        let addr_i = NetworkAddress::from(peer_i.peer_id);
+        
+        for peer_j in &sorted_peers {
+            let addr_j = NetworkAddress::from(peer_j.peer_id);
+            let distance = addr_i.distance(&addr_j);
+            
+            // Display distance with ilog2 for readability
+            if addr_i == addr_j {
+                print!("   -    ");
+            } else {
+                print!("{:?} ", distance.ilog2());
             }
         }
         println!();

--- a/autonomi/src/client/analyze.rs
+++ b/autonomi/src/client/analyze.rs
@@ -73,7 +73,6 @@ impl std::fmt::Display for Analysis {
         match self {
             Analysis::Chunk(chunk) => {
                 writeln!(f, "Chunk stored at: {}", chunk.address().to_hex())?;
-                writeln!(f, "Chunk content in hex: {}", hex::encode(chunk.value()))?;
             }
             Analysis::GraphEntry(graph_entry) => {
                 writeln!(

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -10,7 +10,7 @@ use crate::Client;
 use crate::networking::NetworkError;
 use crate::networking::version::PackageVersion;
 use ant_protocol::NetworkAddress;
-use libp2p::kad::PeerInfo;
+use libp2p::kad::{PeerInfo, Record};
 
 impl Client {
     /// Retrieve the closest peers to the given network address.
@@ -20,6 +20,20 @@ impl Client {
     ) -> Result<Vec<PeerInfo>, NetworkError> {
         self.network
             .get_closest_peers_with_retries(network_address.into())
+            .await
+    }
+
+    /// Get a record directly from a specific peer.
+    /// Returns:
+    /// - Some(Record) if the peer holds the record
+    /// - None if the peer doesn't hold the record or the request fails
+    pub async fn get_record_from_peer(
+        &self,
+        network_address: impl Into<NetworkAddress>,
+        peer: PeerInfo,
+    ) -> Result<Option<Record>, NetworkError> {
+        self.network
+            .get_record_from_peer(network_address.into(), peer)
             .await
     }
 

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -395,6 +395,22 @@ impl NetworkDriver {
                 self.pending_tasks
                     .insert_query(req_id, NetworkTask::GetVersion { peer, resp });
             }
+            NetworkTask::GetRecordFromPeer { addr, peer, resp } => {
+                let req = Request::Query(Query::GetReplicatedRecord {
+                    // using the recipient's address as the requester as a placeholder
+                    requester: NetworkAddress::from(peer.peer_id),
+                    key: addr.clone(),
+                });
+
+                let req_id =
+                    self.req()
+                        .send_request_with_addresses(&peer.peer_id, req, peer.addrs.clone());
+
+                self.pending_tasks.insert_query(
+                    req_id,
+                    NetworkTask::GetRecordFromPeer { addr, peer, resp },
+                );
+            }
             NetworkTask::ConnectionsMade { resp } => {
                 // Send the current count of connections made
                 if let Err(e) = resp.send(Ok(self.connections_made)) {

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -189,6 +189,10 @@ impl NetworkDriver {
             Response::Query(QueryResponse::GetVersion { peer: _, version }) => {
                 self.pending_tasks.update_get_version(request_id, version)?;
             }
+            Response::Query(QueryResponse::GetReplicatedRecord(result)) => {
+                self.pending_tasks
+                    .update_get_record_from_peer(request_id, result)?;
+            }
             _ => {
                 info!("Other request response event({request_id:?}): {response:?}");
                 // Unrecoganized req/rsp DM indicates peer is in an incorrect version

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -73,6 +73,13 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         resp: OneShotTaskResult<String>,
     },
+    /// Get a record directly from a specific peer using request/response
+    GetRecordFromPeer {
+        addr: NetworkAddress,
+        peer: PeerInfo,
+        #[debug(skip)]
+        resp: OneShotTaskResult<Option<Record>>,
+    },
     /// Get information about the amount of connections made
     ConnectionsMade {
         #[debug(skip)]

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -422,6 +422,28 @@ impl Network {
         }
     }
 
+    /// Get a record directly from a specific peer on the Network
+    /// Returns:
+    /// - Some(Record) if the peer holds the record
+    /// - None if the peer doesn't hold the record or the request fails
+    pub async fn get_record_from_peer(
+        &self,
+        addr: NetworkAddress,
+        peer: PeerInfo,
+    ) -> Result<Option<Record>, NetworkError> {
+        let (tx, rx) = oneshot::channel();
+        let task = NetworkTask::GetRecordFromPeer {
+            addr,
+            peer,
+            resp: tx,
+        };
+        self.task_sender
+            .send(task)
+            .await
+            .map_err(|_| NetworkError::NetworkDriverOffline)?;
+        rx.await?
+    }
+
     /// Get a quote for a record from a Peer on the Network
     /// Returns an Option:
     /// - Some(PaymentQuote) if the quote is successfully received


### PR DESCRIPTION
### Description

This PR expands the existing analyze tool, allow user to check the holding status of particular record.

Example to use:

```
ant analyze -v --closest-nodes f4003b5d8111a5f4fa6725e36b9a7886d2600a294a1bd3d9d572ddc23cd7b22d
``` 

The expected closest nodes' distance to the taget will be printed out.
Together with a 2-D table of distances among those closest nodes.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
