### PR TITLE
checking close group record holding status

### DIFF
--- a/ant-cli/src/commands/analyze.rs
+++ b/ant-cli/src/commands/analyze.rs
@@ -7,8 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::actions::NetworkContext;
-use autonomi::{Multiaddr, RewardsAddress, SecretKey, Wallet, client::analyze::AnalysisError,
-    networking::NetworkAddress};
+use autonomi::{
+    Multiaddr, RewardsAddress, SecretKey, Wallet, client::analyze::AnalysisError,
+    networking::NetworkAddress,
+};
 use color_eyre::eyre::Result;
 use std::str::FromStr;
 
@@ -149,9 +151,9 @@ async fn print_closest_nodes(client: &autonomi::Client, addr: &str, verbose: boo
 
     // Get closest group to the target addr
     let peers = client
-            .get_closest_to_address(target_addr.clone())
-            .await
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to get closest peers: {e}"))?;
+        .get_closest_to_address(target_addr.clone(), Some(20))
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to get closest peers: {e}"))?;
 
     // Sort peers by peer_id for consistent output
     let mut sorted_peers = peers;
@@ -163,11 +165,17 @@ async fn print_closest_nodes(client: &autonomi::Client, addr: &str, verbose: boo
     // Check holding status for each peer
     for (i, peer) in sorted_peers.iter().enumerate() {
         println!("{}. Peer ID: {}", i + 1, peer.peer_id);
-        
+
         // Query the peer directly to check if it holds the record
-        match client.get_record_from_peer(target_addr.clone(), peer.clone()).await {
+        match client
+            .get_record_from_peer(target_addr.clone(), peer.clone())
+            .await
+        {
             Ok(Some(record)) => {
-                println!("   Status: ✅ HOLDING record (size: {} bytes)", record.value.len());
+                println!(
+                    "   Status: ✅ HOLDING record (size: {} bytes)",
+                    record.value.len()
+                );
             }
             Ok(None) => {
                 println!("   Status: ❌ NOT holding record");
@@ -176,7 +184,7 @@ async fn print_closest_nodes(client: &autonomi::Client, addr: &str, verbose: boo
                 println!("   Status: ⚠️  Failed to query: {e}");
             }
         }
-        
+
         if verbose {
             println!("   Addresses:");
             for addr in &peer.addrs {

--- a/autonomi/src/client/analyze.rs
+++ b/autonomi/src/client/analyze.rs
@@ -73,7 +73,6 @@ impl std::fmt::Display for Analysis {
         match self {
             Analysis::Chunk(chunk) => {
                 writeln!(f, "Chunk stored at: {}", chunk.address().to_hex())?;
-                writeln!(f, "Chunk content in hex: {}", hex::encode(chunk.value()))?;
             }
             Analysis::GraphEntry(graph_entry) => {
                 writeln!(

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -198,7 +198,7 @@ impl Client {
             };
             let target_nodes = self
                 .network
-                .get_closest_peers_with_retries(net_addr.clone())
+                .get_closest_peers_with_retries(net_addr.clone(), None)
                 .await
                 .map_err(|e| PutError::Network {
                     address: Box::new(net_addr),
@@ -315,7 +315,7 @@ impl Client {
         // store the pointer on the network
         let target_nodes = self
             .network
-            .get_closest_peers_with_retries(net_addr.clone())
+            .get_closest_peers_with_retries(net_addr.clone(), None)
             .await
             .map_err(|e| PutError::Network {
                 address: Box::new(net_addr),

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -277,7 +277,7 @@ impl Client {
             };
             let target_nodes = self
                 .network
-                .get_closest_peers_with_retries(net_addr.clone())
+                .get_closest_peers_with_retries(net_addr.clone(), None)
                 .await
                 .map_err(|e| PutError::Network {
                     address: Box::new(net_addr),
@@ -424,7 +424,7 @@ impl Client {
         // store the scratchpad on the network
         let target_nodes = self
             .network
-            .get_closest_peers_with_retries(net_addr.clone())
+            .get_closest_peers_with_retries(net_addr.clone(), None)
             .await
             .map_err(|e| PutError::Network {
                 address: Box::new(net_addr),

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -14,12 +14,15 @@ use libp2p::kad::{PeerInfo, Record};
 
 impl Client {
     /// Retrieve the closest peers to the given network address.
+    ///
+    /// Optionally specify a count of peers to retrieve; if None, CLOSE_GROUP+2 peers will be returned.
     pub async fn get_closest_to_address(
         &self,
         network_address: impl Into<NetworkAddress>,
+        count: Option<usize>,
     ) -> Result<Vec<PeerInfo>, NetworkError> {
         self.network
-            .get_closest_peers_with_retries(network_address.into())
+            .get_closest_peers_with_retries(network_address.into(), count)
             .await
     }
 

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -10,7 +10,7 @@ use crate::Client;
 use crate::networking::NetworkError;
 use crate::networking::version::PackageVersion;
 use ant_protocol::NetworkAddress;
-use libp2p::kad::PeerInfo;
+use libp2p::kad::{PeerInfo, Record};
 
 impl Client {
     /// Retrieve the closest peers to the given network address.
@@ -20,6 +20,20 @@ impl Client {
     ) -> Result<Vec<PeerInfo>, NetworkError> {
         self.network
             .get_closest_peers_with_retries(network_address.into())
+            .await
+    }
+
+    /// Get a record directly from a specific peer.
+    /// Returns:
+    /// - Some(Record) if the peer holds the record
+    /// - None if the peer doesn't hold the record or the request fails
+    pub async fn get_record_from_peer(
+        &self,
+        network_address: impl Into<NetworkAddress>,
+        peer: PeerInfo,
+    ) -> Result<Option<Record>, NetworkError> {
+        self.network
+            .get_record_from_peer(network_address.into(), peer)
             .await
     }
 

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -406,10 +406,8 @@ impl NetworkDriver {
                     self.req()
                         .send_request_with_addresses(&peer.peer_id, req, peer.addrs.clone());
 
-                self.pending_tasks.insert_query(
-                    req_id,
-                    NetworkTask::GetRecordFromPeer { addr, peer, resp },
-                );
+                self.pending_tasks
+                    .insert_query(req_id, NetworkTask::GetRecordFromPeer { addr, peer, resp });
             }
             NetworkTask::ConnectionsMade { resp } => {
                 // Send the current count of connections made

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -395,6 +395,22 @@ impl NetworkDriver {
                 self.pending_tasks
                     .insert_query(req_id, NetworkTask::GetVersion { peer, resp });
             }
+            NetworkTask::GetRecordFromPeer { addr, peer, resp } => {
+                let req = Request::Query(Query::GetReplicatedRecord {
+                    // using the recipient's address as the requester as a placeholder
+                    requester: NetworkAddress::from(peer.peer_id),
+                    key: addr.clone(),
+                });
+
+                let req_id =
+                    self.req()
+                        .send_request_with_addresses(&peer.peer_id, req, peer.addrs.clone());
+
+                self.pending_tasks.insert_query(
+                    req_id,
+                    NetworkTask::GetRecordFromPeer { addr, peer, resp },
+                );
+            }
             NetworkTask::ConnectionsMade { resp } => {
                 // Send the current count of connections made
                 if let Err(e) = resp.send(Ok(self.connections_made)) {

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -189,6 +189,10 @@ impl NetworkDriver {
             Response::Query(QueryResponse::GetVersion { peer: _, version }) => {
                 self.pending_tasks.update_get_version(request_id, version)?;
             }
+            Response::Query(QueryResponse::GetReplicatedRecord(result)) => {
+                self.pending_tasks
+                    .update_get_record_from_peer(request_id, result)?;
+            }
             _ => {
                 info!("Other request response event({request_id:?}): {response:?}");
                 // Unrecoganized req/rsp DM indicates peer is in an incorrect version

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -414,12 +414,12 @@ impl TaskHandler {
         id: OutboundRequestId,
         result: Result<(NetworkAddress, bytes::Bytes), ant_protocol::error::Error>,
     ) -> Result<(), TaskHandlerError> {
-        let responder = self
-            .get_record_from_peer
-            .remove(&id)
-            .ok_or(TaskHandlerError::UnknownQuery(format!(
-                "OutboundRequestId {id:?}"
-            )))?;
+        let responder =
+            self.get_record_from_peer
+                .remove(&id)
+                .ok_or(TaskHandlerError::UnknownQuery(format!(
+                    "OutboundRequestId {id:?}"
+                )))?;
 
         match result {
             Ok((holder, record_content)) => {

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -73,6 +73,13 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         resp: OneShotTaskResult<String>,
     },
+    /// Get a record directly from a specific peer using request/response
+    GetRecordFromPeer {
+        addr: NetworkAddress,
+        peer: PeerInfo,
+        #[debug(skip)]
+        resp: OneShotTaskResult<Option<Record>>,
+    },
     /// Get information about the amount of connections made
     ConnectionsMade {
         #[debug(skip)]

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -422,6 +422,28 @@ impl Network {
         }
     }
 
+    /// Get a record directly from a specific peer on the Network
+    /// Returns:
+    /// - Some(Record) if the peer holds the record
+    /// - None if the peer doesn't hold the record or the request fails
+    pub async fn get_record_from_peer(
+        &self,
+        addr: NetworkAddress,
+        peer: PeerInfo,
+    ) -> Result<Option<Record>, NetworkError> {
+        let (tx, rx) = oneshot::channel();
+        let task = NetworkTask::GetRecordFromPeer {
+            addr,
+            peer,
+            resp: tx,
+        };
+        self.task_sender
+            .send(task)
+            .await
+            .map_err(|_| NetworkError::NetworkDriverOffline)?;
+        rx.await?
+    }
+
     /// Get a quote for a record from a Peer on the Network
     /// Returns an Option:
     /// - Some(PaymentQuote) if the quote is successfully received

--- a/autonomi/src/networking/retries.rs
+++ b/autonomi/src/networking/retries.rs
@@ -123,14 +123,15 @@ impl Network {
         Err(NetworkError::InvalidRetryStrategy)
     }
 
-    /// Get closest peers to an address with retries
+    /// Get closest peers to an address with retries, optionally specifying count of peers to retrieve.
     pub async fn get_closest_peers_with_retries(
         &self,
         addr: NetworkAddress,
+        count: Option<usize>,
     ) -> Result<Vec<PeerInfo>, NetworkError> {
         let mut errors = vec![];
         for duration in RetryStrategy::Once.backoff() {
-            match self.get_closest_peers(addr.clone()).await {
+            match self.get_closest_peers(addr.clone(), count).await {
                 // return success
                 Ok(peers) => return Ok(peers),
                 // return fatal errors


### PR DESCRIPTION
Description
This PR is on top of the PR https://github.com/maidsafe/autonomi/pull/3273
which:
* expands the existing analyze tool, allow user to check the holding status of particular record.
* The expected closest nodes' distance to the taget will be printed out.
* Together with a 2-D table of distances among those closest nodes.
* The closest group will be checked with a range of 20

Example to use:
```
ant analyze -v --closest-nodes f4003b5d8111a5f4fa6725e36b9a7886d2600a294a1bd3d9d572ddc23cd7b22d
```

Close https://github.com/maidsafe/autonomi/pull/3273

