### PR TITLE
feat(ant): analyze output flatten json as well

### DIFF
--- a/ant-cli/src/commands/analyze/json.rs
+++ b/ant-cli/src/commands/analyze/json.rs
@@ -15,6 +15,7 @@ use file_rotate::{ContentLimit, FileRotate, compression::Compression, suffix::Ap
 use serde::Serialize;
 use std::io::Write;
 use std::path::Path;
+use std::time::SystemTime;
 
 /// Root JSON output structure
 #[derive(Debug, Serialize)]
@@ -296,12 +297,125 @@ fn strip_0x_prefix(s: &str) -> String {
     s.trim_start_matches("0x").to_string()
 }
 
+/// Flattened JSON entry for transformed output
+#[derive(Debug, Serialize)]
+pub struct FlattenedEntry {
+    pub target_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer: Option<usize>,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distance_to_target_ilog2: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_size_bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub holding_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub holding_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub holders_among_closest: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_type: Option<String>,
+    pub timestamp: u128,
+}
+
+impl FlattenedEntry {
+    /// Flatten holder_query entries
+    fn from_holder_query(
+        target_address: &str,
+        peer_idx: usize,
+        holder: &KadHolders,
+        holding_count: u32,
+        query_status: &str,
+        address_type: Option<&str>,
+        timestamp: u128,
+    ) -> Self {
+        Self {
+            target_address: target_address.to_string(),
+            peer: Some(peer_idx),
+            source: "holder_query".to_string(),
+            peer_id: Some(holder.peer_id.clone()),
+            distance_to_target_ilog2: Some(holder.distance_to_target_ilog2),
+            record_size_bytes: holder.record_size_bytes,
+            holding_count: Some(holding_count),
+            holding_status: None,
+            holders_among_closest: None,
+            query_status: Some(query_status.to_string()),
+            address_type: address_type.map(|s| s.to_string()),
+            timestamp,
+        }
+    }
+
+    /// Flatten closest_peers entries
+    fn from_closest_peer(
+        target_address: &str,
+        peer_idx: usize,
+        peer: &ClosestPeer,
+        query_status: &str,
+        address_type: Option<&str>,
+        timestamp: u128,
+    ) -> Self {
+        let holding_status = match &peer.holding_status {
+            ClosestPeerHoldingStatus::Holding => "Holding",
+            ClosestPeerHoldingStatus::NotHolding => "NotHolding",
+            ClosestPeerHoldingStatus::FailedQuery => "FailedQuery",
+        };
+
+        Self {
+            target_address: target_address.to_string(),
+            peer: Some(peer_idx),
+            source: "closest_peers".to_string(),
+            peer_id: Some(peer.peer_id.clone()),
+            distance_to_target_ilog2: Some(peer.distance_to_target_ilog2),
+            record_size_bytes: peer.record_size_bytes,
+            holding_count: None,
+            holding_status: Some(holding_status.to_string()),
+            holders_among_closest: None,
+            query_status: Some(query_status.to_string()),
+            address_type: address_type.map(|s| s.to_string()),
+            timestamp,
+        }
+    }
+
+    /// Flatten closest_7 or closest_20 summary
+    fn from_closest_summary(
+        target_address: &str,
+        source: &str,
+        holders_count: usize,
+        query_status: &str,
+        address_type: Option<&str>,
+        timestamp: u128,
+    ) -> Self {
+        Self {
+            target_address: target_address.to_string(),
+            peer: None,
+            source: source.to_string(),
+            peer_id: None,
+            distance_to_target_ilog2: None,
+            record_size_bytes: None,
+            holding_count: None,
+            holding_status: None,
+            holders_among_closest: Some(holders_count),
+            query_status: Some(query_status.to_string()),
+            address_type: address_type.map(|s| s.to_string()),
+            timestamp,
+        }
+    }
+}
+
 const MAX_FILE_SIZE: usize = 50 * 1024 * 1024; // 50 MB
 const MAX_FILES: usize = 10;
 
 /// Writer for JSON output that supports both file and directory targets
 pub struct JsonWriter {
     writer: WriterType,
+    transformed_writer: WriterType,
+    /// Current timestamp base for the current target address batch (in nanoseconds)
+    current_timestamp_base_ns: u128,
 }
 
 enum WriterType {
@@ -320,8 +434,8 @@ impl JsonWriter {
     /// - 10 files max
     /// - No compression
     pub fn new(path: &Path) -> Result<Self> {
-        let writer = if path.is_dir() {
-            // Directory: use rotating writer
+        let (writer, transformed_writer) = if path.is_dir() {
+            // Directory: use rotating writers for both files
             let json_file_path = path.join("analyze.json");
             let file_rotate = FileRotate::new(
                 json_file_path,
@@ -331,26 +445,169 @@ impl JsonWriter {
                 #[cfg(unix)]
                 None,
             );
-            WriterType::Rotating(file_rotate)
+            
+            let transformed_file_path = path.join("analyze_transformed.json");
+            let transformed_rotate = FileRotate::new(
+                transformed_file_path,
+                AppendCount::new(MAX_FILES),
+                ContentLimit::BytesSurpassed(MAX_FILE_SIZE),
+                Compression::None,
+                #[cfg(unix)]
+                None,
+            );
+            
+            (WriterType::Rotating(file_rotate), WriterType::Rotating(transformed_rotate))
         } else {
             // File: use simple append mode
             // Create parent directory if it doesn't exist
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
+            
             let file = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)?;
-            WriterType::File(file)
+            
+            // Create transformed file path by inserting "_transformed" before extension
+            let transformed_path = if let Some(parent) = path.parent() {
+                let file_name = path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("analyze");
+                let ext = path.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("json");
+                parent.join(format!("{file_name}_transformed.{ext}"))
+            } else {
+                let file_name = path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("analyze");
+                let ext = path.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("json");
+                Path::new(&format!("{file_name}_transformed.{ext}")).to_path_buf()
+            };
+            
+            let transformed_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(transformed_path)?;
+            
+            (WriterType::File(file), WriterType::File(transformed_file))
         };
 
-        Ok(Self { writer })
+        // Initialize timestamp with current time in nanoseconds
+        let current_timestamp_base_ns = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+
+        Ok(Self { 
+            writer,
+            transformed_writer,
+            current_timestamp_base_ns,
+        })
     }
 
-    /// Write JSON string to the output
+    /// Write JSON string to the original analyze.json output
     pub fn write_json(&mut self, json_str: &str) -> Result<()> {
         match &mut self.writer {
+            WriterType::File(file) => {
+                writeln!(file, "{json_str}")?;
+                file.flush()?;
+            }
+            WriterType::Rotating(rotate) => {
+                writeln!(rotate, "{json_str}")?;
+                rotate.flush()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Write the transformed JSON output for the given JsonOutput
+    pub fn write_transformed_json(&mut self, json_output: &JsonOutput) -> Result<()> {
+        // Process each analyzed address
+        for analyzed_addr in &json_output.analyzed_addresses {
+            let base_timestamp = self.current_timestamp_base_ns;
+            let mut timestamp = base_timestamp;
+
+            // Get query status and address type from kad_method
+            let kad_query_status = match analyzed_addr.kad_method.analysis_query.query_status {
+                QueryStatus::Success => "Success",
+                QueryStatus::Error => "Error",
+            };
+            let kad_address_type = analyzed_addr.kad_method.analysis_query.address_type.as_deref();
+
+            // Flatten holder_query peers
+            for (idx, holder) in analyzed_addr.kad_method.holder_query.holders.iter().enumerate() {
+                let entry = FlattenedEntry::from_holder_query(
+                    &analyzed_addr.target_address,
+                    idx,
+                    holder,
+                    analyzed_addr.kad_method.holder_query.holding_count,
+                    kad_query_status,
+                    kad_address_type,
+                    timestamp,
+                );
+                self.write_flattened_entry(&entry)?;
+                timestamp += 1;
+            }
+
+            // Process closest_method if present
+            if let Some(closest_method) = &analyzed_addr.closest_method {
+                let closest_query_status = match closest_method.query_status {
+                    QueryStatus::Success => "Success",
+                    QueryStatus::Error => "Error",
+                };
+
+                // Flatten closest_peers
+                for (idx, peer) in closest_method.closest_peers.iter().enumerate() {
+                    let entry = FlattenedEntry::from_closest_peer(
+                        &analyzed_addr.target_address,
+                        idx,
+                        peer,
+                        closest_query_status,
+                        kad_address_type,
+                        timestamp,
+                    );
+                    self.write_flattened_entry(&entry)?;
+                    timestamp += 1;
+                }
+
+                // Flatten closest_7 summary (offset +0)
+                let entry_7 = FlattenedEntry::from_closest_summary(
+                    &analyzed_addr.target_address,
+                    "closest_7",
+                    closest_method.holders_among_7_closest,
+                    closest_query_status,
+                    kad_address_type,
+                    base_timestamp,
+                );
+                self.write_flattened_entry(&entry_7)?;
+
+                // Flatten closest_20 summary (offset +1)
+                let entry_20 = FlattenedEntry::from_closest_summary(
+                    &analyzed_addr.target_address,
+                    "closest_20",
+                    closest_method.holders_among_20_closest,
+                    closest_query_status,
+                    kad_address_type,
+                    base_timestamp + 1,
+                );
+                self.write_flattened_entry(&entry_20)?;
+            }
+
+            // Increment base timestamp by 1ms for next target address
+            self.current_timestamp_base_ns += 1_000_000;
+        }
+
+        Ok(())
+    }
+
+    /// Write a single flattened entry to the transformed output
+    fn write_flattened_entry(&mut self, entry: &FlattenedEntry) -> Result<()> {
+        let json_str = serde_json::to_string(entry)?;
+        match &mut self.transformed_writer {
             WriterType::File(file) => {
                 writeln!(file, "{json_str}")?;
                 file.flush()?;

--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -268,7 +268,35 @@ fn output_json(
     let json_str = serde_json::to_string(&json_output)?;
     let mut writer = json::JsonWriter::new(output_path)?;
     writer.write_json(&json_str)?;
+    
+    // Also write the transformed JSON output in parallel
+    writer.write_transformed_json(&json_output)?;
+    
     println!("JSON output written to: {}", output_path.display());
+    
+    // Print transformed output location
+    if output_path.is_dir() {
+        println!("Transformed JSON output written to: {}", output_path.join("transformedJson.json").display());
+    } else {
+        let transformed_path = if let Some(parent) = output_path.parent() {
+            let file_name = output_path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("analyze");
+            let ext = output_path.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("json");
+            parent.join(format!("{file_name}Transformed.{ext}"))
+        } else {
+            let file_name = output_path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("analyze");
+            let ext = output_path.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("json");
+            Path::new(&format!("{file_name}Transformed.{ext}")).to_path_buf()
+        };
+        println!("Transformed JSON output written to: {}", transformed_path.display());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Make ant analyze output a transformed flatten json as well, which will be only focused on vital metrics and make each entry as a new line.

Example cmd:
```
ant analyze -v --closest-nodes --holders --recursive --json 7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999.json 7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999
```

Example of screen output:
```
--------------------------------------------------------------------------------

JSON output written to: 7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999.json
Transformed JSON output written to: 7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999_transformed.json
```

Example of a transformed json :
```
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":0,"source":"holder_query","peer_id":"12D3KooWRetKL5f45mjziEchgBsVrKnsbWMyDfoxmAno9RtvL2Xn","distance_to_target_ilog2":233,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697800}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":1,"source":"holder_query","peer_id":"12D3KooWAN2Eo3vhybteTHwhZfXyZypMSkdZ9zQAM3e6ckdCEtAg","distance_to_target_ilog2":235,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697801}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":2,"source":"holder_query","peer_id":"12D3KooWDY4DGzCS4dUKX8JvTTaSXGRq5n4q6sCMBRzhpFFtuFUX","distance_to_target_ilog2":235,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697802}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":3,"source":"holder_query","peer_id":"12D3KooWDfEuD4eYHKD537mfH6qQjWEkPsYuKwPrYSbh5PUmNjEK","distance_to_target_ilog2":236,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697803}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":4,"source":"holder_query","peer_id":"12D3KooWB3j8DHGJtyCVsNd8tYVroKK4Ly3gutxa8nHL7PCUV1kh","distance_to_target_ilog2":236,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697804}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":5,"source":"holder_query","peer_id":"12D3KooWSgMWCZ9QpU5DWgKUaiGuozzE5gDcGbqJs6nMebtt2Kkt","distance_to_target_ilog2":236,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697805}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":6,"source":"holder_query","peer_id":"12D3KooWFFFk5tR9n149zxvY9V11drNGbWBeK7bPYV9foAZHKCqJ","distance_to_target_ilog2":236,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697806}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":7,"source":"holder_query","peer_id":"12D3KooWAd5F5nSGgyZtbH9k8rKCZvWhvGj8LvskJeMKnwRGtyiA","distance_to_target_ilog2":237,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697807}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":8,"source":"holder_query","peer_id":"12D3KooWLEJD42Ux27pZ96EeqqqSUUxRxobe5c8NwJhhH3wsPBhW","distance_to_target_ilog2":237,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697808}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":9,"source":"holder_query","peer_id":"12D3KooWCv7vmUeUnsn2CH91PRfZwqR4cJBfT9JQmDy99jM4U4H9","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697809}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":10,"source":"holder_query","peer_id":"12D3KooWCkGvkdKuJcFsErSDX2GUVKNeK8G9gwYLYEgJrJkAcf6S","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697810}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":11,"source":"holder_query","peer_id":"12D3KooWSEZiJ2dwJzwpb5u7PtufYqX4rw8UQHX4sv3PSbepueho","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697811}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":12,"source":"holder_query","peer_id":"12D3KooWCwQSWnmpS3TbSbv8o9AGGfdd18cbrBCDExieiTmavsAi","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697812}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":13,"source":"holder_query","peer_id":"12D3KooWRsUk4NGyeavJRxz9Wi2uG5mF6xFDVwoJJP93LDYFaxFH","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697813}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":14,"source":"holder_query","peer_id":"12D3KooWAfs9TnLSkz62sAHJG54gMLuYX3tgmVhNJ1GQwJStVPiZ","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697814}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":15,"source":"holder_query","peer_id":"12D3KooWAQB4GNpb3fVLbqRhTN9mPe7LSm7P2h3FUNXAyiRR3pDA","distance_to_target_ilog2":238,"record_size_bytes":0,"holding_count":16,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697815}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":0,"source":"closest_peers","peer_id":"12D3KooWRetKL5f45mjziEchgBsVrKnsbWMyDfoxmAno9RtvL2Xn","distance_to_target_ilog2":233,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697816}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":1,"source":"closest_peers","peer_id":"12D3KooWAN2Eo3vhybteTHwhZfXyZypMSkdZ9zQAM3e6ckdCEtAg","distance_to_target_ilog2":235,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697817}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":2,"source":"closest_peers","peer_id":"12D3KooWDY4DGzCS4dUKX8JvTTaSXGRq5n4q6sCMBRzhpFFtuFUX","distance_to_target_ilog2":235,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697818}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":3,"source":"closest_peers","peer_id":"12D3KooWDfEuD4eYHKD537mfH6qQjWEkPsYuKwPrYSbh5PUmNjEK","distance_to_target_ilog2":236,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697819}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":4,"source":"closest_peers","peer_id":"12D3KooWHb6aULhwn8d2oBaLsYjgVLK1qGtgJFzubDa45ERcPe4W","distance_to_target_ilog2":236,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697820}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":5,"source":"closest_peers","peer_id":"12D3KooWB3j8DHGJtyCVsNd8tYVroKK4Ly3gutxa8nHL7PCUV1kh","distance_to_target_ilog2":236,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697821}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":6,"source":"closest_peers","peer_id":"12D3KooWRY7ir4TK3oCYrC5wCLdPM7mqH5LWzHmaZGagFTitR6W8","distance_to_target_ilog2":236,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697822}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":7,"source":"closest_peers","peer_id":"12D3KooWSgMWCZ9QpU5DWgKUaiGuozzE5gDcGbqJs6nMebtt2Kkt","distance_to_target_ilog2":236,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697823}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":8,"source":"closest_peers","peer_id":"12D3KooWFFFk5tR9n149zxvY9V11drNGbWBeK7bPYV9foAZHKCqJ","distance_to_target_ilog2":236,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697824}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":9,"source":"closest_peers","peer_id":"12D3KooWAd5F5nSGgyZtbH9k8rKCZvWhvGj8LvskJeMKnwRGtyiA","distance_to_target_ilog2":237,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697825}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":10,"source":"closest_peers","peer_id":"12D3KooWLDSX379HegXuWRDRT43PaXDvkSEDF2EeuiXteJYUQWLV","distance_to_target_ilog2":237,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697826}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":11,"source":"closest_peers","peer_id":"12D3KooWKkricjCFiNiMTEEV1aiseBW87453DJmcJQPeG3gdjZhE","distance_to_target_ilog2":237,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697827}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":12,"source":"closest_peers","peer_id":"12D3KooWLEJD42Ux27pZ96EeqqqSUUxRxobe5c8NwJhhH3wsPBhW","distance_to_target_ilog2":237,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697828}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":13,"source":"closest_peers","peer_id":"12D3KooWJZc3TbPntJnYEQd4TpG3PJVtvdyiLvwumTsBAL4zXjEG","distance_to_target_ilog2":237,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697829}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":14,"source":"closest_peers","peer_id":"12D3KooWQJZWge4BDB3iiKsY5s6bBGEozHVPCNFGicWeQxP5ExJM","distance_to_target_ilog2":237,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697830}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":15,"source":"closest_peers","peer_id":"12D3KooWCv7vmUeUnsn2CH91PRfZwqR4cJBfT9JQmDy99jM4U4H9","distance_to_target_ilog2":238,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697831}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":16,"source":"closest_peers","peer_id":"12D3KooWCkGvkdKuJcFsErSDX2GUVKNeK8G9gwYLYEgJrJkAcf6S","distance_to_target_ilog2":238,"record_size_bytes":337,"holding_status":"Holding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697832}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":17,"source":"closest_peers","peer_id":"12D3KooWSEZiJ2dwJzwpb5u7PtufYqX4rw8UQHX4sv3PSbepueho","distance_to_target_ilog2":238,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697833}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":18,"source":"closest_peers","peer_id":"12D3KooWS1f5unREfodvQhg55xRyhTeBBqfPUqoXYhyvmENrqPkm","distance_to_target_ilog2":238,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697834}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","peer":19,"source":"closest_peers","peer_id":"12D3KooWCwQSWnmpS3TbSbv8o9AGGfdd18cbrBCDExieiTmavsAi","distance_to_target_ilog2":238,"holding_status":"NotHolding","query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697835}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","source":"closest_7","holders_among_closest":1,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697800}
{"target_address":"7b104439ad192c3e4e934f8025175f5ffbbf0fd07c7d843dd8e5e58194b52999","source":"closest_20","holders_among_closest":7,"query_status":"Success","address_type":"PublicArchive","timestamp":1761918834979697801}

```


### Type of Change

Please mark the types of changes made in this pull request.

- [x] New feature (non-breaking change which adds functionality)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
