### PR TITLE
feat: add windows binary signing support with DigiCert KeyLocker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,220 @@ jobs:
           SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
           SLACK_TITLE: "Release Failed"
 
+  sign-windows-binaries:
+    if: ${{
+        github.repository_owner == 'maidsafe' &&
+        (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/heads/rc'))
+      }}
+    name: sign windows binaries
+    runs-on: windows-latest
+    needs: [ build ]
+    environment: ${{ github.ref == 'refs/heads/stable' && 'stable' || 'release-candidate' }}
+
+    env:
+      SM_HOST: ${{ secrets.SM_HOST }}
+      SM_API_KEY: ${{ secrets.SM_API_KEY }}
+      SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
+      SM_LOG_LEVEL: trace
+      SM_LOG_FILE: ${{ github.workspace }}\smctl-signing.log
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download unsigned Windows binaries from build job
+      - uses: actions/download-artifact@master
+        with:
+          name: autonomi-x86_64-pc-windows-msvc
+          path: artifacts/x86_64-pc-windows-msvc/release
+
+      # --- Create client certificate file from base64 secret
+      - name: Create client certificate file from base64
+        id: prepare_cert
+        shell: pwsh
+        run: |
+          $raw = @'
+          ${{ secrets.SM_CLIENT_CERT_B64 }}
+          '@
+
+          # Strip whitespace/newlines
+          $clean = ($raw -replace '\s','')
+
+          if ([string]::IsNullOrWhiteSpace($clean)) {
+            Write-Error "SM_CLIENT_CERT_B64 is empty after normalization."
+            exit 1
+          }
+
+          # Decode base64 to binary
+          try {
+            $certBytes = [Convert]::FromBase64String($clean)
+          } catch {
+            Write-Error "SM_CLIENT_CERT_B64 is not valid Base64. Ensure you pasted a base64-encoded P12."
+            exit 1
+          }
+
+          # Write the certificate file to disk
+          $certPath = Join-Path $env:RUNNER_TEMP "Certificate.p12"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+
+          if (-not (Test-Path $certPath)) {
+            Write-Error "Failed to create certificate file at: $certPath"
+            exit 1
+          }
+
+          # Set SM_CLIENT_CERT_FILE for all subsequent steps
+          "SM_CLIENT_CERT_FILE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          # Also expose for immediate use
+          "cert_path=$certPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "sm_client_cert_b64=$clean" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # --- Install DigiCert tools (installs smctl) and wire up the client cert
+      - name: Setup DigiCert Software Trust Manager tools (installs smctl)
+        uses: digicert/ssm-code-signing@v1.1.1
+        with:
+          sm_host: ${{ secrets.SM_HOST }}
+          sm_api_key: ${{ secrets.SM_API_KEY }}
+          sm_client_cert_b64: ${{ steps.prepare_cert.outputs.sm_client_cert_b64 }}
+          sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Verify smctl installation and certificate access
+        shell: pwsh
+        run: |
+          smctl -v
+          smctl healthcheck
+          smctl keypair ls
+
+      # --- Sign all Windows executables in the artifacts directory
+      - name: Sign Windows executables
+        shell: pwsh
+        run: |
+          $artifactsPath = "artifacts\x86_64-pc-windows-msvc\release"
+          $files = Get-ChildItem $artifactsPath -Filter *.exe -Recurse
+
+          if ($files.Count -eq 0) {
+            Write-Error "No .exe files found in $artifactsPath"
+            exit 1
+          }
+
+          Write-Host "Found $($files.Count) executable(s) to sign:"
+          $files | ForEach-Object { Write-Host "  - $($_.Name)" }
+          Write-Host ""
+
+          # Capture all required environment variables for the jobs
+          $smHostValue = $env:SM_HOST
+          $smApiKey = $env:SM_API_KEY
+          $smClientCertFile = $env:SM_CLIENT_CERT_FILE
+          $smClientCertPassword = $env:SM_CLIENT_CERT_PASSWORD
+          $smKeypairAlias = $env:SM_KEYPAIR_ALIAS
+          $smLogLevel = $env:SM_LOG_LEVEL
+          $smLogFile = $env:SM_LOG_FILE
+
+          # Create signing jobs for parallel execution
+          $jobs = @()
+          $maxParallel = 3  # Adjust based on DigiCert API rate limits
+
+          foreach ($f in $files) {
+            # Wait if we've hit the parallel limit
+            while ((Get-Job -State Running).Count -ge $maxParallel) {
+              Start-Sleep -Milliseconds 500
+            }
+
+            Write-Host "Starting signing job for: $($f.Name)"
+            $job = Start-Job -ScriptBlock {
+              param($filePath, $alias, $smHostValue, $apiKey, $certFile, $certPassword, $logLevel, $logFile)
+
+              # Set environment variables in the job context
+              $env:SM_HOST = $smHostValue
+              $env:SM_API_KEY = $apiKey
+              $env:SM_CLIENT_CERT_FILE = $certFile
+              $env:SM_CLIENT_CERT_PASSWORD = $certPassword
+              $env:SM_KEYPAIR_ALIAS = $alias
+              $env:SM_LOG_LEVEL = $logLevel
+              $env:SM_LOG_FILE = $logFile
+
+              $result = & smctl sign --keypair-alias "$alias" --input "$filePath" 2>&1
+              if ($LASTEXITCODE -ne 0) {
+                throw "Signing failed for $filePath : $result"
+              }
+              return "Successfully signed: $filePath"
+            } -ArgumentList $f.FullName, $smKeypairAlias, $smHostValue, $smApiKey, $smClientCertFile, $smClientCertPassword, $smLogLevel, $smLogFile
+
+            $jobs += $job
+          }
+
+          # Wait for all jobs and collect results
+          $failed = @()
+          foreach ($job in $jobs) {
+            $result = Receive-Job -Job $job -Wait
+            if ($job.State -eq 'Failed') {
+              $failed += $job.ChildJobs[0].JobStateInfo.Reason.Message
+            } else {
+              Write-Host $result
+            }
+            Remove-Job -Job $job
+          }
+
+          if ($failed.Count -gt 0) {
+            Write-Error ("Signing failed for the following files:`n" + ($failed -join "`n"))
+            exit 1
+          }
+
+          Write-Host ""
+          Write-Host "All files signed successfully!"
+
+      # --- Verify Authenticode signatures
+      - name: Verify signatures (Authenticode)
+        shell: pwsh
+        run: |
+          $artifactsPath = "artifacts\x86_64-pc-windows-msvc\release"
+          $files = Get-ChildItem $artifactsPath -Filter *.exe -Recurse
+          $bad = @()
+          $verified = 0
+
+          foreach ($f in $files) {
+            $sig = Get-AuthenticodeSignature $f.FullName
+            "{0} -> {1}" -f $f.Name, $sig.Status | Write-Host
+
+            if ($sig.Status -eq "Valid") {
+              $verified++
+              # Display certificate details for validation
+              Write-Host "  Signer: $($sig.SignerCertificate.Subject)"
+              Write-Host "  Issuer: $($sig.SignerCertificate.Issuer)"
+            } else {
+              $bad += $f.Name
+            }
+          }
+
+          Write-Host "`nVerification Summary: $verified/$($files.Count) files verified successfully"
+
+          if ($bad.Count -gt 0) {
+            Write-Error ("Signature validation failed for:`n" + ($bad -join "`n"))
+            exit 1
+          }
+
+      # Upload signed binaries separately
+      - uses: actions/upload-artifact@v4
+        with:
+          name: autonomi-x86_64-pc-windows-msvc-signed
+          path: artifacts/x86_64-pc-windows-msvc/release
+
+      - name: Upload signing logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-signing-logs
+          path: ${{ github.workspace }}\smctl-signing.log
+          if-no-files-found: ignore
+
+      - name: post notification to slack on failure
+        if: ${{ failure() }}
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Release Signing Failed"
+
   s3-release:
     if: ${{
         github.repository_owner == 'maidsafe' &&
@@ -193,7 +407,7 @@ jobs:
       }}
     name: s3 release
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build, sign-windows-binaries ]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
@@ -204,6 +418,10 @@ jobs:
         with:
           name: autonomi-x86_64-pc-windows-msvc
           path: artifacts/x86_64-pc-windows-msvc/release
+      - uses: actions/download-artifact@master
+        with:
+          name: autonomi-x86_64-pc-windows-msvc-signed
+          path: artifacts/x86_64-pc-windows-msvc-signed/release
       - uses: actions/download-artifact@master
         with:
           name: autonomi-x86_64-unknown-linux-musl
@@ -257,13 +475,17 @@ jobs:
       }}
     name: github release
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build, sign-windows-binaries ]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@master
         with:
           name: autonomi-x86_64-pc-windows-msvc
           path: artifacts/x86_64-pc-windows-msvc/release
+      - uses: actions/download-artifact@master
+        with:
+          name: autonomi-x86_64-pc-windows-msvc-signed
+          path: artifacts/x86_64-pc-windows-msvc-signed/release
       - uses: actions/download-artifact@master
         with:
           name: autonomi-x86_64-unknown-linux-musl

--- a/.github/workflows/sign-build-binaries.yaml
+++ b/.github/workflows/sign-build-binaries.yaml
@@ -1,0 +1,311 @@
+name: Build & Sign Autonomi (Windows, Keypair-only)
+
+on:
+  # Run on every PR to main branch
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+
+  # Manual trigger from Actions tab or API/CLI
+  workflow_dispatch:
+    inputs:
+      bins:
+        description: "Space-separated bin names to build & sign"
+        required: false
+        default: "nat-detection node-launchpad ant antnode antctl antctld antnode_rpc_client evm-testnet"
+      keypair_alias:
+        description: "Override SM_KEYPAIR_ALIAS (optional)"
+        required: false
+        default: ""
+
+jobs:
+  build-and-sign-windows:
+    # Run on all PRs and manual triggers
+    runs-on: windows-latest
+
+    env:
+      # DigiCert (from Secrets)
+      SM_HOST: ${{ secrets.SM_HOST }}
+      SM_API_KEY: ${{ secrets.SM_API_KEY }}
+      SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      SM_CLIENT_CERT_B64: ${{ secrets.SM_CLIENT_CERT_B64 }}
+
+      # Use workflow input if provided; otherwise fall back to repo secret
+      SM_KEYPAIR_ALIAS: ${{ (inputs.keypair_alias != '' && inputs.keypair_alias) || secrets.SM_KEYPAIR_ALIAS }}
+
+      # Helpful logging (save to workspace for artifact upload if needed)
+      SM_LOG_LEVEL: trace
+      SM_LOG_FILE: ${{ github.workspace }}\smctl-signing.log
+
+      # Binaries to build: use manual input if provided, else defaults
+      AUTONOMI_BINS: ${{ (inputs.bins != '' && inputs.bins) || 'nat-detection node-launchpad ant antnode antctl antctld antnode_rpc_client evm-testnet' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # --- Early validation of required secrets/values
+      - name: Sanity-check required secrets/values
+        shell: pwsh
+        run: |
+          $missing = @()
+          if (-not $env:SM_HOST) { $missing += "SM_HOST" }
+          if (-not $env:SM_API_KEY) { $missing += "SM_API_KEY" }
+          if (-not "${{ secrets.SM_CLIENT_CERT_B64 }}") { $missing += "SM_CLIENT_CERT_B64" }
+          if (-not $env:SM_CLIENT_CERT_PASSWORD) { $missing += "SM_CLIENT_CERT_PASSWORD" }
+          if (-not $env:SM_KEYPAIR_ALIAS) { $missing += "SM_KEYPAIR_ALIAS (secret or manual input)" }
+          if ($missing.Count -gt 0) {
+            Write-Error ("Missing required secrets/inputs: " + ($missing -join ", "))
+            exit 1
+          }
+
+      # --- Create client certificate file from base64 secret
+      - name: Create client certificate file from base64
+        id: prepare_cert
+        shell: pwsh
+        run: |
+          $raw = @'
+          ${{ secrets.SM_CLIENT_CERT_B64 }}
+          '@
+          # Strip whitespace/newlines
+          $clean = ($raw -replace '\s','')
+
+          if ([string]::IsNullOrWhiteSpace($clean)) {
+            Write-Error "SM_CLIENT_CERT_B64 is empty after normalization."
+            exit 1
+          }
+
+          # Decode base64 to binary
+          try {
+            $certBytes = [Convert]::FromBase64String($clean)
+          } catch {
+            Write-Error "SM_CLIENT_CERT_B64 is not valid Base64. Ensure you pasted a base64-encoded P12."
+            exit 1
+          }
+
+          # Write the certificate file to disk
+          $certPath = Join-Path $env:RUNNER_TEMP "Certificate.p12"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+
+          if (-not (Test-Path $certPath)) {
+            Write-Error "Failed to create certificate file at: $certPath"
+            exit 1
+          }
+
+          Write-Host "Certificate file created successfully at: $certPath"
+          Write-Host "Certificate file size: $((Get-Item $certPath).Length) bytes"
+
+          # Set SM_CLIENT_CERT_FILE for all subsequent steps
+          "SM_CLIENT_CERT_FILE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          # Also expose for immediate use
+          "cert_path=$certPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "sm_client_cert_b64=$clean" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # --- Install DigiCert tools (installs smctl) and wire up the client cert
+      - name: Setup DigiCert Software Trust Manager tools (installs smctl)
+        uses: digicert/ssm-code-signing@v1.1.1
+        with:
+          sm_host: ${{ secrets.SM_HOST }}
+          sm_api_key: ${{ secrets.SM_API_KEY }}
+          sm_client_cert_b64: ${{ steps.prepare_cert.outputs.sm_client_cert_b64 }}
+          sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Verify smctl installation and certificate access
+        shell: pwsh
+        run: |
+          Write-Host "=== smctl version ==="
+          smctl -v
+          Write-Host ""
+
+          Write-Host "=== Environment verification ==="
+          Write-Host "SM_CLIENT_CERT_FILE: $env:SM_CLIENT_CERT_FILE"
+          Write-Host "Certificate file exists: $(Test-Path $env:SM_CLIENT_CERT_FILE)"
+          Write-Host "SM_HOST: $($env:SM_HOST -ne $null)"
+          Write-Host "SM_API_KEY: $($env:SM_API_KEY -ne $null)"
+          Write-Host "SM_CLIENT_CERT_PASSWORD: $($env:SM_CLIENT_CERT_PASSWORD -ne $null)"
+          Write-Host "SM_KEYPAIR_ALIAS: $env:SM_KEYPAIR_ALIAS"
+          Write-Host ""
+
+          Write-Host "=== DigiCert healthcheck ==="
+          smctl healthcheck
+          Write-Host ""
+
+          Write-Host "=== Available keypairs ==="
+          smctl keypair ls
+          Write-Host ""
+
+          Write-Host "DigiCert KeyLocker authenticated successfully"
+          Write-Host "Log file location: $env:SM_LOG_FILE"
+
+      # --- Install Rust & cache
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
+
+      # --- Build requested Autonomi binaries
+      - name: Build Autonomi binaries (release)
+        shell: pwsh
+        run: |
+          $bins = $env:AUTONOMI_BINS.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+          if (-not $bins -or $bins.Count -eq 0) {
+            Write-Error "No binaries listed in AUTONOMI_BINS."
+            exit 1
+          }
+
+          foreach ($b in $bins) {
+            Write-Host "=== cargo build --release --bin $b ==="
+            cargo build --release --bin $b
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Build failed for bin: $b"
+              exit 1
+            }
+          }
+
+          # Collect .exe outputs to a clean dist folder
+          $dist = Join-Path $env:RUNNER_WORKSPACE "dist"
+          if (Test-Path $dist) { Remove-Item $dist -Recurse -Force }
+          New-Item -ItemType Directory -Path $dist -Force | Out-Null
+
+          # Copy ONLY the explicitly listed bins
+          $copiedCount = 0
+          foreach ($b in $bins) {
+            $exe = Join-Path "${{ github.workspace }}\target\release" "$b.exe"
+            if (Test-Path $exe) {
+              Copy-Item $exe $dist -Force
+              $copiedCount++
+              Write-Host "Copied: $b.exe"
+            } else {
+              Write-Error "Required exe not found: $exe"
+              Write-Error "Ensure the binary name is correct and it was built successfully"
+              exit 1
+            }
+          }
+
+          if ($copiedCount -eq 0) {
+            Write-Error "No .exe files found to sign. Check build output."
+            exit 1
+          }
+
+          $found = Get-ChildItem $dist -Filter *.exe
+          Write-Host "Executables staged for signing ($copiedCount files):"
+          $found | ForEach-Object { Write-Host " - " $_.Name }
+
+      # --- Sign all executables IN PLACE using Keypair alias (with parallel jobs)
+      - name: Sign executables (Keypair alias, in-place)
+        shell: pwsh
+        run: |
+          $dist = Join-Path $env:RUNNER_WORKSPACE "dist"
+          $files = Get-ChildItem $dist -Filter *.exe
+
+          # Capture all required environment variables for the jobs
+          $smHost = $env:SM_HOST
+          $smApiKey = $env:SM_API_KEY
+          $smClientCertFile = $env:SM_CLIENT_CERT_FILE
+          $smClientCertPassword = $env:SM_CLIENT_CERT_PASSWORD
+          $smKeypairAlias = $env:SM_KEYPAIR_ALIAS
+          $smLogLevel = $env:SM_LOG_LEVEL
+          $smLogFile = $env:SM_LOG_FILE
+
+          # Create signing jobs for parallel execution
+          $jobs = @()
+          $maxParallel = 3  # Adjust based on DigiCert API rate limits
+
+          foreach ($f in $files) {
+            # Wait if we've hit the parallel limit
+            while ((Get-Job -State Running).Count -ge $maxParallel) {
+              Start-Sleep -Milliseconds 500
+            }
+
+            Write-Host "Starting signing job for: $($f.Name)"
+            $job = Start-Job -ScriptBlock {
+              param($filePath, $alias, $smHostValue, $apiKey, $certFile, $certPassword, $logLevel, $logFile)
+
+              # Set environment variables in the job context
+              $env:SM_HOST = $smHostValue
+              $env:SM_API_KEY = $apiKey
+              $env:SM_CLIENT_CERT_FILE = $certFile
+              $env:SM_CLIENT_CERT_PASSWORD = $certPassword
+              $env:SM_KEYPAIR_ALIAS = $alias
+              $env:SM_LOG_LEVEL = $logLevel
+              $env:SM_LOG_FILE = $logFile
+
+              $result = & smctl sign --keypair-alias "$alias" --input "$filePath" 2>&1
+              if ($LASTEXITCODE -ne 0) {
+                throw "Signing failed for $filePath : $result"
+              }
+              return "Successfully signed: $filePath"
+            } -ArgumentList $f.FullName, $smKeypairAlias, $smHost, $smApiKey, $smClientCertFile, $smClientCertPassword, $smLogLevel, $smLogFile
+
+            $jobs += $job
+          }
+
+          # Wait for all jobs and collect results
+          $failed = @()
+          foreach ($job in $jobs) {
+            $result = Receive-Job -Job $job -Wait
+            if ($job.State -eq 'Failed') {
+              $failed += $job.ChildJobs[0].JobStateInfo.Reason.Message
+            } else {
+              Write-Host $result
+            }
+            Remove-Job -Job $job
+          }
+
+          if ($failed.Count -gt 0) {
+            Write-Error ("Signing failed for the following files:`n" + ($failed -join "`n"))
+            exit 1
+          }
+
+          Write-Host "All files signed successfully!"
+
+      # --- Verify Authenticode signatures
+      - name: Verify signatures (Authenticode)
+        shell: pwsh
+        run: |
+          $dist = Join-Path $env:RUNNER_WORKSPACE "dist"
+          $files = Get-ChildItem $dist -Filter *.exe
+          $bad = @()
+          $verified = 0
+
+          foreach ($f in $files) {
+            $sig = Get-AuthenticodeSignature $f.FullName
+            "{0} -> {1}" -f $f.Name, $sig.Status | Write-Host
+
+            if ($sig.Status -eq "Valid") {
+              $verified++
+              # Display certificate details for validation
+              Write-Host "  Signer: $($sig.SignerCertificate.Subject)"
+              Write-Host "  Issuer: $($sig.SignerCertificate.Issuer)"
+            } else {
+              $bad += $f.Name
+            }
+          }
+
+          Write-Host "`nVerification Summary: $verified/$($files.Count) files verified successfully"
+
+          if ($bad.Count -gt 0) {
+            Write-Error ("Signature validation failed for:`n" + ($bad -join "`n"))
+            exit 1
+          }
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: autonomi-signed-exes
+          path: ${{ runner.workspace }}\dist\*.exe
+          if-no-files-found: error
+
+      - name: Upload signing logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: signing-logs
+          path: ${{ github.workspace }}\smctl-signing.log
+          if-no-files-found: ignore


### PR DESCRIPTION
This PR restores the Windows binary signing support using DigiCert KeyLocker that was previously reverted. The implementation adds automated code signing for Windows binaries during the release process, ensuring that distributed executables are properly signed and trusted by Windows systems.
The changes include: 
- Integration of DigiCert KeyLocker signing workflow in the release pipeline                                                                                                - Addition of dedicated signing workflow for Windows binaries                                                                                                                     - Configuration for automated signing during build and release processes                                                                                                   This reapplies the functionality that was temporarily removed to address compatibility issues, which have now been resolved.                                              
Related Issue          
This reverts commit 2ce554b94af10c147abe5798988b7b5c37c73091 which removed the signing support. 