### PR TITLE
fix(node): out-of-sync record_store indexing cache shall be pruned

### DIFF
--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -13,13 +13,13 @@ use std::{
 
 use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
-    NetworkAddress, PrettyPrintRecordKey,
     storage::{DataTypes, ValidationType},
+    NetworkAddress, PrettyPrintRecordKey,
 };
 use libp2p::{
-    PeerId,
     core::Multiaddr,
     kad::{KBucketDistance as Distance, Record, RecordKey},
+    PeerId,
 };
 use tokio::sync::oneshot;
 
@@ -102,7 +102,8 @@ pub(crate) enum LocalSwarmCmd {
         is_client_put: bool,
     },
     /// Remove a local record from the RecordStore
-    /// Typically because the write failed
+    /// Typically because the disk write failure
+    /// or record indexing cache is out-of-sync with disk files
     RemoveFailedLocalRecord {
         key: RecordKey,
     },


### PR DESCRIPTION
### Description

out-of-sync record_store indexing cache shall be pruned

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
