### PR TITLE
feat(antnode): expose new replication metrics from node

### DIFF
--- a/ant-node/src/metrics.rs
+++ b/ant-node/src/metrics.rs
@@ -9,7 +9,7 @@
 use crate::Marker;
 #[cfg(feature = "open-metrics")]
 use crate::networking::MetricsRegistries;
-use ant_protocol::storage::DataTypes;
+use ant_protocol::{CLOSE_GROUP_SIZE, storage::DataTypes};
 use prometheus_client::{
     encoding::{EncodeLabelSet, EncodeLabelValue},
     metrics::{
@@ -33,6 +33,7 @@ pub(crate) struct NodeMetricsRecorder {
     /// replication
     replication_triggered: Counter,
     replication_keys_to_fetch: Histogram,
+    pub(crate) network_wide_replication_holders: Histogram,
 
     // routing table
     peer_added_to_routing_table: Counter,
@@ -104,6 +105,19 @@ impl NodeMetricsRecorder {
             replication_keys_to_fetch.clone(),
         );
 
+        let network_wide_replication_holders = Histogram::new([
+            1.0 / CLOSE_GROUP_SIZE as f64,
+            2.0 / CLOSE_GROUP_SIZE as f64,
+            3.0 / CLOSE_GROUP_SIZE as f64,
+            4.0 / CLOSE_GROUP_SIZE as f64,
+            5.0 / CLOSE_GROUP_SIZE as f64,
+        ]);
+        sub_registry.register(
+            "network_wide_replication_holders",
+            "The histogram of fraction of holders for a record during network wide replication. I.e, number of holders / CLOSE_GROUP_SIZE",
+            network_wide_replication_holders.clone(),
+        );
+
         let peer_added_to_routing_table = Counter::default();
         sub_registry.register(
             "peer_added_to_routing_table",
@@ -145,6 +159,7 @@ impl NodeMetricsRecorder {
             put_record_err_v2,
             replication_triggered,
             replication_keys_to_fetch,
+            network_wide_replication_holders,
             peer_added_to_routing_table,
             peer_removed_from_routing_table,
             current_reward_wallet_balance,

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -798,16 +798,26 @@ impl SwarmDriver {
             let peers_in_range = get_peers_in_range(&closest_k_peers, target, responsible_range);
 
             if peers_in_range.len() >= expected_candidates {
+                self.record_metrics(Marker::ReplicateCandidatesObtained {
+                    length: peers_in_range.len(),
+                    within_responsible_distance: true,
+                });
                 return Ok(peers_in_range);
             }
         }
 
         // In case the range is too narrow, fall back to at least expected_candidates peers.
-        Ok(closest_k_peers
+        let closest_k_peers: Vec<(PeerId, Addresses)> = closest_k_peers
             .iter()
             .take(expected_candidates)
             .cloned()
-            .collect())
+            .collect();
+
+        self.record_metrics(Marker::ReplicateCandidatesObtained {
+            length: closest_k_peers.len(),
+            within_responsible_distance: false,
+        });
+        Ok(closest_k_peers)
     }
 }
 

--- a/ant-node/src/networking/driver/event/request_response.rs
+++ b/ant-node/src/networking/driver/event/request_response.rs
@@ -357,6 +357,7 @@ impl SwarmDriver {
                     sender: &holder,
                     keys_count: incoming_keys.len(),
                     in_range: false,
+                    network_under_load: false,
                 });
                 return Ok(());
             }
@@ -383,6 +384,7 @@ impl SwarmDriver {
                     sender: &holder,
                     keys_count: incoming_keys.len(),
                     in_range: false,
+                    network_under_load: true,
                 });
                 return Ok(());
             }
@@ -396,6 +398,7 @@ impl SwarmDriver {
             sender: &holder,
             keys_count: incoming_keys.len(),
             in_range: true,
+            network_under_load: self.network_wide_replication.is_network_under_load(),
         });
 
         // On receive a replication_list from a close up peer, we undertake:

--- a/ant-node/src/networking/driver/event/request_response.rs
+++ b/ant-node/src/networking/driver/event/request_response.rs
@@ -20,6 +20,9 @@ use ant_protocol::{
 use libp2p::kad::{KBucketDistance as Distance, U256};
 use libp2p::request_response::{self, Message};
 
+const REPLICATION_SENDER_CLOSE_GROUP_THRESHOLD: usize = 40;
+const REPLICATION_SENDER_EXTENDED_DISTANCE_MULTIPLIER: usize = 10;
+
 impl SwarmDriver {
     /// Forwards `Request` to the upper layers using `Sender<NetworkEvent>`. Sends `Response` to the peers
     pub(super) fn handle_req_resp_events(
@@ -338,9 +341,23 @@ impl SwarmDriver {
             incoming_keys.len()
         );
 
-        // accept replication requests from the K_VALUE peers away,
+        // accept replication requests from the 40 peers away,
         // giving us some margin for replication
-        let closest_40_peers = self.get_closest_40_local_peers_to_self();
+        let closest_40_peers =
+            self.get_closest_local_peers_to_self(REPLICATION_SENDER_CLOSE_GROUP_THRESHOLD);
+
+        #[cfg(feature = "open-metrics")]
+        if let Some(metrics_recorder) = self.metrics_recorder.as_ref() {
+            let _ = metrics_recorder
+                .replication_sender_close_group_threshold
+                .set(REPLICATION_SENDER_CLOSE_GROUP_THRESHOLD as i64);
+            let _ = metrics_recorder
+                .replication_sender_extended_distance_multiplier
+                .set(REPLICATION_SENDER_EXTENDED_DISTANCE_MULTIPLIER as i64);
+        }
+
+        let mut within_closest_group = true; // set to false below if checks fail
+        let mut within_extended_distance_range = false; // set to true below if checks pass
         if !closest_40_peers
             .iter()
             .any(|(peer_id, _)| peer_id == &holder)
@@ -352,11 +369,13 @@ impl SwarmDriver {
                 "Holder {holder:?} is self or not within the 40 closest peers. Distance is {distance:?}({:?})",
                 distance.ilog2()
             );
+            within_closest_group = false;
             if !self.network_wide_replication.is_network_under_load() {
                 self.record_metrics(Marker::ReplicationSenderInRange {
                     sender: &holder,
                     keys_count: incoming_keys.len(),
-                    in_range: false,
+                    within_closest_group,
+                    within_extended_distance_range,
                     network_under_load: false,
                 });
                 return Ok(());
@@ -373,7 +392,20 @@ impl SwarmDriver {
             let holder_distance =
                 NetworkAddress::from(holder).distance(&NetworkAddress::from(self.self_peer_id));
             // increases the ilog2 value by 3 to 4. check test_distance_multiplication_and_ilog2
-            let increased_distance = Distance(farthest_distance.0.saturating_mul(U256::from(10)));
+            let increased_distance = Distance(
+                farthest_distance
+                    .0
+                    .saturating_mul(U256::from(REPLICATION_SENDER_EXTENDED_DISTANCE_MULTIPLIER)),
+            );
+            #[cfg(feature = "open-metrics")]
+            if let Some(metrics_recorder) = self.metrics_recorder.as_ref()
+                && let Some(farthest_ilog2) = farthest_distance.ilog2()
+            {
+                let _ = metrics_recorder
+                    .replication_sender_extended_distance_ilog2
+                    .set(farthest_ilog2 as i64);
+            }
+
             if holder_distance.0 > increased_distance.0 {
                 debug!(
                     "Holder {holder:?} is not within increased replication range {increased_distance:?}({:?}) during high network load",
@@ -383,7 +415,8 @@ impl SwarmDriver {
                 self.record_metrics(Marker::ReplicationSenderInRange {
                     sender: &holder,
                     keys_count: incoming_keys.len(),
-                    in_range: false,
+                    within_closest_group,
+                    within_extended_distance_range,
                     network_under_load: true,
                 });
                 return Ok(());
@@ -392,12 +425,14 @@ impl SwarmDriver {
                 "Holder {holder:?} is within increased replication range {increased_distance:?}({:?}) during high network load",
                 increased_distance.ilog2()
             );
+            within_extended_distance_range = true;
         }
 
         self.record_metrics(Marker::ReplicationSenderInRange {
             sender: &holder,
             keys_count: incoming_keys.len(),
-            in_range: true,
+            within_closest_group,
+            within_extended_distance_range,
             network_under_load: self.network_wide_replication.is_network_under_load(),
         });
 

--- a/ant-node/src/networking/driver/mod.rs
+++ b/ant-node/src/networking/driver/mod.rs
@@ -350,6 +350,10 @@ impl SwarmDriver {
                     self.swarm.behaviour_mut().kademlia.store_mut().set_responsible_distance_range(distance);
                     // the distance range within the replication_fetcher shall be in sync as well
                     self.replication_fetcher.set_replication_distance_range(distance);
+                    #[cfg(feature = "open-metrics")]
+                    if let Some(metrics_recorder) = &self.metrics_recorder.as_ref() && let Some(ilog2) = distance.ilog2() {
+                        let _ = metrics_recorder.distance_range.set(ilog2 as i64);
+                    }
                 }
                 _ = relay_manager_reservation_interval.tick() => {
                     if let Some(relay_manager) = &mut self.relay_manager {

--- a/ant-node/src/networking/driver/mod.rs
+++ b/ant-node/src/networking/driver/mod.rs
@@ -418,10 +418,17 @@ impl SwarmDriver {
         )
     }
 
-    /// Get 40 closest peers to self, from our local RoutingTable.
+    /// Get closest peers to self, from our local RoutingTable.
     /// Always includes self in.
-    pub(crate) fn get_closest_40_local_peers_to_self(&mut self) -> Vec<(PeerId, Addresses)> {
-        self.get_closest_local_peers_to_target(&NetworkAddress::from(self.self_peer_id), true, 40)
+    pub(crate) fn get_closest_local_peers_to_self(
+        &mut self,
+        num_peers: usize,
+    ) -> Vec<(PeerId, Addresses)> {
+        self.get_closest_local_peers_to_target(
+            &NetworkAddress::from(self.self_peer_id),
+            true,
+            num_peers,
+        )
     }
 
     /// Get K closest peers to the target, from our local RoutingTable.

--- a/ant-node/src/networking/log_markers.rs
+++ b/ant-node/src/networking/log_markers.rs
@@ -25,13 +25,41 @@ pub(crate) enum Marker<'a> {
     PeerConsideredAsBad { bad_peer: &'a PeerId },
     /// We have been flagged as a bad node by a peer.
     FlaggedAsBadNode { flagged_by: &'a PeerId },
+    /// Replicate candidates obtained
+    ReplicateCandidatesObtained {
+        length: usize,
+        within_responsible_distance: bool,
+    },
+    /// Replication sender range check result
+    ReplicationSenderInRange {
+        sender: &'a PeerId,
+        keys_count: usize,
+        in_range: bool,
+    },
+    /// Incoming replication keys statistics
+    IncomingReplicationKeysStats {
+        holder: PeerId,
+        total_keys: usize,
+        new_keys: usize,
+        out_of_range_keys: usize,
+    },
 }
 
 impl Marker<'_> {
     /// Returns the string representation of the LogMarker.
     pub(crate) fn log(&self) {
-        // Down the line, if some logs are noisier than others, we can
-        // match the type and log a different level.
-        info!("{self:?}");
+        if let Marker::IncomingReplicationKeysStats {
+            holder: _,
+            total_keys: _,
+            new_keys,
+            out_of_range_keys,
+        } = self
+        {
+            if *out_of_range_keys > 0 || *new_keys > 0 {
+                info!("{self:?}");
+            }
+        } else {
+            info!("{self:?}");
+        }
     }
 }

--- a/ant-node/src/networking/log_markers.rs
+++ b/ant-node/src/networking/log_markers.rs
@@ -35,6 +35,7 @@ pub(crate) enum Marker<'a> {
         sender: &'a PeerId,
         keys_count: usize,
         in_range: bool,
+        network_under_load: bool,
     },
     /// Incoming replication keys statistics
     IncomingReplicationKeysStats {

--- a/ant-node/src/networking/log_markers.rs
+++ b/ant-node/src/networking/log_markers.rs
@@ -34,7 +34,8 @@ pub(crate) enum Marker<'a> {
     ReplicationSenderInRange {
         sender: &'a PeerId,
         keys_count: usize,
-        in_range: bool,
+        within_closest_group: bool,
+        within_extended_distance_range: bool,
         network_under_load: bool,
     },
     /// Incoming replication keys statistics

--- a/ant-node/src/networking/metrics/mod.rs
+++ b/ant-node/src/networking/metrics/mod.rs
@@ -427,17 +427,13 @@ impl NetworkMetricsRecorder {
                 sender: _,
                 keys_count: _,
                 in_range,
+                network_under_load,
             } => {
-                let in_range_label = if in_range {
-                    replication::InRange::True
-                } else {
-                    replication::InRange::False
-                };
-
                 let _ = self
                     .replication_sender_range
                     .get_or_create(&replication::ReplicationSenderRangeLabels {
-                        in_range: in_range_label,
+                        in_range,
+                        network_under_load,
                     })
                     .inc();
             }

--- a/ant-node/src/networking/metrics/replication.rs
+++ b/ant-node/src/networking/metrics/replication.rs
@@ -1,0 +1,110 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::encoding::EncodeLabelValue;
+use std::collections::VecDeque;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct ReplicateCandidateLabels {
+    pub(crate) range: Range,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub(crate) enum Range {
+    WithinResponsibleDistance,
+    OutsideResponsibleDistance,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct ReplicationSenderRangeLabels {
+    pub(crate) in_range: InRange,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub(crate) enum InRange {
+    True,
+    False,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct IncomingKeysMetricLabels {
+    pub(crate) metric_type: IncomingMetricType,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub(crate) enum IncomingMetricType {
+    NewKeysPercent,
+    OutOfRangeKeysPercent,
+}
+
+const STATS_WINDOW_SIZE: usize = 50;
+
+/// Sliding window for tracking replication statistics
+pub(crate) struct ReplicationStatsWindow {
+    // Stores (total_keys, new_keys, out_of_range_keys) for last N requests
+    window: VecDeque<(usize, usize, usize)>,
+}
+
+impl ReplicationStatsWindow {
+    pub(crate) fn new() -> Self {
+        Self {
+            window: VecDeque::with_capacity(STATS_WINDOW_SIZE),
+        }
+    }
+
+    /// Add a new entry to the sliding window
+    pub(crate) fn add_entry(
+        &mut self,
+        total_keys: usize,
+        new_keys: usize,
+        out_of_range_keys: usize,
+    ) {
+        if self.window.len() >= STATS_WINDOW_SIZE {
+            let _ = self.window.pop_front();
+        }
+        self.window
+            .push_back((total_keys, new_keys, out_of_range_keys));
+    }
+
+    /// Calculate the percentage of new keys across the window
+    pub(crate) fn calculate_new_keys_percent(&self) -> f64 {
+        if self.window.is_empty() {
+            return 0.0;
+        }
+
+        let (total_keys, total_new_keys) = self.window.iter().fold(
+            (0usize, 0usize),
+            |(acc_total, acc_new), &(total, new, _)| (acc_total + total, acc_new + new),
+        );
+
+        if total_keys == 0 {
+            return 0.0;
+        }
+
+        (total_new_keys as f64 / total_keys as f64) * 100.0
+    }
+
+    /// Calculate the percentage of out-of-range keys across the window
+    pub(crate) fn calculate_out_of_range_percent(&self) -> f64 {
+        if self.window.is_empty() {
+            return 0.0;
+        }
+
+        let (total_keys, total_out_of_range) = self.window.iter().fold(
+            (0usize, 0usize),
+            |(acc_total, acc_oor), &(total, _, oor)| (acc_total + total, acc_oor + oor),
+        );
+
+        if total_keys == 0 {
+            return 0.0;
+        }
+
+        (total_out_of_range as f64 / total_keys as f64) * 100.0
+    }
+}

--- a/ant-node/src/networking/metrics/replication.rs
+++ b/ant-node/src/networking/metrics/replication.rs
@@ -23,13 +23,8 @@ pub(crate) enum Range {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub(crate) struct ReplicationSenderRangeLabels {
-    pub(crate) in_range: InRange,
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
-pub(crate) enum InRange {
-    True,
-    False,
+    pub(crate) in_range: bool,
+    pub(crate) network_under_load: bool,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]

--- a/ant-node/src/networking/metrics/replication.rs
+++ b/ant-node/src/networking/metrics/replication.rs
@@ -23,8 +23,10 @@ pub(crate) enum Range {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub(crate) struct ReplicationSenderRangeLabels {
-    pub(crate) in_range: bool,
-    pub(crate) network_under_load: bool,
+    pub(crate) within_closest_group: bool,
+    pub(crate) within_extended_distance_range: bool,
+    pub(crate) network_load: bool,
+    pub(crate) outcome: bool,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]

--- a/ant-node/src/replication.rs
+++ b/ant-node/src/replication.rs
@@ -252,11 +252,9 @@ impl Node {
     ) {
         for (key, val_type) in keys {
             #[cfg(feature = "open-metrics")]
-            let network_wide_replication_holders = if let Some(recorder) = self.metrics_recorder() {
-                Some(recorder.network_wide_replication_holders.clone())
-            } else {
-                None
-            };
+            let network_wide_replication_holders = self
+                .metrics_recorder()
+                .map(|recorder| recorder.network_wide_replication_holders.clone());
             let network = self.network().clone();
             let _handle = spawn(async move {
                 Self::network_wide_replication_per_key(


### PR DESCRIPTION
Adds 3 new replication metrics from node that depend on the distance range value:

- `replicate_candidates` contains the # of times that we picked the 5 (non-periodic) or 10 (periodic) replication candidates that were either `WithinResponsibleDistance` or `OutsideResponsibleDistance`. 
- `replication_sender_range` tells where a node received replication message from `InRange` sender or not.
- `replication_keys_incoming_percentages` contains the percentage (tracked over a sliding window of 50 requests) of replication record keys that we got from a peer that we've never seen before `NewKeysPercent` and the percentage of keys that are out of range `OutOfRangeKeysPercent`
- `distance_range` the ilog2 value of the distance range used for replication 
- `network_wide_replication_holders` contains the histogram of the # of holders of a particular record in the network among the CLOSE_GROUP