### PR TITLE
feat(antnode): perform network wide replication of all our keys

### DIFF
--- a/ant-cli/src/commands/analyze/json.rs
+++ b/ant-cli/src/commands/analyze/json.rs
@@ -445,7 +445,7 @@ impl JsonWriter {
                 #[cfg(unix)]
                 None,
             );
-            
+
             let transformed_file_path = path.join("analyze_transformed.json");
             let transformed_rotate = FileRotate::new(
                 transformed_file_path,
@@ -455,44 +455,45 @@ impl JsonWriter {
                 #[cfg(unix)]
                 None,
             );
-            
-            (WriterType::Rotating(file_rotate), WriterType::Rotating(transformed_rotate))
+
+            (
+                WriterType::Rotating(file_rotate),
+                WriterType::Rotating(transformed_rotate),
+            )
         } else {
             // File: use simple append mode
             // Create parent directory if it doesn't exist
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            
+
             let file = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)?;
-            
+
             // Create transformed file path by inserting "_transformed" before extension
             let transformed_path = if let Some(parent) = path.parent() {
-                let file_name = path.file_stem()
+                let file_name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("analyze");
-                let ext = path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("json");
+                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("json");
                 parent.join(format!("{file_name}_transformed.{ext}"))
             } else {
-                let file_name = path.file_stem()
+                let file_name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("analyze");
-                let ext = path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("json");
+                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("json");
                 Path::new(&format!("{file_name}_transformed.{ext}")).to_path_buf()
             };
-            
+
             let transformed_file = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(transformed_path)?;
-            
+
             (WriterType::File(file), WriterType::File(transformed_file))
         };
 
@@ -502,7 +503,7 @@ impl JsonWriter {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
 
-        Ok(Self { 
+        Ok(Self {
             writer,
             transformed_writer,
             current_timestamp_base_ns,
@@ -536,10 +537,20 @@ impl JsonWriter {
                 QueryStatus::Success => "Success",
                 QueryStatus::Error => "Error",
             };
-            let kad_address_type = analyzed_addr.kad_method.analysis_query.address_type.as_deref();
+            let kad_address_type = analyzed_addr
+                .kad_method
+                .analysis_query
+                .address_type
+                .as_deref();
 
             // Flatten holder_query peers
-            for (idx, holder) in analyzed_addr.kad_method.holder_query.holders.iter().enumerate() {
+            for (idx, holder) in analyzed_addr
+                .kad_method
+                .holder_query
+                .holders
+                .iter()
+                .enumerate()
+            {
                 let entry = FlattenedEntry::from_holder_query(
                     &analyzed_addr.target_address,
                     idx,

--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -268,34 +268,44 @@ fn output_json(
     let json_str = serde_json::to_string(&json_output)?;
     let mut writer = json::JsonWriter::new(output_path)?;
     writer.write_json(&json_str)?;
-    
+
     // Also write the transformed JSON output in parallel
     writer.write_transformed_json(&json_output)?;
-    
+
     println!("JSON output written to: {}", output_path.display());
-    
+
     // Print transformed output location
     if output_path.is_dir() {
-        println!("Transformed JSON output written to: {}", output_path.join("transformedJson.json").display());
+        println!(
+            "Transformed JSON output written to: {}",
+            output_path.join("transformedJson.json").display()
+        );
     } else {
         let transformed_path = if let Some(parent) = output_path.parent() {
-            let file_name = output_path.file_stem()
+            let file_name = output_path
+                .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("analyze");
-            let ext = output_path.extension()
+            let ext = output_path
+                .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("json");
             parent.join(format!("{file_name}Transformed.{ext}"))
         } else {
-            let file_name = output_path.file_stem()
+            let file_name = output_path
+                .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("analyze");
-            let ext = output_path.extension()
+            let ext = output_path
+                .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("json");
             Path::new(&format!("{file_name}Transformed.{ext}")).to_path_buf()
         };
-        println!("Transformed JSON output written to: {}", transformed_path.display());
+        println!(
+            "Transformed JSON output written to: {}",
+            transformed_path.display()
+        );
     }
 
     Ok(())

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -407,7 +407,8 @@ impl SwarmDriver {
             }
             LocalSwarmCmd::GetKCloseLocalPeersToTarget { key, sender } => {
                 cmd_string = "GetKCloseLocalPeersToTarget";
-                let closest_peers = self.get_closest_local_peers_to_target(&key, true, K_VALUE.get());
+                let closest_peers =
+                    self.get_closest_local_peers_to_target(&key, true, K_VALUE.get());
 
                 let _ = sender.send(closest_peers);
             }

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -217,6 +217,10 @@ impl SwarmDriver {
                     .store_mut()
                     .payment_received();
             }
+            LocalSwarmCmd::RecordNotAtTargetLocation => {
+                cmd_string = "RecordNotAtTargetLocation";
+                self.network_wide_replication.set_network_under_load();
+            }
             LocalSwarmCmd::GetLocalRecord { key, sender } => {
                 cmd_string = "GetLocalRecord";
                 let record = self

--- a/ant-node/src/networking/driver/event/swarm.rs
+++ b/ant-node/src/networking/driver/event/swarm.rs
@@ -497,7 +497,9 @@ impl SwarmDriver {
                 }
 
                 if let Some((addr, remote_peer_id)) = redial {
-                    info!("Attempting to dial corrected peer {remote_peer_id:?} at {addr:?}, after received WrongPeerId from {failed_peer_id:?}");
+                    info!(
+                        "Attempting to dial corrected peer {remote_peer_id:?} at {addr:?}, after received WrongPeerId from {failed_peer_id:?}"
+                    );
 
                     if let Err(err) = self.swarm.dial(
                         DialOpts::peer_id(remote_peer_id)
@@ -506,7 +508,9 @@ impl SwarmDriver {
                             .addresses(vec![addr.clone()])
                             .build(),
                     ) {
-                        warn!("Failed to dial to {remote_peer_id:?} at {addr:?}: {err:?}, during WrongPeerId correction of {failed_peer_id:?}");
+                        warn!(
+                            "Failed to dial to {remote_peer_id:?} at {addr:?}: {err:?}, during WrongPeerId correction of {failed_peer_id:?}"
+                        );
                     }
                 }
             }

--- a/ant-node/src/networking/driver/network_wide_replication.rs
+++ b/ant-node/src/networking/driver/network_wide_replication.rs
@@ -1,0 +1,335 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Result;
+use crate::networking::driver::{NETWORK_WIDE_REPLICATION_INTERVAL, NodeBehaviour};
+use crate::networking::interface::NetworkEvent;
+use ant_protocol::NetworkAddress;
+use ant_protocol::storage::ValidationType;
+use libp2p::Swarm;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+pub(crate) struct NetworkWideReplication {
+    last_record_count: usize,
+    pending_records: VecDeque<(NetworkAddress, ValidationType)>,
+    completed_records: Vec<(NetworkAddress, ValidationType)>,
+    last_replication_time: Option<std::time::Instant>,
+    complete_replication_within: std::time::Instant,
+    event_sender: mpsc::Sender<NetworkEvent>,
+}
+
+impl NetworkWideReplication {
+    pub(crate) fn new(event_sender: mpsc::Sender<NetworkEvent>) -> Self {
+        let complete_replication_within = Instant::now() + Duration::from_secs(7 * 24 * 60 * 60); // 7 days
+        Self {
+            pending_records: VecDeque::new(),
+            completed_records: Vec::new(),
+            last_record_count: 0,
+            last_replication_time: None,
+            complete_replication_within,
+            event_sender,
+        }
+    }
+
+    /// Calculate how many keys to send in this execution to complete replication within deadline.
+    /// Returns `None` if we should skip this execution (not enough time passed or no pending keys).
+    fn calculate_keys_to_send(
+        pending_count: usize,
+        time_remaining_secs: u64,
+        elapsed_since_last: Option<Duration>,
+        execute_interval_secs: u64,
+    ) -> Option<usize> {
+        if pending_count == 0 {
+            return None;
+        }
+
+        // Calculate how many execute runs remain until deadline
+        let execute_runs_remaining = if time_remaining_secs == 0 {
+            0
+        } else {
+            (time_remaining_secs / execute_interval_secs).max(1)
+        };
+
+        // Calculate how many keys to send per execution
+        if execute_runs_remaining == 0 {
+            // Deadline passed, send all immediately
+            Some(pending_count)
+        } else {
+            // Calculate keys per execution to finish within deadline
+            let keys_per_execution =
+                (pending_count as f64 / execute_runs_remaining as f64).ceil() as usize;
+
+            // For low key counts with many executions remaining, check if we should send this time
+            if keys_per_execution == 0 || (pending_count < execute_runs_remaining as usize) {
+                // We have more executions than keys, so space them out
+                // Calculate the interval between sends
+                let target_interval_secs = time_remaining_secs / pending_count as u64;
+
+                // Check if enough time has passed since last replication
+                if let Some(elapsed) = elapsed_since_last {
+                    if elapsed.as_secs() < target_interval_secs {
+                        // Not enough time has passed, don't send yet
+                        return None;
+                    }
+                    // Calculate how many we should send based on elapsed time
+                    let sends = (elapsed.as_secs() / target_interval_secs).max(1) as usize;
+                    Some(sends.min(pending_count))
+                } else {
+                    // First send
+                    Some(1)
+                }
+            } else {
+                // We have more keys than remaining executions, send multiple per execution
+                Some(keys_per_execution.min(pending_count))
+            }
+        }
+    }
+
+    pub(crate) async fn execute(&mut self, swarm: &mut Swarm<NodeBehaviour>) -> Result<()> {
+        // add a new records to the queue
+        let current_count = swarm.behaviour_mut().kademlia.store_mut().count();
+        if self.last_record_count != current_count {
+            self.last_record_count = current_count;
+            let new_keys = swarm
+                .behaviour_mut()
+                .kademlia
+                .store_mut()
+                .record_addresses_ref()
+                .iter()
+                .map(|(_, (addr, validation_type, _))| (addr.clone(), validation_type.clone()))
+                .filter(|key| {
+                    !self.pending_records.contains(key) && !self.completed_records.contains(key)
+                })
+                .collect::<Vec<_>>();
+
+            info!(
+                "Adding {} new records to network wide replication queue",
+                new_keys.len()
+            );
+            for key in new_keys {
+                self.pending_records.push_back(key);
+            }
+        }
+
+        let now = Instant::now();
+        let pending_count = self.pending_records.len();
+
+        // Calculate time remaining until deadline
+        let time_remaining_secs = if self.complete_replication_within > now {
+            self.complete_replication_within
+                .duration_since(now)
+                .as_secs()
+        } else {
+            0
+        };
+
+        // Calculate elapsed time since last replication
+        let elapsed_since_last = self
+            .last_replication_time
+            .map(|last_time| now.duration_since(last_time));
+
+        // Calculate how many keys to send
+        let Some(keys_to_send) = Self::calculate_keys_to_send(
+            pending_count,
+            time_remaining_secs,
+            elapsed_since_last,
+            NETWORK_WIDE_REPLICATION_INTERVAL.as_secs(),
+        ) else {
+            // Not enough time has passed or no pending keys, skip this execution
+            return Ok(());
+        };
+
+        info!(
+            "Network wide replication: sending {keys_to_send} keys out of {pending_count} pending",
+        );
+
+        let mut keys_list = Vec::with_capacity(keys_to_send);
+        for _i in 0..keys_to_send {
+            if let Some(_key) = self.pending_records.pop_front() {
+                keys_list.push(_key);
+            }
+        }
+        // Send event to trigger replication
+        let event = NetworkEvent::NetworkWideReplication { keys: keys_list };
+        if let Err(err) = self.event_sender.send(event).await {
+            warn!("Failed to send NetworkWideReplication event: {err}");
+        } else {
+            self.last_replication_time = Some(now);
+        }
+
+        // Check if we've completed the 7-day cycle (deadline passed and no pending records)
+        if time_remaining_secs == 0 && self.pending_records.is_empty() {
+            info!(
+                "Network wide replication cycle completed. Completed {} records. Starting new 7-day cycle.",
+                self.completed_records.len()
+            );
+            // Reset for a new 7-day cycle
+            self.completed_records.clear();
+            self.complete_replication_within = now + Duration::from_secs(7 * 24 * 60 * 60);
+            self.last_replication_time = None;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXECUTE_INTERVAL_SECS: u64 = NETWORK_WIDE_REPLICATION_INTERVAL.as_secs(); // 15 minutes
+    const SEVEN_DAYS_SECS: u64 = 7 * 24 * 60 * 60;
+
+    // Boundary/Invalid Input Tests
+    #[test]
+    fn keys_to_send_should_be_none_when_no_pending_keys() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            0,
+            SEVEN_DAYS_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn keys_to_send_should_be_all_pending_when_deadline_passed() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            100,
+            0, // deadline passed
+            Some(Duration::from_secs(100)),
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(100));
+    }
+
+    // High Key Count Tests - More keys than executions
+    #[test]
+    fn keys_to_send_should_be_10_when_100_keys_with_10_runs_remaining() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            100,
+            10 * EXECUTE_INTERVAL_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(10));
+    }
+
+    #[test]
+    fn keys_to_send_should_ceil_when_keys_dont_divide_evenly() {
+        // 100 keys / 7 runs = 14.28... -> should ceil to 15
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            100,
+            7 * EXECUTE_INTERVAL_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(15));
+    }
+
+    #[test]
+    fn keys_to_send_should_be_all_pending_when_only_one_run_remaining() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            50,
+            EXECUTE_INTERVAL_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(50));
+    }
+
+    // Low Key Count Tests - More executions than keys
+    #[test]
+    fn keys_to_send_should_be_1_during_first_send() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            7,
+            SEVEN_DAYS_SECS,
+            None, // first send
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn keys_to_send_should_be_1_when_exactly_one_interval_elapsed() {
+        // 7 keys over 7 days = target interval of 24 hours (86400 secs)
+        let target_interval = SEVEN_DAYS_SECS / 7;
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            7,
+            SEVEN_DAYS_SECS,
+            Some(Duration::from_secs(target_interval)), // exactly 1 interval
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn keys_to_send_should_be_none_when_not_enough_time_elapsed() {
+        // 7 keys over 7 days = target interval of 24 hours (86400 secs)
+        let target_interval = SEVEN_DAYS_SECS / 7;
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            7,
+            SEVEN_DAYS_SECS,
+            Some(Duration::from_secs(target_interval / 2)), // only half interval
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn keys_to_send_should_be_3_when_three_intervals_elapsed() {
+        // 7 keys over 7 days = target interval of 24 hours (86400 secs)
+        let target_interval = SEVEN_DAYS_SECS / 7;
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            7,
+            SEVEN_DAYS_SECS,
+            Some(Duration::from_secs(target_interval * 3)), // 3 intervals
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(3));
+    }
+
+    // Edge Cases
+    #[test]
+    fn keys_to_send_should_be_1_when_exactly_one_key_per_execution() {
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            100,
+            100 * EXECUTE_INTERVAL_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn keys_to_send_should_be_all_when_very_short_time_remaining() {
+        // 1000 keys but only 1 execute interval remaining
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            1000,
+            EXECUTE_INTERVAL_SECS,
+            None,
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(1000));
+    }
+
+    #[test]
+    fn keys_to_send_should_cap_at_pending_count_when_many_intervals_passed() {
+        // Only 5 keys pending but 100 intervals passed
+        let target_interval = SEVEN_DAYS_SECS / 5;
+        let result = NetworkWideReplication::calculate_keys_to_send(
+            5,
+            SEVEN_DAYS_SECS,
+            Some(Duration::from_secs(target_interval * 100)),
+            EXECUTE_INTERVAL_SECS,
+        );
+        assert_eq!(result, Some(5)); // capped at 5, not 100
+    }
+}

--- a/ant-node/src/networking/driver/network_wide_replication.rs
+++ b/ant-node/src/networking/driver/network_wide_replication.rs
@@ -23,6 +23,7 @@ pub(crate) struct NetworkWideReplication {
     last_replication_time: Option<std::time::Instant>,
     complete_replication_within: std::time::Instant,
     event_sender: mpsc::Sender<NetworkEvent>,
+    network_is_under_load: bool,
 }
 
 impl NetworkWideReplication {
@@ -35,7 +36,13 @@ impl NetworkWideReplication {
             last_replication_time: None,
             complete_replication_within,
             event_sender,
+            network_is_under_load: false,
         }
+    }
+
+    /// The network is under load if we performed network wide replication in the last 72 hours.
+    pub(crate) fn is_network_under_load(&self) -> bool {
+        self.network_is_under_load
     }
 
     /// Calculate how many keys to send in this execution to complete replication within deadline.
@@ -93,6 +100,14 @@ impl NetworkWideReplication {
     }
 
     pub(crate) async fn execute(&mut self, swarm: &mut Swarm<NodeBehaviour>) -> Result<()> {
+        // reset network load flag after 72 hours
+        if self.network_is_under_load
+            && let Some(last_time) = self.last_replication_time
+            && Instant::now().duration_since(last_time) > Duration::from_secs(72 * 60 * 60)
+        {
+            self.network_is_under_load = false;
+        }
+
         // add a new records to the queue
         let current_count = swarm.behaviour_mut().kademlia.store_mut().count();
         if self.last_record_count != current_count {
@@ -162,6 +177,7 @@ impl NetworkWideReplication {
             warn!("Failed to send NetworkWideReplication event: {err}");
         } else {
             self.last_replication_time = Some(now);
+            self.network_is_under_load = true;
         }
 
         // Check if we've completed the 7-day cycle (deadline passed and no pending records)

--- a/ant-node/src/networking/error.rs
+++ b/ant-node/src/networking/error.rs
@@ -7,13 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ant_protocol::storage::GraphEntryAddress;
-use ant_protocol::{messages::Response, storage::RecordKind, NetworkAddress};
+use ant_protocol::{NetworkAddress, messages::Response, storage::RecordKind};
 use libp2p::swarm::ListenError;
 use libp2p::{
+    TransportError,
     kad::{self, QueryId},
     request_response::{OutboundFailure, OutboundRequestId},
     swarm::DialError,
-    TransportError,
 };
 use std::{collections::HashMap, fmt::Debug, io, path::PathBuf};
 use thiserror::Error;
@@ -221,7 +221,7 @@ fn transport_err_to_str(err: &TransportError<std::io::Error>) -> (String, Level)
 #[cfg(test)]
 mod tests {
     use ant_protocol::{
-        storage::ChunkAddress, NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey,
+        NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey, storage::ChunkAddress,
     };
     use xor_name::XorName;
 

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -13,13 +13,13 @@ use std::{
 
 use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
-    storage::{DataTypes, ValidationType},
     NetworkAddress, PrettyPrintRecordKey,
+    storage::{DataTypes, ValidationType},
 };
 use libp2p::{
+    PeerId,
     core::Multiaddr,
     kad::{KBucketDistance as Distance, Record, RecordKey},
-    PeerId,
 };
 use tokio::sync::oneshot;
 

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -161,6 +161,8 @@ pub(crate) enum LocalSwarmCmd {
     RemovePeer {
         peer: PeerId,
     },
+    /// Some records were not found at their target location
+    RecordNotAtTargetLocation,
 }
 
 /// Debug impl for LocalSwarmCmd to avoid printing full Record, instead only RecodKey
@@ -283,6 +285,9 @@ impl Debug for LocalSwarmCmd {
             }
             LocalSwarmCmd::RemovePeer { peer } => {
                 write!(f, "LocalSwarmCmd::RemovePeer({peer:?})")
+            }
+            LocalSwarmCmd::RecordNotAtTargetLocation => {
+                write!(f, "LocalSwarmCmd::RecordNotAtTargetLocation")
             }
         }
     }

--- a/ant-node/src/networking/interface/network_event.rs
+++ b/ant-node/src/networking/interface/network_event.rs
@@ -67,6 +67,10 @@ pub(crate) enum NetworkEvent {
     },
     /// Peers of picked bucket for version query.
     PeersForVersionQuery(Vec<(PeerId, Addresses)>),
+    /// Check if the nodes close to these keys hold the record, else replicate to them.
+    NetworkWideReplication {
+        keys: Vec<(NetworkAddress, ValidationType)>,
+    },
 }
 
 /// Terminate node for the following reason
@@ -150,6 +154,9 @@ impl std::fmt::Debug for NetworkEvent {
                         .map(|(peer, _addrs)| peer)
                         .collect::<Vec<&PeerId>>()
                 )
+            }
+            NetworkEvent::NetworkWideReplication { keys } => {
+                write!(f, "NetworkEvent::NetworkWideReplication({keys:?})")
             }
         }
     }

--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -13,6 +13,7 @@ use crate::networking::{
     circular_vec::CircularVec,
     driver::{
         InitialBootstrapTrigger, NodeBehaviour, SwarmDriver, network_discovery::NetworkDiscovery,
+        network_wide_replication::NetworkWideReplication,
     },
     error::{NetworkError, Result},
     external_address::ExternalAddressManager,
@@ -413,6 +414,7 @@ fn init_swarm_driver(
         bootstrap: config.bootstrap,
         relay_manager,
         connected_relay_clients: Default::default(),
+        network_wide_replication: NetworkWideReplication::new(network_event_sender.clone()),
         external_address_manager,
         replication_fetcher,
         #[cfg(feature = "open-metrics")]

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -170,6 +170,10 @@ impl Network {
         self.send_local_swarm_cmd(LocalSwarmCmd::PaymentReceived);
     }
 
+    pub(crate) fn notify_record_not_at_target_location(&self) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::RecordNotAtTargetLocation);
+    }
+
     /// Get `Record` from the local RecordStore
     pub(crate) async fn get_local_record(&self, key: &RecordKey) -> Result<Option<Record>> {
         let (sender, receiver) = oneshot::channel();

--- a/ant-node/src/networking/record_store.rs
+++ b/ant-node/src/networking/record_store.rs
@@ -622,6 +622,10 @@ impl NodeRecordStore {
         &self.records
     }
 
+    pub(crate) fn count(&self) -> usize {
+        self.records.len()
+    }
+
     /// The follow up to `put_verified`, this only registers the RecordKey
     /// in the RecordStore records set. After this it should be safe
     /// to return the record as stored.
@@ -880,7 +884,7 @@ impl RecordStore for NodeRecordStore {
             // The pruning has to be undertaken in an async way.
             let cloned_cmd_sender = self.local_swarm_cmd_sender.clone();
             let cmd = LocalSwarmCmd::RemoveFailedLocalRecord { key: k.clone() };
-            
+
             send_local_swarm_cmd(cloned_cmd_sender, cmd);
         }
 

--- a/ant-node/src/networking/replication_fetcher.rs
+++ b/ant-node/src/networking/replication_fetcher.rs
@@ -336,12 +336,8 @@ impl ReplicationFetcher {
         closest_peers: Vec<NetworkAddress>,
     ) -> Vec<(PeerId, NetworkAddress, ValidationType)> {
         // Always trust the holder
-        let new_incoming_keys = self.in_range_new_keys(
-            holder,
-            incoming_keys,
-            locally_stored_keys,
-            closest_peers,
-        );
+        let new_incoming_keys =
+            self.in_range_new_keys(holder, incoming_keys, locally_stored_keys, closest_peers);
 
         // Requiring three replicas
         self.initial_majority_replicates(holder, new_incoming_keys)
@@ -467,12 +463,10 @@ impl ReplicationFetcher {
 
         // Sort closest_peers by distance to self
         closest_peers.sort_by_key(|peer| self_address.distance(peer));
-        
+
         // Get the distance to the farthest peer in closest_peers
-        let farthest_peer_distance = closest_peers
-            .last()
-            .map(|peer| self_address.distance(peer));
-        
+        let farthest_peer_distance = closest_peers.last().map(|peer| self_address.distance(peer));
+
         // Filter out those out_of_range ones among the incoming_keys.
         // A key is in range if it's closer to self than the farthest peer in closest_peers
         if let Some(max_distance) = farthest_peer_distance {
@@ -482,7 +476,6 @@ impl ReplicationFetcher {
                     "Distance to target {addr:?} is {distance:?}, max peer distance: {max_distance:?}"
                 );
                 let is_in_range = distance <= max_distance;
-                
                 if !is_in_range {
                     out_of_range_keys.push(addr.clone());
                     debug!(
@@ -695,10 +688,7 @@ mod tests {
     use ant_protocol::{NetworkAddress, storage::ValidationType};
     use eyre::Result;
     use libp2p::{PeerId, kad::RecordKey};
-    use std::{
-        collections::HashMap,
-        time::Duration,
-    };
+    use std::{collections::HashMap, time::Duration};
     use tokio::{sync::mpsc, time::sleep};
 
     #[tokio::test]
@@ -840,11 +830,12 @@ mod tests {
 
         // Sort closest_peers by distance to self
         closest_k_peers.sort_by_key(|peer| self_address.distance(peer));
-        
+
         // Get the distance to the farthest peer in closest_peers
         let distance_range = closest_k_peers
             .last()
-            .map(|peer| self_address.distance(peer)).unwrap();
+            .map(|peer| self_address.distance(peer))
+            .unwrap();
 
         let mut incoming_keys = Vec::new();
         let mut in_range_keys = 0;

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -564,6 +564,10 @@ impl Node {
                     Self::query_peers_version(network, peers).await;
                 });
             }
+            NetworkEvent::NetworkWideReplication { keys } => {
+                event_header = "NetworkWideReplication";
+                self.perform_network_wide_replication(keys);
+            }
         }
 
         trace!(

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -673,9 +673,9 @@ impl Node {
                         key: Box::new(key.clone()),
                     }),
                     // Use `PutRecordFailed` as place holder
-                    Err(err) => Err(ProtocolError::PutRecordFailed(
-                        format!("Error to fetch local record for GetReplicatedRecord {err:?}")
-                    )),
+                    Err(err) => Err(ProtocolError::PutRecordFailed(format!(
+                        "Error to fetch local record for GetReplicatedRecord {err:?}"
+                    ))),
                 };
 
                 QueryResponse::GetReplicatedRecord(result)


### PR DESCRIPTION
For each `key` that a node holds, it tries to query the network wide closest peers for that key and check if they hold the record, else we send a `Cmd::Replicate` to them.

We perform this check for all our keys over a span of 7 days. This number is chosen such that, assuming >7 peers hold a particular record (due to the interval replication), then each record would be replicated across the network using this new method once every day on avg.