### PR TITLE
feat(ant): analyze large datamap that do not fit in memory

### DIFF
--- a/ant-cli/src/actions/download.rs
+++ b/ant-cli/src/actions/download.rs
@@ -135,7 +135,7 @@ async fn download_public(
 
     let data = match client.data_get_public(&address).await {
         Ok(data) => data,
-        Err(GetError::TooLargeForMemory) => {
+        Err(GetError::TooLargeForMemory(_)) => {
             println!("Detected large file at: {addr}, downloading via streaming");
             info!("Detected large file at: {addr}, downloading via streaming");
             client

--- a/ant-cli/src/commands/analyze/error.rs
+++ b/ant-cli/src/commands/analyze/error.rs
@@ -46,7 +46,7 @@ impl AnalysisErrorDisplay {
                 GetError::RecordKindMismatch(_) => Self::RecordKindMismatch,
                 GetError::Configuration(_) => Self::Configuration,
                 GetError::UnrecognizedDataMap(_) => Self::UnrecognizedDataMap,
-                GetError::TooLargeForMemory => Self::TooLargeForMemory,
+                GetError::TooLargeForMemory(_) => Self::TooLargeForMemory,
             },
         }
     }

--- a/ant-cli/src/commands/analyze/json.rs
+++ b/ant-cli/src/commands/analyze/json.rs
@@ -445,7 +445,7 @@ impl JsonWriter {
                 #[cfg(unix)]
                 None,
             );
-            
+
             let transformed_file_path = path.join("analyze_transformed.json");
             let transformed_rotate = FileRotate::new(
                 transformed_file_path,
@@ -455,44 +455,45 @@ impl JsonWriter {
                 #[cfg(unix)]
                 None,
             );
-            
-            (WriterType::Rotating(file_rotate), WriterType::Rotating(transformed_rotate))
+
+            (
+                WriterType::Rotating(file_rotate),
+                WriterType::Rotating(transformed_rotate),
+            )
         } else {
             // File: use simple append mode
             // Create parent directory if it doesn't exist
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            
+
             let file = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(path)?;
-            
+
             // Create transformed file path by inserting "_transformed" before extension
             let transformed_path = if let Some(parent) = path.parent() {
-                let file_name = path.file_stem()
+                let file_name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("analyze");
-                let ext = path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("json");
+                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("json");
                 parent.join(format!("{file_name}_transformed.{ext}"))
             } else {
-                let file_name = path.file_stem()
+                let file_name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("analyze");
-                let ext = path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("json");
+                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("json");
                 Path::new(&format!("{file_name}_transformed.{ext}")).to_path_buf()
             };
-            
+
             let transformed_file = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(transformed_path)?;
-            
+
             (WriterType::File(file), WriterType::File(transformed_file))
         };
 
@@ -502,7 +503,7 @@ impl JsonWriter {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
 
-        Ok(Self { 
+        Ok(Self {
             writer,
             transformed_writer,
             current_timestamp_base_ns,
@@ -536,10 +537,20 @@ impl JsonWriter {
                 QueryStatus::Success => "Success",
                 QueryStatus::Error => "Error",
             };
-            let kad_address_type = analyzed_addr.kad_method.analysis_query.address_type.as_deref();
+            let kad_address_type = analyzed_addr
+                .kad_method
+                .analysis_query
+                .address_type
+                .as_deref();
 
             // Flatten holder_query peers
-            for (idx, holder) in analyzed_addr.kad_method.holder_query.holders.iter().enumerate() {
+            for (idx, holder) in analyzed_addr
+                .kad_method
+                .holder_query
+                .holders
+                .iter()
+                .enumerate()
+            {
                 let entry = FlattenedEntry::from_holder_query(
                     &analyzed_addr.target_address,
                     idx,

--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -322,34 +322,44 @@ fn output_json(
     let json_str = serde_json::to_string(&json_output)?;
     let mut writer = json::JsonWriter::new(output_path)?;
     writer.write_json(&json_str)?;
-    
+
     // Also write the transformed JSON output in parallel
     writer.write_transformed_json(&json_output)?;
-    
+
     println!("JSON output written to: {}", output_path.display());
-    
+
     // Print transformed output location
     if output_path.is_dir() {
-        println!("Transformed JSON output written to: {}", output_path.join("transformedJson.json").display());
+        println!(
+            "Transformed JSON output written to: {}",
+            output_path.join("transformedJson.json").display()
+        );
     } else {
         let transformed_path = if let Some(parent) = output_path.parent() {
-            let file_name = output_path.file_stem()
+            let file_name = output_path
+                .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("analyze");
-            let ext = output_path.extension()
+            let ext = output_path
+                .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("json");
             parent.join(format!("{file_name}Transformed.{ext}"))
         } else {
-            let file_name = output_path.file_stem()
+            let file_name = output_path
+                .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("analyze");
-            let ext = output_path.extension()
+            let ext = output_path
+                .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("json");
             Path::new(&format!("{file_name}Transformed.{ext}")).to_path_buf()
         };
-        println!("Transformed JSON output written to: {}", transformed_path.display());
+        println!(
+            "Transformed JSON output written to: {}",
+            transformed_path.display()
+        );
     }
 
     Ok(())

--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -1895,10 +1895,10 @@ async fn handle_repair(
                 println!("⚠️  Address {addr_str} has only {holders_count} holder(s) in closest 7");
             }
 
-            // Try to get the record info from one of the holders
-            if let Some(ClosestPeerStatus::Holding { target_address, .. }) = 
-                statuses.iter().find(|s| matches!(s, ClosestPeerStatus::Holding { .. })) 
-            {
+            // Get target_address from the first entry (all variants have this field)
+            if let Some(first_status) = statuses.first() {
+                let target_address = first_status.target_address();
+                
                 // Try to get the record data via kad query
                 match client.get_record_and_holders(target_address.clone(), Quorum::One).await {
                     Ok((Some(record), _holders)) => {
@@ -1919,7 +1919,7 @@ async fn handle_repair(
                     }
                 }
             } else {
-                println!("   鈿狅笍  No holders found for {addr_str}, cannot repair");
+                println!("   ⚠️  No status entries found for {addr_str}, cannot repair");
             }
         }
     }

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -61,7 +61,7 @@ pub(crate) fn get_error_exit_code(err: &GetError) -> i32 {
         GetError::RecordKindMismatch(_) => 34,
         GetError::Configuration(_) => 35,
         GetError::UnrecognizedDataMap(_) => 31,
-        GetError::TooLargeForMemory => 31,
+        GetError::TooLargeForMemory(_) => 31,
     }
 }
 

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -632,7 +632,7 @@ fn start_new_node_process(retain_peer_id: bool, root_dir: PathBuf, port: u16) {
 
     // Remove `--first` argument. If node is restarted, it is not the first anymore.
     args.retain(|arg| arg != "--first");
-    
+
     // Remove arguments that will be re-added with correct values to avoid duplicates
     let args_to_remove = ["--auto-restart-delay", "--root-dir", "--port"];
     for arg_name in &args_to_remove {
@@ -643,7 +643,7 @@ fn start_new_node_process(retain_peer_id: bool, root_dir: PathBuf, port: u16) {
             }
         }
     }
-    
+
     info!("Cleaned args for restart: {args:?}");
 
     // Convert current exe path to string, log an error and return if it fails
@@ -714,8 +714,14 @@ fn start_new_node_process(retain_peer_id: bool, root_dir: PathBuf, port: u16) {
     // Execute the command
     let _handle = match cmd.spawn() {
         Ok(child) => {
-            info!("Successfully spawned new node process with PID: {}", child.id());
-            println!("Successfully spawned new node process with PID: {}", child.id());
+            info!(
+                "Successfully spawned new node process with PID: {}",
+                child.id()
+            );
+            println!(
+                "Successfully spawned new node process with PID: {}",
+                child.id()
+            );
             child
         }
         Err(e) => {

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -13,13 +13,13 @@ use std::{
 
 use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::{
-    storage::{DataTypes, ValidationType},
     NetworkAddress, PrettyPrintRecordKey,
+    storage::{DataTypes, ValidationType},
 };
 use libp2p::{
+    PeerId,
     core::Multiaddr,
     kad::{KBucketDistance as Distance, Record, RecordKey},
-    PeerId,
 };
 use tokio::sync::oneshot;
 

--- a/ant-node/src/networking/record_store.rs
+++ b/ant-node/src/networking/record_store.rs
@@ -880,7 +880,7 @@ impl RecordStore for NodeRecordStore {
             // The pruning has to be undertaken in an async way.
             let cloned_cmd_sender = self.local_swarm_cmd_sender.clone();
             let cmd = LocalSwarmCmd::RemoveFailedLocalRecord { key: k.clone() };
-            
+
             send_local_swarm_cmd(cloned_cmd_sender, cmd);
         }
 

--- a/autonomi/src/client/analyze.rs
+++ b/autonomi/src/client/analyze.rs
@@ -413,7 +413,7 @@ async fn analyze_datamap(
     println_if!(verbose, "Fetching data from the Network...");
     let data = match client.data_get(datamap).await {
         Ok(data) => data,
-        Err(GetError::TooLargeForMemory) => {
+        Err(GetError::TooLargeForMemory(data_map)) => {
             println_if!(
                 verbose,
                 "Datamap points to a large sized file, not suitable for in-memory fetch."
@@ -421,12 +421,12 @@ async fn analyze_datamap(
             let analysis = match stored_at {
                 Some(addr) => Analysis::DataMap {
                     address: addr,
-                    chunks: chunk_list_from_datamap(map),
+                    chunks: chunk_list_from_datamap(data_map),
                     data: None,
                     points_to_a_data_map,
                 },
                 None => Analysis::RawDataMap {
-                    chunks: chunk_list_from_datamap(map),
+                    chunks: chunk_list_from_datamap(data_map),
                     data: None,
                     points_to_a_data_map,
                 },
@@ -542,7 +542,7 @@ async fn analyze_datamap_old(
     println_if!(verbose, "Fetching data from the Network...");
     let data = match client.data_get(datamap).await {
         Ok(data) => data,
-        Err(GetError::TooLargeForMemory) => {
+        Err(GetError::TooLargeForMemory(data_map)) => {
             println_if!(
                 verbose,
                 "Datamap points to a large sized file, not suitable for in-memory fetch."

--- a/autonomi/src/client/data_map_restoration.rs
+++ b/autonomi/src/client/data_map_restoration.rs
@@ -39,7 +39,10 @@ impl Client {
             info!("Restoring from new root data_map:\n{data_map:?}");
             let file_data_map = self.fetch_new_data_map(&data_map)?;
 
-            info!("Fetched file data_map of new version: \n{file_data_map:?}");
+            info!(
+                "Fetched file data_map from {:?} of new version: \n{file_data_map:?}",
+                data_map_chunk.0.address()
+            );
             return Ok(file_data_map);
         }
 

--- a/autonomi/src/client/high_level/data/private.rs
+++ b/autonomi/src/client/high_level/data/private.rs
@@ -44,7 +44,12 @@ impl Client {
         let chunk_count = datamap.infos().len();
 
         if chunk_count > *crate::client::config::MAX_IN_MEMORY_DOWNLOAD_SIZE {
-            return Err(GetError::TooLargeForMemory);
+            warn!(
+                "Data map {:?} has {chunk_count} chunks, which exceeds the maximum allowed in-memory download size of {} chunks",
+                data_map.0.address(),
+                *crate::client::config::MAX_IN_MEMORY_DOWNLOAD_SIZE
+            );
+            return Err(GetError::TooLargeForMemory(datamap));
         }
 
         datamap.child = None;

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -55,6 +55,7 @@ use ant_evm::EvmNetwork;
 use config::ClientConfig;
 use payment::PayError;
 use quote::CostError;
+use self_encryption::DataMap;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
 
@@ -177,7 +178,7 @@ pub enum GetError {
     #[error(
         "DataMap points to a file too large to be handled in memory, you can increase the MAX_IN_MEMORY_DOWNLOAD_SIZE env var or use streaming to avoid this error."
     )]
-    TooLargeForMemory,
+    TooLargeForMemory(DataMap),
 }
 
 impl Client {


### PR DESCRIPTION
- Return the found datamap inside the `GetError::TooLargeForMemory` error. This can be used to analyze the addresses of a datamap even if it is too large for memory.