### PR TITLE
client fetch with best effort

### DIFF
--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -104,8 +104,27 @@ impl NetworkDriver {
 
         // set transport
         let mut quic_config = libp2p::quic::Config::new(&keypair);
-        // Reduce to 1MB from the default 10MB.
-        quic_config.max_stream_data = 1024 * 1024;
+        
+        // CRITICAL: Set to 1MB for maximum node compatibility.
+        // Testing shows that 1MB works with ALL nodes, while higher values (16MB, 32MB) cause 
+        // QUIC negotiation failures. This is because most nodes use libp2p's default QUIC config
+        // (~1-2MB), and large mismatches in max_stream_data between client and node can cause
+        // the QUIC handshake to fail or timeout.
+        //
+        // Why this works for 4MB records: QUIC streams can transfer data larger than the 
+        // initial window through flow control updates during the transfer. The max_stream_data
+        // is the initial/minimum window, not a hard limit on total transfer size.
+        let max_stream_data = std::env::var("ANT_MAX_STREAM_DATA")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1024 * 1024); // 1 MB - proven to work with all nodes
+        
+        quic_config.max_stream_data = max_stream_data;
+        
+        info!("Client QUIC max_stream_data: {} bytes ({:.2} MB)", 
+              max_stream_data, 
+              max_stream_data as f64 / (1024.0 * 1024.0));
+        
         let transport_gen = QuicTransport::new(quic_config);
         let trans = transport_gen.map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
         let transport = trans.boxed();

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -246,12 +246,11 @@ impl TaskHandler {
         let expected_holders = get_quorum_amount(&quorum);
 
         if holders.len() < expected_holders {
-            let holder_peers: Vec<_> = holders.keys().cloned().collect();
             responder
                 .send(Err(NetworkError::GetRecordQuorumFailed {
                     got_holders: holders.len(),
                     expected_holders,
-                    holders: holder_peers,
+                    holders,
                 }))
                 .map_err(|_| TaskHandlerError::NetworkClientDropped(format!("{id:?}")))?;
 

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -124,7 +124,7 @@ pub enum NetworkError {
     GetRecordQuorumFailed {
         got_holders: usize,
         expected_holders: usize,
-        holders: Vec<PeerId>,
+        holders: HashMap<PeerId, Record>,
     },
     #[error("Failed to get record: {0}")]
     GetRecordError(String),


### PR DESCRIPTION
### Description

* using Quorum::N(20) in kad get_record query to fetch the record in best effort
* set max_stream_data to 1MB on client side
* pruning duplicated entries acorss bad_list and white_list
* using DM query to closest_20 as the fall_back fetching approach, when kad get_record query still failing

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
