### PR TITLE
Reduce max stream data to 1 mb

### DIFF
--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -103,7 +103,9 @@ impl NetworkDriver {
         info!("Client Peer ID: {peer_id}");
 
         // set transport
-        let quic_config = libp2p::quic::Config::new(&keypair);
+        let mut quic_config = libp2p::quic::Config::new(&keypair);
+        // Reduce to 1MB from the default 10MB.
+        quic_config.max_stream_data = 1024 * 1024;
         let transport_gen = QuicTransport::new(quic_config);
         let trans = transport_gen.map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
         let transport = trans.boxed();


### PR DESCRIPTION
### Description

Reduce max stream data to 1 mb to improve the nodes' response rate on record fetching.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
