### PR TITLE
feat(client): for Chunk, fall back to get from closest_20 if kad query fetch failed

### DIFF
--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -8,7 +8,7 @@
 
 use crate::networking::{Quorum, RetryStrategy, Strategy};
 pub use ant_bootstrap::{
-    Bootstrap, BootstrapConfig, InitialPeersConfig, error::Error as BootstrapError,
+    error::Error as BootstrapError, Bootstrap, BootstrapConfig, InitialPeersConfig,
 };
 use ant_evm::EvmNetwork;
 use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;
@@ -160,7 +160,7 @@ impl Default for ClientOperatingStrategy {
                 put_retry: RetryStrategy::Balanced,
                 verification_quorum: Quorum::N(two),
                 get_quorum: Quorum::One, // chunks are content addressed so one is enough as there is no fork possible
-                get_retry: RetryStrategy::Quick,
+                get_retry: RetryStrategy::None, // leave to the fall-back approach of fetching from closest_20
             },
             graph_entry: Strategy {
                 put_quorum: Quorum::Majority,

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -138,16 +138,77 @@ impl Client {
         }
     }
 
+    /// Helper function to fetch a record from the closest peers directly.
+    /// This is useful as a fallback when normal DHT queries fail.
+    /// 
+    /// Returns the first successfully retrieved record, or None if all peers fail.
+    async fn fetch_record_from_closest_peers(
+        &self,
+        key: NetworkAddress,
+        num_peers: usize,
+    ) -> Option<Record> {
+        debug!("Querying closest {num_peers} nodes directly for {key:?}");
+        
+        let closest_peers = match self.network.get_closest_peers(key.clone(), Some(num_peers)).await {
+            Ok(peers) => peers,
+            Err(e) => {
+                error!("Failed to get closest peers for {key:?}: {e}");
+                return None;
+            }
+        };
+
+        debug!("Querying {} closest peers in parallel for {key:?}", closest_peers.len());
+        
+        // Create query tasks for all closest peers
+        let mut query_tasks = vec![];
+        for peer in closest_peers.iter() {
+            let network = self.network.clone();
+            let key = key.clone();
+            let peer = peer.clone();
+            query_tasks.push(async move {
+                network.get_record_from_peer(key, peer).await
+            });
+        }
+
+        // Process tasks with max concurrency of num_peers
+        let results = process_tasks_with_max_concurrency(query_tasks, num_peers).await;
+
+        // Find the first successful record
+        for result in results.into_iter() {
+            match result {
+                Ok(Some(record)) => {
+                    debug!("✅ Retrieved record {key:?} from one of the closest {num_peers} peers");
+                    return Some(record);
+                }
+                _ => continue,
+            }
+        }
+
+        error!("❌ All {} closest peers failed to return the record {key:?}", closest_peers.len());
+        None
+    }
+
     async fn fetch_chunk_from_network(&self, addr: &ChunkAddress) -> Result<Chunk, GetError> {
         let key = NetworkAddress::from(*addr);
         debug!("Fetching chunk from network at: {key:?}");
 
-        let record = self
+        // Try normal fetch first
+        let record_result = self
             .network
-            .get_record_with_retries(key, &self.config.chunks)
+            .get_record_with_retries(key.clone(), &self.config.chunks)
             .await
-            .inspect_err(|err| error!("Error fetching chunk: {err:?}"))?
-            .ok_or(GetError::RecordNotFound)?;
+            .inspect_err(|err| error!("Error fetching chunk: {err:?}"));
+
+        let record = match record_result {
+            Ok(Some(record)) => record,
+            Ok(None) | Err(_) => {
+                // Fallback: Try fetching from closest 20 nodes directly
+                debug!("Normal fetch failed, trying fallback for {key:?}");
+                self.fetch_record_from_closest_peers(key, 20)
+                    .await
+                    .ok_or(GetError::RecordNotFound)?
+            }
+        };
 
         let header = RecordHeader::from_record(&record)?;
 


### PR DESCRIPTION
### Description

When client downloading a Chunk, fall back to get from closest_20 if kad query fetch failed

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
