### PR TITLE
fix(client): remove upload fallback approach

### DIFF
--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -41,6 +41,7 @@ pub(super) enum NetworkTask {
         resp: OneShotTaskResult<(Option<Record>, Vec<PeerId>)>,
     },
     /// cf [`crate::driver::task_handler::TaskHandler::update_put_record_kad`]
+    #[allow(dead_code)]
     PutRecordKad {
         #[debug(skip)]
         record: Record,


### PR DESCRIPTION
### Description

As all nodes are now upgraded, the fallback approach (using `kad put_record`) during upload can now be removed.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
