### PR TITLE
Further Support for Automatic Upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,6 +6699,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "service-manager",
  "signal-hook",
  "strip-ansi-escapes",
  "strum 0.26.3",
@@ -9086,13 +9087,13 @@ dependencies = [
 [[package]]
 name = "service-manager"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cae942acfe9cecd4450998408f52e1c1ee083145226b7b803bd0d82e1c86912"
+source = "git+https://github.com/jacderida/service-manager-rs?branch=generic_restart_policy#6ba8721d2a6660bf40ece0d2f732be0551d17931"
 dependencies = [
  "cfg-if",
  "dirs",
  "encoding-utils",
  "encoding_rs",
+ "log",
  "plist",
  "which 4.4.2",
  "xml-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ checksum = "003f46c54f22854a32b9cc7972660a476968008ad505427eabab49225309ec40"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -500,7 +500,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -671,7 +671,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.110",
+ "syn 2.0.111",
  "syn-solidity",
 ]
 
@@ -760,7 +760,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -969,6 +969,7 @@ dependencies = [
  "ant-evm",
  "ant-logging",
  "ant-protocol",
+ "ant-releases 0.4.1 (git+https://github.com/jacderida/ant-releases?branch=feat-latest_release_info)",
  "ant-service-management",
  "assert_fs",
  "async-trait",
@@ -985,6 +986,7 @@ dependencies = [
  "evmlib",
  "eyre",
  "file-rotate",
+ "fs2",
  "futures",
  "hex",
  "hkdf",
@@ -1002,6 +1004,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.24",
  "rmp-serde",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "sha2",
@@ -1032,7 +1035,7 @@ dependencies = [
  "ant-evm",
  "ant-logging",
  "ant-protocol",
- "ant-releases",
+ "ant-releases 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ant-service-management",
  "anyhow",
  "assert_cmd",
@@ -1138,6 +1141,25 @@ name = "ant-releases"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff175a84ced7e285b62da255aa5d87fdcef8a83ccfc04277b463a07b1bb46e24"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "flate2",
+ "lazy_static",
+ "regex",
+ "reqwest 0.12.24",
+ "semver 1.0.27",
+ "serde_json",
+ "tar",
+ "thiserror 1.0.69",
+ "tokio",
+ "zip",
+]
+
+[[package]]
+name = "ant-releases"
+version = "0.4.1"
+source = "git+https://github.com/jacderida/ant-releases?branch=feat-latest_release_info#a60c43e742a999b17229435a392ddfc4201bde52"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1310,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1348,7 +1370,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1459,7 +1481,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -1471,7 +1493,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1580,7 +1602,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1591,7 +1613,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1630,7 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.0",
  "log",
  "url",
 ]
@@ -1654,7 +1676,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2054,7 +2076,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2387,7 +2409,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2846,7 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2882,7 +2904,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2903,7 +2925,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -2938,7 +2960,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2953,7 +2975,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2964,7 +2986,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2975,7 +2997,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3015,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3110,7 +3132,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "unicode-xid",
 ]
 
@@ -3227,7 +3249,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3326,7 +3348,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3393,7 +3415,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3413,7 +3435,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3590,7 +3612,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3738,6 +3760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,7 +3873,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4244,7 +4276,7 @@ checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4574,7 +4606,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap 2.12.1",
  "slab",
  "tokio",
@@ -4817,12 +4849,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -4844,7 +4875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -4855,7 +4886,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -4944,7 +4975,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -4975,7 +5006,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.35",
@@ -5009,7 +5040,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
@@ -5197,7 +5228,7 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -5255,7 +5286,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5336,7 +5367,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5941,7 +5972,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6142,7 +6173,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6302,7 +6333,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6446,7 +6477,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6461,7 +6492,7 @@ dependencies = [
  "quote",
  "regex",
  "semver 1.0.27",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6635,7 +6666,7 @@ dependencies = [
  "ant-logging",
  "ant-node-manager",
  "ant-protocol",
- "ant-releases",
+ "ant-releases 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ant-service-management",
  "arboard",
  "atty",
@@ -6787,7 +6818,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7226,7 +7257,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7339,7 +7370,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7379,7 +7410,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7624,7 +7655,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7662,7 +7693,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7841,7 +7872,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -7854,7 +7885,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -8201,7 +8232,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -8283,7 +8314,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -8916,7 +8947,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9001,7 +9032,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9049,7 +9080,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9334,7 +9365,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9346,7 +9377,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9368,9 +9399,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9386,7 +9417,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9412,7 +9443,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9570,7 +9601,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9581,7 +9612,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9738,7 +9769,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10010,7 +10041,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
@@ -10063,7 +10094,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10183,7 +10214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10211,7 +10242,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -10599,7 +10630,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -10807,7 +10838,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10818,7 +10849,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -11323,7 +11354,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -11344,7 +11375,7 @@ checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -11364,7 +11395,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -11385,7 +11416,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -11418,7 +11449,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
 dependencies = [
  "serde",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ dependencies = [
  "ant-evm",
  "ant-logging",
  "ant-protocol",
- "ant-releases 0.4.1 (git+https://github.com/jacderida/ant-releases?branch=feat-latest_release_info)",
+ "ant-releases",
  "ant-service-management",
  "assert_fs",
  "async-trait",
@@ -1035,7 +1035,7 @@ dependencies = [
  "ant-evm",
  "ant-logging",
  "ant-protocol",
- "ant-releases 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ant-releases",
  "ant-service-management",
  "anyhow",
  "assert_cmd",
@@ -1138,28 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "ant-releases"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff175a84ced7e285b62da255aa5d87fdcef8a83ccfc04277b463a07b1bb46e24"
-dependencies = [
- "async-trait",
- "chrono",
- "flate2",
- "lazy_static",
- "regex",
- "reqwest 0.12.24",
- "semver 1.0.27",
- "serde_json",
- "tar",
- "thiserror 1.0.69",
- "tokio",
- "zip",
-]
-
-[[package]]
-name = "ant-releases"
-version = "0.4.1"
-source = "git+https://github.com/jacderida/ant-releases?branch=feat-latest_release_info#a60c43e742a999b17229435a392ddfc4201bde52"
+checksum = "cadde4a1a3d1e6e7d83bd517eb354779915e6a45ee76d66136f73fd139650e8d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1925,7 +1906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.1",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -2058,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -2068,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -2667,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -4749,9 +4730,9 @@ checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
@@ -6666,7 +6647,7 @@ dependencies = [
  "ant-logging",
  "ant-node-manager",
  "ant-protocol",
- "ant-releases 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ant-releases",
  "ant-service-management",
  "arboard",
  "atty",
@@ -9896,7 +9877,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9908,7 +9889,7 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -9917,7 +9898,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -10035,9 +10016,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -10077,21 +10058,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10100,9 +10081,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11128,9 +11109,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -11361,18 +11342,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Justfile
+++ b/Justfile
@@ -397,3 +397,52 @@ package-arch arch:
   fi
 
   cd ../../..
+
+build-artifact-hashes:
+  #!/usr/bin/env bash
+  set -e
+
+  architectures=(
+    "x86_64-pc-windows-msvc"
+    "x86_64-apple-darwin"
+    "aarch64-apple-darwin"
+    "x86_64-unknown-linux-musl"
+    "arm-unknown-linux-musleabi"
+    "armv7-unknown-linux-musleabihf"
+    "aarch64-unknown-linux-musl"
+  )
+
+  binaries=(
+    "nat-detection"
+    "node-launchpad"
+    "ant"
+    "antnode"
+    "antctl"
+    "antctld"
+    "antnode_rpc_client"
+    "evm-testnet"
+  )
+
+  echo "## Binary Hashes"
+  echo ""
+
+  for arch in "${architectures[@]}"; do
+    echo "### $arch"
+    echo ""
+    echo "| Binary | SHA256 Hash |"
+    echo "|--------|-------------|"
+
+    for binary in "${binaries[@]}"; do
+      if [[ "$arch" == *"windows"* ]]; then
+        binary_path="artifacts/$arch/release/${binary}.exe"
+      else
+        binary_path="artifacts/$arch/release/${binary}"
+      fi
+
+      if [[ -f "$binary_path" ]]; then
+        hash=$(sha256sum "$binary_path" | awk '{print $1}')
+        echo "| $binary | \`$hash\` |"
+      else
+        echo "| $binary | *not found* |"
+      fi
+    done

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -51,7 +51,7 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-service-manager = "0.8.0"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43", features = ["full"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -34,7 +34,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.1" }
+ant-releases = "0.4.2"
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 evmlib = { path = "../evmlib", version = "0.4.5" }
 chrono = "~0.4.19"

--- a/ant-node-manager/src/add_services/config.rs
+++ b/ant-node-manager/src/add_services/config.rs
@@ -92,6 +92,7 @@ pub struct InstallNodeServiceCtxBuilder {
     pub rewards_address: RewardsAddress,
     pub rpc_socket_addr: SocketAddr,
     pub service_user: Option<String>,
+    pub stop_on_upgrade: bool,
     pub write_older_cache_files: bool,
 }
 
@@ -152,6 +153,11 @@ impl InstallNodeServiceCtxBuilder {
             args.push(OsString::from("--write-older-cache-files"));
         }
 
+        if self.stop_on_upgrade {
+            args.push(OsString::from("--stop-on-upgrade"));
+        }
+
+        // The EVM details must always be the last arguments.
         args.push(OsString::from(self.evm_network.to_string()));
         if let EvmNetwork::Custom(custom_network) = &self.evm_network {
             args.push(OsString::from("--rpc-url"));
@@ -254,6 +260,7 @@ mod tests {
             restart_policy: RestartPolicy::OnFailure { delay_secs: None },
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: true,
             write_older_cache_files: false,
         }
     }
@@ -293,6 +300,7 @@ mod tests {
                 .unwrap(),
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: false,
             write_older_cache_files: false,
         }
     }
@@ -332,6 +340,7 @@ mod tests {
                 .unwrap(),
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: true,
             write_older_cache_files: false,
         }
     }
@@ -356,6 +365,7 @@ mod tests {
             "/logs",
             "--rewards-address",
             "0x03B770D9cD32077cC0bF330c13C114a87643B124",
+            "--stop-on-upgrade",
             "evm-arbitrum-one",
         ];
         assert_eq!(
@@ -464,6 +474,7 @@ mod tests {
             "--rewards-address",
             "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             "--write-older-cache-files",
+            "--stop-on-upgrade",
             "evm-custom",
             "--rpc-url",
             "http://localhost:8545/",

--- a/ant-node-manager/src/add_services/mod.rs
+++ b/ant-node-manager/src/add_services/mod.rs
@@ -192,11 +192,12 @@ pub async fn add_node(
 
         let install_ctx = InstallNodeServiceCtxBuilder {
             alpha: options.alpha,
+            antnode_path: service_antnode_path.clone(),
             autostart: options.auto_restart,
             data_dir_path: service_data_dir_path.clone(),
             env_variables: options.env_variables.clone(),
             evm_network: options.evm_network.clone(),
-            relay: options.relay,
+            init_peers_config: options.init_peers_config.clone(),
             log_dir_path: service_log_dir_path.clone(),
             log_format: options.log_format,
             max_archived_log_files: options.max_archived_log_files,
@@ -204,14 +205,14 @@ pub async fn add_node(
             metrics_port: metrics_free_port,
             name: service_name.clone(),
             network_id: options.network_id,
+            no_upnp: options.no_upnp,
             node_ip: options.node_ip,
             node_port,
-            init_peers_config: options.init_peers_config.clone(),
+            relay: options.relay,
+            restart_policy: options.restart_policy,
             rewards_address: options.rewards_address,
             rpc_socket_addr,
-            antnode_path: service_antnode_path.clone(),
             service_user: options.user.clone(),
-            no_upnp: options.no_upnp,
             write_older_cache_files: options.write_older_cache_files,
         }
         .build()?;
@@ -354,9 +355,9 @@ pub async fn add_daemon(
         environment: options.env_variables,
         label: DAEMON_SERVICE_NAME.parse()?,
         program: options.daemon_install_bin_path.clone(),
+        restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
         username: Some(options.user),
         working_directory: None,
-        disable_restart_on_failure: false,
     };
 
     match service_control.install(install_ctx, false) {

--- a/ant-node-manager/src/add_services/mod.rs
+++ b/ant-node-manager/src/add_services/mod.rs
@@ -213,6 +213,7 @@ pub async fn add_node(
             rewards_address: options.rewards_address,
             rpc_socket_addr,
             service_user: options.user.clone(),
+            stop_on_upgrade: true,
             write_older_cache_files: options.write_older_cache_files,
         }
         .build()?;

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -137,6 +137,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -520,6 +521,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -571,6 +573,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -622,6 +625,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -808,6 +812,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -1002,6 +1007,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -1148,6 +1154,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                     OsString::from("--first"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1301,6 +1308,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                         "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1449,6 +1457,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                     OsString::from("--local"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1601,6 +1610,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                     OsString::from("http://localhost:8080/contacts,http://localhost:8081/contacts"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1749,6 +1759,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                     OsString::from("--ignore-cache"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1898,6 +1909,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                     OsString::from("/path/to/bootstrap/cache"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2041,6 +2053,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                     OsString::from("5"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2182,6 +2195,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                     OsString::from(custom_ip.to_string()),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2329,6 +2343,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -2453,6 +2468,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12000"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2512,6 +2528,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2571,6 +2588,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12002"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3109,6 +3127,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                     OsString::from("15001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3243,6 +3262,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                     OsString::from("20"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3378,6 +3398,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                     OsString::from("20"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3512,6 +3533,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12000"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3571,6 +3593,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3630,6 +3653,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12002"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4003,6 +4027,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4055,6 +4080,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4107,6 +4133,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4504,6 +4531,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4631,6 +4659,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4757,6 +4786,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4884,6 +4914,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -5148,6 +5179,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5275,6 +5307,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5403,6 +5436,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5527,6 +5561,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5643,6 +5678,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -5786,6 +5822,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
         no_upnp: true,
         write_older_cache_files: true,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5914,6 +5951,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                     OsString::from("--alpha"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -27,7 +27,7 @@ use assert_matches::assert_matches;
 use color_eyre::Result;
 use mockall::{Sequence, mock, predicate::*};
 use predicates::prelude::*;
-use service_manager::ServiceInstallCtx;
+use service_manager::{RestartPolicy, ServiceInstallCtx};
 use std::{
     ffi::OsString,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -82,6 +82,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
     let antnode_download_path = temp_dir.child(ANTNODE_FILE_NAME);
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let mut mock_service_control = MockServiceControl::new();
@@ -135,6 +136,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -185,6 +187,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -247,6 +250,7 @@ async fn add_genesis_node_should_return_an_error_if_there_is_already_a_genesis_n
     let mock_service_control = MockServiceControl::new();
 
     let latest_version = "0.96.4";
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
 
     let init_peers_config = InitialPeersConfig {
         first: true,
@@ -354,6 +358,7 @@ async fn add_genesis_node_should_return_an_error_if_there_is_already_a_genesis_n
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -375,6 +380,7 @@ async fn add_genesis_node_should_return_an_error_if_count_is_greater_than_1() ->
     let node_reg_path = tmp_data_dir.child("node_reg.json");
     let mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let init_peers_config = InitialPeersConfig {
@@ -436,6 +442,7 @@ async fn add_genesis_node_should_return_an_error_if_count_is_greater_than_1() ->
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -459,6 +466,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
     let mut mock_service_control = MockServiceControl::new();
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let node_data_dir = temp_dir.child("data");
@@ -511,6 +519,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -561,6 +570,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -611,6 +621,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -662,6 +673,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -742,6 +754,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         ("RUST_LOG".to_owned(), "libp2p=debug".to_owned()),
     ]);
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let latest_version = "0.96.4";
@@ -794,6 +807,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -844,6 +858,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -890,6 +905,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
@@ -985,6 +1001,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -1036,6 +1053,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1075,6 +1093,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1145,9 +1164,9 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1195,6 +1214,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1221,6 +1241,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1296,9 +1317,9 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1346,6 +1367,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1372,6 +1394,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1442,9 +1465,9 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1492,6 +1515,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1518,6 +1542,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1592,9 +1617,9 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1642,6 +1667,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1668,6 +1694,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1738,9 +1765,9 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1788,6 +1815,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1814,6 +1842,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1885,9 +1914,9 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1935,6 +1964,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1964,6 +1994,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2026,9 +2057,9 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2076,6 +2107,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2101,6 +2133,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2165,9 +2198,9 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2215,6 +2248,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2240,6 +2274,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2293,6 +2328,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -2344,6 +2380,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2369,6 +2406,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2431,9 +2469,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2490,9 +2528,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2549,9 +2587,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2599,6 +2637,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2625,6 +2664,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_is_used() -> R
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -2721,6 +2761,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_is_used() -> R
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -2742,6 +2783,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_in_range_is_us
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -2838,6 +2880,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_in_range_is_us
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -2859,6 +2902,7 @@ async fn add_node_should_return_an_error_if_port_and_node_count_do_not_match() -
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2910,6 +2954,7 @@ async fn add_node_should_return_an_error_if_port_and_node_count_do_not_match() -
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -2936,6 +2981,7 @@ async fn add_node_should_return_an_error_if_multiple_services_are_specified_with
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2987,6 +3033,7 @@ async fn add_node_should_return_an_error_if_multiple_services_are_specified_with
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3014,6 +3061,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -3077,9 +3125,9 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3127,6 +3175,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3146,6 +3195,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -3209,9 +3259,9 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3259,6 +3309,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3277,6 +3328,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
@@ -3342,9 +3394,9 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3392,6 +3444,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3410,6 +3463,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -3474,9 +3528,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3533,9 +3587,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3592,9 +3646,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3642,6 +3696,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3666,6 +3721,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_is_use
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -3762,6 +3818,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_is_use
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3784,6 +3841,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_in_ran
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -3880,6 +3938,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_in_ran
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3903,6 +3962,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let latest_version = "0.96.4";
@@ -3959,9 +4019,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4011,9 +4071,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4063,9 +4123,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4113,6 +4173,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4147,6 +4208,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_is_used() 
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -4243,6 +4305,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_is_used() 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -4265,6 +4328,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_in_range_i
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -4361,6 +4425,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_in_range_i
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -4382,6 +4447,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4437,6 +4503,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4487,6 +4554,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4506,6 +4574,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4561,6 +4630,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4611,6 +4681,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4630,6 +4701,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4684,6 +4756,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4734,6 +4807,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4754,6 +4828,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4808,6 +4883,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4858,6 +4934,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4877,6 +4954,7 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let daemon_install_dir = temp_dir.child("install");
@@ -4905,9 +4983,9 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
                 environment: Some(vec![("ANT_LOG".to_string(), "ALL".to_string())]),
                 label: "antctld".parse()?,
                 program: daemon_install_path.to_path_buf(),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: false,
             }),
             eq(false),
         )
@@ -5012,6 +5090,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5068,6 +5147,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5119,6 +5199,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5136,6 +5217,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5192,6 +5274,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5243,6 +5326,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5261,6 +5345,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5317,6 +5402,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5368,6 +5454,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5383,6 +5470,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5438,6 +5526,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5489,6 +5578,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5508,6 +5598,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let node_data_dir = temp_dir.child("data");
@@ -5568,9 +5659,9 @@ async fn add_node_should_auto_restart() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -5619,6 +5710,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5637,6 +5729,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5692,6 +5785,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: true,
+        restart_policy,
     }
     .build()?;
 
@@ -5743,6 +5837,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: true,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5762,6 +5857,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5834,9 +5930,9 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -5884,6 +5980,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -22,6 +22,7 @@ use ant_service_management::NodeRegistryManager;
 use clap::{Parser, Subcommand};
 use color_eyre::{Result, eyre::eyre};
 use libp2p::Multiaddr;
+use service_manager::RestartPolicy;
 use std::{net::Ipv4Addr, path::PathBuf};
 use tracing::Level;
 
@@ -876,6 +877,7 @@ async fn main() -> Result<()> {
                 node_registry,
                 peers,
                 relay,
+                RestartPolicy::Always { delay_secs: None },
                 rewards_address,
                 rpc_address,
                 rpc_port,

--- a/ant-node-manager/src/cmd/node.rs
+++ b/ant-node-manager/src/cmd/node.rs
@@ -33,6 +33,7 @@ use color_eyre::{Help, Result, eyre::eyre};
 use colored::Colorize;
 use libp2p_identity::PeerId;
 use semver::Version;
+use service_manager::RestartPolicy;
 use std::{
     cmp::Ordering, io::Write, net::Ipv4Addr, path::PathBuf, str::FromStr, sync::Arc, time::Duration,
 };
@@ -60,6 +61,7 @@ pub async fn add(
     node_registry: NodeRegistryManager,
     mut init_peers_config: InitialPeersConfig,
     relay: bool,
+    restart_policy: RestartPolicy,
     rewards_address: RewardsAddress,
     rpc_address: Option<Ipv4Addr>,
     rpc_port: Option<PortRange>,
@@ -121,6 +123,8 @@ pub async fn add(
 
     let options = AddNodeServiceOptions {
         alpha,
+        antnode_dir_path: service_data_dir_path.clone(),
+        antnode_src_path,
         auto_restart,
         auto_set_nat_flags,
         count,
@@ -128,23 +132,22 @@ pub async fn add(
         enable_metrics_server,
         evm_network: evm_network.unwrap_or(EvmNetwork::ArbitrumOne),
         env_variables,
-        relay,
+        init_peers_config,
         log_format,
         max_archived_log_files,
         max_log_files,
         metrics_port,
         network_id,
+        no_upnp,
         node_ip,
         node_port,
-        init_peers_config,
+        relay,
+        restart_policy,
         rewards_address,
         rpc_address,
         rpc_port,
-        antnode_src_path,
-        antnode_dir_path: service_data_dir_path.clone(),
         service_data_dir_path,
         service_log_dir_path,
-        no_upnp,
         user: service_user,
         user_mode,
         version,
@@ -617,6 +620,7 @@ pub async fn maintain_n_running_nodes(
     peers_args: InitialPeersConfig,
     relay: bool,
     rewards_address: RewardsAddress,
+    restart_policy: RestartPolicy,
     rpc_address: Option<Ipv4Addr>,
     rpc_port: Option<PortRange>,
     src_path: Option<PathBuf>,
@@ -731,6 +735,7 @@ pub async fn maintain_n_running_nodes(
                         node_registry.clone(),
                         peers_args.clone(),
                         relay,
+                        restart_policy,
                         rewards_address,
                         rpc_address,
                         rpc_port.clone(),

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -673,7 +673,7 @@ mod tests {
     use libp2p_identity::PeerId;
     use mockall::{mock, predicate::*};
     use predicates::prelude::*;
-    use service_manager::ServiceInstallCtx;
+    use service_manager::{RestartPolicy, ServiceInstallCtx};
     use std::{
         ffi::OsString,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -2721,9 +2721,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -2897,9 +2897,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3073,9 +3073,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3239,9 +3239,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3413,9 +3413,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3592,9 +3592,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3766,9 +3766,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3946,9 +3946,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4113,9 +4113,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4280,9 +4280,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4447,9 +4447,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4614,9 +4614,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4781,9 +4781,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4948,9 +4948,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5115,9 +5115,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5282,9 +5282,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5450,9 +5450,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5621,9 +5621,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5801,9 +5801,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5975,9 +5975,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -6146,9 +6146,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -6707,9 +6707,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )

--- a/ant-node-manager/src/rpc.rs
+++ b/ant-node-manager/src/rpc.rs
@@ -21,6 +21,7 @@ use color_eyre::{
     eyre::{OptionExt, eyre},
 };
 use libp2p::PeerId;
+use service_manager::RestartPolicy;
 use std::sync::Arc;
 
 pub async fn restart_node_service(
@@ -82,6 +83,8 @@ pub async fn restart_node_service(
             node_ip: current_node_clone.node_ip,
             node_port: current_node_clone.get_antnode_port(),
             no_upnp: current_node_clone.no_upnp,
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            restart_policy: RestartPolicy::Never,
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             service_user: current_node_clone.user.clone(),
@@ -198,6 +201,8 @@ pub async fn restart_node_service(
             node_ip: current_node_clone.node_ip,
             node_port: None,
             no_upnp: current_node_clone.no_upnp,
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            restart_policy: RestartPolicy::Never,
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             antnode_path: antnode_path.clone(),

--- a/ant-node-manager/src/rpc.rs
+++ b/ant-node-manager/src/rpc.rs
@@ -88,6 +88,8 @@ pub async fn restart_node_service(
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             service_user: current_node_clone.user.clone(),
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            stop_on_upgrade: true,
             write_older_cache_files: current_node_clone.write_older_cache_files,
         }
         .build()?;
@@ -207,6 +209,8 @@ pub async fn restart_node_service(
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             antnode_path: antnode_path.clone(),
             service_user: current_node_clone.user.clone(),
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            stop_on_upgrade: true,
             write_older_cache_files: current_node_clone.write_older_cache_files,
         }
         .build()?;

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -28,6 +28,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52", features = ["process-metrics"] }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-releases = { git = "https://github.com/jacderida/ant-releases", branch = "feat-latest_release_info" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -41,6 +42,7 @@ custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 eyre = "0.6.8"
 file-rotate = "0.7.3"
+fs2 = "0.4"
 futures = "~0.3.13"
 hex = "~0.4.3"
 hkdf = "0.12"
@@ -77,6 +79,7 @@ pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"], optional
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
+semver = "1.0"
 sha2 = "0.10"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 strum = { version = "0.26.2", features = ["derive"] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -28,7 +28,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52", features = ["process-metrics"] }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { git = "https://github.com/jacderida/ant-releases", branch = "feat-latest_release_info" }
+ant-releases = "0.4.2"
 ant-service-management = { path = "../ant-service-management", version = "0.4.16" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -468,11 +468,12 @@ You can check your reward balance by running:
                     Ok(()) => {
                         let delay = calculate_restart_delay(&running_node_clone).await;
                         info!("Calculated delay: {delay:?}");
+                        sleep(node_restart_delay).await;
 
                         let node_ctrl = if stop_on_upgrade {
                             info!("Upgrade successful. Triggering stop...");
                             NodeCtrl::Stop {
-                                delay,
+                                delay: Duration::from_secs(0),
                                 result: StopResult::Success(
                                     "Upgrade completed successfully".to_string(),
                                 ),
@@ -480,7 +481,7 @@ You can check your reward balance by running:
                         } else {
                             info!("Upgrade successful. Triggering restart...");
                             NodeCtrl::Restart {
-                                delay,
+                                delay: Duration::from_secs(0),
                                 retain_peer_id: true,
                             }
                         };

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -232,6 +232,12 @@ struct Opt {
     /// Set this to true if you want the node to write the cache files in the older formats.
     #[clap(long, default_value_t = false)]
     write_older_cache_files: bool,
+
+    /// Stop the node instead of restarting after a successful upgrade.
+    ///
+    /// Useful when running under a service manager that handles restarts.
+    #[clap(long, default_value_t = false)]
+    stop_on_upgrade: bool,
 }
 
 fn main() -> Result<()> {
@@ -348,8 +354,14 @@ fn main() -> Result<()> {
         };
         #[cfg(feature = "open-metrics")]
         node_builder.metrics_server_port(metrics_server_port);
-        let restart_options =
-            run_node(node_builder, opt.rpc, &log_output_dest, log_reload_handle).await?;
+        let restart_options = run_node(
+            node_builder,
+            opt.rpc,
+            &log_output_dest,
+            log_reload_handle,
+            opt.stop_on_upgrade,
+        )
+        .await?;
 
         Ok::<_, eyre::Report>(restart_options)
     })?;
@@ -378,6 +390,7 @@ async fn run_node(
     rpc: Option<SocketAddr>,
     log_output_dest: &str,
     log_reload_handle: ReloadHandle,
+    stop_on_upgrade: bool,
 ) -> Result<Option<(bool, PathBuf, u16)>> {
     let started_instant = std::time::Instant::now();
 
@@ -453,19 +466,27 @@ You can check your reward balance by running:
                 sleep(Duration::from_secs(delay_secs)).await;
                 match upgrade::perform_upgrade().await {
                     Ok(()) => {
-                        info!("Upgrade successful. Triggering restart...");
-
                         let delay = calculate_restart_delay(&running_node_clone).await;
-                        info!("Calculated restart delay: {delay:?}");
+                        info!("Calculated delay: {delay:?}");
 
-                        if let Err(err) = ctrl_tx_restart
-                            .send(NodeCtrl::Restart {
+                        let node_ctrl = if stop_on_upgrade {
+                            info!("Upgrade successful. Triggering stop...");
+                            NodeCtrl::Stop {
+                                delay,
+                                result: StopResult::Success(
+                                    "Upgrade completed successfully".to_string(),
+                                ),
+                            }
+                        } else {
+                            info!("Upgrade successful. Triggering restart...");
+                            NodeCtrl::Restart {
                                 delay,
                                 retain_peer_id: true,
-                            })
-                            .await
-                        {
-                            error!("Failed to send restart command: {err}");
+                            }
+                        };
+
+                        if let Err(err) = ctrl_tx_restart.send(node_ctrl).await {
+                            error!("Failed to send control command: {err}");
                         }
                         break;
                     }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -462,16 +462,23 @@ You can check your reward balance by running:
                 // 72 hours (259200 seconds) with ±5% randomization to prevent simultaneous upgrades
                 let base_delay = 259200;
                 let variance = rand::thread_rng().gen_range(-12960..=12960);
-                let delay_secs = (base_delay + variance) as u64;
-                sleep(Duration::from_secs(delay_secs)).await;
+                let upgrade_check_delay_secs = (base_delay + variance) as u64;
+                let upgrade_check_wake_time =
+                    chrono::Utc::now() + chrono::Duration::seconds(upgrade_check_delay_secs as i64);
+                info!(
+                    "Next upgrade check scheduled for {}",
+                    upgrade_check_wake_time
+                );
+                sleep(Duration::from_secs(upgrade_check_delay_secs)).await;
+
                 match upgrade::perform_upgrade().await {
                     Ok(()) => {
-                        let delay = calculate_restart_delay(&running_node_clone).await;
-                        info!("Calculated delay: {delay:?}");
+                        let node_restart_delay = calculate_restart_delay(&running_node_clone).await;
+                        let node_restart_wake_time = chrono::Utc::now() + node_restart_delay;
+                        info!("Node will stop/restart for upgrade at {node_restart_wake_time}");
                         sleep(node_restart_delay).await;
 
                         let node_ctrl = if stop_on_upgrade {
-                            info!("Upgrade successful. Triggering stop...");
                             NodeCtrl::Stop {
                                 delay: Duration::from_secs(0),
                                 result: StopResult::Success(
@@ -479,7 +486,6 @@ You can check your reward balance by running:
                                 ),
                             }
                         } else {
-                            info!("Upgrade successful. Triggering restart...");
                             NodeCtrl::Restart {
                                 delay: Duration::from_secs(0),
                                 retain_peer_id: true,
@@ -492,7 +498,7 @@ You can check your reward balance by running:
                         break;
                     }
                     Err(e) => {
-                        debug!("Upgrade check: {e}");
+                        error!("Error during upgrade process: {e}");
                     }
                 }
             }

--- a/ant-node/src/bin/antnode/rpc_service.rs
+++ b/ant-node/src/bin/antnode/rpc_service.rs
@@ -176,6 +176,7 @@ impl AntNode for SafeNodeRpcService {
         let kbuckets: HashMap<u32, k_buckets_response::Peers> =
             match self.running_node.get_kbuckets().await {
                 Ok(kbuckets) => kbuckets
+                    .0
                     .into_iter()
                     .map(|(ilog2_distance, peers)| {
                         let peers = peers.into_iter().map(|peer| peer.to_bytes()).collect();

--- a/ant-node/src/bin/antnode/upgrade.rs
+++ b/ant-node/src/bin/antnode/upgrade.rs
@@ -1,0 +1,297 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_releases::{AntReleaseRepoActions, AutonomiReleaseInfo};
+use color_eyre::{Result, eyre::eyre};
+use fs2::FileExt;
+use semver::Version;
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+const LOCK_TIMEOUT_SECS: u64 = 300; // 5 minutes
+const LOCK_RETRY_INTERVAL_MS: u64 = 100;
+
+/// Calculate SHA256 hash of a file.
+pub fn calculate_sha256(path: &Path) -> Result<String> {
+    debug!("Calculating SHA256 for: {}", path.display());
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    let result = hasher.finalize();
+    let hash = format!("{result:x}");
+    debug!("SHA256 hash: {hash}");
+    Ok(hash)
+}
+
+/// Verify that a binary's SHA256 hash matches the expected hash.
+pub fn verify_binary_hash(path: &Path, expected_hash: &str) -> Result<bool> {
+    let actual_hash = calculate_sha256(path)?;
+    let matches = actual_hash.eq_ignore_ascii_case(expected_hash);
+
+    if !matches {
+        warn!(
+            "Hash mismatch for {}: expected {}, got {}.",
+            path.display(),
+            expected_hash,
+            actual_hash
+        );
+    }
+
+    Ok(matches)
+}
+
+/// Get the upgrade directory path in the user's data directory.
+pub fn get_upgrade_dir_path() -> Result<PathBuf> {
+    let upgrade_dir_path = dirs_next::data_dir()
+        .ok_or_else(|| eyre!("Could not determine user data directory"))?
+        .join("autonomi")
+        .join("upgrades");
+    debug!("Upgrade directory: {}", upgrade_dir_path.display());
+    Ok(upgrade_dir_path)
+}
+
+/// Get the path where a binary for a specific version should be stored.
+pub fn get_binary_path_for_version(commit_hash: &str) -> Result<PathBuf> {
+    let upgrade_dir = get_upgrade_dir_path()?;
+    let binary_name = if cfg!(target_os = "windows") {
+        format!("antnode-{commit_hash}.exe")
+    } else {
+        format!("antnode-{commit_hash}")
+    };
+    Ok(upgrade_dir.join(binary_name))
+}
+
+/// Acquire an exclusive lock on the upgrade directory.
+///
+/// It's possible two or more processes could try to download and extract a new binary at the same
+/// time.
+///
+/// Returns the lock file handle that must be kept alive to maintain the lock.
+fn acquire_upgrade_lock(upgrade_dir: &Path) -> Result<File> {
+    let lock_path = upgrade_dir.join(".lock");
+    debug!("Acquiring lock at: {}", lock_path.display());
+
+    let lock_file = File::create(&lock_path)?;
+    let start = std::time::Instant::now();
+    loop {
+        match lock_file.try_lock_exclusive() {
+            Ok(_) => {
+                info!("Lock acquired");
+                return Ok(lock_file);
+            }
+            Err(_) if start.elapsed().as_secs() < LOCK_TIMEOUT_SECS => {
+                debug!("Lock busy. Retrying...");
+                std::thread::sleep(Duration::from_millis(LOCK_RETRY_INTERVAL_MS));
+            }
+            Err(_) => {
+                warn!(
+                    "Lock timeout after {} seconds. Proceeding without lock...",
+                    LOCK_TIMEOUT_SECS
+                );
+                // Proceed without exclusive lock: hash verification after download will catch any
+                // corruption if multiple processes race.
+                return Ok(lock_file);
+            }
+        }
+    }
+}
+
+/// Download and extract the upgrade binary to the shared location.
+///
+/// If the binary already exists with the correct hash, returns immediately.
+pub async fn download_and_extract_upgrade_binary(
+    release_info: &AutonomiReleaseInfo,
+    release_repo: &dyn AntReleaseRepoActions,
+) -> Result<(PathBuf, String)> {
+    info!("Starting upgrade binary download process");
+
+    let platform = ant_releases::get_running_platform()?;
+    debug!("Current platform: {:?}", platform);
+
+    let platform_binaries = release_info
+        .platform_binaries
+        .iter()
+        .find(|pb| pb.platform == platform)
+        .ok_or_else(|| eyre!("No binaries found for platform: {:?}", platform))?;
+    let antnode_binary = platform_binaries
+        .binaries
+        .iter()
+        .find(|b| b.name == "antnode")
+        .ok_or_else(|| {
+            eyre!(
+                "antnode binary not found in release for platform: {:?}",
+                platform
+            )
+        })?;
+    info!(
+        "Found antnode binary version {} with hash {}",
+        antnode_binary.version, antnode_binary.sha256
+    );
+
+    let target_path = get_binary_path_for_version(&release_info.commit_hash)?;
+    if target_path.exists() {
+        info!(
+            "Binary already exists at {}. Will now verify hash...",
+            target_path.display()
+        );
+        if let Ok(true) = verify_binary_hash(&target_path, &antnode_binary.sha256) {
+            info!("Existing binary hash verified. Will use binary that has already been obtained.");
+            return Ok((target_path, antnode_binary.sha256.clone()));
+        }
+        warn!("Existing binary verification failed. Will download again...");
+    }
+
+    let upgrade_dir_path = get_upgrade_dir_path()?;
+    fs::create_dir_all(&upgrade_dir_path)?;
+
+    let _lock = acquire_upgrade_lock(&upgrade_dir_path)?;
+
+    if target_path.exists() {
+        match verify_binary_hash(&target_path, &antnode_binary.sha256) {
+            Ok(true) => {
+                info!("Binary verified after acquiring lock. Will use existing binary.");
+                return Ok((target_path, antnode_binary.sha256.clone()));
+            }
+            Ok(false) | Err(_) => {
+                fs::remove_file(&target_path)?;
+            }
+        }
+    }
+
+    info!("Downloading antnode binary...");
+    let temp_download_dir_path = upgrade_dir_path.join("tmp");
+    fs::create_dir_all(&temp_download_dir_path)?;
+
+    let version = Version::parse(&antnode_binary.version)?;
+    let archive_type = ant_releases::ArchiveType::TarGz;
+    let callback: Box<dyn Fn(u64, u64) + Send + Sync> = Box::new(|downloaded, total| {
+        if total > 0 && downloaded % (total / 10).max(1) == 0 {
+            debug!("Download progress: {}/{} bytes", downloaded, total);
+        }
+    });
+
+    let archive_path = release_repo
+        .download_release_from_s3(
+            &ant_releases::ReleaseType::AntNode,
+            &version,
+            &platform,
+            &archive_type,
+            &temp_download_dir_path,
+            &callback,
+        )
+        .await?;
+    info!("Download complete. Extracting archive...");
+
+    let extracted_path =
+        release_repo.extract_release_archive(&archive_path, &temp_download_dir_path)?;
+    if !verify_binary_hash(&extracted_path, &antnode_binary.sha256)? {
+        return Err(eyre!(
+            "Downloaded binary hash does not match expected hash: {}",
+            antnode_binary.sha256
+        ));
+    }
+    info!("Binary hash verified successfully");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&extracted_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extracted_path, perms)?;
+    }
+    fs::rename(&extracted_path, &target_path)?;
+
+    let _ = fs::remove_dir_all(&temp_download_dir_path);
+    info!("Binary successfully prepared at: {}", target_path.display());
+    Ok((target_path, antnode_binary.sha256.clone()))
+}
+
+pub fn replace_current_binary(new_binary_path: &Path, expected_hash: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        info!("Starting in-place binary replacement");
+
+        if !verify_binary_hash(new_binary_path, expected_hash)? {
+            return Err(eyre!("New binary hash verification failed"));
+        }
+
+        let mut current_exe_path = std::env::current_exe()?;
+        let current_exe_str = current_exe_path.to_string_lossy();
+        if current_exe_str.ends_with(" (deleted)") {
+            let cleaned = current_exe_str.trim_end_matches(" (deleted)");
+            current_exe_path = PathBuf::from(cleaned);
+        }
+        info!("Current executable: {}", current_exe_path.display());
+
+        // In this case another process has already upgraded the binary, so the rename that occurs
+        // below doesn't need to happen again.
+        if current_exe_path.exists()
+            && let Ok(current_hash) = calculate_sha256(&current_exe_path)
+            && current_hash == expected_hash
+        {
+            info!("Current binary already matches upgrade hash");
+            return Ok(());
+        }
+
+        // The reason for this copy is because you cannot *copy* over a running binary, only
+        // rename/move. If we didn't do the copy, it would move the cached binary and other
+        // processes would need to download it again.
+        let temp_path = current_exe_path.with_extension(format!("tmp-{}", std::process::id()));
+        fs::copy(new_binary_path, &temp_path)?;
+
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&temp_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&temp_path, perms)?;
+        fs::rename(&temp_path, &current_exe_path)?;
+
+        info!(
+            "Successfully replaced binary at: {}",
+            current_exe_path.display()
+        );
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        Err(eyre!(
+            "Automatic upgrade is only supported on Unix platforms (Linux/macOS)"
+        ))
+    }
+}
+
+pub async fn perform_upgrade() -> Result<()> {
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
+    let release_info = release_repo.get_latest_autonomi_release_info().await?;
+    if release_info
+        .commit_hash
+        .starts_with(ant_build_info::git_sha())
+    {
+        return Err(eyre!("Already running latest version"));
+    }
+    info!("New version detected: {}", release_info.commit_hash);
+
+    let (new_binary_path, expected_hash) =
+        download_and_extract_upgrade_binary(&release_info, release_repo.as_ref()).await?;
+    replace_current_binary(&new_binary_path, &expected_hash)?;
+
+    Ok(())
+}

--- a/ant-node/src/lib.rs
+++ b/ant-node/src/lib.rs
@@ -148,11 +148,18 @@ impl RunningNode {
         Ok(addresses)
     }
 
-    /// Returns a map where each key is the ilog2 distance of that Kbucket and each value is a vector of peers in that
-    /// bucket.
-    pub async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
+    /// Returns a two-element tuple, where the first element is a map where each key is the ilog2
+    /// distance of that Kbucket and each value is a vector of peers in that bucket, and the second
+    /// element is the estimated network size.
+    pub async fn get_kbuckets(&self) -> Result<(BTreeMap<u32, Vec<PeerId>>, usize)> {
         let kbuckets = self.network.get_kbuckets().await?;
         Ok(kbuckets)
+    }
+
+    /// Returns the estimated network size based on the current kbucket state.
+    pub async fn get_estimated_network_size(&self) -> Result<usize> {
+        let kbuckets = self.get_kbuckets().await?;
+        Ok(kbuckets.1)
     }
 
     /// Returns the node's reward address

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -390,7 +390,9 @@ impl SwarmDriver {
                         error!("bucket is ourself ???!!!");
                     }
                 }
-                let _ = sender.send(ilog2_kbuckets);
+
+                let status = self.get_kbuckets_status();
+                let _ = sender.send((ilog2_kbuckets, status.estimated_network_size));
             }
             LocalSwarmCmd::GetPeersWithMultiaddr { sender } => {
                 cmd_string = "GetPeersWithMultiAddr";

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -64,7 +64,7 @@ pub(crate) enum LocalSwarmCmd {
     /// Get a map where each key is the ilog2 distance of that Kbucket
     /// and each value is a vector of peers in that bucket.
     GetKBuckets {
-        sender: oneshot::Sender<BTreeMap<u32, Vec<PeerId>>>,
+        sender: oneshot::Sender<(BTreeMap<u32, Vec<PeerId>>, usize)>,
     },
     // Get K closest peers to target from the local RoutingTable, self is included
     GetKCloseLocalPeersToTarget {

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -109,10 +109,12 @@ impl Network {
             .map_err(|_e| NetworkError::InternalMsgChannelDropped)
     }
 
-    /// Returns a map where each key is the ilog2 distance of that Kbucket
-    /// and each value is a vector of peers in that bucket.
+    /// Returns a two-element tuple, where the first element is a map where each key is the ilog2
+    /// distance of that Kbucket and each value is a vector of peers in that bucket, and the second
+    /// element is the estimated network size.
+    ///
     /// Does not include self
-    pub(crate) async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
+    pub(crate) async fn get_kbuckets(&self) -> Result<(BTreeMap<u32, Vec<PeerId>>, usize)> {
         let (sender, receiver) = oneshot::channel();
         self.send_local_swarm_cmd(LocalSwarmCmd::GetKBuckets { sender });
         receiver

--- a/ant-node/src/networking/transport.rs
+++ b/ant-node/src/networking/transport.rs
@@ -9,9 +9,9 @@
 #[cfg(feature = "open-metrics")]
 use crate::networking::MetricsRegistries;
 use libp2p::{
+    PeerId, Transport as _,
     core::{muxing::StreamMuxerBox, transport},
     identity::Keypair,
-    PeerId, Transport as _,
 };
 
 pub(crate) fn build_transport(

--- a/ant-node/src/python.rs
+++ b/ant-node/src/python.rs
@@ -160,6 +160,7 @@ impl PyAntNode {
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to get kbuckets: {e}")))?;
 
             Ok(kbuckets
+                .0
                 .into_iter()
                 .map(|(distance, peers)| {
                     (

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -22,7 +22,7 @@ prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0.20"
-service-manager = "0.8.0"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43.1", features = ["time"] }

--- a/ant-service-management/src/daemon.rs
+++ b/ant-service-management/src/daemon.rs
@@ -77,9 +77,9 @@ impl ServiceStateActions for DaemonService {
             environment: None,
             label: self.service_data.read().await.service_name.parse()?,
             program: self.service_data.read().await.daemon_path.clone(),
+            restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
             username: None,
             working_directory: None,
-            disable_restart_on_failure: false,
         };
         Ok(install_ctx)
     }

--- a/ant-service-management/src/node/mod.rs
+++ b/ant-service-management/src/node/mod.rs
@@ -142,9 +142,9 @@ impl ServiceStateActions for NodeService {
             environment: options.env_variables,
             label: label.clone(),
             program: service_data.antnode_path.to_path_buf(),
+            restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
             username: service_data.user.clone(),
             working_directory: None,
-            disable_restart_on_failure: true,
         })
     }
 

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -8,7 +8,7 @@
 
 use crate::networking::{Quorum, RetryStrategy, Strategy};
 pub use ant_bootstrap::{
-    error::Error as BootstrapError, Bootstrap, BootstrapConfig, InitialPeersConfig,
+    Bootstrap, BootstrapConfig, InitialPeersConfig, error::Error as BootstrapError,
 };
 use ant_evm::EvmNetwork;
 use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -140,7 +140,7 @@ impl Client {
 
     /// Helper function to fetch a record from the closest peers directly.
     /// This is useful as a fallback when normal DHT queries fail.
-    /// 
+    ///
     /// Returns the first successfully retrieved record, or None if all peers fail.
     async fn fetch_record_from_closest_peers(
         &self,
@@ -148,8 +148,12 @@ impl Client {
         num_peers: usize,
     ) -> Option<Record> {
         debug!("Querying closest {num_peers} nodes directly for {key:?}");
-        
-        let closest_peers = match self.network.get_closest_peers(key.clone(), Some(num_peers)).await {
+
+        let closest_peers = match self
+            .network
+            .get_closest_peers(key.clone(), Some(num_peers))
+            .await
+        {
             Ok(peers) => peers,
             Err(e) => {
                 error!("Failed to get closest peers for {key:?}: {e}");
@@ -157,17 +161,18 @@ impl Client {
             }
         };
 
-        debug!("Querying {} closest peers in parallel for {key:?}", closest_peers.len());
-        
+        debug!(
+            "Querying {} closest peers in parallel for {key:?}",
+            closest_peers.len()
+        );
+
         // Create query tasks for all closest peers
         let mut query_tasks = vec![];
         for peer in closest_peers.iter() {
             let network = self.network.clone();
             let key = key.clone();
             let peer = peer.clone();
-            query_tasks.push(async move {
-                network.get_record_from_peer(key, peer).await
-            });
+            query_tasks.push(async move { network.get_record_from_peer(key, peer).await });
         }
 
         // Process tasks with max concurrency of num_peers
@@ -184,7 +189,10 @@ impl Client {
             }
         }
 
-        error!("❌ All {} closest peers failed to return the record {key:?}", closest_peers.len());
+        error!(
+            "❌ All {} closest peers failed to return the record {key:?}",
+            closest_peers.len()
+        );
         None
     }
 

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -66,7 +66,13 @@ impl Client {
         peer: PeerInfo,
         nonce: u64,
         difficulty: usize,
-    ) -> Result<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>, NetworkError> {
+    ) -> Result<
+        Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
+        NetworkError,
+    > {
         self.network
             .get_storage_proofs_from_peer(network_address.into(), peer, nonce, difficulty)
             .await

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -175,8 +175,11 @@ impl NetworkDriver {
                 peer_address,
                 storage_proofs,
             }) => {
-                if self.pending_tasks
-                    .update_get_quote(request_id, quote, peer_address).is_err() {
+                if self
+                    .pending_tasks
+                    .update_get_quote(request_id, quote, peer_address)
+                    .is_err()
+                {
                     self.pending_tasks
                         .update_get_storage_proofs_from_peer(request_id, storage_proofs)?;
                 }

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -50,7 +50,15 @@ pub(crate) struct TaskHandler {
     get_record_accumulator: HashMap<QueryId, HashMap<PeerId, Record>>,
     get_version: HashMap<OutboundRequestId, OneShotTaskResult<String>>,
     get_record_from_peer: HashMap<OutboundRequestId, OneShotTaskResult<Option<Record>>>,
-    get_storage_proofs_from_peer: HashMap<OutboundRequestId, OneShotTaskResult<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>>>,
+    get_storage_proofs_from_peer: HashMap<
+        OutboundRequestId,
+        OneShotTaskResult<
+            Vec<(
+                NetworkAddress,
+                Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+            )>,
+        >,
+    >,
 }
 
 impl TaskHandler {
@@ -455,16 +463,22 @@ impl TaskHandler {
     pub fn update_get_storage_proofs_from_peer(
         &mut self,
         id: OutboundRequestId,
-        storage_proofs: Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>,
+        storage_proofs: Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
     ) -> Result<(), TaskHandlerError> {
-        let responder = self
-            .get_storage_proofs_from_peer
-            .remove(&id)
-            .ok_or(TaskHandlerError::UnknownQuery(format!(
-                "OutboundRequestId {id:?}"
-            )))?;
+        let responder =
+            self.get_storage_proofs_from_peer
+                .remove(&id)
+                .ok_or(TaskHandlerError::UnknownQuery(format!(
+                    "OutboundRequestId {id:?}"
+                )))?;
 
-        trace!("OutboundRequestId({id}): got {} storage proofs", storage_proofs.len());
+        trace!(
+            "OutboundRequestId({id}): got {} storage proofs",
+            storage_proofs.len()
+        );
         responder
             .send(Ok(storage_proofs))
             .map_err(|_| TaskHandlerError::NetworkClientDropped(format!("{id:?}")))?;

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -10,8 +10,8 @@ use crate::networking::OneShotTaskResult;
 use ant_evm::PaymentQuote;
 use ant_protocol::NetworkAddress;
 use libp2p::{
-    kad::{PeerInfo, Quorum, Record},
     PeerId,
+    kad::{PeerInfo, Quorum, Record},
 };
 use std::num::NonZeroUsize;
 

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -391,7 +391,13 @@ impl Network {
         peer: PeerInfo,
         nonce: u64,
         difficulty: usize,
-    ) -> Result<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>, NetworkError> {
+    ) -> Result<
+        Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
+        NetworkError,
+    > {
         let (tx, rx) = oneshot::channel();
         let task = NetworkTask::GetStorageProofsFromPeer {
             addr,

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 semver = "1.0.20"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -24,7 +24,7 @@ ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.2.52" }
 ant-node-manager = { version = "0.13.3", path = "../ant-node-manager" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.1" }
+ant-releases = "0.4.2"
 ant-service-management = { version = "0.4.16", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -15,6 +15,7 @@ use ant_releases::{self, AntReleaseRepoActions, ReleaseType};
 use ant_service_management::NodeRegistryManager;
 use color_eyre::Result;
 use color_eyre::eyre::eyre;
+use service_manager::RestartPolicy;
 use std::{path::PathBuf, str::FromStr};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc::{self, UnboundedSender};
@@ -441,6 +442,7 @@ async fn add_node(args: MaintainNodesArgs, node_registry: NodeRegistryManager) {
         node_registry.clone(),
         config.init_peers_config.clone(),
         config.relay, // relay,
+        RestartPolicy::Never,
         RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
         None,                        // rpc_address,
         None,                        // rpc_port,
@@ -683,6 +685,7 @@ async fn scale_down_nodes(config: &NodeConfig, count: u16, node_registry: NodeRe
         config.init_peers_config.clone(),
         config.relay,
         RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
+        RestartPolicy::Never,
         None,
         None,
         config.antnode_path.clone(),
@@ -759,6 +762,7 @@ async fn add_nodes(
             config.init_peers_config.clone(),
             config.relay,
             RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
+            RestartPolicy::Never,
             None,
             None,
             config.antnode_path.clone(),


### PR DESCRIPTION
- d63bf1271 **chore: utility target for providing binary hashes**

  The automatic upgrading process is going to require the sha256 hashes of the binaries be included in
  the information for each release.

  This new target in the Justfile can operate on the populated `artifacts` directory to get all the
  hashes. It will output them in a markdown table which can be pasted into the release description.

- 7b2d6b0fc **feat: `antnode` automatic upgrades for unix platforms**

  Automatic upgrades aim to make it as easy as possible for node operators to obtain new versions of
  the `antnode` binary. We also provide a 'staggering' mechanism to attempt to avoid the turbulence
  caused when everyone upgrades around the same time. If the majority of operators use this feature,
  we should see better network health and stability, because newer versions of the node will propagate
  quicker and safer.

  Initially, we only support Linux and macOS. The Windows operating system does not allow a binary
  associated with a running process to be overwritten, which is part of the upgrade process (see
  below).

  An upgrade is performed by a background thread that wakes up every 72 hours.

  After the upgrade is performed, the restart of the binary is delayed for a period of time that is
  determined by taking the hash of the peer ID and the size of the network into account, with a cap of
  72 hours. This is to make the upgrades 'staggered', to avoid many thousands of node processes
  restarting at the same time. To facilitate the calculation, the `get_kbuckets` API is slightly
  modified to return the estimated network size.

  The upgrade process works as follows:

  * Get the latest release information from the `autonomi` repository.
  * If the commit hash of the latest release matches the commit hash of the currently running binary,
    do nothing and the process ends. Otherwise the upgrade proceeds.
  * Get the currently running platform. This information is used to locate the correct binary and
    sha256 hash.
  * Check if another `antnode` process has already downloaded the new binary to a temporary location
    and its sha256 hash matches that of the binary from the fetched release information. This will
    prevent many `antnode` processes continually downloading the new binary. If the new binary has not
    already been downloaded, it will be downloaded and extracted to the temporary location.
  * The hash of the downloaded binary will be compared to the hash of the binary in the new release
    information.
  * The binary of the currently running process will be overwritten by the new binary. We will check
    to see if the hash of the running binary matches the hash of the upgrade binary; in this case,
    another process already upgraded the binary and we don't need to do anything.

  If an upgrade occurred, the `antnode` process will be restarted after a delay of some period, as
  mentioned above.

  Given the more elaborate implementation of automatic upgrades, the workflow for self restarting was
  deleted.

- 6674bf164 **chore!: use 'always' restart policy for `antctl add`**

  BREAKING CHANGE: new node deployments with `antctl` will apply a different restart policy.

  With `antctl` we are going to configure services for node deployments to always restart. This is so
  we can use the node deployments with the automatic upgrades feature and let the service manager
  handle the restart of the `antnode` process. If `antnode` itself were to restart the process, the
  service manager would consider it to be dead, which would break the status tracking for `antctl`.

  We need to provide a `--stop-on-upgrade` argument for `antnode` such that it will stop the process
  on the upgrade rather than restart it, and allow the service manager to perform the restart. This
  will be coming in the next commit.

  The `node-launchpad` has been configured to use 'never' for the restart policy because we ran into
  problems with the UPnP feature if the launchpad continually restarted nodes. So automatic upgrades
  just won't be supported when using the launchpad. We will need to provide another `antnode` argument
  to disable automatic upgrades, which will come in another commit.

- 73e1de96c **feat: provide `--stop-on-upgrade` argument for `antctl`**

  If this argument is used the node will be stopped after it is upgraded, rather than restarted.

  This is to allow the service manager to restart the process if the node is being run in this
  context, which it will be if it is deployed using `antctl`, which is updated in this commit to
  always supply the argument as part of the service definition for a node.

- c5fb3e828 **feat: improve process detection for antnode services**

  The upgrade process introduced a problem with the detection of processes using the path-based
  approach we had. When the binary is overwritten, it seems the text " (deleted)" gets appended to the
  path, and thus the `antctl status` command was marking services as stopped when they were still
  running and scheduled to be upgraded.

  This new approach first tries to use the stored PID, then falls back on the path-detection
  mechanism, attempting to take the "(deleted)" suffix into account.

- a07daab7c **chore: update reference to `ant-releases`**

  The new version with the release information was published to `crates.io`, so the development
  reference can now be replaced.

- e1c1ee255 **chore: sleep in upgrade loop rather than handler**

  It was pointed out in review feedback that it would be better to perform the upgrade delay in the
  upgrade loop rather than in the node control handler because it could interfere with the node
  stopping on errors or when using ctrl+c.

- 643f14642 **chore: improve logging for upgrades**

  I added the information I found useful during the development process.