### PR TITLE
Support for `antnode` Automatic Upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6680,6 +6680,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "service-manager",
  "signal-hook",
  "strip-ansi-escapes",
  "strum 0.26.3",
@@ -9067,13 +9068,13 @@ dependencies = [
 [[package]]
 name = "service-manager"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cae942acfe9cecd4450998408f52e1c1ee083145226b7b803bd0d82e1c86912"
+source = "git+https://github.com/jacderida/service-manager-rs?branch=generic_restart_policy#6ba8721d2a6660bf40ece0d2f732be0551d17931"
 dependencies = [
  "cfg-if",
  "dirs",
  "encoding-utils",
  "encoding_rs",
+ "log",
  "plist",
  "which 4.4.2",
  "xml-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "ant-evm",
  "ant-logging",
  "ant-protocol",
+ "ant-releases",
  "ant-service-management",
  "assert_fs",
  "async-trait",
@@ -985,6 +986,7 @@ dependencies = [
  "evmlib",
  "eyre",
  "file-rotate",
+ "fs2",
  "futures",
  "hex",
  "hkdf",
@@ -1002,6 +1004,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.24",
  "rmp-serde",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "sha2",
@@ -2245,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3736,6 +3739,16 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fs_extra"
@@ -5465,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -8622,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "web-time",
  "zeroize",
@@ -8974,9 +8987,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -8993,9 +9006,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -10032,9 +10045,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -10145,9 +10158,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -10555,9 +10568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10568,9 +10581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -10581,9 +10594,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10591,9 +10604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10604,9 +10617,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
@@ -10627,9 +10640,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "ant-releases"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadde4a1a3d1e6e7d83bd517eb354779915e6a45ee76d66136f73fd139650e8d"
+checksum = "6094e57fe43c52e8e1be858df477611e0cfa8b659fe11ea747a31addac299c05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1149,6 +1149,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.24",
  "semver 1.0.27",
+ "serde",
  "serde_json",
  "tar",
  "thiserror 1.0.69",

--- a/Justfile
+++ b/Justfile
@@ -397,3 +397,53 @@ package-arch arch:
   fi
 
   cd ../../..
+
+build-artifact-hashes:
+  #!/usr/bin/env bash
+  set -e
+
+  architectures=(
+    "x86_64-pc-windows-msvc"
+    "x86_64-apple-darwin"
+    "aarch64-apple-darwin"
+    "x86_64-unknown-linux-musl"
+    "arm-unknown-linux-musleabi"
+    "armv7-unknown-linux-musleabihf"
+    "aarch64-unknown-linux-musl"
+  )
+
+  binaries=(
+    "nat-detection"
+    "node-launchpad"
+    "ant"
+    "antnode"
+    "antctl"
+    "antctld"
+    "antnode_rpc_client"
+    "evm-testnet"
+  )
+
+  echo "## Binary Hashes"
+  echo ""
+
+  for arch in "${architectures[@]}"; do
+    echo "### $arch"
+    echo ""
+    echo "| Binary | SHA256 Hash |"
+    echo "|--------|-------------|"
+
+    for binary in "${binaries[@]}"; do
+      if [[ "$arch" == *"windows"* ]]; then
+        binary_path="artifacts/$arch/release/${binary}.exe"
+      else
+        binary_path="artifacts/$arch/release/${binary}"
+      fi
+
+      if [[ -f "$binary_path" ]]; then
+        hash=$(sha256sum "$binary_path" | awk '{print $1}')
+        echo "| $binary | \`$hash\` |"
+      else
+        echo "| $binary | *not found* |"
+      fi
+    done
+  done

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -34,7 +34,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.2" }
+ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
 evmlib = { path = "../evmlib", version = "0.4.5" }
 chrono = "~0.4.19"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -34,7 +34,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.1" }
+ant-releases = { version = "0.4.2" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
 evmlib = { path = "../evmlib", version = "0.4.5" }
 chrono = "~0.4.19"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -51,7 +51,7 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-service-manager = "0.8.0"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43", features = ["full"] }

--- a/ant-node-manager/src/add_services/config.rs
+++ b/ant-node-manager/src/add_services/config.rs
@@ -92,6 +92,7 @@ pub struct InstallNodeServiceCtxBuilder {
     pub rewards_address: RewardsAddress,
     pub rpc_socket_addr: SocketAddr,
     pub service_user: Option<String>,
+    pub stop_on_upgrade: bool,
     pub write_older_cache_files: bool,
 }
 
@@ -152,6 +153,11 @@ impl InstallNodeServiceCtxBuilder {
             args.push(OsString::from("--write-older-cache-files"));
         }
 
+        if self.stop_on_upgrade {
+            args.push(OsString::from("--stop-on-upgrade"));
+        }
+
+        // The EVM details must always be the last arguments.
         args.push(OsString::from(self.evm_network.to_string()));
         if let EvmNetwork::Custom(custom_network) = &self.evm_network {
             args.push(OsString::from("--rpc-url"));
@@ -254,6 +260,7 @@ mod tests {
             restart_policy: RestartPolicy::OnFailure { delay_secs: None },
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: true,
             write_older_cache_files: false,
         }
     }
@@ -293,6 +300,7 @@ mod tests {
                 .unwrap(),
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: false,
             write_older_cache_files: false,
         }
     }
@@ -332,6 +340,7 @@ mod tests {
                 .unwrap(),
             rpc_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             service_user: None,
+            stop_on_upgrade: true,
             write_older_cache_files: false,
         }
     }
@@ -356,6 +365,7 @@ mod tests {
             "/logs",
             "--rewards-address",
             "0x03B770D9cD32077cC0bF330c13C114a87643B124",
+            "--stop-on-upgrade",
             "evm-arbitrum-one",
         ];
         assert_eq!(
@@ -464,6 +474,7 @@ mod tests {
             "--rewards-address",
             "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             "--write-older-cache-files",
+            "--stop-on-upgrade",
             "evm-custom",
             "--rpc-url",
             "http://localhost:8545/",

--- a/ant-node-manager/src/add_services/mod.rs
+++ b/ant-node-manager/src/add_services/mod.rs
@@ -192,11 +192,12 @@ pub async fn add_node(
 
         let install_ctx = InstallNodeServiceCtxBuilder {
             alpha: options.alpha,
+            antnode_path: service_antnode_path.clone(),
             autostart: options.auto_restart,
             data_dir_path: service_data_dir_path.clone(),
             env_variables: options.env_variables.clone(),
             evm_network: options.evm_network.clone(),
-            relay: options.relay,
+            init_peers_config: options.init_peers_config.clone(),
             log_dir_path: service_log_dir_path.clone(),
             log_format: options.log_format,
             max_archived_log_files: options.max_archived_log_files,
@@ -204,14 +205,14 @@ pub async fn add_node(
             metrics_port: metrics_free_port,
             name: service_name.clone(),
             network_id: options.network_id,
+            no_upnp: options.no_upnp,
             node_ip: options.node_ip,
             node_port,
-            init_peers_config: options.init_peers_config.clone(),
+            relay: options.relay,
+            restart_policy: options.restart_policy,
             rewards_address: options.rewards_address,
             rpc_socket_addr,
-            antnode_path: service_antnode_path.clone(),
             service_user: options.user.clone(),
-            no_upnp: options.no_upnp,
             write_older_cache_files: options.write_older_cache_files,
         }
         .build()?;
@@ -354,9 +355,9 @@ pub async fn add_daemon(
         environment: options.env_variables,
         label: DAEMON_SERVICE_NAME.parse()?,
         program: options.daemon_install_bin_path.clone(),
+        restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
         username: Some(options.user),
         working_directory: None,
-        disable_restart_on_failure: false,
     };
 
     match service_control.install(install_ctx, false) {

--- a/ant-node-manager/src/add_services/mod.rs
+++ b/ant-node-manager/src/add_services/mod.rs
@@ -213,6 +213,7 @@ pub async fn add_node(
             rewards_address: options.rewards_address,
             rpc_socket_addr,
             service_user: options.user.clone(),
+            stop_on_upgrade: true,
             write_older_cache_files: options.write_older_cache_files,
         }
         .build()?;

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -137,6 +137,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -520,6 +521,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -571,6 +573,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -622,6 +625,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -808,6 +812,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -1002,6 +1007,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -1148,6 +1154,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                     OsString::from("--first"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1301,6 +1308,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                         "/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1449,6 +1457,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                     OsString::from("--local"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1601,6 +1610,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                     OsString::from("http://localhost:8080/contacts,http://localhost:8081/contacts"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1749,6 +1759,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                     OsString::from("--ignore-cache"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -1898,6 +1909,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                     OsString::from("/path/to/bootstrap/cache"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2041,6 +2053,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                     OsString::from("5"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2182,6 +2195,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                     OsString::from(custom_ip.to_string()),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2329,6 +2343,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -2453,6 +2468,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12000"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2512,6 +2528,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -2571,6 +2588,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     OsString::from("12002"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3109,6 +3127,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                     OsString::from("15001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3243,6 +3262,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                     OsString::from("20"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3378,6 +3398,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                     OsString::from("20"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3512,6 +3533,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12000"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3571,6 +3593,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12001"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -3630,6 +3653,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     OsString::from("12002"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4003,6 +4027,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4055,6 +4080,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4107,6 +4133,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -4504,6 +4531,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4631,6 +4659,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4757,6 +4786,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -4884,6 +4914,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
     mock_service_control
@@ -5148,6 +5179,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5275,6 +5307,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5403,6 +5436,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
         no_upnp: false,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5527,6 +5561,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
         no_upnp: true,
         write_older_cache_files: false,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5643,6 +5678,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
                     ),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),
@@ -5786,6 +5822,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
         no_upnp: true,
         write_older_cache_files: true,
         restart_policy,
+        stop_on_upgrade: true,
     }
     .build()?;
 
@@ -5914,6 +5951,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                     OsString::from("--alpha"),
                     OsString::from("--rewards-address"),
                     OsString::from("0x03B770D9cD32077cC0bF330c13C114a87643B124"),
+                    OsString::from("--stop-on-upgrade"),
                     OsString::from("evm-custom"),
                     OsString::from("--rpc-url"),
                     OsString::from("http://localhost:8545/"),

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -27,7 +27,7 @@ use assert_matches::assert_matches;
 use color_eyre::Result;
 use mockall::{Sequence, mock, predicate::*};
 use predicates::prelude::*;
-use service_manager::ServiceInstallCtx;
+use service_manager::{RestartPolicy, ServiceInstallCtx};
 use std::{
     ffi::OsString,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -82,6 +82,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
     let antnode_download_path = temp_dir.child(ANTNODE_FILE_NAME);
     antnode_download_path.write_binary(b"fake antnode bin")?;
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let mut mock_service_control = MockServiceControl::new();
@@ -135,6 +136,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -185,6 +187,7 @@ async fn add_genesis_node_should_use_latest_version_and_add_one_service() -> Res
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -247,6 +250,7 @@ async fn add_genesis_node_should_return_an_error_if_there_is_already_a_genesis_n
     let mock_service_control = MockServiceControl::new();
 
     let latest_version = "0.96.4";
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
 
     let init_peers_config = InitialPeersConfig {
         first: true,
@@ -354,6 +358,7 @@ async fn add_genesis_node_should_return_an_error_if_there_is_already_a_genesis_n
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -375,6 +380,7 @@ async fn add_genesis_node_should_return_an_error_if_count_is_greater_than_1() ->
     let node_reg_path = tmp_data_dir.child("node_reg.json");
     let mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let init_peers_config = InitialPeersConfig {
@@ -436,6 +442,7 @@ async fn add_genesis_node_should_return_an_error_if_count_is_greater_than_1() ->
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -459,6 +466,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
     let mut mock_service_control = MockServiceControl::new();
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let node_data_dir = temp_dir.child("data");
@@ -511,6 +519,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -561,6 +570,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -611,6 +621,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -662,6 +673,7 @@ async fn add_node_should_use_latest_version_and_add_three_services() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -742,6 +754,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         ("RUST_LOG".to_owned(), "libp2p=debug".to_owned()),
     ]);
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let latest_version = "0.96.4";
@@ -794,6 +807,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -844,6 +858,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -890,6 +905,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
@@ -985,6 +1001,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -1036,6 +1053,7 @@ async fn add_new_node_should_add_another_service() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1075,6 +1093,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1145,9 +1164,9 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1195,6 +1214,7 @@ async fn add_node_should_create_service_file_with_first_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1221,6 +1241,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1296,9 +1317,9 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1346,6 +1367,7 @@ async fn add_node_should_create_service_file_with_peers_args() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1372,6 +1394,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1442,9 +1465,9 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1492,6 +1515,7 @@ async fn add_node_should_create_service_file_with_local_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1518,6 +1542,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1592,9 +1617,9 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1642,6 +1667,7 @@ async fn add_node_should_create_service_file_with_network_contacts_url_arg() -> 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1668,6 +1694,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1738,9 +1765,9 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1788,6 +1815,7 @@ async fn add_node_should_create_service_file_with_ignore_cache_arg() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1814,6 +1842,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -1885,9 +1914,9 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -1935,6 +1964,7 @@ async fn add_node_should_create_service_file_with_custom_bootstrap_cache_path() 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -1964,6 +1994,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2026,9 +2057,9 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2076,6 +2107,7 @@ async fn add_node_should_create_service_file_with_network_id() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2101,6 +2133,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2165,9 +2198,9 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2215,6 +2248,7 @@ async fn add_node_should_use_custom_ip() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2240,6 +2274,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2293,6 +2328,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -2344,6 +2380,7 @@ async fn add_node_should_use_custom_ports_for_one_service() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2369,6 +2406,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2431,9 +2469,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2490,9 +2528,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2549,9 +2587,9 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -2599,6 +2637,7 @@ async fn add_node_should_use_a_custom_port_range() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -2625,6 +2664,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_is_used() -> R
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -2721,6 +2761,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_is_used() -> R
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -2742,6 +2783,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_in_range_is_us
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -2838,6 +2880,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_port_in_range_is_us
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -2859,6 +2902,7 @@ async fn add_node_should_return_an_error_if_port_and_node_count_do_not_match() -
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2910,6 +2954,7 @@ async fn add_node_should_return_an_error_if_port_and_node_count_do_not_match() -
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -2936,6 +2981,7 @@ async fn add_node_should_return_an_error_if_multiple_services_are_specified_with
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -2987,6 +3033,7 @@ async fn add_node_should_return_an_error_if_multiple_services_are_specified_with
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3014,6 +3061,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -3077,9 +3125,9 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3127,6 +3175,7 @@ async fn add_node_should_set_random_ports_if_enable_metrics_server_is_true() -> 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3146,6 +3195,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
@@ -3209,9 +3259,9 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3259,6 +3309,7 @@ async fn add_node_should_set_max_archived_log_files() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3277,6 +3328,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
@@ -3342,9 +3394,9 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3392,6 +3444,7 @@ async fn add_node_should_set_max_log_files() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3410,6 +3463,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -3474,9 +3528,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3533,9 +3587,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3592,9 +3646,9 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -3642,6 +3696,7 @@ async fn add_node_should_use_a_custom_port_range_for_metrics_server() -> Result<
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -3666,6 +3721,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_is_use
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -3762,6 +3818,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_is_use
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3784,6 +3841,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_in_ran
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -3880,6 +3938,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_metrics_port_in_ran
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -3903,6 +3962,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
 
     let mut mock_service_control = MockServiceControl::new();
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
 
     let latest_version = "0.96.4";
@@ -3959,9 +4019,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4011,9 +4071,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode2")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4063,9 +4123,9 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                     .to_path_buf()
                     .join("antnode3")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -4113,6 +4173,7 @@ async fn add_node_should_use_a_custom_port_range_for_the_rpc_server() -> Result<
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4147,6 +4208,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_is_used() 
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -4243,6 +4305,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_is_used() 
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry,
         &MockServiceControl::new(),
@@ -4265,6 +4328,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_in_range_i
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
     node_registry
         .push_node(NodeServiceData {
@@ -4361,6 +4425,7 @@ async fn add_node_should_return_an_error_if_duplicate_custom_rpc_port_in_range_i
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &MockServiceControl::new(),
@@ -4382,6 +4447,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4437,6 +4503,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4487,6 +4554,7 @@ async fn add_node_should_disable_upnp_and_relay_if_nat_status_is_public() -> Res
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4506,6 +4574,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4561,6 +4630,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4611,6 +4681,7 @@ async fn add_node_should_not_set_no_upnp_if_nat_status_is_upnp() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4630,6 +4701,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4684,6 +4756,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4734,6 +4807,7 @@ async fn add_node_should_enable_relay_if_nat_status_is_private() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4754,6 +4828,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -4808,6 +4883,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
     mock_service_control
@@ -4858,6 +4934,7 @@ async fn add_node_should_set_relay_and_no_upnp_if_nat_status_is_none_but_auto_se
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -4877,6 +4954,7 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let daemon_install_dir = temp_dir.child("install");
@@ -4905,9 +4983,9 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
                 environment: Some(vec![("ANT_LOG".to_string(), "ALL".to_string())]),
                 label: "antctld".parse()?,
                 program: daemon_install_path.to_path_buf(),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: false,
             }),
             eq(false),
         )
@@ -5012,6 +5090,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5068,6 +5147,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5119,6 +5199,7 @@ async fn add_node_should_not_delete_the_source_binary_if_path_arg_is_used() -> R
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5136,6 +5217,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5192,6 +5274,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5243,6 +5326,7 @@ async fn add_node_should_apply_the_relay_flag_if_it_is_used() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5261,6 +5345,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5317,6 +5402,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: false,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5368,6 +5454,7 @@ async fn add_node_should_add_the_node_in_user_mode() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5383,6 +5470,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5438,6 +5526,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: false,
+        restart_policy,
     }
     .build()?;
 
@@ -5489,6 +5578,7 @@ async fn add_node_should_add_the_node_with_no_upnp_flag() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5508,6 +5598,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let latest_version = "0.96.4";
     let temp_dir = assert_fs::TempDir::new()?;
     let node_data_dir = temp_dir.child("data");
@@ -5568,9 +5659,9 @@ async fn add_node_should_auto_restart() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -5619,6 +5710,7 @@ async fn add_node_should_auto_restart() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5637,6 +5729,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5692,6 +5785,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
         service_user: Some(get_username()),
         no_upnp: true,
         write_older_cache_files: true,
+        restart_policy,
     }
     .build()?;
 
@@ -5743,6 +5837,7 @@ async fn add_node_should_add_the_node_with_write_older_cache_files() -> Result<(
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: true,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,
@@ -5762,6 +5857,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
     let tmp_data_dir = assert_fs::TempDir::new()?;
     let node_reg_path = tmp_data_dir.child("node_reg.json");
 
+    let restart_policy = RestartPolicy::Always { delay_secs: None };
     let mut mock_service_control = MockServiceControl::new();
 
     let node_registry = NodeRegistryManager::empty(node_reg_path.to_path_buf());
@@ -5834,9 +5930,9 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                     .to_path_buf()
                     .join("antnode1")
                     .join(ANTNODE_FILE_NAME),
+                restart_policy,
                 username: Some(get_username()),
                 working_directory: None,
-                disable_restart_on_failure: true,
             }),
             eq(false),
         )
@@ -5884,6 +5980,7 @@ async fn add_node_should_create_service_file_with_alpha_arg() -> Result<()> {
                 "0x03B770D9cD32077cC0bF330c13C114a87643B124",
             )?,
             write_older_cache_files: false,
+            restart_policy,
         },
         node_registry.clone(),
         &mock_service_control,

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -22,6 +22,7 @@ use ant_service_management::NodeRegistryManager;
 use clap::{Parser, Subcommand};
 use color_eyre::{Result, eyre::eyre};
 use libp2p::Multiaddr;
+use service_manager::RestartPolicy;
 use std::{net::Ipv4Addr, path::PathBuf};
 use tracing::Level;
 
@@ -876,6 +877,7 @@ async fn main() -> Result<()> {
                 node_registry,
                 peers,
                 relay,
+                RestartPolicy::Always { delay_secs: None },
                 rewards_address,
                 rpc_address,
                 rpc_port,

--- a/ant-node-manager/src/cmd/node.rs
+++ b/ant-node-manager/src/cmd/node.rs
@@ -33,6 +33,7 @@ use color_eyre::{Help, Result, eyre::eyre};
 use colored::Colorize;
 use libp2p_identity::PeerId;
 use semver::Version;
+use service_manager::RestartPolicy;
 use std::{
     cmp::Ordering, io::Write, net::Ipv4Addr, path::PathBuf, str::FromStr, sync::Arc, time::Duration,
 };
@@ -60,6 +61,7 @@ pub async fn add(
     node_registry: NodeRegistryManager,
     mut init_peers_config: InitialPeersConfig,
     relay: bool,
+    restart_policy: RestartPolicy,
     rewards_address: RewardsAddress,
     rpc_address: Option<Ipv4Addr>,
     rpc_port: Option<PortRange>,
@@ -121,6 +123,8 @@ pub async fn add(
 
     let options = AddNodeServiceOptions {
         alpha,
+        antnode_dir_path: service_data_dir_path.clone(),
+        antnode_src_path,
         auto_restart,
         auto_set_nat_flags,
         count,
@@ -128,23 +132,22 @@ pub async fn add(
         enable_metrics_server,
         evm_network: evm_network.unwrap_or(EvmNetwork::ArbitrumOne),
         env_variables,
-        relay,
+        init_peers_config,
         log_format,
         max_archived_log_files,
         max_log_files,
         metrics_port,
         network_id,
+        no_upnp,
         node_ip,
         node_port,
-        init_peers_config,
+        relay,
+        restart_policy,
         rewards_address,
         rpc_address,
         rpc_port,
-        antnode_src_path,
-        antnode_dir_path: service_data_dir_path.clone(),
         service_data_dir_path,
         service_log_dir_path,
-        no_upnp,
         user: service_user,
         user_mode,
         version,
@@ -617,6 +620,7 @@ pub async fn maintain_n_running_nodes(
     peers_args: InitialPeersConfig,
     relay: bool,
     rewards_address: RewardsAddress,
+    restart_policy: RestartPolicy,
     rpc_address: Option<Ipv4Addr>,
     rpc_port: Option<PortRange>,
     src_path: Option<PathBuf>,
@@ -731,6 +735,7 @@ pub async fn maintain_n_running_nodes(
                         node_registry.clone(),
                         peers_args.clone(),
                         relay,
+                        restart_policy,
                         rewards_address,
                         rpc_address,
                         rpc_port.clone(),

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -673,7 +673,7 @@ mod tests {
     use libp2p_identity::PeerId;
     use mockall::{mock, predicate::*};
     use predicates::prelude::*;
-    use service_manager::ServiceInstallCtx;
+    use service_manager::{RestartPolicy, ServiceInstallCtx};
     use std::{
         ffi::OsString,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -2721,9 +2721,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -2897,9 +2897,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3073,9 +3073,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3239,9 +3239,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3413,9 +3413,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3592,9 +3592,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3766,9 +3766,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -3946,9 +3946,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4113,9 +4113,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4280,9 +4280,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4447,9 +4447,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4614,9 +4614,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4781,9 +4781,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -4948,9 +4948,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5115,9 +5115,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5282,9 +5282,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5450,9 +5450,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5621,9 +5621,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5801,9 +5801,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -5975,9 +5975,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -6146,9 +6146,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )
@@ -6707,9 +6707,9 @@ mod tests {
                     environment: None,
                     label: "antnode1".parse()?,
                     program: current_node_bin.to_path_buf(),
+                    restart_policy: RestartPolicy::Always { delay_secs: None },
                     username: Some("ant".to_string()),
                     working_directory: None,
-                    disable_restart_on_failure: true,
                 }),
                 eq(false),
             )

--- a/ant-node-manager/src/rpc.rs
+++ b/ant-node-manager/src/rpc.rs
@@ -21,6 +21,7 @@ use color_eyre::{
     eyre::{OptionExt, eyre},
 };
 use libp2p::PeerId;
+use service_manager::RestartPolicy;
 use std::sync::Arc;
 
 pub async fn restart_node_service(
@@ -82,6 +83,8 @@ pub async fn restart_node_service(
             node_ip: current_node_clone.node_ip,
             node_port: current_node_clone.get_antnode_port(),
             no_upnp: current_node_clone.no_upnp,
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            restart_policy: RestartPolicy::Never,
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             service_user: current_node_clone.user.clone(),
@@ -198,6 +201,8 @@ pub async fn restart_node_service(
             node_ip: current_node_clone.node_ip,
             node_port: None,
             no_upnp: current_node_clone.no_upnp,
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            restart_policy: RestartPolicy::Never,
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             antnode_path: antnode_path.clone(),

--- a/ant-node-manager/src/rpc.rs
+++ b/ant-node-manager/src/rpc.rs
@@ -88,6 +88,8 @@ pub async fn restart_node_service(
             rewards_address: current_node_clone.rewards_address,
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             service_user: current_node_clone.user.clone(),
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            stop_on_upgrade: true,
             write_older_cache_files: current_node_clone.write_older_cache_files,
         }
         .build()?;
@@ -207,6 +209,8 @@ pub async fn restart_node_service(
             rpc_socket_addr: current_node_clone.rpc_socket_addr,
             antnode_path: antnode_path.clone(),
             service_user: current_node_clone.user.clone(),
+            // This setting doesn't really matter because RPC will soon be taken out of use.
+            stop_on_upgrade: true,
             write_older_cache_files: current_node_clone.write_older_cache_files,
         }
         .build()?;

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -28,7 +28,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.2" }
+ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -82,6 +82,7 @@ rayon = "1.8.0"
 semver = "1.0"
 sha2 = "0.10"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
+serde_json = "1.0"
 strum = { version = "0.26.2", features = ["derive"] }
 sysinfo = { version = "0.30.8", default-features = false, optional = true }
 thiserror = "1.0.23"

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -28,6 +28,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-releases = { version = "0.4.2" }
 ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
@@ -41,6 +42,7 @@ custom_debug = "~0.6.1"
 dirs-next = "~2.0.0"
 eyre = "0.6.8"
 file-rotate = "0.7.3"
+fs2 = "0.4"
 futures = "~0.3.13"
 hex = "~0.4.3"
 hkdf = "0.12"
@@ -77,6 +79,7 @@ pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"], optional
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
+semver = "1.0"
 sha2 = "0.10"
 serde = { version = "1.0.133", features = ["derive", "rc"] }
 strum = { version = "0.26.2", features = ["derive"] }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -493,8 +493,11 @@ You can check your reward balance by running:
                         }
                         break;
                     }
+                    Err(upgrade::UpgradeError::AlreadyLatest) => {
+                        info!("Already running latest version");
+                    }
                     Err(e) => {
-                        error!("Error during upgrade process: {e}");
+                        warn!("Error during upgrade process: {e}");
                     }
                 }
             }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -232,6 +232,12 @@ struct Opt {
     /// Set this to true if you want the node to write the cache files in the older formats.
     #[clap(long, default_value_t = false)]
     write_older_cache_files: bool,
+
+    /// Stop the node instead of restarting after a successful upgrade.
+    ///
+    /// Useful when running under a service manager that handles restarts.
+    #[clap(long, default_value_t = false)]
+    stop_on_upgrade: bool,
 }
 
 /// Calculates a deterministic restart delay based on peer ID and network size.
@@ -388,8 +394,14 @@ fn main() -> Result<()> {
         };
         #[cfg(feature = "open-metrics")]
         node_builder.metrics_server_port(metrics_server_port);
-        let restart_options =
-            run_node(node_builder, opt.rpc, &log_output_dest, log_reload_handle).await?;
+        let restart_options = run_node(
+            node_builder,
+            opt.rpc,
+            &log_output_dest,
+            log_reload_handle,
+            opt.stop_on_upgrade,
+        )
+        .await?;
 
         Ok::<_, eyre::Report>(restart_options)
     })?;
@@ -418,6 +430,7 @@ async fn run_node(
     rpc: Option<SocketAddr>,
     log_output_dest: &str,
     log_reload_handle: ReloadHandle,
+    stop_on_upgrade: bool,
 ) -> Result<Option<(bool, PathBuf, u16)>> {
     let started_instant = std::time::Instant::now();
 
@@ -494,20 +507,28 @@ You can check your reward balance by running:
                 sleep(Duration::from_secs(delay_secs)).await;
                 match upgrade::perform_upgrade().await {
                     Ok(()) => {
-                        info!("Upgrade successful. Triggering restart...");
-
                         let delay = calculate_restart_delay(&running_node_clone).await;
-                        info!("Calculated restart delay: {delay:?}");
+                        info!("Calculated delay: {delay:?}");
                         sleep(delay).await;
 
-                        if let Err(err) = ctrl_tx_restart
-                            .send(NodeCtrl::Restart {
+                        let node_ctrl = if stop_on_upgrade {
+                            info!("Upgrade successful. Triggering stop...");
+                            NodeCtrl::Stop {
+                                delay: Duration::from_secs(0),
+                                result: StopResult::Success(
+                                    "Upgrade completed successfully".to_string(),
+                                ),
+                            }
+                        } else {
+                            info!("Upgrade successful. Triggering restart...");
+                            NodeCtrl::Restart {
                                 delay: Duration::from_secs(0),
                                 retain_peer_id: true,
-                            })
-                            .await
-                        {
-                            error!("Failed to send restart command: {err}");
+                            }
+                        };
+
+                        if let Err(err) = ctrl_tx_restart.send(node_ctrl).await {
+                            error!("Failed to send control command: {err}");
                         }
                         break;
                     }

--- a/ant-node/src/bin/antnode/rpc_service.rs
+++ b/ant-node/src/bin/antnode/rpc_service.rs
@@ -176,6 +176,7 @@ impl AntNode for SafeNodeRpcService {
         let kbuckets: HashMap<u32, k_buckets_response::Peers> =
             match self.running_node.get_kbuckets().await {
                 Ok(kbuckets) => kbuckets
+                    .0
                     .into_iter()
                     .map(|(ilog2_distance, peers)| {
                         let peers = peers.into_iter().map(|peer| peer.to_bytes()).collect();

--- a/ant-node/src/bin/antnode/upgrade.rs
+++ b/ant-node/src/bin/antnode/upgrade.rs
@@ -89,7 +89,12 @@ fn acquire_upgrade_lock(upgrade_dir: &Path) -> Result<File> {
     let lock_path = upgrade_dir.join(".lock");
     debug!("Acquiring lock at: {}", lock_path.display());
 
-    let lock_file = File::create(&lock_path)?;
+    let lock_file = File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
     let start = std::time::Instant::now();
     loop {
         match lock_file.try_lock_exclusive() {

--- a/ant-node/src/bin/antnode/upgrade.rs
+++ b/ant-node/src/bin/antnode/upgrade.rs
@@ -1,0 +1,297 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_releases::{AntReleaseRepoActions, AutonomiReleaseInfo};
+use color_eyre::{Result, eyre::eyre};
+use fs2::FileExt;
+use semver::Version;
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+const LOCK_TIMEOUT_SECS: u64 = 300; // 5 minutes
+const LOCK_RETRY_INTERVAL_MS: u64 = 100;
+
+/// Calculate SHA256 hash of a file.
+pub fn calculate_sha256(path: &Path) -> Result<String> {
+    debug!("Calculating SHA256 for: {}", path.display());
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    let result = hasher.finalize();
+    let hash = format!("{result:x}");
+    debug!("SHA256 hash: {hash}");
+    Ok(hash)
+}
+
+/// Verify that a binary's SHA256 hash matches the expected hash.
+pub fn verify_binary_hash(path: &Path, expected_hash: &str) -> Result<bool> {
+    let actual_hash = calculate_sha256(path)?;
+    let matches = actual_hash.eq_ignore_ascii_case(expected_hash);
+
+    if !matches {
+        warn!(
+            "Hash mismatch for {}: expected {}, got {}.",
+            path.display(),
+            expected_hash,
+            actual_hash
+        );
+    }
+
+    Ok(matches)
+}
+
+/// Get the upgrade directory path in the user's data directory.
+pub fn get_upgrade_dir_path() -> Result<PathBuf> {
+    let upgrade_dir_path = dirs_next::data_dir()
+        .ok_or_else(|| eyre!("Could not determine user data directory"))?
+        .join("autonomi")
+        .join("upgrades");
+    debug!("Upgrade directory: {}", upgrade_dir_path.display());
+    Ok(upgrade_dir_path)
+}
+
+/// Get the path where a binary for a specific version should be stored.
+pub fn get_binary_path_for_version(commit_hash: &str) -> Result<PathBuf> {
+    let upgrade_dir = get_upgrade_dir_path()?;
+    let binary_name = if cfg!(target_os = "windows") {
+        format!("antnode-{commit_hash}.exe")
+    } else {
+        format!("antnode-{commit_hash}")
+    };
+    Ok(upgrade_dir.join(binary_name))
+}
+
+/// Acquire an exclusive lock on the upgrade directory.
+///
+/// It's possible two or more processes could try to download and extract a new binary at the same
+/// time.
+///
+/// Returns the lock file handle that must be kept alive to maintain the lock.
+fn acquire_upgrade_lock(upgrade_dir: &Path) -> Result<File> {
+    let lock_path = upgrade_dir.join(".lock");
+    debug!("Acquiring lock at: {}", lock_path.display());
+
+    let lock_file = File::create(&lock_path)?;
+    let start = std::time::Instant::now();
+    loop {
+        match lock_file.try_lock_exclusive() {
+            Ok(_) => {
+                info!("Lock acquired");
+                return Ok(lock_file);
+            }
+            Err(_) if start.elapsed().as_secs() < LOCK_TIMEOUT_SECS => {
+                debug!("Lock busy. Retrying...");
+                std::thread::sleep(Duration::from_millis(LOCK_RETRY_INTERVAL_MS));
+            }
+            Err(_) => {
+                warn!(
+                    "Lock timeout after {} seconds. Proceeding without lock...",
+                    LOCK_TIMEOUT_SECS
+                );
+                // Proceed without exclusive lock: hash verification after download will catch any
+                // corruption if multiple processes race.
+                return Ok(lock_file);
+            }
+        }
+    }
+}
+
+/// Download and extract the upgrade binary to the shared location.
+///
+/// If the binary already exists with the correct hash, returns immediately.
+pub async fn download_and_extract_upgrade_binary(
+    release_info: &AutonomiReleaseInfo,
+    release_repo: &dyn AntReleaseRepoActions,
+) -> Result<(PathBuf, String)> {
+    info!("Starting upgrade binary download process");
+
+    let platform = ant_releases::get_running_platform()?;
+    debug!("Current platform: {:?}", platform);
+
+    let platform_binaries = release_info
+        .platform_binaries
+        .iter()
+        .find(|pb| pb.platform == platform)
+        .ok_or_else(|| eyre!("No binaries found for platform: {:?}", platform))?;
+    let antnode_binary = platform_binaries
+        .binaries
+        .iter()
+        .find(|b| b.name == "antnode")
+        .ok_or_else(|| {
+            eyre!(
+                "antnode binary not found in release for platform: {:?}",
+                platform
+            )
+        })?;
+    info!(
+        "Found antnode binary version {} with hash {}",
+        antnode_binary.version, antnode_binary.sha256
+    );
+
+    let target_path = get_binary_path_for_version(&release_info.commit_hash)?;
+    if target_path.exists() {
+        info!(
+            "Binary already exists at {}. Will now verify hash...",
+            target_path.display()
+        );
+        if let Ok(true) = verify_binary_hash(&target_path, &antnode_binary.sha256) {
+            info!("Existing binary hash verified. Will use binary that has already been obtained.");
+            return Ok((target_path, antnode_binary.sha256.clone()));
+        }
+        warn!("Existing binary verification failed. Will download again...");
+    }
+
+    let upgrade_dir_path = get_upgrade_dir_path()?;
+    fs::create_dir_all(&upgrade_dir_path)?;
+
+    let _lock = acquire_upgrade_lock(&upgrade_dir_path)?;
+
+    if target_path.exists() {
+        match verify_binary_hash(&target_path, &antnode_binary.sha256) {
+            Ok(true) => {
+                info!("Binary verified after acquiring lock. Will use existing binary.");
+                return Ok((target_path, antnode_binary.sha256.clone()));
+            }
+            Ok(false) | Err(_) => {
+                fs::remove_file(&target_path)?;
+            }
+        }
+    }
+
+    info!("Downloading antnode binary...");
+    let temp_download_dir_path = upgrade_dir_path.join("tmp");
+    fs::create_dir_all(&temp_download_dir_path)?;
+
+    let version = Version::parse(&antnode_binary.version)?;
+    let archive_type = ant_releases::ArchiveType::TarGz;
+    let callback: Box<dyn Fn(u64, u64) + Send + Sync> = Box::new(|downloaded, total| {
+        if total > 0 && downloaded % (total / 10).max(1) == 0 {
+            debug!("Download progress: {}/{} bytes", downloaded, total);
+        }
+    });
+
+    let archive_path = release_repo
+        .download_release_from_s3(
+            &ant_releases::ReleaseType::AntNode,
+            &version,
+            &platform,
+            &archive_type,
+            &temp_download_dir_path,
+            &callback,
+        )
+        .await?;
+    info!("Download complete. Extracting archive...");
+
+    let extracted_path =
+        release_repo.extract_release_archive(&archive_path, &temp_download_dir_path)?;
+    if !verify_binary_hash(&extracted_path, &antnode_binary.sha256)? {
+        return Err(eyre!(
+            "Downloaded binary hash does not match expected hash: {}",
+            antnode_binary.sha256
+        ));
+    }
+    info!("Binary hash verified successfully");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&extracted_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extracted_path, perms)?;
+    }
+    fs::rename(&extracted_path, &target_path)?;
+
+    let _ = fs::remove_dir_all(&temp_download_dir_path);
+    info!("Binary successfully prepared at: {}", target_path.display());
+    Ok((target_path, antnode_binary.sha256.clone()))
+}
+
+pub fn replace_current_binary(new_binary_path: &Path, expected_hash: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        info!("Starting in-place binary replacement");
+
+        if !verify_binary_hash(new_binary_path, expected_hash)? {
+            return Err(eyre!("New binary hash verification failed"));
+        }
+
+        let mut current_exe_path = std::env::current_exe()?;
+        let current_exe_str = current_exe_path.to_string_lossy();
+        if current_exe_str.ends_with(" (deleted)") {
+            let cleaned = current_exe_str.trim_end_matches(" (deleted)");
+            current_exe_path = PathBuf::from(cleaned);
+        }
+        info!("Current executable: {}", current_exe_path.display());
+
+        // In this case another process has already upgraded the binary, so the rename that occurs
+        // below doesn't need to happen again.
+        if current_exe_path.exists()
+            && let Ok(current_hash) = calculate_sha256(&current_exe_path)
+            && current_hash == expected_hash
+        {
+            info!("Current binary already matches upgrade hash");
+            return Ok(());
+        }
+
+        // The reason for this copy is because you cannot *copy* over a running binary, only
+        // rename/move. If we didn't do the copy, it would move the cached binary and other
+        // processes would need to download it again.
+        let temp_path = current_exe_path.with_extension(format!("tmp-{}", std::process::id()));
+        fs::copy(new_binary_path, &temp_path)?;
+
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&temp_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&temp_path, perms)?;
+        fs::rename(&temp_path, &current_exe_path)?;
+
+        info!(
+            "Successfully replaced binary at: {}",
+            current_exe_path.display()
+        );
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        Err(eyre!(
+            "Automatic upgrade is only supported on Unix platforms (Linux/macOS)"
+        ))
+    }
+}
+
+pub async fn perform_upgrade() -> Result<()> {
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
+    let release_info = release_repo.get_latest_autonomi_release_info().await?;
+    if release_info
+        .commit_hash
+        .starts_with(ant_build_info::git_sha())
+    {
+        return Err(eyre!("Already running latest version"));
+    }
+    info!("New version detected: {}", release_info.commit_hash);
+
+    let (new_binary_path, expected_hash) =
+        download_and_extract_upgrade_binary(&release_info, release_repo.as_ref()).await?;
+    replace_current_binary(&new_binary_path, &expected_hash)?;
+
+    Ok(())
+}

--- a/ant-node/src/bin/antnode/upgrade/error.rs
+++ b/ant-node/src/bin/antnode/upgrade/error.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[allow(dead_code)]
+pub enum UpgradeError {
+    #[error("Already running latest version")]
+    AlreadyLatest,
+
+    #[error("Failed to fetch release info: {0}")]
+    FetchReleaseInfoFailed(String),
+
+    #[error("No binaries found for platform: {0}")]
+    PlatformBinariesNotFound(String),
+
+    #[error("Binary download failed: {0}")]
+    DownloadFailed(String),
+
+    #[error("Binary hash verification failed")]
+    HashVerificationFailed,
+
+    #[error("Binary replacement failed: {0}")]
+    BinaryReplacementFailed(String),
+
+    #[error("Failed to manage upgrade lock: {0}")]
+    LockError(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("Release error: {0}")]
+    Release(#[from] ant_releases::Error),
+
+    #[error("Version parsing error: {0}")]
+    VersionParsing(#[from] semver::Error),
+}
+
+pub type Result<T> = std::result::Result<T, UpgradeError>;

--- a/ant-node/src/bin/antnode/upgrade/release_cache.rs
+++ b/ant-node/src/bin/antnode/upgrade/release_cache.rs
@@ -7,8 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ant_releases::AutonomiReleaseInfo;
-use color_eyre::Result;
 use serde::{Deserialize, Serialize};
+
+use super::Result;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read as _, Seek, SeekFrom, Write as _};
 use std::path::{Path, PathBuf};

--- a/ant-node/src/bin/antnode/upgrade/release_cache.rs
+++ b/ant-node/src/bin/antnode/upgrade/release_cache.rs
@@ -1,0 +1,261 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ant_releases::AutonomiReleaseInfo;
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read as _, Seek, SeekFrom, Write as _};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tracing::{debug, info, warn};
+
+const CACHE_TTL_SECS: u64 = 3600; // 1 hour
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedReleaseInfo {
+    pub release_info: AutonomiReleaseInfo,
+    pub cached_at: SystemTime,
+}
+
+impl CachedReleaseInfo {
+    /// Check if the cache is still valid based on TTL
+    pub fn is_valid(&self) -> bool {
+        match self.cached_at.elapsed() {
+            Ok(elapsed) => elapsed < Duration::from_secs(CACHE_TTL_SECS),
+            Err(_) => {
+                // SystemTime went backwards (clock adjustment)
+                warn!("Clock skew detected - invalidating cache");
+                false
+            }
+        }
+    }
+}
+
+/// Get the path to the release info cache file
+///
+/// The optional directory is for testing purposes.
+pub fn get_release_cache_path(cache_path: Option<&Path>) -> Result<PathBuf> {
+    let upgrade_path = match cache_path {
+        Some(dir) => dir.to_path_buf(),
+        None => super::get_upgrade_dir_path()?,
+    };
+    Ok(upgrade_path.join("release_info_cache.json"))
+}
+
+/// Get the path to the release cache lock file
+///
+/// The optional directory is for testing purposes.
+fn get_release_cache_lock_path(cache_path: Option<&Path>) -> Result<PathBuf> {
+    let upgrade_path = match cache_path {
+        Some(dir) => dir.to_path_buf(),
+        None => super::get_upgrade_dir_path()?,
+    };
+    Ok(upgrade_path.join(".release_info.lock"))
+}
+
+/// Acquire exclusive lock on the release cache
+fn acquire_release_cache_lock(lock_path: &Path) -> Result<File> {
+    super::acquire_exclusive_lock(lock_path, "Release cache lock")
+}
+
+/// Read cached release info from disk
+///
+/// The optional directory is for testing purposes.
+pub fn read_cached_release_info(cache_path: Option<&Path>) -> Result<Option<CachedReleaseInfo>> {
+    let cache_path = get_release_cache_path(cache_path)?;
+
+    if !cache_path.exists() {
+        debug!("Release cache file does not exist");
+        return Ok(None);
+    }
+
+    let mut file = File::open(&cache_path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+
+    match serde_json::from_str::<CachedReleaseInfo>(&contents) {
+        Ok(cached) => {
+            if cached.is_valid() {
+                info!(
+                    "Valid release cache found (age: {:?})",
+                    cached.cached_at.elapsed().unwrap_or_default()
+                );
+                Ok(Some(cached))
+            } else {
+                info!("Release cache expired");
+                Ok(None)
+            }
+        }
+        Err(e) => {
+            warn!("Failed to parse release cache: {}", e);
+            // Delete corrupted cache
+            let _ = fs::remove_file(&cache_path);
+            Ok(None)
+        }
+    }
+}
+
+/// Write release info to cache with proper locking
+///
+/// The optional directory is for testing purposes.
+pub fn write_cached_release_info(
+    release_info: &AutonomiReleaseInfo,
+    cache_dir_path: Option<&Path>,
+) -> Result<()> {
+    let cache_path = get_release_cache_path(cache_dir_path)?;
+    let lock_path = get_release_cache_lock_path(cache_dir_path)?;
+
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let _lock = acquire_release_cache_lock(&lock_path)?;
+
+    #[allow(clippy::suspicious_open_options)]
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&cache_path)?;
+
+    let cached = CachedReleaseInfo {
+        release_info: release_info.clone(),
+        cached_at: SystemTime::now(),
+    };
+
+    let json = serde_json::to_string_pretty(&cached)?;
+
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    file.sync_all()?;
+
+    info!("Release cache written to disk: {}", cache_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ant_releases::{BinaryInfo, Platform, PlatformBinaries};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn create_test_release_info() -> AutonomiReleaseInfo {
+        AutonomiReleaseInfo {
+            commit_hash: "abc123def456".to_string(),
+            name: "v0.1.0".to_string(),
+            platform_binaries: vec![PlatformBinaries {
+                platform: Platform::LinuxMusl,
+                binaries: vec![BinaryInfo {
+                    name: "antnode".to_string(),
+                    version: "0.1.0".to_string(),
+                    sha256: "deadbeef".to_string(),
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn test_cache_write_and_read() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let cache_dir = temp_dir.path();
+
+        let release_info = create_test_release_info();
+
+        write_cached_release_info(&release_info, Some(cache_dir))?;
+
+        let cached = read_cached_release_info(Some(cache_dir))?.expect("Cache should exist");
+
+        assert_eq!(cached.release_info.commit_hash, "abc123def456");
+        assert_eq!(cached.release_info.name, "v0.1.0");
+        assert!(cached.is_valid());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cache_expiration() {
+        let cached = CachedReleaseInfo {
+            release_info: create_test_release_info(),
+            cached_at: SystemTime::now() - Duration::from_secs(CACHE_TTL_SECS + 1),
+        };
+
+        assert!(!cached.is_valid(), "Cache should be expired");
+    }
+
+    #[test]
+    fn test_concurrent_cache_access() -> Result<()> {
+        const THREAD_COUNT: usize = 10;
+        const ITERATIONS_PER_THREAD: usize = 5;
+
+        let temp_dir = tempfile::tempdir()?;
+        let cache_dir = temp_dir.path().to_path_buf();
+
+        let barrier = Arc::new(Barrier::new(THREAD_COUNT + 1));
+        let mut handles = Vec::with_capacity(THREAD_COUNT);
+
+        let release_info = create_test_release_info();
+        write_cached_release_info(&release_info, Some(&cache_dir))?;
+
+        for thread_id in 0..THREAD_COUNT {
+            let barrier_clone = Arc::clone(&barrier);
+            let cache_dir_clone = cache_dir.clone();
+
+            handles.push(thread::spawn(move || {
+                barrier_clone.wait();
+
+                for i in 0..ITERATIONS_PER_THREAD {
+                    if thread_id % 2 == 0 {
+                        let _ = read_cached_release_info(Some(&cache_dir_clone));
+                    } else {
+                        let mut info = create_test_release_info();
+                        info.commit_hash = format!("commit_{thread_id}_{i}");
+                        let _ = write_cached_release_info(&info, Some(&cache_dir_clone));
+                    }
+                }
+            }));
+        }
+
+        barrier.wait();
+
+        for handle in handles {
+            handle.join().expect("Thread should complete successfully");
+        }
+
+        let final_cached = read_cached_release_info(Some(&cache_dir))?;
+        assert!(
+            final_cached.is_some(),
+            "Cache should exist after concurrent access"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_corrupted_cache_recovery() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let cache_dir = temp_dir.path();
+        let cache_path = get_release_cache_path(Some(cache_dir))?;
+
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::write(&cache_path, b"{ invalid json }")?;
+
+        let result = read_cached_release_info(Some(cache_dir))?;
+        assert!(result.is_none(), "Corrupted cache should return None");
+        assert!(!cache_path.exists(), "Corrupted cache should be deleted");
+
+        Ok(())
+    }
+}

--- a/ant-node/src/lib.rs
+++ b/ant-node/src/lib.rs
@@ -148,11 +148,18 @@ impl RunningNode {
         Ok(addresses)
     }
 
-    /// Returns a map where each key is the ilog2 distance of that Kbucket and each value is a vector of peers in that
-    /// bucket.
-    pub async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
+    /// Returns a two-element tuple, where the first element is a map where each key is the ilog2
+    /// distance of that Kbucket and each value is a vector of peers in that bucket, and the second
+    /// element is the estimated network size.
+    pub async fn get_kbuckets(&self) -> Result<(BTreeMap<u32, Vec<PeerId>>, usize)> {
         let kbuckets = self.network.get_kbuckets().await?;
         Ok(kbuckets)
+    }
+
+    /// Returns the estimated network size based on the current kbucket state.
+    pub async fn get_estimated_network_size(&self) -> Result<usize> {
+        let kbuckets = self.get_kbuckets().await?;
+        Ok(kbuckets.1)
     }
 
     /// Returns the node's reward address

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -390,7 +390,9 @@ impl SwarmDriver {
                         error!("bucket is ourself ???!!!");
                     }
                 }
-                let _ = sender.send(ilog2_kbuckets);
+
+                let status = self.get_kbuckets_status();
+                let _ = sender.send((ilog2_kbuckets, status.estimated_network_size));
             }
             LocalSwarmCmd::GetPeersWithMultiaddr { sender } => {
                 cmd_string = "GetPeersWithMultiAddr";

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -64,7 +64,7 @@ pub(crate) enum LocalSwarmCmd {
     /// Get a map where each key is the ilog2 distance of that Kbucket
     /// and each value is a vector of peers in that bucket.
     GetKBuckets {
-        sender: oneshot::Sender<BTreeMap<u32, Vec<PeerId>>>,
+        sender: oneshot::Sender<(BTreeMap<u32, Vec<PeerId>>, usize)>,
     },
     // Get K closest peers to target from the local RoutingTable, self is included
     GetKCloseLocalPeersToTarget {

--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -208,6 +208,7 @@ fn init_swarm_driver(
         "Self PeerID {peer_id} is represented as kbucket_key {:?}",
         PrettyPrintKBucketKey(NetworkAddress::from(peer_id).as_kbucket_key())
     );
+    info!("Node is running on port: {}", config.listen_addr.port());
 
     #[cfg(feature = "open-metrics")]
     let mut metrics_registries = config.metrics_registries;

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -109,10 +109,12 @@ impl Network {
             .map_err(|_e| NetworkError::InternalMsgChannelDropped)
     }
 
-    /// Returns a map where each key is the ilog2 distance of that Kbucket
-    /// and each value is a vector of peers in that bucket.
+    /// Returns a two-element tuple, where the first element is a map where each key is the ilog2
+    /// distance of that Kbucket and each value is a vector of peers in that bucket, and the second
+    /// element is the estimated network size.
+    ///
     /// Does not include self
-    pub(crate) async fn get_kbuckets(&self) -> Result<BTreeMap<u32, Vec<PeerId>>> {
+    pub(crate) async fn get_kbuckets(&self) -> Result<(BTreeMap<u32, Vec<PeerId>>, usize)> {
         let (sender, receiver) = oneshot::channel();
         self.send_local_swarm_cmd(LocalSwarmCmd::GetKBuckets { sender });
         receiver

--- a/ant-node/src/networking/transport.rs
+++ b/ant-node/src/networking/transport.rs
@@ -9,9 +9,9 @@
 #[cfg(feature = "open-metrics")]
 use crate::networking::MetricsRegistries;
 use libp2p::{
+    PeerId, Transport as _,
     core::{muxing::StreamMuxerBox, transport},
     identity::Keypair,
-    PeerId, Transport as _,
 };
 
 pub(crate) fn build_transport(

--- a/ant-node/src/python.rs
+++ b/ant-node/src/python.rs
@@ -160,6 +160,7 @@ impl PyAntNode {
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to get kbuckets: {e}")))?;
 
             Ok(kbuckets
+                .0
                 .into_iter()
                 .map(|(distance, peers)| {
                     (

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -22,7 +22,7 @@ prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0.20"
-service-manager = "0.8.0"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43.1", features = ["time"] }

--- a/ant-service-management/src/daemon.rs
+++ b/ant-service-management/src/daemon.rs
@@ -77,9 +77,9 @@ impl ServiceStateActions for DaemonService {
             environment: None,
             label: self.service_data.read().await.service_name.parse()?,
             program: self.service_data.read().await.daemon_path.clone(),
+            restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
             username: None,
             working_directory: None,
-            disable_restart_on_failure: false,
         };
         Ok(install_ctx)
     }

--- a/ant-service-management/src/node/mod.rs
+++ b/ant-service-management/src/node/mod.rs
@@ -142,9 +142,9 @@ impl ServiceStateActions for NodeService {
             environment: options.env_variables,
             label: label.clone(),
             program: service_data.antnode_path.to_path_buf(),
+            restart_policy: service_manager::RestartPolicy::Always { delay_secs: None },
             username: service_data.user.clone(),
             working_directory: None,
-            disable_restart_on_failure: true,
         })
     }
 

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -8,7 +8,7 @@
 
 use crate::networking::{Quorum, RetryStrategy, Strategy};
 pub use ant_bootstrap::{
-    error::Error as BootstrapError, Bootstrap, BootstrapConfig, InitialPeersConfig,
+    Bootstrap, BootstrapConfig, InitialPeersConfig, error::Error as BootstrapError,
 };
 use ant_evm::EvmNetwork;
 use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;

--- a/autonomi/src/client/data_types/chunk.rs
+++ b/autonomi/src/client/data_types/chunk.rs
@@ -140,7 +140,7 @@ impl Client {
 
     /// Helper function to fetch a record from the closest peers directly.
     /// This is useful as a fallback when normal DHT queries fail.
-    /// 
+    ///
     /// Returns the first successfully retrieved record, or None if all peers fail.
     async fn fetch_record_from_closest_peers(
         &self,
@@ -148,8 +148,12 @@ impl Client {
         num_peers: usize,
     ) -> Option<Record> {
         debug!("Querying closest {num_peers} nodes directly for {key:?}");
-        
-        let closest_peers = match self.network.get_closest_peers(key.clone(), Some(num_peers)).await {
+
+        let closest_peers = match self
+            .network
+            .get_closest_peers(key.clone(), Some(num_peers))
+            .await
+        {
             Ok(peers) => peers,
             Err(e) => {
                 error!("Failed to get closest peers for {key:?}: {e}");
@@ -157,17 +161,18 @@ impl Client {
             }
         };
 
-        debug!("Querying {} closest peers in parallel for {key:?}", closest_peers.len());
-        
+        debug!(
+            "Querying {} closest peers in parallel for {key:?}",
+            closest_peers.len()
+        );
+
         // Create query tasks for all closest peers
         let mut query_tasks = vec![];
         for peer in closest_peers.iter() {
             let network = self.network.clone();
             let key = key.clone();
             let peer = peer.clone();
-            query_tasks.push(async move {
-                network.get_record_from_peer(key, peer).await
-            });
+            query_tasks.push(async move { network.get_record_from_peer(key, peer).await });
         }
 
         // Process tasks with max concurrency of num_peers
@@ -184,7 +189,10 @@ impl Client {
             }
         }
 
-        error!("❌ All {} closest peers failed to return the record {key:?}", closest_peers.len());
+        error!(
+            "❌ All {} closest peers failed to return the record {key:?}",
+            closest_peers.len()
+        );
         None
     }
 

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -66,7 +66,13 @@ impl Client {
         peer: PeerInfo,
         nonce: u64,
         difficulty: usize,
-    ) -> Result<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>, NetworkError> {
+    ) -> Result<
+        Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
+        NetworkError,
+    > {
         self.network
             .get_storage_proofs_from_peer(network_address.into(), peer, nonce, difficulty)
             .await

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -175,8 +175,11 @@ impl NetworkDriver {
                 peer_address,
                 storage_proofs,
             }) => {
-                if self.pending_tasks
-                    .update_get_quote(request_id, quote, peer_address).is_err() {
+                if self
+                    .pending_tasks
+                    .update_get_quote(request_id, quote, peer_address)
+                    .is_err()
+                {
                     self.pending_tasks
                         .update_get_storage_proofs_from_peer(request_id, storage_proofs)?;
                 }

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -50,7 +50,15 @@ pub(crate) struct TaskHandler {
     get_record_accumulator: HashMap<QueryId, HashMap<PeerId, Record>>,
     get_version: HashMap<OutboundRequestId, OneShotTaskResult<String>>,
     get_record_from_peer: HashMap<OutboundRequestId, OneShotTaskResult<Option<Record>>>,
-    get_storage_proofs_from_peer: HashMap<OutboundRequestId, OneShotTaskResult<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>>>,
+    get_storage_proofs_from_peer: HashMap<
+        OutboundRequestId,
+        OneShotTaskResult<
+            Vec<(
+                NetworkAddress,
+                Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+            )>,
+        >,
+    >,
 }
 
 impl TaskHandler {
@@ -455,16 +463,22 @@ impl TaskHandler {
     pub fn update_get_storage_proofs_from_peer(
         &mut self,
         id: OutboundRequestId,
-        storage_proofs: Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>,
+        storage_proofs: Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
     ) -> Result<(), TaskHandlerError> {
-        let responder = self
-            .get_storage_proofs_from_peer
-            .remove(&id)
-            .ok_or(TaskHandlerError::UnknownQuery(format!(
-                "OutboundRequestId {id:?}"
-            )))?;
+        let responder =
+            self.get_storage_proofs_from_peer
+                .remove(&id)
+                .ok_or(TaskHandlerError::UnknownQuery(format!(
+                    "OutboundRequestId {id:?}"
+                )))?;
 
-        trace!("OutboundRequestId({id}): got {} storage proofs", storage_proofs.len());
+        trace!(
+            "OutboundRequestId({id}): got {} storage proofs",
+            storage_proofs.len()
+        );
         responder
             .send(Ok(storage_proofs))
             .map_err(|_| TaskHandlerError::NetworkClientDropped(format!("{id:?}")))?;

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -10,8 +10,8 @@ use crate::networking::OneShotTaskResult;
 use ant_evm::PaymentQuote;
 use ant_protocol::NetworkAddress;
 use libp2p::{
-    kad::{PeerInfo, Quorum, Record},
     PeerId,
+    kad::{PeerInfo, Quorum, Record},
 };
 use std::num::NonZeroUsize;
 

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -391,7 +391,13 @@ impl Network {
         peer: PeerInfo,
         nonce: u64,
         difficulty: usize,
-    ) -> Result<Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>, NetworkError> {
+    ) -> Result<
+        Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
+        NetworkError,
+    > {
         let (tx, rx) = oneshot::channel();
         let task = NetworkTask::GetStorageProofsFromPeer {
             addr,

--- a/autonomi/src/utils.rs
+++ b/autonomi/src/utils.rs
@@ -25,10 +25,7 @@ where
         .buffer_unordered(batch_size)
         .collect()
         .await;
-    info!(
-        "Completed {} tasks in parallel.",
-        result.len()
-    );
+    info!("Completed {} tasks in parallel.", result.len());
     result
 }
 

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 semver = "1.0.20"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -24,7 +24,7 @@ ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.13.4", path = "../ant-node-manager" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.2" }
+ant-releases = "0.4.3"
 ant-service-management = { version = "0.4.17", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -24,7 +24,7 @@ ant-evm = { path = "../ant-evm", version = "0.1.17" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.13.4", path = "../ant-node-manager" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-ant-releases = { version = "0.4.1" }
+ant-releases = { version = "0.4.2" }
 ant-service-management = { version = "0.4.17", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"

--- a/node-launchpad/src/node_mgmt.rs
+++ b/node-launchpad/src/node_mgmt.rs
@@ -15,6 +15,7 @@ use ant_releases::{self, AntReleaseRepoActions, ReleaseType};
 use ant_service_management::NodeRegistryManager;
 use color_eyre::Result;
 use color_eyre::eyre::eyre;
+use service_manager::RestartPolicy;
 use std::{path::PathBuf, str::FromStr};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc::{self, UnboundedSender};
@@ -441,6 +442,7 @@ async fn add_node(args: MaintainNodesArgs, node_registry: NodeRegistryManager) {
         node_registry.clone(),
         config.init_peers_config.clone(),
         config.relay, // relay,
+        RestartPolicy::Never,
         RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
         None,                        // rpc_address,
         None,                        // rpc_port,
@@ -683,6 +685,7 @@ async fn scale_down_nodes(config: &NodeConfig, count: u16, node_registry: NodeRe
         config.init_peers_config.clone(),
         config.relay,
         RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
+        RestartPolicy::Never,
         None,
         None,
         config.antnode_path.clone(),
@@ -759,6 +762,7 @@ async fn add_nodes(
             config.init_peers_config.clone(),
             config.relay,
             RewardsAddress::from_str(config.rewards_address.as_str()).unwrap(),
+            RestartPolicy::Never,
             None,
             None,
             config.antnode_path.clone(),


### PR DESCRIPTION
- 60a3fc9c2 **chore: utility target for providing binary hashes**

  The automatic upgrading process is going to require the sha256 hashes of the binaries be included in
  the information for each release.

  This new target in the Justfile can operate on the populated `artifacts` directory to get all the
  hashes. It will output them in a markdown table which can be pasted into the release description.

- c9ed698d3 **feat: `antnode` automatic upgrades for unix platforms**

  Automatic upgrades aim to make it as easy as possible for node operators to obtain new versions of
  the `antnode` binary. We also provide a 'staggering' mechanism to attempt to avoid the turbulence
  caused when everyone upgrades around the same time. If the majority of operators use this feature,
  we should see better network health and stability, because newer versions of the node will propagate
  quicker and safer.

  Initially, we only support Linux and macOS. The Windows operating system does not allow a binary
  associated with a running process to be overwritten, which is part of the upgrade process (see
  below).

  An upgrade is performed by a background thread that wakes up every 72 hours.

  After the upgrade is performed, the restart of the binary is delayed for a period of time that is
  determined by taking the hash of the peer ID and the size of the network into account, with a cap of
  72 hours. This is to make the upgrades 'staggered', to avoid many thousands of node processes
  restarting at the same time. To facilitate the calculation, the `get_kbuckets` API is slightly
  modified to return the estimated network size.

  The upgrade process works as follows:

  * Get the latest release information from the `autonomi` repository.
  * If the commit hash of the latest release matches the commit hash of the currently running binary,
    do nothing and the process ends. Otherwise the upgrade proceeds.
  * Get the currently running platform. This information is used to locate the correct binary and
    sha256 hash.
  * Check if another `antnode` process has already downloaded the new binary to a temporary location
    and its sha256 hash matches that of the binary from the fetched release information. This will
    prevent many `antnode` processes continually downloading the new binary. If the new binary has not
    already been downloaded, it will be downloaded and extracted to the temporary location.
  * The hash of the downloaded binary will be compared to the hash of the binary in the new release
    information.
  * The binary of the currently running process will be overwritten by the new binary. We will check
    to see if the hash of the running binary matches the hash of the upgrade binary; in this case,
    another process already upgraded the binary and we don't need to do anything.

  If an upgrade occurred, the `antnode` process will be restarted after a delay of some period, as
  mentioned above.

  Given the more elaborate implementation of automatic upgrades, the workflow for self restarting was
  deleted.

- a506e71c6 **chore!: use 'always' restart policy for `antctl add`**

  BREAKING CHANGE: new node deployments with `antctl` will apply a different restart policy.

  With `antctl` we are going to configure services for node deployments to always restart. This is so
  we can use the node deployments with the automatic upgrades feature and let the service manager
  handle the restart of the `antnode` process. If `antnode` itself were to restart the process, the
  service manager would consider it to be dead, which would break the status tracking for `antctl`.

  We need to provide a `--stop-on-upgrade` argument for `antnode` such that it will stop the process
  on the upgrade rather than restart it, and allow the service manager to perform the restart. This
  will be coming in the next commit.

  The `node-launchpad` has been configured to use 'never' for the restart policy because we ran into
  problems with the UPnP feature if the launchpad continually restarted nodes. So automatic upgrades
  just won't be supported when using the launchpad. We will need to provide another `antnode` argument
  to disable automatic upgrades, which will come in another commit.

- 5e5528283 **feat: provide `--stop-on-upgrade` argument for `antctl`**

  If this argument is used the node will be stopped after it is upgraded, rather than restarted.

  This is to allow the service manager to restart the process if the node is being run in this
  context, which it will be if it is deployed using `antctl`, which is updated in this commit to
  always supply the argument as part of the service definition for a node.

- 48ec66a98 **chore: improve logging for upgrades**

  I added the information I found useful during the development process.

- 609a2a2a8 **fix: do not truncate upgrade lock file**

  By examining the logs on a testnet run I determined all the `antnode` processes on the same
  host downloaded the upgrade binary. This is something we expressly wanted to avoid.

  The problem was the `File::create` function was truncating the lock file. It has now been changed to
  avoid this behaviour, so other processes should wait to acquire the lock.

- d84051e89 **chore: output node port to log**

  This will be used to verify all nodes participating in the automatic-upgrade process will be
  restarted with the same port.
  
- 03b5e9acd **feat: provide cache for release info**

  In a similar fashion to the cache for the upgrade binary, we provide a cache for the release
  information.

  While performing a test with 5000 nodes I got rate limited by Github when thousands of processes
  queried for the release information at approximately the same time. Now it should only be one query
  per host.

- ef9e8e6af **chore: use sha256 hash in restart delay calculation**

  In the test run with 1000 nodes we observed a distribution of restart times that seemed a bit too
  tightly clustered.

  Using this alternative hashing mechanism resulted in a distribution that was more even.

  The restart delay calculation is also moved outside the loop because it only needs to be calculated
  once.

- 7b89cac04 **chore: more elaborate error handling**

  An `UpgradeError` type is introduced to make it easier to distinguish between errors and the case
  where there is no new release available. The latter of those will now log at `INFO` level.