### PR TITLE
feat: support upload of large files in 4GB batches

### DIFF
--- a/ant-evm/src/merkle_payments/mod.rs
+++ b/ant-evm/src/merkle_payments/mod.rs
@@ -21,6 +21,6 @@ pub use merkle_payment::{
     MerklePaymentVerificationError,
 };
 pub use merkle_tree::{
-    BadMerkleProof, MERKLE_PAYMENT_EXPIRATION, MerkleBranch, MerkleTree, MerkleTreeError,
-    MidpointProof, verify_merkle_proof,
+    BadMerkleProof, MAX_LEAVES, MERKLE_PAYMENT_EXPIRATION, MerkleBranch, MerkleTree,
+    MerkleTreeError, MidpointProof, verify_merkle_proof,
 };

--- a/autonomi/src/client/merkle_payments/file.rs
+++ b/autonomi/src/client/merkle_payments/file.rs
@@ -293,11 +293,12 @@ impl Client {
 
             // report progress
             if let Some(public_addr) = stream.data_address() {
-                let relative_path = stream.relative_path.clone();
+                let path = &stream.relative_path;
+                let f = results.len();
+                debug!("[File {f}/{total_files}] ({path:?}) is now available at: {public_addr:?}");
                 #[cfg(feature = "loud")]
                 println!(
-                    "[File {}/{total_files}] ({relative_path:?}) is now available at: {public_addr:?}",
-                    results.len(),
+                    "[File {f}/{total_files}] ({path:?}) is now available at: {public_addr:?}"
                 );
             }
         }
@@ -407,6 +408,7 @@ impl Client {
         })?;
 
         let batch_size = batch_xornames.len();
+        debug!("Merkle Tree {batch_num}/{num_batches}: Paying for {batch_size} chunks...");
         #[cfg(feature = "loud")]
         println!("💸 Merkle Tree {batch_num}/{num_batches}: Paying for {batch_size} chunks...");
 
@@ -443,10 +445,10 @@ fn collect_xor_names_from_stream(mut encryption_stream: EncryptionStream) -> Vec
     let mut total = 0;
     let estimated_total = encryption_stream.total_chunks();
     let file_path = &encryption_stream.file_path;
-    #[cfg(feature = "loud")]
     let start = std::time::Instant::now();
     #[cfg(feature = "loud")]
     println!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
+    debug!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
     while let Some(batch) = encryption_stream.next_batch(xorname_collection_batch_size) {
         let batch_len = batch.len();
         total += batch_len;
@@ -455,6 +457,10 @@ fn collect_xor_names_from_stream(mut encryption_stream: EncryptionStream) -> Vec
         }
         #[cfg(feature = "loud")]
         println!(
+            "Encrypted {total}/{estimated_total} chunks in {:?}",
+            start.elapsed()
+        );
+        debug!(
             "Encrypted {total}/{estimated_total} chunks in {:?}",
             start.elapsed()
         );

--- a/autonomi/src/client/merkle_payments/file.rs
+++ b/autonomi/src/client/merkle_payments/file.rs
@@ -366,10 +366,11 @@ fn collect_xor_names_from_stream(mut encryption_stream: EncryptionStream) -> Vec
     let xorname_collection_batch_size: usize = std::cmp::max(32, *CHUNK_UPLOAD_BATCH_SIZE);
     let mut total = 0;
     let estimated_total = encryption_stream.total_chunks();
+    let file_path = &encryption_stream.file_path;
     #[cfg(feature = "loud")]
     let start = std::time::Instant::now();
     #[cfg(feature = "loud")]
-    println!("Begin encrypting ~{estimated_total} chunks...");
+    println!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
     while let Some(batch) = encryption_stream.next_batch(xorname_collection_batch_size) {
         let batch_len = batch.len();
         total += batch_len;

--- a/autonomi/src/client/merkle_payments/mod.rs
+++ b/autonomi/src/client/merkle_payments/mod.rs
@@ -10,6 +10,6 @@ mod file;
 mod payments;
 mod upload;
 
-pub use file::{MerkleFilePutError, MerklePaymentOption};
+pub use file::{MerklePaymentOption, MerkleUploadError, MerkleUploadErrorWithReceipt};
 pub use payments::{MerklePaymentError, MerklePaymentReceipt};
 pub use upload::MerklePutError;

--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -112,22 +112,20 @@ impl Client {
                 _ => {
                     // Stream exhausted - harvest datamap and remove stream
                     let exhausted_stream = streams.remove(0);
-                    let relative_path = exhausted_stream.relative_path.clone();
+                    let path = exhausted_stream.relative_path.clone();
                     let metadata = exhausted_stream.metadata.clone();
                     let datamap = exhausted_stream
                         .data_map_chunk()
                         .ok_or(MerklePutError::StreamShouldHaveDatamap)?;
-                    completed_files.push((relative_path.clone(), datamap, metadata));
+                    completed_files.push((path.clone(), datamap, metadata));
 
                     // report progress
-                    let completed_files_count = total_files - streams.len();
-                    if let Some(public_addr) = exhausted_stream.data_address() {
+                    let f = total_files - streams.len();
+                    if let Some(a) = exhausted_stream.data_address() {
+                        debug!("[File {f}/{total_files}] ({path:?}) is now available at: {a:?}");
                         #[cfg(feature = "loud")]
-                        println!(
-                            "[File {completed_files_count}/{total_files}] ({relative_path:?}) is now available at: {public_addr:?}"
-                        );
+                        println!("[File {f}/{total_files}] ({path:?}) is now available at: {a:?}");
                     }
-                    debug!("File completed: {relative_path:?}");
                 }
             }
         }

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -66,7 +66,7 @@ const CLIENT_EVENT_CHANNEL_SIZE: usize = 100;
 
 // Amount of peers to confirm into our routing table before we consider the client ready.
 use crate::client::config::ClientOperatingStrategy;
-use crate::client::merkle_payments::MerkleFilePutError;
+use crate::client::merkle_payments::MerkleUploadError;
 use crate::networking::{Multiaddr, Network, NetworkAddress, NetworkError, multiaddr_is_global};
 pub use ant_protocol::CLOSE_GROUP_SIZE;
 use ant_protocol::storage::RecordKind;
@@ -151,7 +151,7 @@ pub enum PutError {
     #[error("Batch upload: {0}")]
     Batch(ChunkBatchUploadState),
     #[error("Merkle batch upload: {0}")]
-    MerkleBatch(MerkleFilePutError),
+    MerkleBatch(MerkleUploadError),
 }
 
 /// Errors that can occur during the get operation.

--- a/evmlib/src/merkle_batch_payment.rs
+++ b/evmlib/src/merkle_batch_payment.rs
@@ -29,7 +29,7 @@ pub type PoolHash = [u8; 32];
 pub const CANDIDATES_PER_POOL: usize = 16;
 
 /// Maximum supported Merkle tree depth
-pub const MAX_MERKLE_DEPTH: u8 = 12;
+pub const MAX_MERKLE_DEPTH: u8 = 10;
 
 /// Calculate expected number of reward pools for a given tree depth
 ///

--- a/evmlib/src/merkle_batch_payment.rs
+++ b/evmlib/src/merkle_batch_payment.rs
@@ -29,7 +29,7 @@ pub type PoolHash = [u8; 32];
 pub const CANDIDATES_PER_POOL: usize = 16;
 
 /// Maximum supported Merkle tree depth
-pub const MAX_MERKLE_DEPTH: u8 = 5;
+pub const MAX_MERKLE_DEPTH: u8 = 10;
 
 /// Calculate expected number of reward pools for a given tree depth
 ///

--- a/evmlib/src/merkle_batch_payment.rs
+++ b/evmlib/src/merkle_batch_payment.rs
@@ -29,7 +29,7 @@ pub type PoolHash = [u8; 32];
 pub const CANDIDATES_PER_POOL: usize = 16;
 
 /// Maximum supported Merkle tree depth
-pub const MAX_MERKLE_DEPTH: u8 = 10;
+pub const MAX_MERKLE_DEPTH: u8 = 5;
 
 /// Calculate expected number of reward pools for a given tree depth
 ///


### PR DESCRIPTION
- Max merkle tree depth set at decided `10`
- support upload of large files in 4GB batches (multiple trees/payments for anything larger)
- refactor to support pay/upload/pay next loop upload routine