### PR TITLE
refactor(evmlib): reduce MAX_MERKLE_DEPTH to 8

### DIFF
--- a/evmlib/src/merkle_batch_payment.rs
+++ b/evmlib/src/merkle_batch_payment.rs
@@ -29,7 +29,7 @@ pub type PoolHash = [u8; 32];
 pub const CANDIDATES_PER_POOL: usize = 16;
 
 /// Maximum supported Merkle tree depth
-pub const MAX_MERKLE_DEPTH: u8 = 12;
+pub const MAX_MERKLE_DEPTH: u8 = 8;
 
 /// Calculate expected number of reward pools for a given tree depth
 ///


### PR DESCRIPTION
The calldata size limit is `128KB`. With a `MAX_MERKLE_DEPTH` of `8` we stay just under that limit in the worst case scenario of `256` chunks in a tree. The max calldata size with a depth of `8` is around `~110KB`. 