### PR TITLE
feat(node): skip replication once closeup peer restart pattern detected

### DIFF
--- a/ant-node/src/networking/driver/mod.rs
+++ b/ant-node/src/networking/driver/mod.rs
@@ -74,6 +74,9 @@ pub(crate) const BOOTSTRAP_CHECK_INTERVAL: std::time::Duration =
 
 pub(crate) const NETWORK_WIDE_REPLICATION_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
+/// Maximum number of peers to keep in the blocklist before evicting oldest entries
+pub(crate) const BLOCKLIST_CACHE_SIZE: usize = 1000;
+
 /// The ways in which the Get Closest queries are used.
 pub(crate) enum PendingGetClosestType {
     /// The network discovery method is present at the networking layer
@@ -165,6 +168,8 @@ pub(crate) struct SwarmDriver {
     pub(crate) last_connection_pruning_time: Instant,
     /// record versions of those peers that in the non-full-kbuckets.
     pub(crate) peers_version: HashMap<PeerId, String>,
+    /// FIFO cache to track blocked peers, allowing us to unblock the oldest when limit is reached
+    pub(crate) blocklist_cache: CircularVec<PeerId>,
 }
 
 impl SwarmDriver {

--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -12,8 +12,8 @@ use crate::networking::{
     CLOSE_GROUP_SIZE, NetworkEvent,
     circular_vec::CircularVec,
     driver::{
-        InitialBootstrapTrigger, NodeBehaviour, SwarmDriver, network_discovery::NetworkDiscovery,
-        network_wide_replication::NetworkWideReplication,
+        BLOCKLIST_CACHE_SIZE, InitialBootstrapTrigger, NodeBehaviour, SwarmDriver,
+        network_discovery::NetworkDiscovery, network_wide_replication::NetworkWideReplication,
     },
     error::{NetworkError, Result},
     external_address::ExternalAddressManager,
@@ -445,6 +445,7 @@ fn init_swarm_driver(
         last_connection_pruning_time: Instant::now(),
         peers_version: Default::default(),
         dial_queue: Default::default(),
+        blocklist_cache: CircularVec::new(BLOCKLIST_CACHE_SIZE),
     };
 
     (network_event_receiver, swarm_driver)

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -930,11 +930,12 @@ impl Network {
                 Err(e) => errors.push(e),
             }
 
-            // if we have enough quotes, return them
-            if quotes.len() >= minimum_quotes {
+            if quotes.len() >= minimum_quotes && (no_need_to_pay.is_empty() || tasks.is_empty()) {
+                // if we have enough quotes AND no sign of enough existing copies,
+                // return with collected quotes. 
                 let peer_ids = quotes.iter().map(|(p, _)| p.peer_id).collect::<Vec<_>>();
                 debug!("Get quotes for {addr}: got enough quotes from peers: {peer_ids:?}");
-                return Ok(Some(quotes));
+                return Ok(Some(quotes.into_iter().take(minimum_quotes).collect()));
             } else if no_need_to_pay.len() >= CLOSE_GROUP_SIZE_MAJORITY {
                 let peer_ids = no_need_to_pay.iter().map(|p| p.peer_id).collect::<Vec<_>>();
                 debug!(


### PR DESCRIPTION
### Description

* Replication only triggered on close-up (among 20 closest) peers churning
* Trying to detect a `restart` (dropped out then rejoin with same peer_id within certain time) pattern among close-up peers
* For those `restart` detected peers, if churning again, skip replication
* Fixed a potential issue that libp2p::blocklist grows unlimited
* Fixed a potential issue that during re-upload, an existing copy could be missed

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
