### PR TITLE
feat: support restarting symlinked binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9057,8 +9057,9 @@ dependencies = [
 
 [[package]]
 name = "service-manager"
-version = "0.8.0"
-source = "git+https://github.com/jacderida/service-manager-rs?branch=generic_restart_policy#b976028085b948eb608e97b63f6db40fa190ae4d"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44843b1e23129168ae92a47dda1f8b1a86f82fbc06336b9344b4646508f28c73"
 dependencies = [
  "cfg-if",
  "dirs",

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -51,7 +51,7 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
+service-manager = "0.9.0"
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43", features = ["full"] }

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -40,7 +40,7 @@ use rand::Rng;
 use std::{
     env,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     time::Duration,
 };
@@ -364,8 +364,8 @@ fn main() -> Result<()> {
     rt.shutdown_timeout(Duration::from_secs(2));
 
     // Restart only if we received a restart command.
-    if let Some((retain_peer_id, root_dir, port)) = restart_options {
-        start_new_node_process(retain_peer_id, root_dir, port);
+    if let Some((root_dir, port)) = restart_options {
+        start_new_node_process(root_dir, port);
         println!("A new node process has been started successfully.");
     } else {
         println!("The node process has been stopped.");
@@ -376,7 +376,7 @@ fn main() -> Result<()> {
 
 /// Start a node with the given configuration.
 /// Returns:
-/// - `Ok(Some(_))` if we receive a restart request.
+/// - `Ok(Some((root_dir, port)))` if we receive a restart request.
 /// - `Ok(None)` if we want to shutdown the node.
 /// - `Err(_)` if we want to shutdown the node with an error.
 async fn run_node(
@@ -385,7 +385,7 @@ async fn run_node(
     log_output_dest: &str,
     log_reload_handle: ReloadHandle,
     stop_on_upgrade: bool,
-) -> Result<Option<(bool, PathBuf, u16)>> {
+) -> Result<Option<(PathBuf, u16)>> {
     let started_instant = std::time::Instant::now();
 
     reset_critical_failure(log_output_dest);
@@ -510,7 +510,7 @@ You can check your reward balance by running:
         match ctrl_rx.recv().await {
             Some(NodeCtrl::Restart {
                 delay,
-                retain_peer_id,
+                retain_peer_id: _,
             }) => {
                 let root_dir = running_node.root_dir_path();
                 let node_port = running_node.get_node_listening_port().await?;
@@ -520,7 +520,7 @@ You can check your reward balance by running:
                 println!("{msg} Node path: {log_output_dest}");
                 sleep(delay).await;
 
-                return Ok(Some((retain_peer_id, root_dir, node_port)));
+                return Ok(Some((root_dir, node_port)));
             }
             Some(NodeCtrl::Stop { delay, result }) => {
                 let msg = format!("Node is stopping in {delay:?}...");
@@ -652,65 +652,68 @@ fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Opt
 }
 
 /// Starts a new process running the binary with the same args as the current process.
-///
-/// Optionally provide the node's root dir and listen port to retain its PeerId.
-fn start_new_node_process(retain_peer_id: bool, root_dir: PathBuf, port: u16) {
-    let current_exe = env::current_exe().expect("could not get current executable path");
-
-    // Retrieve the command-line arguments passed to this process
-    let mut args: Vec<String> = env::args().collect();
-
-    info!("Original args are: {args:?}");
-    info!("Current exe is: {current_exe:?}");
-
-    // Remove `--first` argument. If node is restarted, it is not the first anymore.
-    args.retain(|arg| arg != "--first");
-
-    // Convert current exe path to string, log an error and return if it fails
-    let current_exe = match current_exe.to_str() {
-        Some(s) => {
-            // remove "(deleted)" string from current exe path
-            if s.contains(" (deleted)") {
-                warn!(
-                    "The current executable path contains ' (deleted)', which may lead to unexpected behavior. This has been removed from the exe location string"
-                );
-                s.replace(" (deleted)", "")
-            } else {
-                s.to_string()
-            }
-        }
-        None => {
-            error!("Failed to convert current executable path to string");
-            return;
-        }
+/// Injects `--root-dir` and `--port` at the beginning if they are not already present,
+/// to ensure the node retains its peer ID on restart.
+fn start_new_node_process(root_dir: PathBuf, port: u16) {
+    // The invoked path is the path the process was actually launched with. In the case where a
+    // symlink was used, this path will be different from the current exe path, which is the source
+    // of the symlink, or the canonical path. The invoked path will be preferred for the automatic
+    // upgrading process, to support the use of symlinked binaries.
+    let invoked_path = env::args().next().expect("failed to get invoked path");
+    let current_exe_path = env::current_exe().expect("could not get current executable path");
+    let executable_path = if Path::new(&invoked_path).exists() {
+        invoked_path
+    } else {
+        current_exe_path.to_string_lossy().to_string()
     };
 
-    // Create a new Command instance to run the current executable
-    let mut cmd = Command::new(current_exe);
+    let mut args: Vec<String> = env::args().collect();
+    debug!("Arguments used for the initial process: {args:?}");
 
-    // Set the arguments for the new Command
-    cmd.args(&args[1..]); // Exclude the first argument (binary path)
+    // Handle "(deleted)" suffix
+    let executable_path = if executable_path.contains(" (deleted)") {
+        warn!(
+            "The executable path contains ' (deleted)', which indicates the binary was replaced.
+             This has been removed from the exe location string"
+        );
+        executable_path.replace(" (deleted)", "")
+    } else {
+        executable_path
+    };
 
-    if retain_peer_id {
-        cmd.arg("--root-dir");
-        cmd.arg(format!("{root_dir:?}"));
-        cmd.arg("--port");
-        cmd.arg(port.to_string());
+    // Remove the --first flag: it's only valid for the initial start.
+    args.retain(|arg| arg != "--first");
+
+    let has_root_dir = args.iter().any(|arg| arg == "--root-dir");
+    let has_port = args.iter().any(|arg| arg == "--port");
+    let mut final_args = Vec::new();
+
+    // To have the restarted node retain its peer ID, inject --root-dir and --port at the beginning
+    // if they are not already present.
+    // The arguments must be at the beginning rather than appended at the end because the EVM
+    // options must be at the end.
+    if !has_root_dir {
+        final_args.push("--root-dir".to_string());
+        final_args.push(root_dir.to_string_lossy().to_string());
+    }
+    if !has_port {
+        final_args.push("--port".to_string());
+        final_args.push(port.to_string());
     }
 
-    warn!(
-        "Attempting to start a new process as node process loop has been broken: {:?}",
-        cmd
-    );
-    // Execute the command
+    final_args.extend_from_slice(&args[1..]);
+
+    let mut cmd = Command::new(&executable_path);
+    cmd.args(&final_args);
+
+    info!("A new process will be launched: {cmd:?}");
     let _handle = match cmd.spawn() {
         Ok(status) => status,
         Err(e) => {
             // Do not return an error as this isn't a critical failure.
             // The current node can continue.
-            eprintln!("Failed to execute hard-restart command: {e:?}");
-            error!("Failed to execute hard-restart command: {e:?}");
-
+            eprintln!("Failed to execute restart: {e:?}");
+            error!("Failed to execute restart: {e:?}");
             return;
         }
     };

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -22,7 +22,7 @@ prost = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0.20"
-service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
+service-manager = "0.9.0"
 sysinfo = "0.30.12"
 thiserror = "1.0.23"
 tokio = { version = "1.43.1", features = ["time"] }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -65,7 +65,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 semver = "1.0.20"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-service-manager = { git = "https://github.com/jacderida/service-manager-rs", branch = "generic_restart_policy" }
+service-manager = "0.9.0"
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.26.1", features = ["derive"] }


### PR DESCRIPTION
- 41ebda323 **feat: support restarting symlinked binaries**

  The code performing restarts of `antnode` was using the canonical path of the executable, which in
  the case of symlinks, is the path of the source of the link rather than the link itself.

  To support a symlinked binary setup in automatic upgrades, we now modify the restart mechanism to
  use the invoked path, which is the location of the symlink. For non-symlinked binaries the mechanism
  should work as normal.

  The way the new `antnode` process is launched was also changed slightly. We were using a
  `retain_peer_id` flag, which was supplied from the RPC command. Since RPC will be phased out, this
  flag is no longer relevant and was removed. The restart will now always retain the peer ID. If the
  original process supplied the `--root-dir` and `--port` arguments, we'll use them again, but if it
  didn't, they will be injected. Now they need to be injected at the beginning rather than appended at
  the end, because the EVM options must be at the end.

- ac5734d3f **chore: use new version of service manager crate**

  The changes we made were merged and published as a new version.