### PR TITLE
refactor(ant-node): rename `get_closest_peers_verified`

### DIFF
--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -389,7 +389,7 @@ impl Network {
         Ok(closest_peers)
     }
 
-    /// Returns the closest peers with multi-stage verification.
+    /// Returns the closest peers with multi-stage verification based on majority knowledge.
     /// This function verifies the candidates by:
     /// 1. Getting N candidates via Kademlia
     /// 2. Querying each candidate for their view of closest peers
@@ -399,7 +399,7 @@ impl Network {
     /// This is more accurate but slower than `get_closest_peers` due to the additional verification round-trips.
     /// Use this for critical operations like Merkle payment topology verification.
     #[allow(dead_code)]
-    pub(crate) async fn get_closest_peers_verified(
+    pub(crate) async fn get_closest_peers_with_majority_knowledge(
         &self,
         key: &NetworkAddress,
     ) -> Result<Vec<(PeerId, Addresses)>> {

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -1237,16 +1237,16 @@ impl Node {
 
         // Verify network topology (>50% of paid nodes in closest)
         // Get closest peers to the midpoint address (same address the client used to collect candidates)
-        // Use verified method for accuracy in this critical payment verification
+        // Use majority knowledge method for accuracy in this critical payment verification
         let midpoint_address = proof.winner_pool.midpoint_proof.address();
         let reward_pool_address = NetworkAddress::ChunkAddress(ChunkAddress::new(midpoint_address));
-        let all_closest_peers = match self.network().get_closest_peers_verified(&reward_pool_address).await {
+        let all_closest_peers = match self.network().get_closest_peers_with_majority_knowledge(&reward_pool_address).await {
             Ok(peers) => peers,
             Err(e) => {
-                warn!("Failed to get verified closest peers for topology verification: {e:?}");
+                warn!("Failed to get closest peers with majority knowledge for topology verification: {e:?}");
                 return Err(PutValidationError::MerklePaymentVerificationFailed {
                     record_key: pretty_key.clone().into_owned(),
-                    error: format!("Failed to get verified closest peers to {midpoint_address:?}: {e:?}"),
+                    error: format!("Failed to get closest peers with majority knowledge to {midpoint_address:?}: {e:?}"),
                 });
             }
         };


### PR DESCRIPTION
Rename `get_closest_peers_verified` to `get_closest_peers_with_majority_knowledge` for clarity.