### PR TITLE
chore(release): stable release 2025.12.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.2.13-rc.1"
+version = "0.2.13"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.4.13-rc.1"
+version = "0.4.13"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.18-rc.1"
+version = "0.1.18"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.10-rc.1"
+version = "0.4.10"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.14.0-rc.1"
+version = "0.14.0"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.10-rc.1"
+version = "1.0.10"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -1681,7 +1681,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.7.2-rc.1"
+version = "0.7.2"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "autonomi-nodejs"
-version = "0.3.1-rc.1"
+version = "0.3.1"
 dependencies = [
  "autonomi",
  "bytes",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.17-rc.1"
+version = "0.1.17"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.6-rc.1"
+version = "0.4.6"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ant-bootstrap"
-version = "0.2.12"
+version = "0.2.13-rc.1"
 dependencies = [
  "ant-logging",
  "ant-protocol",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.4.12"
+version = "0.4.13-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.17"
+version = "0.1.18-rc.1"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.9"
+version = "0.4.10-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.13.4"
+version = "0.14.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.9"
+version = "1.0.10-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.4.17"
+version = "0.5.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -1681,7 +1681,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.7.1"
+version = "0.7.2-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "autonomi-nodejs"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "autonomi",
  "bytes",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.16"
+version = "0.1.17-rc.1"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.5"
+version = "0.4.6-rc.1"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.5.12"
+version = "0.6.0-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.13-rc.1"
+version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0"
 name = "ant-bootstrap"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.2.12"
+version = "0.2.13-rc.1"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2025";
-pub const RELEASE_MONTH: &str = "11";
-pub const RELEASE_CYCLE: &str = "2";
+pub const RELEASE_MONTH: &str = "12";
+pub const RELEASE_CYCLE: &str = "1";
 pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.4.12"
+version = "0.4.13-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,8 +25,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
-autonomi = { path = "../autonomi", version = "0.7.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+autonomi = { path = "../autonomi", version = "0.7.2-rc.1", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -58,7 +58,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.7.1" }
+autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.4.13-rc.1"
+version = "0.4.13"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -25,8 +25,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
-autonomi = { path = "../autonomi", version = "0.7.2-rc.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
+autonomi = { path = "../autonomi", version = "0.7.2", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -58,7 +58,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
+autonomi = { path = "../autonomi", version = "0.7.2" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.18-rc.1"
+version = "0.1.18"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.6", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.17"
+version = "0.1.18-rc.1"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.5" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.5", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.13.4"
+version = "0.14.0-rc.1"
 
 [[bin]]
 name = "antctl"
@@ -29,14 +29,14 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.12" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
-evmlib = { path = "../evmlib", version = "0.4.5" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.14.0-rc.1"
+version = "0.14.0"
 
 [[bin]]
 name = "antctl"
@@ -29,14 +29,14 @@ tcp = []
 websockets = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.9" }
+ant-node = { path = "../ant-node", version = "0.4.10-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.10-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.10" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,9 +19,9 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.9" }
-ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.10-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,9 +19,9 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.10-rc.1" }
-ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.10" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.9"
+version = "0.4.10-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -23,13 +23,13 @@ otlp = ["ant-logging/otlp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.12" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.4.17" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
@@ -106,10 +106,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.9", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.5" }
-autonomi = { path = "../autonomi", version = "0.7.1" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.10-rc.1"
+version = "0.4.10"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -23,13 +23,13 @@ otlp = ["ant-logging/otlp"]
 
 [dependencies]
 aes-gcm-siv = "0.11.1"
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.0-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.0" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
@@ -106,10 +106,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
-autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
+autonomi = { path = "../autonomi", version = "0.7.2" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.10-rc.1"
+version = "1.0.10"
 
 [features]
 default = []
@@ -15,7 +15,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.9"
+version = "1.0.10-rc.1"
 
 [features]
 default = []
@@ -15,7 +15,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.17"
+version = "0.5.0-rc.1"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.12" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "autonomi-nodejs"
-version = "0.3.1-rc.1"
+version = "0.3.1"
 description = "NodeJS bindings for the autonomi client"
 license = "GPL-3.0"
 
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
+autonomi = { path = "../autonomi", version = "0.7.2" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "autonomi-nodejs"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 description = "NodeJS bindings for the autonomi client"
 license = "GPL-3.0"
 
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.7.1" }
+autonomi = { path = "../autonomi", version = "0.7.2-rc.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/npm/darwin-arm64/package.json
+++ b/autonomi-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-arm64",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-arm64/package.json
+++ b/autonomi-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-arm64",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-x64/package.json
+++ b/autonomi-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-x64",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/darwin-x64/package.json
+++ b/autonomi-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-darwin-x64",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/linux-x64-gnu/package.json
+++ b/autonomi-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-linux-x64-gnu",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/linux-x64-gnu/package.json
+++ b/autonomi-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-linux-x64-gnu",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/win32-x64-msvc/package.json
+++ b/autonomi-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-win32-x64-msvc",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/npm/win32-x64-msvc/package.json
+++ b/autonomi-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi-win32-x64-msvc",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/autonomi.git",

--- a/autonomi-nodejs/package-lock.json
+++ b/autonomi-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withautonomi/autonomi",
-      "version": "0.7.1",
+      "version": "0.7.3-rc.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/autonomi-nodejs/package-lock.json
+++ b/autonomi-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withautonomi/autonomi",
-      "version": "0.7.3-rc.1",
+      "version": "0.7.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/autonomi-nodejs/package.json
+++ b/autonomi-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.7.3-rc.1",
+  "version": "0.7.2",
   "description": "NodeJS bindings for Autonomi client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/autonomi-nodejs/package.json
+++ b/autonomi-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withautonomi/autonomi",
-  "version": "0.7.1",
+  "version": "0.7.3-rc.1",
   "description": "NodeJS bindings for Autonomi client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.7.1"
+version = "0.7.2-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,9 +26,9 @@ extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.12" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -37,7 +37,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.5" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -78,7 +78,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.5" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.7.2-rc.1"
+version = "0.7.2"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,9 +26,9 @@ extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -37,7 +37,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -78,7 +78,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.17-rc.1"
+version = "0.1.17"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.16"
+version = "0.1.17-rc.1"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.5" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.5"
+version = "0.4.6-rc.1"
 
 [features]
 external-signer = []

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.6-rc.1"
+version = "0.4.6"
 
 [features]
 external-signer = []

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.5.12"
+version = "0.6.0-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,14 +18,14 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.12" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.17" }
+ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-node-manager = { version = "0.13.4", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.9" }
+ant-node-manager = { version = "0.14.0-rc.1", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { version = "0.4.17", path = "../ant-service-management" }
+ant-service-management = { version = "0.5.0-rc.1", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -18,14 +18,14 @@ path = "src/bin/tui/main.rs"
 nightly = []
 
 [dependencies]
-ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13-rc.1" }
+ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.18-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.18" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-node-manager = { version = "0.14.0-rc.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.10-rc.1" }
+ant-node-manager = { version = "0.14.0", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.10" }
 ant-releases = "0.4.3"
-ant-service-management = { version = "0.5.0-rc.1", path = "../ant-service-management" }
+ant-service-management = { version = "0.5.0", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -13,6 +13,6 @@
 # Both of these numbers are used in the packaged version number, which is a collective version
 # number for all the released binaries.
 release-year: 2025
-release-month: 11
-release-cycle: 2
+release-month: 12
+release-cycle: 1
 release-cycle-counter: 1

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.5" }
+evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.6-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.6" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }


### PR DESCRIPTION
    ==================
      Crate Versions
    ==================
    ant-bootstrap: 0.2.13
    ant-build-info: 0.1.29
    ant-cli: 0.4.13
    ant-evm: 0.1.18
    ant-logging: 0.3.0
    ant-metrics: 0.1.30
    ant-node: 0.4.10
    ant-node-manager: 0.14.0
    ant-node-rpc-client: 0.6.49
    ant-protocol: 1.0.10
    ant-service-management: 0.5.0
    ant-token-supplies: 0.1.67
    autonomi: 0.7.2
    evmlib: 0.4.6
    evm-testnet: 0.1.17
    nat-detection: 0.2.22
    node-launchpad: 0.6.0
    autonomi-nodejs: 0.3.1
    ant-node-nodejs: 0.1.5
    test-utils: 0.4.21
    ===================
      Binary Versions
    ===================
    ant: 0.4.13
    antctl: 0.14.0
    antctld: 0.14.0
    antnode: 0.4.10
    antnode_rpc_client: 0.6.49
    nat-detection: 0.2.22
    node-launchpad: 0.6.0
