### PR TITLE
feat: clear NodeRegistryManager during reset op

### DIFF
--- a/ant-node-manager/src/cmd/node.rs
+++ b/ant-node-manager/src/cmd/node.rs
@@ -277,7 +277,7 @@ pub async fn reset(
     }
 
     stop(None, node_registry.clone(), vec![], vec![], verbosity).await?;
-    remove(false, vec![], node_registry, vec![], verbosity).await?;
+    remove(false, vec![], node_registry.clone(), vec![], verbosity).await?;
 
     // Due the possibility of repeated runs of the `reset` command, we need to check for the
     // existence of this file before attempting to delete it, since `remove_file` will return an
@@ -287,6 +287,8 @@ pub async fn reset(
         info!("Removing node registry file: {node_registry_path:?}");
         std::fs::remove_file(node_registry_path)?;
     }
+    info!("Resetting NodeRegistryManager in memory");
+    node_registry.reset().await;
 
     Ok(())
 }
@@ -713,6 +715,8 @@ pub async fn maintain_n_running_nodes(
                     }
                     None => vec![],
                 };
+
+                info!("Ports to use for new nodes: {:?}", ports_to_use);
 
                 for (i, port) in ports_to_use.into_iter().enumerate() {
                     let added_service = add(

--- a/ant-service-management/src/registry.rs
+++ b/ant-service-management/src/registry.rs
@@ -63,6 +63,20 @@ impl NodeRegistryManager {
         }
     }
 
+    pub async fn reset(&self) {
+        let mut daemon_lock = self.daemon.write().await;
+        *daemon_lock = None;
+
+        let mut env_vars_lock = self.environment_variables.write().await;
+        *env_vars_lock = None;
+
+        let mut nat_status_lock = self.nat_status.write().await;
+        *nat_status_lock = None;
+
+        let mut nodes_lock = self.nodes.write().await;
+        nodes_lock.clear();
+    }
+
     /// Loads the node registry from the specified path.
     /// If the file does not exist, it returns a default `NodeRegistryManager` with an empty state.
     #[allow(clippy::unused_async)]

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -1564,8 +1564,12 @@ impl Component for Status<'_> {
         if let Some(error_popup) = &mut self.error_popup
             && error_popup.is_visible()
         {
-            error_popup.handle_input(key);
-            return Ok(vec![Action::SwitchInputMode(InputMode::Navigation)]);
+            if error_popup.handle_input(key) {
+                // Popup was dismissed, switch back to navigation mode
+                return Ok(vec![Action::SwitchInputMode(InputMode::Navigation)]);
+            }
+            // Popup is still visible, stay in entry mode
+            return Ok(vec![]);
         }
         Ok(vec![])
     }


### PR DESCRIPTION
- We had sync issues between the node registry that is stored locally and the in memory representation. This caused phantom nodes to appear after reset operation.
- Now the in memory struct is also cleared after the reset op