### PR TITLE
feat: add verbosity CLI flag and refactor logging targets

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Start a local network
         uses: maidsafe/ant-local-testnet-action@main
         env:
-          ANT_LOG: "all"
+          ANT_LOG: "verbose"
         with:
           action: start
           enable-evm-testnet: true
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: ./target/release/ant --log-output-dest=data-dir --local file upload "./the-test-data.zip"
         env:
-          ANT_LOG: "all"
+          ANT_LOG: "verbose"
         timeout-minutes: 5
 
       - name: Cleanup uploaded_files folder to avoid pollute download benchmark

--- a/.github/workflows/files.yml
+++ b/.github/workflows/files.yml
@@ -270,7 +270,7 @@ jobs:
             echo "🎉 All tests passed!"
           fi
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 45
 
       - name: Stop the local network and upload logs
@@ -588,7 +588,7 @@ jobs:
             Write-Host "🎉 All tests passed!"
           }
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 45
 
       - name: Stop the local network and upload logs

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -101,7 +101,7 @@ jobs:
         shell: bash
         run: cargo run --bin ant --release -- --log-output-dest data-dir --local file upload the-test-data.zip
         env:
-          ANT_LOG: "all"
+          ANT_LOG: "verbose"
 
       #########################
       ### Stop Network      ###

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -55,7 +55,7 @@ jobs:
             --root-dir $RESTART_TEST_NODE_DATA_PATH --log-output-dest $RESTART_TEST_NODE_DATA_PATH --local --rewards-address "0x03B770D9cD32077cC0bF330c13C114a87643B124" &
           sleep 10
         env:
-          ANT_LOG: "all"
+          ANT_LOG: verbose
 
       - name: Download 95mb file to be uploaded with the safe client
         shell: bash
@@ -68,7 +68,7 @@ jobs:
       - name: File upload
         run: ./target/release/ant --log-output-dest=data-dir --local file upload --public "./the-test-data.zip" --retry-failed 3 > ./upload_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: showing the upload terminal output
@@ -111,7 +111,7 @@ jobs:
             exit 1
           fi
         env:
-          ANT_LOG: "all"
+          ANT_LOG: verbose
         timeout-minutes: 25
 
       - name: showing the second upload terminal output
@@ -131,7 +131,7 @@ jobs:
             --rewards-address "0x03B770D9cD32077cC0bF330c13C114a87643B124" &
           sleep 10
         env:
-          ANT_LOG: "all"
+          ANT_LOG: verbose
 
       # Records are encrypted, and seeds will change after restart
       # Currently, there will be `Existing record found`, but NO `Existing record loaded`
@@ -162,7 +162,7 @@ jobs:
       - name: File Download
         run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_file
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: Check nodes running

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Set ANT_LOG environment variable
-        run: echo "ANT_LOG=all" >> $GITHUB_ENV
+        run: echo "ANT_LOG=std" >> $GITHUB_ENV
 
       - name: Run autonomi tests
         timeout-minutes: 25
@@ -227,7 +227,7 @@ jobs:
       - name: Run autonomi --tests
         run: cargo test --package autonomi --tests -- --nocapture
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
           # only set the target dir for windows to bypass the linker issue.
           # happens if we build the node manager via testnet action
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
@@ -246,13 +246,13 @@ jobs:
       - name: Get file cost
         run: ./target/release/ant --log-output-dest=data-dir --local file cost "./resources"
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: File upload
         run: ./target/release/ant --log-output-dest=data-dir --local file upload "./resources" > ./upload_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: parse address (unix)
@@ -272,7 +272,7 @@ jobs:
       - name: File Download
         run: ./target/release/ant --log-output-dest=data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources/downloaded_file2
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: Generate register signing key
@@ -281,7 +281,7 @@ jobs:
       - name: Create register (writeable by owner)
         run: ./target/release/ant --log-output-dest=data-dir --local register create baobao 123 > ./register_create_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 10
 
       - name: parse register address (unix)
@@ -301,25 +301,25 @@ jobs:
       - name: Get register
         run: ./target/release/ant --log-output-dest=data-dir --local register get ${{ env.REGISTER_ADDRESS }}
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: Edit register
         run: ./target/release/ant --log-output-dest=data-dir --local register edit ${{ env.REGISTER_ADDRESS }} 456
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 10
 
       - name: Get register (after edit)
         run: ./target/release/ant --log-output-dest=data-dir --local register get ${{ env.REGISTER_ADDRESS }}
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: Create Register
         run: ./target/release/ant --log-output-dest=data-dir --local register create bao 111 > ./register2_create_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: parse register address (unix)
@@ -339,13 +339,13 @@ jobs:
       - name: Get Register (current key is the owner)
         run: ./target/release/ant --log-output-dest=data-dir --local register get ${{ env.REGISTER2_ADDRESS }}
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: Edit Register (current key is the owner)
         run: ./target/release/ant --log-output-dest=data-dir --local register edit ${{ env.REGISTER2_ADDRESS }} 222
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 10
 
       - name: Delete current register signing key
@@ -358,43 +358,43 @@ jobs:
       - name: Get Register (new signing key is not the owner)
         run: ./target/release/ant --log-output-dest data-dir --local register get ${{ env.REGISTER2_ADDRESS }}
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: Get Register (new signing key is not the owner)
         run: ./target/release/ant --log-output-dest data-dir --local register get ${{ env.REGISTER2_ADDRESS }}
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: create local user file
         run: echo random > random.txt
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: file upload
         run: ./target/release/ant --log-output-dest data-dir --local file upload random.txt
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: create a local register
         run: ./target/release/ant --log-output-dest data-dir --local register create sample_new_register 1234
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: Estimate cost to create a vault
         run: ./target/release/ant --log-output-dest data-dir --local vault cost
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: create a vault with existing user data as above
         run: ./target/release/ant --log-output-dest data-dir --local vault create
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: add more files - linux/macos
@@ -408,7 +408,7 @@ jobs:
             ./target/release/ant --log-output-dest data-dir --local register create $i random_file_$i.bin
           done
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 25
 
       - name: add more files - windows
@@ -427,19 +427,19 @@ jobs:
               ./target/release/ant --log-output-dest data-dir --local register create $i "random_file_$i.bin"
           }
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 35
 
       - name: sync the vault
         run: ./target/release/ant --log-output-dest data-dir --local vault sync
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: load the vault from network
         run: ./target/release/ant --log-output-dest data-dir --local vault load
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: vault sync validation
@@ -485,7 +485,7 @@ jobs:
           python3 -c 'import sys; assert sys.argv[1] == sys.argv[2], f"Error: local data and vault in network dont match, Local private Files: {sys.argv[1]} and vault private files: {sys.argv[2]} are Not Equal"' $NUM_OF_PRIVATE_FILES $NUM_OF_PRIVATE_FILES_IN_VAULT
           echo "vault synced successfully!"
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: Set up variables - vault sync - windows
@@ -496,7 +496,7 @@ jobs:
           ./target/release/ant --log-output-dest data-dir --local file list > file_list.txt 2>&1
           ./target/release/ant --log-output-dest data-dir --local vault load > vault_data.txt 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: Vault sync validation
@@ -553,13 +553,13 @@ jobs:
           assert NUM_OF_PRIVATE_FILES == NUM_OF_PRIVATE_FILES_IN_VAULT, f"Error: local data and vault in network dont match, Local private Files: {NUM_OF_PRIVATE_FILES} and vault private files: {NUM_OF_PRIVATE_FILES_IN_VAULT} are Not Equal"
           print("Vault synced successfully!")
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: load an existing vault from the network
         run: ./target/release/ant --log-output-dest data-dir --local vault load
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 2
 
       - name: Time profiling for Different files
@@ -584,7 +584,7 @@ jobs:
           rm -rf random*.bin
           rm -rf ${{ matrix.ant_path }}/autonomi
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: Stop the local network and upload logs
@@ -672,7 +672,7 @@ jobs:
         env:
           TEST_DURATION_MINS: 5
           TEST_TOTAL_CHURN_CYCLES: 15
-          ANT_LOG: "all"
+          ANT_LOG: verbose
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 30
 
@@ -826,7 +826,7 @@ jobs:
         run: cargo test --release -p ant-node --test verify_data_location -- --nocapture
         env:
           CHURN_COUNT: 6
-          ANT_LOG: "all"
+          ANT_LOG: standard
           CARGO_TARGET_DIR: ${{ matrix.os == 'windows-latest' && './test-target' || '.' }}
         timeout-minutes: 25
 
@@ -974,7 +974,7 @@ jobs:
       - name: File upload
         run: ./target/release/ant --log-output-dest data-dir --local file upload "./test_data_1.tar.gz" > ./upload_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 15
 
       - name: showing the upload terminal output
@@ -992,7 +992,7 @@ jobs:
       - name: File Download Error Check
         run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} . > ./error_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
         continue-on-error: true
 
@@ -1009,7 +1009,7 @@ jobs:
       - name: File Download
         run: ./target/release/ant --log-output-dest data-dir --local file download ${{ env.UPLOAD_ADDRESS }} ./downloaded_resources/downloaded_file > ./download_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: verbose
         timeout-minutes: 5
 
       - name: showing the download terminal output

--- a/.github/workflows/pointer.yml
+++ b/.github/workflows/pointer.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Upload test data A
         run: ./target/release/ant --local file upload --public test_data_A.txt > ./upload_output_A 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Parse address A (unix)
@@ -100,7 +100,7 @@ jobs:
       - name: Upload test data B
         run: ./target/release/ant --local file upload --public test_data_B.txt > ./upload_output_B 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Parse address B (unix)
@@ -123,13 +123,13 @@ jobs:
       - name: Create pointer pointing to address_A
         run: ./target/release/ant --local pointer create test_pointer ${{ env.ADDRESS_A }} --target-data-type chunk > ./pointer_create_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Edit pointer with address_A
         run: ./target/release/ant --local pointer edit test_pointer ${{ env.ADDRESS_A }} --target-data-type chunk > ./pointer_edit_output_1 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 1 (unix)
@@ -163,7 +163,7 @@ jobs:
       - name: Edit pointer with same address_A again
         run: ./target/release/ant --local pointer edit test_pointer ${{ env.ADDRESS_A }} --target-data-type chunk > ./pointer_edit_output_2 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 2 (unix)
@@ -197,7 +197,7 @@ jobs:
       - name: Get pointer and verify address_A
         run: ./target/release/ant --local pointer get test_pointer > ./pointer_get_output_1 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 5
 
       - name: Verify address_A (unix)
@@ -228,7 +228,7 @@ jobs:
       - name: Edit pointer with address_B
         run: ./target/release/ant --local pointer edit test_pointer ${{ env.ADDRESS_B }} --target-data-type chunk > ./pointer_edit_output_3 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 3 (unix)
@@ -262,7 +262,7 @@ jobs:
       - name: Get pointer and verify address_B
         run: ./target/release/ant --local pointer get test_pointer > ./pointer_get_output_2 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 5
 
       - name: Verify address_B (unix)

--- a/.github/workflows/scratchpad.yml
+++ b/.github/workflows/scratchpad.yml
@@ -76,13 +76,13 @@ jobs:
       - name: Create scratchpad
         run: ./target/release/ant --local scratchpad create test_scratchpad "content_A" > ./scratchpad_create_output 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Edit scratchpad with content_A
         run: ./target/release/ant --local scratchpad edit test_scratchpad "content_A" > ./scratchpad_edit_output_1 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 1 (unix)
@@ -116,7 +116,7 @@ jobs:
       - name: Edit scratchpad with same content_A again
         run: ./target/release/ant --local scratchpad edit test_scratchpad "content_A" > ./scratchpad_edit_output_2 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 2 (unix)
@@ -150,7 +150,7 @@ jobs:
       - name: Get scratchpad and verify content_A
         run: ./target/release/ant --local scratchpad get test_scratchpad > ./scratchpad_get_output_1 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 5
 
       - name: Verify content_A (unix)
@@ -181,7 +181,7 @@ jobs:
       - name: Edit scratchpad with content_B
         run: ./target/release/ant --local scratchpad edit test_scratchpad "content_B" > ./scratchpad_edit_output_3 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 10
 
       - name: Verify counter 3 (unix)
@@ -215,7 +215,7 @@ jobs:
       - name: Get scratchpad and verify content_B
         run: ./target/release/ant --local scratchpad get test_scratchpad > ./scratchpad_get_output_2 2>&1
         env:
-          ANT_LOG: "v"
+          ANT_LOG: "verbose"
         timeout-minutes: 5
 
       - name: Verify content_B (unix)

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -95,14 +95,14 @@ fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGua
     let logging_targets = vec![
         // libs
         ("ant_bootstrap".to_string(), Level::INFO),
-        ("ant_build_info".to_string(), Level::TRACE),
-        ("ant_evm".to_string(), Level::TRACE),
-        ("autonomi".to_string(), Level::TRACE),
-        ("evmlib".to_string(), Level::TRACE),
-        ("ant_logging".to_string(), Level::TRACE),
-        ("ant_protocol".to_string(), Level::TRACE),
+        ("ant_build_info".to_string(), Level::INFO),
+        ("ant_evm".to_string(), Level::INFO),
+        ("autonomi".to_string(), Level::INFO),
+        ("evmlib".to_string(), Level::INFO),
+        ("ant_logging".to_string(), Level::INFO),
+        ("ant_protocol".to_string(), Level::INFO),
         // bins
-        ("ant".to_string(), Level::TRACE),
+        ("ant".to_string(), Level::INFO),
     ];
     let mute = opt
         .command

--- a/ant-cli/src/main.rs
+++ b/ant-cli/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
 }
 
 fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGuard>)> {
-    let logging_targets = vec![
+    let log_targets = vec![
         // libs
         ("ant_bootstrap".to_string(), Level::INFO),
         ("ant_build_info".to_string(), Level::INFO),
@@ -109,10 +109,13 @@ fn init_logging_and_metrics(opt: &Opt) -> Result<(ReloadHandle, Option<WorkerGua
         .as_ref()
         .map(|cmd| matches!(cmd, SubCmd::Analyze { .. }))
         .unwrap_or(false);
-    let mut log_builder = LogBuilder::new(logging_targets);
+    let mut log_builder = LogBuilder::new(log_targets);
     log_builder.output_dest(opt.log_output_dest.clone());
     log_builder.print_updates_to_stdout(!mute);
     log_builder.format(opt.log_format.unwrap_or(LogFormat::Default));
+    if let Some(verbosity) = opt.verbosity {
+        log_builder.verbosity(verbosity);
+    }
     let guards = log_builder.initialize()?;
     Ok(guards)
 }

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::commands::SubCmd;
-use ant_logging::{LogFormat, LogOutputDest};
+use ant_logging::{LogFormat, LogOutputDest, VerbosityLevel};
 use autonomi::InitialPeersConfig;
 use autonomi::Network as EvmNetwork;
 use autonomi::get_evm_network;
@@ -130,6 +130,18 @@ pub(crate) struct Opt {
     #[clap(long, value_parser = LogOutputDest::parse_from_str, verbatim_doc_comment, default_value = "data-dir"
     )]
     pub log_output_dest: LogOutputDest,
+
+    /// Set the logging verbosity level.
+    ///
+    /// Valid values are "minimal", "standard", or "verbose".
+    ///
+    /// - minimal: Uses application default log levels (least logging)
+    /// - standard: Sets all crates to INFO level
+    /// - verbose: Sets all crates to TRACE/DEBUG level (most logging)
+    ///
+    /// If not specified, uses application defaults (minimal).
+    #[clap(long, value_parser = VerbosityLevel::parse_from_str, verbatim_doc_comment)]
+    pub verbosity: Option<VerbosityLevel>,
 
     /// Specify the network ID to use. This will allow you to run the CLI on a different network.
     /// Note that this overrides all other network config options (except in the Custom Network case).

--- a/ant-logging/src/layers.rs
+++ b/ant-logging/src/layers.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    LogFormat, LogOutputDest, appender,
-    error::{Error, Result},
-};
+use crate::{LogFormat, LogOutputDest, VerbosityLevel, appender, error::Result};
 use std::collections::BTreeMap;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_core::{Event, Level, Subscriber};
@@ -46,12 +43,18 @@ pub struct ReloadHandle(pub(crate) Handle<Box<dyn Filter<Registry> + Send + Sync
 
 impl ReloadHandle {
     /// Modify the log level to the provided CSV value
-    /// Example input: `libp2p=DEBUG,tokio=INFO,all,sn_client=ERROR`
+    /// Example input: `libp2p=DEBUG,tokio=INFO,std,sn_client=ERROR`
     ///
     /// Custom keywords will take less precedence if the same target has been manually specified in the CSV.
-    /// `sn_client=ERROR` in the above example will be used instead of the TRACE level set by "all" keyword.
+    /// `sn_client=ERROR` in the above example will be used instead of the INFO level set by "std" keyword.
+    ///
+    /// Note: Dynamic modifications don't have access to application defaults, so custom targets
+    /// without keywords will only log what's explicitly specified.
     pub fn modify_log_level(&self, logging_value: &str) -> Result<()> {
-        let targets: Vec<(String, Level)> = get_logging_targets(logging_value)?;
+        // Pass empty vec for application targets since we don't have them in dynamic context
+        // Pass None for verbosity since this is a runtime modification
+        let targets: Vec<(String, Level)> =
+            get_logging_targets(Some(logging_value), vec![], None, false)?;
         self.0.modify(|old_filter| {
             let new_filter: Box<dyn Filter<Registry> + Send + Sync> =
                 Box::new(Targets::new().with_targets(targets));
@@ -104,14 +107,16 @@ pub(crate) struct TracingLayers {
 }
 
 impl TracingLayers {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn fmt_layer(
         &mut self,
-        default_logging_targets: Vec<(String, Level)>,
+        application_log_targets: Vec<(String, Level)>,
         output_dest: &LogOutputDest,
         format: LogFormat,
         max_uncompressed_log_files: Option<usize>,
         max_compressed_log_files: Option<usize>,
         print_updates_to_stdout: bool,
+        verbosity: Option<VerbosityLevel>,
     ) -> Result<ReloadHandle> {
         let layer = match output_dest {
             LogOutputDest::Stdout => {
@@ -198,15 +203,14 @@ impl TracingLayers {
                 }
             }
         };
-        let targets = match std::env::var("ANT_LOG") {
-            Ok(sn_log_val) => {
-                if print_updates_to_stdout {
-                    println!("Using ANT_LOG={sn_log_val}");
-                }
-                get_logging_targets(&sn_log_val)?
-            }
-            Err(_) => default_logging_targets,
-        };
+        // Single function handles all verbosity/ANT_LOG logic
+        let ant_log = std::env::var("ANT_LOG").ok();
+        let targets = get_logging_targets(
+            ant_log.as_deref(),
+            application_log_targets,
+            verbosity,
+            print_updates_to_stdout,
+        )?;
 
         let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
             Box::new(Targets::new().with_targets(targets));
@@ -222,7 +226,7 @@ impl TracingLayers {
     #[cfg(feature = "otlp")]
     pub(crate) fn otlp_layer(
         &mut self,
-        default_logging_targets: Vec<(String, Level)>,
+        application_log_targets: Vec<(String, Level)>,
     ) -> Result<()> {
         use opentelemetry::{
             KeyValue,
@@ -251,13 +255,13 @@ impl TracingLayers {
             ])))
             .install_batch(opentelemetry::runtime::Tokio)?;
 
-        let targets = match std::env::var("ANT_LOG_OTLP") {
-            Ok(sn_log_val) => {
-                println!("Using ANT_LOG_OTLP={sn_log_val}");
-                get_logging_targets(&sn_log_val)?
-            }
-            Err(_) => default_logging_targets,
-        };
+        let ant_log_otlp = std::env::var("ANT_LOG_OTLP").ok();
+        let targets = get_logging_targets(
+            ant_log_otlp.as_deref(),
+            application_log_targets,
+            None, // No CLI verbosity for OTLP
+            true, // Print updates
+        )?;
 
         let target_filters: Box<dyn Filter<Registry> + Send + Sync> =
             Box::new(Targets::new().with_targets(targets));
@@ -270,111 +274,195 @@ impl TracingLayers {
     }
 }
 
-/// Parses the logging targets from the env variable (ANT_LOG). The crates should be given as a CSV, for e.g.,
-/// `export ANT_LOG = libp2p=DEBUG, tokio=INFO, verbose, autonomi=ERROR`
+/// Computes the final logging targets based on CLI verbosity, ANT_LOG env var, and application defaults.
 ///
-/// Supported verbosity keywords:
-/// - `minimal` or `min`: Uses application's default targets (no override)
-/// - `standard` or `std`: Sets ALL crates to INFO level
-/// - `verbose` or `v`: Sets ALL crates to TRACE/DEBUG level for deep debugging
+/// Precedence for determining base targets:
+/// 1. CLI `--verbosity standard/verbose` sets hardcoded base targets
+/// 2. ANT_LOG keywords (`std`/`verbose`) set hardcoded base targets (when CLI is minimal/none)
+/// 3. Application defaults are used otherwise
 ///
-/// User-specified targets (e.g., `autonomi=ERROR`) take precedence over keyword defaults.
-fn get_logging_targets(logging_env_value: &str) -> Result<Vec<(String, Level)>> {
-    let mut targets = BTreeMap::new();
-    let mut contains_verbose = false;
-    let mut contains_standard = false;
-    // Note: minimal just means "use application defaults", so we only need to skip the keyword
+/// Custom overrides from ANT_LOG (e.g., `libp2p=debug`) are always applied on top of the base.
+///
+/// # Examples
+/// - `--verbosity standard` → hardcoded INFO targets
+/// - `--verbosity standard` + `ANT_LOG=libp2p=debug` → hardcoded INFO + libp2p override
+/// - `ANT_LOG=std,libp2p=debug` → hardcoded INFO + libp2p override
+/// - `ANT_LOG=libp2p=debug` → application defaults + libp2p override
+fn get_logging_targets(
+    ant_log_value: Option<&str>,
+    application_log_targets: Vec<(String, Level)>,
+    verbosity: Option<VerbosityLevel>,
+    print_updates: bool,
+) -> Result<Vec<(String, Level)>> {
+    // Step 1: Parse ANT_LOG for keywords and custom overrides
+    let (ant_log_keyword, custom_overrides) = parse_ant_log(ant_log_value);
 
-    for crate_log_level in logging_env_value.split(',') {
-        let trimmed = crate_log_level.trim();
-        // Check for verbosity keywords
-        if trimmed == VERBOSITY_VERBOSE || trimmed == VERBOSITY_VERBOSE_SHORT {
-            contains_verbose = true;
-            continue;
-        } else if trimmed == VERBOSITY_STANDARD || trimmed == VERBOSITY_STANDARD_SHORT {
-            contains_standard = true;
-            continue;
-        } else if trimmed == VERBOSITY_MINIMAL || trimmed == VERBOSITY_MINIMAL_SHORT {
-            // Minimal = use application defaults, just skip this keyword
-            continue;
+    // Step 2: Determine base targets (CLI verbosity takes precedence)
+    let base_targets = match verbosity {
+        Some(VerbosityLevel::Standard) => {
+            if print_updates {
+                if custom_overrides.is_empty() {
+                    println!("Using verbosity: standard");
+                } else {
+                    println!("Using verbosity: standard with ANT_LOG overrides");
+                }
+            }
+            standard_targets()
         }
-
-        let mut split = trimmed.split('=');
-        let crate_name = split.next().ok_or_else(|| {
-            Error::LoggingConfiguration("Could not obtain crate name in logging string".to_string())
-        })?;
-        // Skip empty crate names
-        if crate_name.is_empty() {
-            continue;
+        Some(VerbosityLevel::Verbose) => {
+            if print_updates {
+                if custom_overrides.is_empty() {
+                    println!("Using verbosity: verbose");
+                } else {
+                    println!("Using verbosity: verbose with ANT_LOG overrides");
+                }
+            }
+            verbose_targets()
         }
-        let log_level = split.next().unwrap_or("trace");
-        targets.insert(crate_name.to_string(), get_log_level_from_str(log_level)?);
-    }
-
-    let mut keyword_targets = if contains_verbose {
-        // Verbose mode: TRACE/DEBUG for all crates
-        BTreeMap::from_iter(vec![
-            // bins
-            ("ant".to_string(), Level::TRACE),
-            ("evm_testnet".to_string(), Level::TRACE),
-            ("antnode".to_string(), Level::TRACE),
-            ("antctl".to_string(), Level::TRACE),
-            ("node_launchpad".to_string(), Level::DEBUG),
-            // libs
-            ("ant_bootstrap".to_string(), Level::TRACE),
-            ("ant_build_info".to_string(), Level::TRACE),
-            ("ant_evm".to_string(), Level::TRACE),
-            ("ant_logging".to_string(), Level::TRACE),
-            ("ant_node".to_string(), Level::TRACE),
-            ("ant_node_manager".to_string(), Level::TRACE),
-            ("ant_node_rpc_client".to_string(), Level::TRACE),
-            ("ant_protocol".to_string(), Level::TRACE),
-            ("ant_service_management".to_string(), Level::TRACE),
-            ("service-manager".to_string(), Level::DEBUG),
-            ("autonomi".to_string(), Level::TRACE),
-            ("evmlib".to_string(), Level::TRACE),
-        ])
-    } else if contains_standard {
-        // Standard mode: INFO level for all crates
-        BTreeMap::from_iter(vec![
-            // bins
-            ("ant".to_string(), Level::INFO),
-            ("evm_testnet".to_string(), Level::INFO),
-            ("antnode".to_string(), Level::INFO),
-            ("antctl".to_string(), Level::INFO),
-            ("node_launchpad".to_string(), Level::INFO),
-            // libs
-            ("ant_bootstrap".to_string(), Level::INFO),
-            ("ant_build_info".to_string(), Level::INFO),
-            ("ant_evm".to_string(), Level::INFO),
-            ("ant_logging".to_string(), Level::INFO),
-            ("ant_node".to_string(), Level::INFO),
-            ("ant_node_manager".to_string(), Level::INFO),
-            ("ant_node_rpc_client".to_string(), Level::INFO),
-            ("ant_protocol".to_string(), Level::INFO),
-            ("ant_service_management".to_string(), Level::INFO),
-            ("service-manager".to_string(), Level::INFO),
-            ("autonomi".to_string(), Level::INFO),
-            ("evmlib".to_string(), Level::INFO),
-        ])
-    } else {
-        // Minimal (default): empty map, use application's default targets
-        Default::default()
+        Some(VerbosityLevel::Minimal) | None => {
+            // Check ANT_LOG keywords
+            match ant_log_keyword {
+                Some(VerbosityLevel::Standard) => {
+                    if print_updates {
+                        if custom_overrides.is_empty() {
+                            println!("Using ANT_LOG: standard");
+                        } else {
+                            println!("Using ANT_LOG: standard with overrides");
+                        }
+                    }
+                    standard_targets()
+                }
+                Some(VerbosityLevel::Verbose) => {
+                    if print_updates {
+                        if custom_overrides.is_empty() {
+                            println!("Using ANT_LOG: verbose");
+                        } else {
+                            println!("Using ANT_LOG: verbose with overrides");
+                        }
+                    }
+                    verbose_targets()
+                }
+                Some(VerbosityLevel::Minimal) | None => {
+                    if print_updates {
+                        if custom_overrides.is_empty() {
+                            println!("Using application default log targets");
+                        } else {
+                            println!("Using application defaults with ANT_LOG overrides");
+                        }
+                    }
+                    BTreeMap::from_iter(application_log_targets)
+                }
+            }
+        }
     };
-    // User-specified targets take precedence over keyword defaults
-    keyword_targets.extend(targets);
-    Ok(keyword_targets.into_iter().collect())
+
+    // Step 3: Apply custom overrides from ANT_LOG on top of base
+    let mut final_targets = base_targets;
+    final_targets.extend(custom_overrides);
+
+    Ok(final_targets.into_iter().collect())
 }
 
-fn get_log_level_from_str(log_level: &str) -> Result<Level> {
+/// Parses ANT_LOG value for keywords (std/verbose/minimal) and custom target overrides.
+/// Returns (keyword_verbosity, custom_overrides)
+/// Invalid entries are silently skipped.
+fn parse_ant_log(ant_log_value: Option<&str>) -> (Option<VerbosityLevel>, BTreeMap<String, Level>) {
+    let Some(value) = ant_log_value else {
+        return (None, BTreeMap::new());
+    };
+
+    let mut keyword_verbosity = None;
+    let mut custom_overrides = BTreeMap::new();
+
+    for part in value.split(',') {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Check for verbosity keywords
+        if trimmed == VERBOSITY_VERBOSE || trimmed == VERBOSITY_VERBOSE_SHORT {
+            keyword_verbosity = Some(VerbosityLevel::Verbose);
+        } else if trimmed == VERBOSITY_STANDARD || trimmed == VERBOSITY_STANDARD_SHORT {
+            keyword_verbosity = Some(VerbosityLevel::Standard);
+        } else if trimmed == VERBOSITY_MINIMAL || trimmed == VERBOSITY_MINIMAL_SHORT {
+            keyword_verbosity = Some(VerbosityLevel::Minimal);
+        } else {
+            // Parse as custom target: "crate_name=level"
+            let mut split = trimmed.split('=');
+            if let Some(crate_name) = split.next()
+                && !crate_name.is_empty()
+            {
+                let log_level = split.next().unwrap_or("trace");
+                if let Some(level) = parse_log_level(log_level) {
+                    custom_overrides.insert(crate_name.to_string(), level);
+                }
+                // Invalid log level is silently skipped
+            }
+        }
+    }
+
+    (keyword_verbosity, custom_overrides)
+}
+
+/// Returns hardcoded INFO-level targets for standard verbosity
+fn standard_targets() -> BTreeMap<String, Level> {
+    BTreeMap::from_iter(vec![
+        // bins
+        ("ant".to_string(), Level::INFO),
+        ("evm_testnet".to_string(), Level::INFO),
+        ("antnode".to_string(), Level::INFO),
+        ("antctl".to_string(), Level::INFO),
+        ("node_launchpad".to_string(), Level::INFO),
+        // libs
+        ("ant_bootstrap".to_string(), Level::INFO),
+        ("ant_build_info".to_string(), Level::INFO),
+        ("ant_evm".to_string(), Level::INFO),
+        ("ant_logging".to_string(), Level::INFO),
+        ("ant_node".to_string(), Level::INFO),
+        ("ant_node_manager".to_string(), Level::INFO),
+        ("ant_node_rpc_client".to_string(), Level::INFO),
+        ("ant_protocol".to_string(), Level::INFO),
+        ("ant_service_management".to_string(), Level::INFO),
+        ("service-manager".to_string(), Level::INFO),
+        ("autonomi".to_string(), Level::INFO),
+        ("evmlib".to_string(), Level::INFO),
+    ])
+}
+
+/// Returns hardcoded TRACE/DEBUG-level targets for verbose mode
+fn verbose_targets() -> BTreeMap<String, Level> {
+    BTreeMap::from_iter(vec![
+        // bins
+        ("ant".to_string(), Level::TRACE),
+        ("evm_testnet".to_string(), Level::TRACE),
+        ("antnode".to_string(), Level::TRACE),
+        ("antctl".to_string(), Level::TRACE),
+        ("node_launchpad".to_string(), Level::DEBUG),
+        // libs
+        ("ant_bootstrap".to_string(), Level::TRACE),
+        ("ant_build_info".to_string(), Level::TRACE),
+        ("ant_evm".to_string(), Level::TRACE),
+        ("ant_logging".to_string(), Level::TRACE),
+        ("ant_node".to_string(), Level::TRACE),
+        ("ant_node_manager".to_string(), Level::TRACE),
+        ("ant_node_rpc_client".to_string(), Level::TRACE),
+        ("ant_protocol".to_string(), Level::TRACE),
+        ("ant_service_management".to_string(), Level::TRACE),
+        ("service-manager".to_string(), Level::DEBUG),
+        ("autonomi".to_string(), Level::TRACE),
+        ("evmlib".to_string(), Level::TRACE),
+    ])
+}
+
+/// Parses a log level string, returning None for invalid values (graceful error handling)
+fn parse_log_level(log_level: &str) -> Option<Level> {
     match log_level.to_lowercase().as_str() {
-        "info" => Ok(Level::INFO),
-        "debug" => Ok(Level::DEBUG),
-        "trace" => Ok(Level::TRACE),
-        "warn" => Ok(Level::WARN),
-        "error" => Ok(Level::WARN),
-        _ => Err(Error::LoggingConfiguration(format!(
-            "Log level {log_level} is not supported"
-        ))),
+        "info" | "i" => Some(Level::INFO),
+        "debug" | "d" => Some(Level::DEBUG),
+        "trace" | "t" => Some(Level::TRACE),
+        "warn" | "w" => Some(Level::WARN),
+        "error" | "e" => Some(Level::ERROR),
+        _ => None,
     }
 }

--- a/ant-logging/src/lib.rs
+++ b/ant-logging/src/lib.rs
@@ -111,6 +111,51 @@ impl LogFormat {
     }
 }
 
+/// Controls the verbosity level of logging output.
+///
+/// - `Minimal`: Reduced logging for production use (~50% less logs). Demotes operational
+///   and marker logs to DEBUG level.
+/// - `Standard`: Normal INFO-level logging (default behavior).
+/// - `Verbose`: Comprehensive DEBUG/TRACE logging for development and debugging.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum VerbosityLevel {
+    Minimal,
+    #[default]
+    Standard,
+    Verbose,
+}
+
+impl VerbosityLevel {
+    /// Parse a verbosity level from a string.
+    ///
+    /// Valid values: "minimal", "min", "standard", "std", "verbose", "v", "all"
+    pub fn parse_from_str(val: &str) -> Result<Self> {
+        match val.to_lowercase().as_str() {
+            "minimal" | "min" => Ok(VerbosityLevel::Minimal),
+            "standard" | "std" => Ok(VerbosityLevel::Standard),
+            "verbose" | "v" | "all" => Ok(VerbosityLevel::Verbose),
+            _ => Err(Error::LoggingConfiguration(
+                "Valid verbosity values are: 'minimal', 'standard', or 'verbose'".to_string(),
+            )),
+        }
+    }
+
+    /// Returns the string representation of the verbosity level.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VerbosityLevel::Minimal => "minimal",
+            VerbosityLevel::Standard => "standard",
+            VerbosityLevel::Verbose => "verbose",
+        }
+    }
+}
+
+impl std::fmt::Display for VerbosityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 pub struct LogBuilder {
     default_logging_targets: Vec<(String, Level)>,
     output_dest: LogOutputDest,

--- a/ant-node-manager/src/add_services/tests.rs
+++ b/ant-node-manager/src/add_services/tests.rs
@@ -786,7 +786,7 @@ async fn add_node_should_update_the_environment_variables_inside_node_registry()
     let mut mock_service_control = MockServiceControl::new();
 
     let env_variables = Some(vec![
-        ("ANT_LOG".to_owned(), "all".to_owned()),
+        ("ANT_LOG".to_owned(), "verbose".to_owned()),
         ("RUST_LOG".to_owned(), "libp2p=debug".to_owned()),
     ]);
 
@@ -5215,7 +5215,7 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
                 ],
                 autostart: true,
                 contents: None,
-                environment: Some(vec![("ANT_LOG".to_string(), "ALL".to_string())]),
+                environment: Some(vec![("ANT_LOG".to_string(), "verbose".to_string())]),
                 label: "antctld".parse()?,
                 program: daemon_install_path.to_path_buf(),
                 restart_policy,
@@ -5231,7 +5231,7 @@ async fn add_daemon_should_add_a_daemon_service() -> Result<()> {
             address: Ipv4Addr::new(127, 0, 0, 1),
             daemon_install_bin_path: daemon_install_path.to_path_buf(),
             daemon_src_bin_path: daemon_download_path.to_path_buf(),
-            env_variables: Some(vec![("ANT_LOG".to_string(), "ALL".to_string())]),
+            env_variables: Some(vec![("ANT_LOG".to_string(), "verbose".to_string())]),
             port: 8080,
             user: get_username(),
             version: latest_version.to_string(),

--- a/ant-node-manager/src/bin/cli/main.rs
+++ b/ant-node-manager/src/bin/cli/main.rs
@@ -126,7 +126,7 @@ pub enum SubCmd {
         ///
         /// Useful to set log levels. Variables should be comma separated without spaces.
         ///
-        /// Example: --env ANT_LOG=all,RUST_LOG=libp2p=debug
+        /// Example: --env ANT_LOG=verbose,RUST_LOG=libp2p=debug
         #[clap(name = "env", long, use_value_delimiter = false, value_parser = parse_environment_variables)]
         env_variables: Option<Vec<(String, String)>>,
         /// Specify what EVM network to use for payments.
@@ -419,7 +419,7 @@ pub enum SubCmd {
         /// Useful to set antnode's log levels. Variables should be comma separated without
         /// spaces.
         ///
-        /// Example: --env ANT_LOG=all,RUST_LOG=libp2p=debug
+        /// Example: --env ANT_LOG=verbose,RUST_LOG=libp2p=debug
         #[clap(name = "env", long, use_value_delimiter = false, value_parser = parse_environment_variables)]
         env_variables: Option<Vec<(String, String)>>,
         /// Set this flag to force the upgrade command to replace binaries without comparing any
@@ -484,7 +484,7 @@ pub enum DaemonSubCmd {
         ///
         /// Useful to set log levels. Variables should be comma separated without spaces.
         ///
-        /// Example: --env ANT_LOG=all,RUST_LOG=libp2p=debug
+        /// Example: --env ANT_LOG=verbose,RUST_LOG=libp2p=debug
         #[clap(name = "env", long, use_value_delimiter = false, value_parser = parse_environment_variables)]
         env_variables: Option<Vec<(String, String)>>,
         /// Specify a port for the daemon to listen on.
@@ -817,7 +817,9 @@ async fn main() -> Result<()> {
         } else {
             Level::TRACE
         };
-        get_log_builder(level)?.initialize()?.1
+        get_log_builder(level)?
+            .initialize()?
+            .1
     } else {
         None
     };

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -26,7 +26,7 @@ use ant_bootstrap::InitialPeersConfig;
 use ant_bootstrap::bootstrap::Bootstrap;
 use ant_evm::{EvmNetwork, RewardsAddress, get_evm_network};
 use ant_logging::metrics::init_metrics;
-use ant_logging::{Level, LogFormat, LogOutputDest, ReloadHandle};
+use ant_logging::{Level, LogFormat, LogOutputDest, ReloadHandle, VerbosityLevel};
 use ant_node::utils::{get_antnode_root_dir, get_root_dir_and_keypair};
 use ant_node::{Marker, NodeBuilder, NodeEvent, NodeEventsReceiver};
 use ant_protocol::{
@@ -139,6 +139,18 @@ struct Opt {
     /// If the argument is not used, the default format will be applied.
     #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
     log_format: Option<LogFormat>,
+
+    /// Set the logging verbosity level.
+    ///
+    /// Valid values are "minimal", "standard", or "verbose".
+    ///
+    /// - minimal: Uses application default log levels (least logging)
+    /// - standard: Sets all crates to INFO level
+    /// - verbose: Sets all crates to TRACE/DEBUG level (most logging)
+    ///
+    /// If not specified, uses application defaults (minimal).
+    #[clap(long, value_parser = VerbosityLevel::parse_from_str, verbatim_doc_comment)]
+    verbosity: Option<VerbosityLevel>,
 
     /// Specify the maximum number of uncompressed log files to store.
     ///
@@ -627,6 +639,9 @@ fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Opt
         if let Some(files) = opt.max_archived_log_files {
             log_builder.max_archived_log_files(files);
         }
+        if let Some(verbosity) = opt.verbosity {
+            log_builder.verbosity(verbosity);
+        }
 
         log_builder.initialize()?
     };
@@ -644,6 +659,9 @@ fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Opt
             }
             if let Some(files) = opt.max_archived_log_files {
                 log_builder.max_archived_log_files(files);
+            }
+            if let Some(verbosity) = opt.verbosity {
+                log_builder.verbosity(verbosity);
             }
             log_builder.initialize()
         })?;

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -598,13 +598,13 @@ fn monitor_node_events(mut node_events_rx: NodeEventsReceiver, ctrl_tx: mpsc::Se
 fn init_logging(opt: &Opt, peer_id: PeerId) -> Result<(String, ReloadHandle, Option<WorkerGuard>)> {
     let logging_targets = vec![
         ("ant_bootstrap".to_string(), Level::INFO),
-        ("ant_build_info".to_string(), Level::DEBUG),
-        ("ant_evm".to_string(), Level::DEBUG),
-        ("ant_logging".to_string(), Level::DEBUG),
+        ("ant_build_info".to_string(), Level::INFO),
+        ("ant_evm".to_string(), Level::INFO),
+        ("ant_logging".to_string(), Level::INFO),
         ("ant_node".to_string(), Level::INFO),
-        ("ant_protocol".to_string(), Level::DEBUG),
+        ("ant_protocol".to_string(), Level::INFO),
         ("antnode".to_string(), Level::INFO),
-        ("evmlib".to_string(), Level::DEBUG),
+        ("evmlib".to_string(), Level::INFO),
     ];
 
     let output_dest = match &opt.log_output_dest {

--- a/node-launchpad/src/bin/tui/main.rs
+++ b/node-launchpad/src/bin/tui/main.rs
@@ -150,12 +150,12 @@ pub fn get_log_builder() -> Result<LogBuilder> {
         .join(format!("launchpad_{timestamp}.log"));
 
     let logging_targets = vec![
-        ("ant_bootstrap".to_string(), Level::DEBUG),
-        ("evmlib".to_string(), Level::DEBUG),
-        ("ant_node_manager".to_string(), Level::DEBUG),
-        ("ant_service_management".to_string(), Level::DEBUG),
-        ("service-manager".to_string(), Level::DEBUG),
-        ("node_launchpad".to_string(), Level::DEBUG),
+        ("ant_bootstrap".to_string(), Level::INFO),
+        ("evmlib".to_string(), Level::INFO),
+        ("ant_node_manager".to_string(), Level::INFO),
+        ("ant_service_management".to_string(), Level::INFO),
+        ("service-manager".to_string(), Level::INFO),
+        ("node_launchpad".to_string(), Level::INFO),
     ];
     let mut log_builder = LogBuilder::new(logging_targets);
     log_builder.output_dest(ant_logging::LogOutputDest::Path(log_path));

--- a/test.sh
+++ b/test.sh
@@ -243,7 +243,7 @@ EOF
         # Set environment variables for Rust logging
         if [ "$ENABLE_DEBUG_LOGGING" = true ]; then
             export RUST_LOG="debug"
-            export ANT_LOG="all"
+            export ANT_LOG="verbose"
         else
             export RUST_LOG="info"
             export ANT_LOG="networking,client,bootstrap"
@@ -397,7 +397,7 @@ run_test_with_logging() {
         # Set up environment for this test
         local test_env=""
         if [ "$ENABLE_DEBUG_LOGGING" = true ]; then
-            test_env="RUST_LOG=debug ANT_LOG=all"
+            test_env="RUST_LOG=debug ANT_LOG=verbose"
         else
             test_env="RUST_LOG=info"
         fi


### PR DESCRIPTION
Adds a 3-level verbosity system to reduce default logging output. Users can now control log verbosity via `--verbosity` CLI flag (minimal/standard/verbose) or `ANT_LOG` keywords, with custom overrides like `ANT_LOG=std,libp2p=debug` working on top of the base level.

  - Add `--verbosity` flag to `ant-cli`, `antnode`, and `antctl` binaries
  - Support verbosity keywords in `ANT_LOG` env var (`std`, `verbose`, `minimal`)
  - CLI flag takes precedence over `ANT_LOG` keywords, but ANT_LOG custom targets always apply as overrides
  - Set all binaries to use INFO level by default
