### PR TITLE
fix(ci): put latest mac intel runner

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,9 @@ jobs:
           - host: macos-15 # arm64
             target: aarch64-apple-darwin
             build: npm run build -- --target aarch64-apple-darwin
-          - host: macos-13 # Intel
+          # macos-15-intel provides x86_64 builds. Retiring Fall 2027.
+          # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+          - host: macos-15-intel # Intel
             target: x86_64-apple-darwin
             build: npm run build -- --target x86_64-apple-darwin
     defaults:
@@ -111,7 +113,9 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: macos-15 # arm64
             target: aarch64-apple-darwin
-          - host: macos-13 # Intel
+          # macos-15-intel provides x86_64 builds. Retiring Fall 2027.
+          # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+          - host: macos-15-intel # Intel
             target: x86_64-apple-darwin
     defaults:
       run:

--- a/.github/workflows/python-publish-client.yml
+++ b/.github/workflows/python-publish-client.yml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          # macos-15-intel provides x86_64 builds. Retiring Fall 2027.
+          # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+          - runner: macos-15-intel
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
Replaced `macos-13` by `macos-15-intel`
It's the latest github runner for CI for mac x86 architecture (or Intel mac)

‼️ But this will be deprecated/discontinued on Fall 2027

Details here: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/