### PR TITLE
fix(client): during mutable data reupload, shall use same quoting range

### DIFF
--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -14,7 +14,7 @@ use crate::{
         payment::{PayError, PaymentOption},
         quote::CostError,
     },
-    networking::{NetworkError, PeerInfo, Record},
+    networking::{NetworkError, PeerInfo, QUOTING_CANDIDATES, Record},
 };
 
 use ant_evm::{Amount, AttoTokens, EvmWalletError};
@@ -198,7 +198,7 @@ impl Client {
             };
             let target_nodes = self
                 .network
-                .get_closest_peers_with_retries(net_addr.clone(), None)
+                .get_closest_peers_with_retries(net_addr.clone(), Some(QUOTING_CANDIDATES))
                 .await
                 .map_err(|e| PutError::Network {
                     address: Box::new(net_addr),
@@ -315,7 +315,7 @@ impl Client {
         // store the pointer on the network
         let target_nodes = self
             .network
-            .get_closest_peers_with_retries(net_addr.clone(), None)
+            .get_closest_peers_with_retries(net_addr.clone(), Some(QUOTING_CANDIDATES))
             .await
             .map_err(|e| PutError::Network {
                 address: Box::new(net_addr),

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -15,7 +15,7 @@ use crate::{
         payment::{PayError, PaymentOption},
         quote::CostError,
     },
-    networking::{NetworkError, PeerInfo},
+    networking::{NetworkError, PeerInfo, QUOTING_CANDIDATES},
 };
 
 use ant_protocol::{
@@ -277,7 +277,7 @@ impl Client {
             };
             let target_nodes = self
                 .network
-                .get_closest_peers_with_retries(net_addr.clone(), None)
+                .get_closest_peers_with_retries(net_addr.clone(), Some(QUOTING_CANDIDATES))
                 .await
                 .map_err(|e| PutError::Network {
                     address: Box::new(net_addr),
@@ -424,7 +424,7 @@ impl Client {
         // store the scratchpad on the network
         let target_nodes = self
             .network
-            .get_closest_peers_with_retries(net_addr.clone(), None)
+            .get_closest_peers_with_retries(net_addr.clone(), Some(QUOTING_CANDIDATES))
             .await
             .map_err(|e| PutError::Network {
                 address: Box::new(net_addr),

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -52,6 +52,9 @@ pub(in crate::networking) type OneShotTaskResult<T> = oneshot::Sender<Result<T, 
 /// The majority size within the close group.
 pub const CLOSE_GROUP_SIZE_MAJORITY: usize = CLOSE_GROUP_SIZE / 2 + 1;
 
+/// The number of quoting candidates to be queried.
+pub(crate) const QUOTING_CANDIDATES: usize = 10;
+
 /// The number of closest peers to request from the network
 const N_CLOSEST_PEERS: NonZeroUsize =
     NonZeroUsize::new(CLOSE_GROUP_SIZE + 2).expect("N_CLOSEST_PEERS must be > 0");
@@ -896,10 +899,10 @@ impl Network {
         data_type: u32,
         data_size: usize,
     ) -> Result<Option<Vec<(PeerInfo, PaymentQuote)>>, NetworkError> {
-        // request 10 quotes, hope that at least 5 respond
+        // request QUOTING_CANDIDATES quotes, hope that at least CLOSE_GROUP_SIZE respond
         let minimum_quotes = CLOSE_GROUP_SIZE;
         let closest_peers = self
-            .get_closest_peers_with_retries(addr.clone(), Some(10))
+            .get_closest_peers_with_retries(addr.clone(), Some(QUOTING_CANDIDATES))
             .await?;
         let closest_peers_id = closest_peers.iter().map(|p| p.peer_id).collect::<Vec<_>>();
         debug!("Get quotes for {addr}: got closest peers: {closest_peers_id:?}");


### PR DESCRIPTION
### Description

during mutable data reupload, the same number of candidates of quoting shall be used.

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
