### PR TITLE
refactor(ant-node): increase `KAD_QUERY_TIMEOUT_S` from 10s to 120s

### DIFF
--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -70,7 +70,7 @@ const RESEND_IDENTIFY_INVERVAL: Duration = Duration::from_secs(3600);
 const NETWORKING_CHANNEL_SIZE: usize = 10_000;
 
 /// Time before a Kad query times out if no response is received
-const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(10);
+const KAD_QUERY_TIMEOUT_S: Duration = Duration::from_secs(120);
 
 #[derive(Debug)]
 pub(crate) struct NetworkConfig {


### PR DESCRIPTION
Increases the `KAD_QUERY_TIMEOUT_S` on the node side from 10s to 120s to address the `GetClosestTimedOut` error observed during merkle payment topology verifications.