### PR TITLE
feat: download binaries from autonomi.com URLs instead of S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8369,6 +8369,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -8388,12 +8389,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util 0.7.17",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -10697,6 +10700,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -80,6 +80,7 @@ pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"], optional
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
+reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls-manual-roots", "stream"] }
 semver = "1.0"
 sha2 = "0.10"
 serde = { version = "1.0.133", features = ["derive", "rc"] }

--- a/ant-node/src/bin/antnode/upgrade/mod.rs
+++ b/ant-node/src/bin/antnode/upgrade/mod.rs
@@ -34,13 +34,13 @@ const DEFAULT_NETWORK_SIZE: usize = 100_000;
 /// These URLs redirect to the actual binary download location.
 fn get_autonomi_download_url(platform: &Platform) -> &'static str {
     match platform {
-        Platform::LinuxMusl => "https://autonomi.com/download/node/linux-x64",
-        Platform::LinuxMuslAarch64 => "https://autonomi.com/download/node/linux-arm64",
-        Platform::LinuxMuslArm => "https://autonomi.com/download/node/linux-arm",
-        Platform::LinuxMuslArmV7 => "https://autonomi.com/download/node/linux-armv7",
-        Platform::MacOs => "https://autonomi.com/download/node/mac-intel",
-        Platform::MacOsAarch64 => "https://autonomi.com/download/node/mac-apple-silicon",
-        Platform::Windows => "https://autonomi.com/download/node/windows",
+        Platform::LinuxMusl => "https://downloads.autonomi.com/node/linux-x64",
+        Platform::LinuxMuslAarch64 => "https://downloads.autonomi.com/node/linux-arm64",
+        Platform::LinuxMuslArm => "https://downloads.autonomi.com/node/linux-arm",
+        Platform::LinuxMuslArmV7 => "https://downloads.autonomi.com/node/linux-armv7",
+        Platform::MacOs => "https://downloads.autonomi.com/node/mac-intel",
+        Platform::MacOsAarch64 => "https://downloads.autonomi.com/node/mac-apple-silicon",
+        Platform::Windows => "https://downloads.autonomi.com/node/windows",
     }
 }
 


### PR DESCRIPTION
Replace S3 downloads with autonomi.com redirect URLs for antnode binary upgrades to prevent outages from affecting the upgrade process. 