### PR TITLE
feat: add developer query `closest-peers`

### DIFF
--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [features]
 default = ["metrics"]
+developer = ["autonomi/developer", "ant-protocol/developer"]
 metrics = ["ant-logging/process-metrics"]
 nightly = []
 

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -486,11 +486,16 @@ pub enum DeveloperCmd {
     /// (not just return its local routing table) and returns the results from
     /// that node's network perspective.
     ClosestPeers {
-        /// Multiaddr of the node to query.
-        /// Example: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW...
+        /// Node to query: either a PeerId or full multiaddr.
+        ///
+        /// Examples:
+        ///   - PeerId: 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
+        ///   - Multiaddr: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW...
+        ///
+        /// When only a PeerId is provided, the peer's address is discovered via the network.
         #[arg(name = "node")]
         node_addr: String,
-        /// Target address to find closest peers for (hex string).
+        /// Target address to find closest peers for (hex string or PeerId).
         #[arg(name = "target")]
         target: String,
         /// Number of peers to return (default: uses K_VALUE, typically 20).

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod analyze;
+#[cfg(feature = "developer")]
+mod developer;
 mod file;
 mod pointer;
 mod register;
@@ -97,6 +99,14 @@ pub enum SubCmd {
         /// If path is a directory, enables file rotations (50MB max per file, 10 files max).
         #[arg(long)]
         json: Option<PathBuf>,
+    },
+
+    /// Developer and analytics tools for network diagnostics.
+    /// Requires the `developer` feature to be enabled on both client and node.
+    #[cfg(feature = "developer")]
+    Developer {
+        #[command(subcommand)]
+        command: DeveloperCmd,
     },
 }
 
@@ -465,6 +475,30 @@ pub enum WalletCmd {
     Balance,
 }
 
+/// Developer and analytics tools for network diagnostics.
+/// Only available when the `developer` feature is enabled.
+#[cfg(feature = "developer")]
+#[derive(Subcommand, Debug)]
+pub enum DeveloperCmd {
+    /// Query a node to get its network view of closest peers to a target address.
+    ///
+    /// This asks the specified node to perform an actual Kademlia network lookup
+    /// (not just return its local routing table) and returns the results from
+    /// that node's network perspective.
+    ClosestPeers {
+        /// Multiaddr of the node to query.
+        /// Example: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW...
+        #[arg(name = "node")]
+        node_addr: String,
+        /// Target address to find closest peers for (hex string).
+        #[arg(name = "target")]
+        target: String,
+        /// Number of peers to return (default: uses K_VALUE, typically 20).
+        #[arg(short = 'n', long)]
+        num_peers: Option<usize>,
+    },
+}
+
 #[derive(Args, Debug)]
 pub(crate) struct TransactionOpt {
     /// Max fee per gas / gas price bid.
@@ -707,6 +741,14 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             )
             .await
         }
+        #[cfg(feature = "developer")]
+        Some(SubCmd::Developer { command }) => match command {
+            DeveloperCmd::ClosestPeers {
+                node_addr,
+                target,
+                num_peers,
+            } => developer::closest_peers(&node_addr, &target, num_peers, network_context).await,
+        },
         None => {
             // If no subcommand is given, default to clap's error behaviour.
             Opt::command()

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -501,6 +501,9 @@ pub enum DeveloperCmd {
         /// Number of peers to return (default: uses K_VALUE, typically 20).
         #[arg(short = 'n', long)]
         num_peers: Option<usize>,
+        /// Compare the node's perspective with the client's perspective.
+        #[arg(long)]
+        compare: bool,
     },
 }
 
@@ -752,7 +755,11 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 node_addr,
                 target,
                 num_peers,
-            } => developer::closest_peers(&node_addr, &target, num_peers, network_context).await,
+                compare,
+            } => {
+                developer::closest_peers(&node_addr, &target, num_peers, compare, network_context)
+                    .await
+            }
         },
         None => {
             // If no subcommand is given, default to clap's error behaviour.

--- a/ant-cli/src/commands/developer.rs
+++ b/ant-cli/src/commands/developer.rs
@@ -63,14 +63,14 @@ pub async fn closest_peers(
         println!("  No peers found.");
     } else {
         println!(
-            "  {:<4} {:<52} {:<20} Multiaddrs",
+            "  {:<4} {:<54} {:<15} Multiaddrs",
             "#", "PeerId", "Distance"
         );
-        println!("  {}", "-".repeat(120));
+        println!("  {}", "-".repeat(130));
 
         for (i, (peer_addr, multiaddrs)) in response.peers.iter().enumerate() {
             let distance = target_addr.distance(peer_addr);
-            let distance_hex = format!("0x{:016x}...", distance.0.leading_zeros());
+            let distance_ilog2 = distance.ilog2().unwrap_or(0);
 
             let multiaddr_str = if multiaddrs.is_empty() {
                 "N/A".to_string()
@@ -82,19 +82,18 @@ pub async fn closest_peers(
                     .join(", ")
             };
 
-            // Truncate peer address for display
-            let peer_str = peer_addr.to_string();
-            let peer_display = if peer_str.len() > 50 {
-                format!("{}...", &peer_str[..47])
+            // Extract PeerId from NetworkAddress, or fall back to string representation
+            let peer_display = if let Some(peer_id) = peer_addr.as_peer_id() {
+                peer_id.to_string()
             } else {
-                peer_str
+                peer_addr.to_string()
             };
 
             println!(
-                "  {:<4} {:<52} {:<20} {}",
+                "  {:<4} {:<54} {:<15} {}",
                 i + 1,
                 peer_display,
-                distance_hex,
+                distance_ilog2,
                 multiaddr_str
             );
         }

--- a/ant-cli/src/commands/developer.rs
+++ b/ant-cli/src/commands/developer.rs
@@ -1,0 +1,148 @@
+// Copyright 2024 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Developer and analytics tools for network diagnostics.
+//!
+//! This module provides commands for debugging and analyzing the network from
+//! the perspective of specific nodes. These commands require the `developer`
+//! feature to be enabled on both the client (ant-cli) and the target node.
+
+use crate::actions::{NetworkContext, connect_to_network};
+use ant_protocol::NetworkAddress;
+use autonomi::networking::{Multiaddr, PeerId, PeerInfo};
+use color_eyre::{Result, eyre::eyre};
+
+/// Query a specific node to get its network view of closest peers to a target address.
+///
+/// This command asks the specified node to perform an actual Kademlia network lookup
+/// and returns the results from that node's network perspective.
+pub async fn closest_peers(
+    node_addr: &str,
+    target: &str,
+    num_peers: Option<usize>,
+    network_context: NetworkContext,
+) -> Result<()> {
+    // Parse the node multiaddr
+    let multiaddr: Multiaddr = node_addr
+        .parse()
+        .map_err(|e| eyre!("Invalid node multiaddr: {e}"))?;
+
+    // Extract PeerId from multiaddr
+    let peer_id = extract_peer_id(&multiaddr)
+        .ok_or_else(|| eyre!("Node multiaddr must contain a peer ID (p2p component)"))?;
+
+    // Parse the target address (hex string)
+    let target_addr = parse_target_address(target)?;
+
+    println!("Connecting to network...");
+    let client = connect_to_network(network_context)
+        .await
+        .map_err(|(err, _exit_code)| err)?;
+
+    println!("Querying node {peer_id} for closest peers to {target}...");
+    println!();
+
+    // Create PeerInfo for the target node
+    let node_info = PeerInfo {
+        peer_id,
+        addrs: vec![multiaddr],
+    };
+
+    // Perform the developer query
+    let response = client
+        .dev_get_closest_peers_from_node(node_info, target_addr.clone(), num_peers)
+        .await
+        .map_err(|e| eyre!("Failed to query node: {e}"))?;
+
+    // Display results
+    println!(
+        "Closest peers to {} from node {}:",
+        target, response.queried_node
+    );
+    println!();
+
+    if response.peers.is_empty() {
+        println!("  No peers found.");
+    } else {
+        println!(
+            "  {:<4} {:<52} {:<20} Multiaddrs",
+            "#", "PeerId", "Distance"
+        );
+        println!("  {}", "-".repeat(120));
+
+        for (i, (peer_addr, multiaddrs)) in response.peers.iter().enumerate() {
+            let distance = target_addr.distance(peer_addr);
+            let distance_hex = format!("0x{:016x}...", distance.0.leading_zeros());
+
+            let multiaddr_str = if multiaddrs.is_empty() {
+                "N/A".to_string()
+            } else {
+                multiaddrs
+                    .iter()
+                    .map(|m: &Multiaddr| m.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+
+            // Truncate peer address for display
+            let peer_str = peer_addr.to_string();
+            let peer_display = if peer_str.len() > 50 {
+                format!("{}...", &peer_str[..47])
+            } else {
+                peer_str
+            };
+
+            println!(
+                "  {:<4} {:<52} {:<20} {}",
+                i + 1,
+                peer_display,
+                distance_hex,
+                multiaddr_str
+            );
+        }
+    }
+
+    println!();
+    println!("Total: {} peers", response.peers.len());
+
+    Ok(())
+}
+
+/// Extract PeerId from a Multiaddr
+fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
+    // The multiaddr should end with /p2p/<peer_id>
+    // We'll extract it from the string representation
+    let addr_str = addr.to_string();
+    let p2p_idx = addr_str.find("/p2p/")?;
+    let peer_id_str = &addr_str[p2p_idx + 5..];
+    peer_id_str.parse().ok()
+}
+
+/// Parse a target address from a hex string
+fn parse_target_address(target: &str) -> Result<NetworkAddress> {
+    // Remove 0x prefix if present
+    let hex_str = target.strip_prefix("0x").unwrap_or(target);
+
+    // Try to parse as raw hex bytes (xor_name)
+    if let Ok(bytes) = hex::decode(hex_str)
+        && bytes.len() == 32
+    {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        return Ok(NetworkAddress::from(xor_name::XorName(arr)));
+    }
+
+    // Try to parse as a PeerId
+    if let Ok(peer_id) = target.parse::<PeerId>() {
+        return Ok(NetworkAddress::from(peer_id));
+    }
+
+    Err(eyre!(
+        "Invalid target address. Expected 32-byte hex string or peer ID. Got: {target}"
+    ))
+}

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/bin/daemon/main.rs"
 [features]
 chaos = []
 default = ["quic"]
+developer = []
 nightly = []
 open-metrics = []
 otlp = []

--- a/ant-node-manager/src/cmd/mod.rs
+++ b/ant-node-manager/src/cmd/mod.rs
@@ -188,6 +188,10 @@ fn build_binary(bin_type: &ReleaseType) -> Result<PathBuf> {
     if cfg!(feature = "open-metrics") {
         args.extend(["--features", "open-metrics"]);
     }
+    if cfg!(feature = "developer") {
+        println!("*** Building with DEVELOPER features enabled. ***");
+        args.extend(["--features", "developer"]);
+    }
 
     print_banner(&format!("Building {bin_name} binary"));
 

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/bin/antnode/main.rs"
 
 [features]
 default = ["open-metrics"]
+developer = ["ant-protocol/developer"]
 extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = [] # loud mode: print important messages to console
 nightly = []

--- a/ant-node/src/networking/driver/event/request_response.rs
+++ b/ant-node/src/networking/driver/event/request_response.rs
@@ -79,6 +79,10 @@ impl SwarmDriver {
                             ant_protocol::messages::Query::GetMerkleCandidateQuote { .. } => {
                                 "Request::Query::GetMerkleCandidateQuote"
                             }
+                            #[cfg(feature = "developer")]
+                            ant_protocol::messages::Query::DevGetClosestPeersFromNetwork {
+                                ..
+                            } => "Request::Query::DevGetClosestPeersFromNetwork",
                         },
                     };
                     connection_action_logging(
@@ -217,6 +221,10 @@ impl SwarmDriver {
                                     result_to_str(result)
                                 )
                             }
+                            #[cfg(feature = "developer")]
+                            ant_protocol::messages::QueryResponse::DevGetClosestPeersFromNetwork {
+                                ..
+                            } => "Response::Query::DevGetClosestPeersFromNetwork".to_string(),
                         },
                     };
                     connection_action_logging(

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -11,6 +11,7 @@ version = "1.0.11"
 
 [features]
 default = []
+developer = []
 rpc = ["tonic", "prost"]
 
 [dependencies]

--- a/ant-protocol/src/messages/query.rs
+++ b/ant-protocol/src/messages/query.rs
@@ -102,6 +102,16 @@ pub enum Query {
         /// Node verifies this is not expired/future, then signs its state with it
         merkle_payment_timestamp: u64,
     },
+    /// Developer/analytics query: Ask a node to query the network for closest peers.
+    /// Unlike GetClosestPeers which returns local routing table, this triggers a full network lookup.
+    /// Only available when the `developer` feature is enabled.
+    #[cfg(feature = "developer")]
+    DevGetClosestPeersFromNetwork {
+        /// Target address to find closest peers for
+        key: NetworkAddress,
+        /// Number of peers to return (optional, defaults to K_VALUE)
+        num_of_peers: Option<usize>,
+    },
 }
 
 impl Query {
@@ -116,6 +126,8 @@ impl Query {
             | Query::GetChunkExistenceProof { key, .. }
             | Query::GetClosestPeers { key, .. }
             | Query::GetMerkleCandidateQuote { key, .. } => key.clone(),
+            #[cfg(feature = "developer")]
+            Query::DevGetClosestPeersFromNetwork { key, .. } => key.clone(),
             Query::PutRecord { holder, .. } => holder.clone(),
         }
     }
@@ -188,6 +200,13 @@ impl std::fmt::Display for Query {
                 write!(
                     f,
                     "Query::GetMerkleCandidateQuote({key:?} {data_type} {data_size} timestamp={merkle_payment_timestamp})"
+                )
+            }
+            #[cfg(feature = "developer")]
+            Query::DevGetClosestPeersFromNetwork { key, num_of_peers } => {
+                write!(
+                    f,
+                    "Query::DevGetClosestPeersFromNetwork({key:?} {num_of_peers:?})"
                 )
             }
         }

--- a/ant-protocol/src/messages/response.rs
+++ b/ant-protocol/src/messages/response.rs
@@ -98,6 +98,22 @@ pub enum QueryResponse {
     ///
     /// [`GetMerkleCandidateQuote`]: crate::messages::Query::GetMerkleCandidateQuote
     GetMerkleCandidateQuote(Result<ant_evm::merkle_payments::MerklePaymentCandidateNode>),
+    // ===== DevGetClosestPeersFromNetwork =====
+    //
+    /// Response to [`DevGetClosestPeersFromNetwork`]
+    /// Returns closest peers from a network query (not just local routing table).
+    /// Only available when the `developer` feature is enabled.
+    ///
+    /// [`DevGetClosestPeersFromNetwork`]: crate::messages::Query::DevGetClosestPeersFromNetwork
+    #[cfg(feature = "developer")]
+    DevGetClosestPeersFromNetwork {
+        /// The target address that the original request is about.
+        target: NetworkAddress,
+        /// The node that performed the query (the queried node's peer address)
+        queried_node: NetworkAddress,
+        /// Closest peers from the network query, with their multiaddresses.
+        peers: Vec<(NetworkAddress, Vec<Multiaddr>)>,
+    },
 }
 
 // Debug implementation for QueryResponse, to avoid printing Vec<u8>
@@ -175,6 +191,19 @@ impl Debug for QueryResponse {
                     write!(f, "GetMerkleCandidateQuote(Err({err:?}))")
                 }
             },
+            #[cfg(feature = "developer")]
+            QueryResponse::DevGetClosestPeersFromNetwork {
+                target,
+                queried_node,
+                peers,
+            } => {
+                let addresses: Vec<_> = peers.iter().map(|(addr, _)| addr.clone()).collect();
+                write!(
+                    f,
+                    "DevGetClosestPeersFromNetwork target {target:?} from {queried_node:?} found {} close peers {addresses:?}",
+                    peers.len()
+                )
+            }
         }
     }
 }

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -21,6 +21,7 @@ name = "put_and_dir_upload"
 
 [features]
 default = []
+developer = ["ant-protocol/developer"]
 external-signer = ["ant-evm/external-signer"]
 extension-module = ["pyo3/extension-module", "pyo3-async-runtimes"]
 loud = []

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -360,6 +360,11 @@ impl Client {
     pub fn evm_network(&self) -> &EvmNetwork {
         &self.evm_network
     }
+
+    /// Get a reference to the underlying network.
+    pub fn network(&self) -> &Network {
+        &self.network
+    }
 }
 
 /// Events that can be sent by the client.
@@ -377,6 +382,41 @@ pub struct UploadSummary {
     pub records_already_paid: usize,
     /// Total cost of the upload
     pub tokens_spent: Amount,
+}
+
+/// Developer analytics methods for the Client.
+/// Only available when the `developer` feature is enabled.
+#[cfg(feature = "developer")]
+impl Client {
+    /// Get closest peers by asking a specific node to query its network.
+    ///
+    /// Unlike methods that return a peer's local routing table,
+    /// this asks the target node to perform an actual Kademlia network lookup
+    /// and return the results from its network perspective.
+    ///
+    /// # Arguments
+    /// * `node` - The node to ask (will perform the network query)
+    /// * `target` - The target address to find closest peers for
+    /// * `num_of_peers` - Optional limit on number of peers to return
+    ///
+    /// # Returns
+    /// * `DevGetClosestPeersFromNetworkResponse` containing:
+    ///   - The target address
+    ///   - The queried node's address
+    ///   - The closest peers found by that node's network query
+    pub async fn dev_get_closest_peers_from_node(
+        &self,
+        node: libp2p::kad::PeerInfo,
+        target: ant_protocol::NetworkAddress,
+        num_of_peers: Option<usize>,
+    ) -> Result<
+        crate::networking::DevGetClosestPeersFromNetworkResponse,
+        crate::networking::NetworkError,
+    > {
+        self.network
+            .dev_get_closest_peers_from_node(node, target, num_of_peers)
+            .await
+    }
 }
 
 #[cfg(test)]
@@ -411,38 +451,5 @@ mod tests {
                 panic!("Expected `ConnectError::TimedOut`, but got `{err:?}`")
             }
         }
-    }
-}
-
-/// Developer analytics methods for the Client.
-/// Only available when the `developer` feature is enabled.
-#[cfg(feature = "developer")]
-impl Client {
-    /// Get closest peers by asking a specific node to query its network.
-    ///
-    /// Unlike methods that return a peer's local routing table,
-    /// this asks the target node to perform an actual Kademlia network lookup
-    /// and return the results from its network perspective.
-    ///
-    /// # Arguments
-    /// * `node` - The node to ask (will perform the network query)
-    /// * `target` - The target address to find closest peers for
-    /// * `num_of_peers` - Optional limit on number of peers to return
-    ///
-    /// # Returns
-    /// * `DevGetClosestPeersFromNetworkResponse` containing:
-    ///   - The target address
-    ///   - The queried node's address
-    ///   - The closest peers found by that node's network query
-    pub async fn dev_get_closest_peers_from_node(
-        &self,
-        node: libp2p::kad::PeerInfo,
-        target: ant_protocol::NetworkAddress,
-        num_of_peers: Option<usize>,
-    ) -> Result<crate::networking::DevGetClosestPeersFromNetworkResponse, crate::networking::NetworkError>
-    {
-        self.network
-            .dev_get_closest_peers_from_node(node, target, num_of_peers)
-            .await
     }
 }

--- a/autonomi/src/client/mod.rs
+++ b/autonomi/src/client/mod.rs
@@ -413,3 +413,36 @@ mod tests {
         }
     }
 }
+
+/// Developer analytics methods for the Client.
+/// Only available when the `developer` feature is enabled.
+#[cfg(feature = "developer")]
+impl Client {
+    /// Get closest peers by asking a specific node to query its network.
+    ///
+    /// Unlike methods that return a peer's local routing table,
+    /// this asks the target node to perform an actual Kademlia network lookup
+    /// and return the results from its network perspective.
+    ///
+    /// # Arguments
+    /// * `node` - The node to ask (will perform the network query)
+    /// * `target` - The target address to find closest peers for
+    /// * `num_of_peers` - Optional limit on number of peers to return
+    ///
+    /// # Returns
+    /// * `DevGetClosestPeersFromNetworkResponse` containing:
+    ///   - The target address
+    ///   - The queried node's address
+    ///   - The closest peers found by that node's network query
+    pub async fn dev_get_closest_peers_from_node(
+        &self,
+        node: libp2p::kad::PeerInfo,
+        target: ant_protocol::NetworkAddress,
+        num_of_peers: Option<usize>,
+    ) -> Result<crate::networking::DevGetClosestPeersFromNetworkResponse, crate::networking::NetworkError>
+    {
+        self.network
+            .dev_get_closest_peers_from_node(node, target, num_of_peers)
+            .await
+    }
+}

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -530,6 +530,32 @@ impl NetworkDriver {
                     },
                 );
             }
+            #[cfg(feature = "developer")]
+            NetworkTask::DevGetClosestPeersFromNetwork {
+                addr,
+                peer,
+                num_of_peers,
+                resp,
+            } => {
+                let req = Request::Query(Query::DevGetClosestPeersFromNetwork {
+                    key: addr.clone(),
+                    num_of_peers,
+                });
+
+                let req_id =
+                    self.req()
+                        .send_request_with_addresses(&peer.peer_id, req, peer.addrs.clone());
+
+                self.pending_tasks.insert_query(
+                    req_id,
+                    NetworkTask::DevGetClosestPeersFromNetwork {
+                        addr,
+                        peer,
+                        num_of_peers,
+                        resp,
+                    },
+                );
+            }
         }
     }
 }

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -214,6 +214,23 @@ impl NetworkDriver {
                 self.pending_tasks
                     .update_get_closest_peers_from_peer(request_id, peers)?;
             }
+            #[cfg(feature = "developer")]
+            Response::Query(QueryResponse::DevGetClosestPeersFromNetwork {
+                target,
+                queried_node,
+                peers,
+            }) => {
+                use crate::networking::interface::DevGetClosestPeersFromNetworkResponse;
+                self.pending_tasks
+                    .update_dev_get_closest_peers_from_network(
+                        request_id,
+                        DevGetClosestPeersFromNetworkResponse {
+                            target,
+                            queried_node,
+                            peers,
+                        },
+                    )?;
+            }
             _ => {
                 info!("Other request response event({request_id:?}): {response:?}");
                 // Unrecoganized req/rsp DM indicates peer is in an incorrect version

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -117,4 +117,32 @@ pub(super) enum NetworkTask {
         #[debug(skip)]
         resp: OneShotTaskResult<MerklePaymentCandidateNode>,
     },
+    /// Developer analytics: Get closest peers by asking a node to query its network.
+    /// Unlike GetClosestPeersFromPeer which returns the peer's local routing table,
+    /// this triggers the peer to perform an actual Kademlia network lookup.
+    /// Only available when the `developer` feature is enabled.
+    #[cfg(feature = "developer")]
+    DevGetClosestPeersFromNetwork {
+        /// Target address to find closest peers for
+        addr: NetworkAddress,
+        /// The node to ask (will perform the network query)
+        peer: PeerInfo,
+        /// Number of peers to return (optional)
+        num_of_peers: Option<usize>,
+        #[debug(skip)]
+        resp: OneShotTaskResult<DevGetClosestPeersFromNetworkResponse>,
+    },
+}
+
+/// Response from DevGetClosestPeersFromNetwork
+/// Contains the query results and metadata about which node performed the query
+#[cfg(feature = "developer")]
+#[derive(Debug, Clone)]
+pub struct DevGetClosestPeersFromNetworkResponse {
+    /// The target address that was queried
+    pub target: NetworkAddress,
+    /// The node that performed the network query
+    pub queried_node: NetworkAddress,
+    /// The closest peers found by that node's network query
+    pub peers: Vec<(NetworkAddress, Vec<libp2p::Multiaddr>)>,
 }


### PR DESCRIPTION
This PR introduces a new `developer` feature flag and CLI subcommand group for network diagnostics and analytics. The initial command allows querying closest peers to a target address **from a specific node's network perspective**, which is useful for debugging network topology issues.

## Motivation

When debugging network issues, it's often necessary to understand how different nodes see the network. The existing `ant analyze --closest-nodes` command shows the client's view, but there was no way to query what a specific node sees when it performs a Kademlia lookup. This feature fills that gap.

## New CLI Command

```bash
ant developer closest-peers <node> <target> [-n <num_peers>]
```

### Arguments

| Argument | Description |
|----------|-------------|
| `node` | Node to query: either a PeerId or full multiaddr |
| `target` | Target address (ChunkAddress, PublicKey, hex, PeerId, or NetworkAddress debug format) |
| `-n, --num-peers` | Optional: Number of peers to return (default: K_VALUE) |
| `--compare` | Compare the node's perspective with the client's perspective |

### Examples

```bash
# Query using full multiaddr
ant developer closest-peers /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW... 0x1234...abcd

# Query using just PeerId (address discovered via network)
ant developer closest-peers 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE 0x1234...abcd

# Limit results to 10 peers
ant developer closest-peers 12D3KooW... 0x1234... -n 10

# Compare node's view with client's view
ant developer closest-peers 12D3KooW... 0x1234... --compare
```

### Output (Standard)

```
Connecting to network...
Querying node 12D3KooW... for closest peers to 0x1234...

Closest peers to 0x1234... from node NetworkAddress::PeerId(12D3KooW...):

  #    PeerId                                                 Distance        Multiaddrs
  ----------------------------------------------------------------------------------------------------------------------------------
  1    12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE   247             /ip4/127.0.0.1/udp/12000/quic-v1
  2    12D3KooWA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2   248             /ip4/127.0.0.1/udp/12001/quic-v1
  ...

Total: 20 peers
```

### Output (with --compare)

```
Connecting to network...
Querying node 12D3KooWQUERIED... for closest peers to 0x1234...
Querying client's perspective...

Comparison of closest peers to 0x1234...
====================================================================================================

Summary:
  Node's view:   20 peers
  Client's view: 21 peers
  In common:     18 peers
  Node only:     2 peers
  Client only:   3 peers

  Note: Client's results include the queried node itself.
        Nodes don't include themselves in their own results.

NODE'S PERSPECTIVE (from NetworkAddress::PeerId(12D3KooWQUERIED...)):
  #    PeerId                                                 Distance   Status
  --------------------------------------------------------------------------------
  1    12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE   247        common
  2    12D3KooWA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2   248        node-only
  ...

CLIENT'S PERSPECTIVE:
  #    PeerId                                                 Distance   Status
  -------------------------------------------------------------------------------------
  1    12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE   247        common
  2    12D3KooWQUERIED...                                     248        queried-node*
  3    12D3KooWX1Y2Z3A4B5C6D7E8F9G0H1I2J3K4L5M6N7O8P9Q0R1S2   249        client-only
  ...

PEERS ONLY IN NODE'S VIEW:
  12D3KooWA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2 (distance: 248)

PEERS ONLY IN CLIENT'S VIEW:
  12D3KooWQUERIED... (distance: 248) <- queried node (nodes don't include themselves)
  12D3KooWX1Y2Z3A4B5C6D7E8F9G0H1I2J3K4L5M6N7O8P9Q0R1S2 (distance: 249)
```

## Feature Flags

The feature is gated behind a `developer` flag that must be enabled on both client and node:

| Crate | Feature | Dependencies |
|-------|---------|--------------|
| `ant-protocol` | `developer = []` | - |
| `ant-node` | `developer = ["ant-protocol/developer"]` | ant-protocol |
| `autonomi` | `developer = ["ant-protocol/developer"]` | ant-protocol |
| `ant-cli` | `developer = ["autonomi/developer", "ant-protocol/developer"]` | autonomi, ant-protocol |
| `ant-node-manager` | `developer = []` | Propagates to node build |

### Building with Developer Features

```bash
# Start local network with developer features (via antctl)
cargo run --bin antctl --features developer -- local run --build --clean --rewards-address <addr>

# Run CLI command with developer features
cargo run --bin ant --features developer -- --local developer closest-peers <node> <target>
```