### PR TITLE
fix: failing merkle payment txs

### DIFF
--- a/evmlib/src/retry.rs
+++ b/evmlib/src/retry.rs
@@ -175,12 +175,13 @@ where
         transaction_request.set_max_fee_per_gas(max_fee_per_gas);
     }
 
-    // Estimate gas and add 20% buffer to avoid out-of-gas reverts
+    // Estimate gas and add 50% buffer to avoid out-of-gas reverts
     // This is especially important for Arbitrum L2 where gas estimation can be tricky
+    // due to L1 calldata costs and variable L2 computation costs
     match provider.estimate_gas(transaction_request.clone()).await {
         Ok(estimated_gas) => {
-            let gas_with_buffer = estimated_gas.saturating_mul(120) / 100;
-            debug!("Estimated gas: {estimated_gas}, with 20% buffer: {gas_with_buffer}");
+            let gas_with_buffer = estimated_gas.saturating_mul(150) / 100;
+            debug!("Estimated gas: {estimated_gas}, with 50% buffer: {gas_with_buffer}");
             transaction_request.set_gas_limit(gas_with_buffer);
         }
         Err(e) => {

--- a/evmlib/src/retry.rs
+++ b/evmlib/src/retry.rs
@@ -1,7 +1,7 @@
 use crate::TX_TIMEOUT;
 use crate::common::{Address, Calldata, TxHash};
 use crate::transaction_config::{MaxFeePerGas, TransactionConfig};
-use alloy::network::{Network, TransactionBuilder};
+use alloy::network::{Network, ReceiptResponse, TransactionBuilder};
 use alloy::providers::{PendingTransactionBuilder, Provider};
 use std::time::Duration;
 
@@ -233,8 +233,49 @@ where
 
     match watch_result {
         Ok(tx_hash) => {
-            debug!("{tx_identifier} transaction with hash {tx_hash:?} is successful");
-            Ok(tx_hash)
+            // CRITICAL: .watch() only confirms the tx was mined, NOT that it succeeded.
+            // We must fetch the receipt and check the status field.
+            match provider.get_transaction_receipt(tx_hash).await {
+                Ok(Some(receipt)) => {
+                    if receipt.status() {
+                        debug!("{tx_identifier} transaction with hash {tx_hash:?} succeeded");
+                        Ok(tx_hash)
+                    } else {
+                        // Transaction was mined but reverted (e.g., out of gas)
+                        let gas_used = receipt.gas_used();
+                        error!(
+                            "{tx_identifier} transaction {tx_hash:?} was mined but reverted. \
+                            Gas used: {gas_used}"
+                        );
+                        Err(TransactionError::TransactionReverted {
+                            message: format!(
+                                "Transaction was mined but execution failed (gas used: {gas_used})"
+                            ),
+                            revert_data: None,
+                            nonce,
+                        })
+                    }
+                }
+                Ok(None) => {
+                    // This shouldn't happen after .watch() succeeds, but handle it
+                    warn!(
+                        "{tx_identifier} transaction {tx_hash:?} receipt not found after watch"
+                    );
+                    Err(TransactionError::TransactionFailedToConfirm(
+                        "Receipt not found after watch".to_string(),
+                        nonce,
+                    ))
+                }
+                Err(err) => {
+                    error!(
+                        "{tx_identifier} failed to get receipt for {tx_hash:?}: {err}"
+                    );
+                    Err(TransactionError::TransactionFailedToConfirm(
+                        format!("Failed to get receipt: {err}"),
+                        nonce,
+                    ))
+                }
+            }
         }
         Err(err) => {
             // Try to get more details about the revert if available


### PR DESCRIPTION
- Adds checks for the transaction receipt status after being mined to avoid false tx confirmations.
- Increases the tx gas limit buffer from 20% to 50%.