### PR TITLE
feat(client): using req/rsp DM as a fallback during mutable_data fetch

### DIFF
--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -13,13 +13,13 @@ pub use error::{AnalysisErrorDisplay, NetworkErrorDisplay};
 
 use crate::actions::NetworkContext;
 use crate::wallet::load_wallet;
+use ant_protocol::storage::DataTypes;
 use autonomi::PublicKey;
 use autonomi::chunk::ChunkAddress;
 use autonomi::client::analyze::{Analysis, AnalysisError};
 use autonomi::client::config::CHUNK_DOWNLOAD_BATCH_SIZE;
 use autonomi::client::payment::PaymentOption;
 use autonomi::graph::GraphEntryAddress;
-use ant_protocol::storage::DataTypes;
 use autonomi::{
     Multiaddr, RewardsAddress, SecretKey, Wallet,
     networking::{NetworkAddress, NetworkError, PeerId, PeerQuoteWithStorageProof, Record},
@@ -1616,7 +1616,14 @@ async fn perform_network_scan_round(
 
         async move {
             let result = client
-                .get_storage_proofs_from_peer(peer_target_addr, peer_clone, nonce, difficulty, DataTypes::Chunk, 0)
+                .get_storage_proofs_from_peer(
+                    peer_target_addr,
+                    peer_clone,
+                    nonce,
+                    difficulty,
+                    DataTypes::Chunk,
+                    0,
+                )
                 .await;
             (peer_id, result)
         }
@@ -2335,7 +2342,14 @@ async fn print_nodes_health(
 
         // Query the peer directly for storage proofs
         match client
-            .get_storage_proofs_from_peer(target_addr.clone(), peer.clone(), nonce, difficulty, DataTypes::Chunk, 0)
+            .get_storage_proofs_from_peer(
+                target_addr.clone(),
+                peer.clone(),
+                nonce,
+                difficulty,
+                DataTypes::Chunk,
+                0,
+            )
             .await
         {
             Ok((_quote, storage_proofs)) => {

--- a/ant-node/src/networking/record_store.rs
+++ b/ant-node/src/networking/record_store.rs
@@ -25,8 +25,8 @@ use itertools::Itertools;
 use libp2p::{
     identity::PeerId,
     kad::{
-        KBucketDistance as Distance, ProviderRecord, Record, RecordKey as Key,
-        store::{Error, RecordStore, Result}, U256
+        KBucketDistance as Distance, ProviderRecord, Record, RecordKey as Key, U256,
+        store::{Error, RecordStore, Result},
     },
 };
 #[cfg(feature = "open-metrics")]
@@ -587,7 +587,7 @@ impl NodeRecordStore {
             return;
         };
 
-        // Increase distance by 10 times to match the allowance margin in other range check places. 
+        // Increase distance by 10 times to match the allowance margin in other range check places.
         let increased_distance = Distance(responsible_distance.0.saturating_mul(U256::from(10)));
 
         // Calculate 10% of total records as candidates for removal

--- a/autonomi/src/client/data_types/graph.rs
+++ b/autonomi/src/client/data_types/graph.rs
@@ -121,16 +121,12 @@ impl Client {
             .map(|(entry, _)| entry)
             .collect();
 
-        match entries_with_max.len() {
-            1 => {
-                let best_entry = entries_with_max
-                    .into_iter()
-                    .next()
-                    .expect("Vec with len() == 1 must contain exactly one item");
+        match &entries_with_max[..] {
+            [best_entry] => {
                 debug!(
                     "Successfully resolved graph entry at {key:?} with {max_copies} consistent copies"
                 );
-                Ok(best_entry)
+                Ok(best_entry.clone())
             }
             _ => {
                 warn!("Fork detected for graph entry at {key:?}");

--- a/autonomi/src/client/data_types/mod.rs
+++ b/autonomi/src/client/data_types/mod.rs
@@ -11,178 +11,19 @@ pub mod graph;
 pub mod pointer;
 pub mod scratchpad;
 
-use crate::Client;
-use crate::networking::{PeerId, Record};
-use crate::utils::process_tasks_with_max_concurrency;
+use crate::networking::Record;
 use ant_protocol::NetworkAddress;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use tracing::{debug, error, warn};
 
-/// Default number of closest peers to query in fallback fetch operations.
-pub(crate) const FALLBACK_PEERS_COUNT: usize = 20;
-
-impl Client {
-    /// Fetches records from the closest peers directly in parallel.
-    ///
-    /// This function queries the closest N peers for a given key and returns all
-    /// successfully retrieved records. This is useful as a fallback mechanism when
-    /// standard DHT queries fail or for CRDT types that may have different versions
-    /// on different nodes.
-    ///
-    /// # Arguments
-    /// * `key` - The network address to query
-    /// * `num_peers` - Maximum number of closest peers to query
-    ///
-    /// # Returns
-    /// * `Some(Vec<Record>)` - All successfully retrieved records from the queried peers.
-    ///   For CRDT types (Pointer, Scratchpad, GraphEntry), this may contain multiple
-    ///   different record versions that need split resolution.
-    /// * `None` - If no peers could be found or all peer queries failed.
-    ///
-    /// # Note
-    /// The caller is responsible for:
-    /// - For Chunk type: using the first valid record
-    /// - For CRDT types (Pointer, Scratchpad, GraphEntry): returning the multiple copies for the further resolving
-    pub(crate) async fn fetch_records_from_closest_peers(
-        &self,
-        key: NetworkAddress,
-        num_peers: usize,
-    ) -> Option<Vec<Record>> {
-        debug!("Querying closest {num_peers} nodes directly for {key:?}");
-
-        let closest_peers = match self
-            .network
-            .get_closest_peers(key.clone(), Some(num_peers))
-            .await
-        {
-            Ok(peers) => peers,
-            Err(e) => {
-                error!("Failed to get closest peers for {key:?}: {e}");
-                return None;
-            }
-        };
-
-        debug!(
-            "Querying {} closest peers in parallel for {key:?}",
-            closest_peers.len()
-        );
-
-        // Create query tasks for all closest peers
-        let mut query_tasks = vec![];
-        for peer in closest_peers.iter() {
-            let network = self.network.clone();
-            let key = key.clone();
-            let peer = peer.clone();
-            query_tasks.push(async move { network.get_record_from_peer(key, peer).await });
-        }
-
-        // Process tasks with max concurrency of num_peers
-        let results = process_tasks_with_max_concurrency(query_tasks, num_peers).await;
-
-        // Collect all successful records
-        let records: Vec<Record> = results
-            .into_iter()
-            .filter_map(|result| match result {
-                Ok(Some(record)) => Some(record),
-                _ => None,
-            })
-            .collect();
-
-        if records.is_empty() {
-            error!(
-                "❌ All {} closest peers failed to return records for {key:?}",
-                closest_peers.len()
-            );
-            None
-        } else {
-            debug!(
-                "✅ Retrieved {} records from closest {num_peers} peers for {key:?}",
-                records.len()
-            );
-            Some(records)
-        }
-    }
-}
-
-/// Resolve split records by selecting the highest counter.
+/// Resolve records from a list of records for CRDT types,
+/// which could be typically from fallback peer queries, or from a SplitRecord error.
+///
+/// It resolves conflicts by selecting the highest counter.
 /// If multiple records share the highest counter but have different content,
 /// return a fork error constructed by the provided closure.
 /// If deserialization fails for any record, return the deserialization error.
 /// If no valid records remain, return a corrupt error constructed by the provided closure.
-pub(crate) fn resolve_split_records<T, E, FDeser, FCounter, FEqual, FFork, FCorrupt>(
-    result_map: HashMap<PeerId, Record>,
-    key: NetworkAddress,
-    deserialize: FDeser,
-    counter_of: FCounter,
-    same_content: FEqual,
-    fork_error: FFork,
-    corrupt_error: FCorrupt,
-) -> Result<T, E>
-where
-    T: Clone + std::hash::Hash + Eq,
-    FDeser: Fn(Record) -> Result<T, E>,
-    FCounter: Fn(&T) -> u64,
-    FEqual: Fn(&T, &T) -> bool,
-    FFork: Fn(HashSet<T>) -> E,
-    FCorrupt: Fn() -> E,
-{
-    debug!("Resolving split records at {key:?}");
-
-    // Deserialize all records; if any fails, propagate the error upstream
-    let mut items: Vec<T> = result_map
-        .into_values()
-        .map(deserialize)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    if items.is_empty() {
-        error!("Got empty records map for {key:?}");
-        return Err(corrupt_error());
-    }
-
-    // Sort by counter then pick the max counter value
-    items.sort_by_key(|t| counter_of(t));
-    let max_counter = match items.last().map(&counter_of) {
-        Some(c) => c,
-        None => {
-            error!("No records left after sorting for {key:?}");
-            return Err(corrupt_error());
-        }
-    };
-
-    // Collect unique entries with max counter
-    let mut latest: HashSet<T> = HashSet::new();
-    for item in items.into_iter() {
-        if counter_of(&item) == max_counter
-            && !latest.iter().any(|existing| same_content(existing, &item))
-        {
-            latest.insert(item);
-        }
-    }
-
-    match latest.len() {
-        1 => {
-            let item = latest
-                .into_iter()
-                .next()
-                .expect("HashSet with len() == 1 must contain exactly one item");
-            Ok(item)
-        }
-        0 => {
-            error!("No latest records found for {key:?}");
-            Err(corrupt_error())
-        }
-        _ => {
-            warn!("Multiple conflicting records found at latest version for {key:?}");
-            Err(fork_error(latest))
-        }
-    }
-}
-
-/// Resolve records from a list of records (typically from fallback peer queries) for CRDT types.
-///
-/// This function requires at least `min_copies` consistent copies to consider the data valid.
-/// It resolves conflicts by selecting the record with the highest counter, and if multiple
-/// records share the highest counter, checks for consistency.
 ///
 /// # Arguments
 /// * `records` - List of records fetched from peers
@@ -272,22 +113,17 @@ where
         .map(|(item, _)| item)
         .collect();
 
-    match best_items.len() {
-        1 => {
-            let item = best_items
-                .into_iter()
-                .next()
-                .expect("HashSet with len() == 1 must contain exactly one item");
-            debug!(
-                "Successfully resolved {key:?} with {max_copies} consistent copies"
-            );
-            Ok(item)
+    let best_vec: Vec<T> = best_items.iter().cloned().collect();
+    match &best_vec[..] {
+        [one] => {
+            debug!("Successfully resolved {key:?} with {max_copies} consistent copies");
+            Ok(one.clone())
         }
-        0 => {
+        [] => {
             error!("No valid content found for {key:?}");
             Err(corrupt_error())
         }
-        _ => {
+        [..] => {
             warn!("Multiple conflicting records with equal copy counts for {key:?}");
             Err(fork_error(best_items))
         }

--- a/autonomi/src/client/data_types/mod.rs
+++ b/autonomi/src/client/data_types/mod.rs
@@ -11,10 +11,103 @@ pub mod graph;
 pub mod pointer;
 pub mod scratchpad;
 
+use crate::Client;
 use crate::networking::{PeerId, Record};
+use crate::utils::process_tasks_with_max_concurrency;
 use ant_protocol::NetworkAddress;
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, error, warn};
+
+/// Minimum number of consistent copies required to consider CRDT data valid.
+/// This applies to Pointer, Scratchpad, and GraphEntry datatypes.
+pub(crate) const MIN_CRDT_CONSISTENT_COPIES: usize = 3;
+
+/// Default number of closest peers to query in fallback fetch operations.
+pub(crate) const FALLBACK_PEERS_COUNT: usize = 20;
+
+impl Client {
+    /// Fetches records from the closest peers directly in parallel.
+    ///
+    /// This function queries the closest N peers for a given key and returns all
+    /// successfully retrieved records. This is useful as a fallback mechanism when
+    /// standard DHT queries fail or for CRDT types that may have different versions
+    /// on different nodes.
+    ///
+    /// # Arguments
+    /// * `key` - The network address to query
+    /// * `num_peers` - Maximum number of closest peers to query
+    ///
+    /// # Returns
+    /// * `Some(Vec<Record>)` - All successfully retrieved records from the queried peers.
+    ///   For CRDT types (Pointer, Scratchpad, GraphEntry), this may contain multiple
+    ///   different record versions that need split resolution.
+    /// * `None` - If no peers could be found or all peer queries failed.
+    ///
+    /// # Note
+    /// The caller is responsible for:
+    /// - For Chunk type: using the first valid record
+    /// - For CRDT types (Pointer, Scratchpad, GraphEntry): resolving splits and ensuring
+    ///   at least `MIN_CRDT_CONSISTENT_COPIES` (3) consistent copies exist for validity
+    pub(crate) async fn fetch_records_from_closest_peers(
+        &self,
+        key: NetworkAddress,
+        num_peers: usize,
+    ) -> Option<Vec<Record>> {
+        debug!("Querying closest {num_peers} nodes directly for {key:?}");
+
+        let closest_peers = match self
+            .network
+            .get_closest_peers(key.clone(), Some(num_peers))
+            .await
+        {
+            Ok(peers) => peers,
+            Err(e) => {
+                error!("Failed to get closest peers for {key:?}: {e}");
+                return None;
+            }
+        };
+
+        debug!(
+            "Querying {} closest peers in parallel for {key:?}",
+            closest_peers.len()
+        );
+
+        // Create query tasks for all closest peers
+        let mut query_tasks = vec![];
+        for peer in closest_peers.iter() {
+            let network = self.network.clone();
+            let key = key.clone();
+            let peer = peer.clone();
+            query_tasks.push(async move { network.get_record_from_peer(key, peer).await });
+        }
+
+        // Process tasks with max concurrency of num_peers
+        let results = process_tasks_with_max_concurrency(query_tasks, num_peers).await;
+
+        // Collect all successful records
+        let records: Vec<Record> = results
+            .into_iter()
+            .filter_map(|result| match result {
+                Ok(Some(record)) => Some(record),
+                _ => None,
+            })
+            .collect();
+
+        if records.is_empty() {
+            error!(
+                "❌ All {} closest peers failed to return records for {key:?}",
+                closest_peers.len()
+            );
+            None
+        } else {
+            debug!(
+                "✅ Retrieved {} records from closest {num_peers} peers for {key:?}",
+                records.len()
+            );
+            Some(records)
+        }
+    }
+}
 
 /// Resolve split records by selecting the highest counter.
 /// If multiple records share the highest counter but have different content,
@@ -86,6 +179,135 @@ where
         _ => {
             warn!("Multiple conflicting records found at latest version for {key:?}");
             Err(fork_error(latest))
+        }
+    }
+}
+
+/// Resolve records from a list of records (typically from fallback peer queries) for CRDT types.
+///
+/// This function requires at least `min_copies` consistent copies to consider the data valid.
+/// It resolves conflicts by selecting the record with the highest counter, and if multiple
+/// records share the highest counter, checks for consistency.
+///
+/// # Arguments
+/// * `records` - List of records fetched from peers
+/// * `key` - The network address (for logging)
+/// * `deserialize` - Function to deserialize a record into type T
+/// * `counter_of` - Function to extract the counter value from type T
+/// * `same_content` - Function to compare if two items have the same content
+/// * `min_copies` - Minimum number of consistent copies required for validity
+/// * `fork_error` - Function to construct a fork error
+/// * `corrupt_error` - Function to construct a corrupt error
+/// * `insufficient_copies_error` - Function to construct an insufficient copies error
+///
+/// # Returns
+/// * `Ok(T)` - The resolved item with the highest counter and sufficient consistent copies
+/// * `Err(E)` - If deserialization fails, data is corrupt, forked, or insufficient copies exist
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_records_from_peers<T, E, FDeser, FCounter, FEqual, FFork, FCorrupt, FInsuff>(
+    records: Vec<Record>,
+    key: NetworkAddress,
+    deserialize: FDeser,
+    counter_of: FCounter,
+    same_content: FEqual,
+    min_copies: usize,
+    fork_error: FFork,
+    corrupt_error: FCorrupt,
+    insufficient_copies_error: FInsuff,
+) -> Result<T, E>
+where
+    T: Clone + std::hash::Hash + Eq,
+    FDeser: Fn(Record) -> Result<T, E>,
+    FCounter: Fn(&T) -> u64,
+    FEqual: Fn(&T, &T) -> bool,
+    FFork: Fn(HashSet<T>) -> E,
+    FCorrupt: Fn() -> E,
+    FInsuff: Fn(usize, usize) -> E,
+{
+    debug!("Resolving {} records from peers for {key:?}, requiring {min_copies} consistent copies", records.len());
+
+    // Deserialize all records
+    let mut items: Vec<T> = Vec::new();
+    for record in records {
+        match deserialize(record) {
+            Ok(item) => items.push(item),
+            Err(_) => {
+                // Skip invalid records in fallback mode, we need to be resilient
+                warn!("Skipping invalid record during fallback resolution at {key:?}");
+            }
+        }
+    }
+
+    if items.is_empty() {
+        error!("No valid records found for {key:?}");
+        return Err(corrupt_error());
+    }
+
+    // Sort by counter then pick the max counter value
+    items.sort_by_key(|t| counter_of(t));
+    let max_counter = match items.last().map(&counter_of) {
+        Some(c) => c,
+        None => {
+            error!("No records left after sorting for {key:?}");
+            return Err(corrupt_error());
+        }
+    };
+
+    // Group items by content at the max counter
+    let items_at_max: Vec<T> = items
+        .into_iter()
+        .filter(|item| counter_of(item) == max_counter)
+        .collect();
+
+    // Count consistent copies for each unique content
+    let mut content_groups: Vec<(T, usize)> = Vec::new();
+    for item in items_at_max.iter() {
+        if let Some((_, count)) = content_groups
+            .iter_mut()
+            .find(|(existing, _)| same_content(existing, item))
+        {
+            *count += 1;
+        } else {
+            content_groups.push((item.clone(), 1));
+        }
+    }
+
+    // Find the group(s) with the most copies
+    let max_copies = content_groups.iter().map(|(_, c)| *c).max().unwrap_or(0);
+
+    // Check if we have enough consistent copies
+    if max_copies < min_copies {
+        warn!(
+            "Insufficient consistent copies for {key:?}: got {max_copies}, need {min_copies}"
+        );
+        return Err(insufficient_copies_error(max_copies, min_copies));
+    }
+
+    // Get all items with the max number of copies
+    let best_items: HashSet<T> = content_groups
+        .into_iter()
+        .filter(|(_, count)| *count == max_copies)
+        .map(|(item, _)| item)
+        .collect();
+
+    match best_items.len() {
+        1 => {
+            let item = best_items
+                .into_iter()
+                .next()
+                .expect("HashSet with len() == 1 must contain exactly one item");
+            debug!(
+                "Successfully resolved {key:?} with {max_copies} consistent copies"
+            );
+            Ok(item)
+        }
+        0 => {
+            error!("No valid content found for {key:?}");
+            Err(corrupt_error())
+        }
+        _ => {
+            warn!("Multiple conflicting records with equal copy counts for {key:?}");
+            Err(fork_error(best_items))
         }
     }
 }

--- a/autonomi/src/client/data_types/pointer.rs
+++ b/autonomi/src/client/data_types/pointer.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    resolve_records_from_peers, resolve_split_records, FALLBACK_PEERS_COUNT,
-    MIN_CRDT_CONSISTENT_COPIES,
-};
+use super::{resolve_records_from_peers, resolve_split_records, FALLBACK_PEERS_COUNT};
 
 use crate::{
     client::{
@@ -71,10 +68,8 @@ impl Client {
     /// or returns a SplitRecord error, it resolves the split. If the initial fetch
     /// completely fails, it falls back to querying the closest peers directly.
     ///
-    /// For Pointer (CRDT type with counter), at least `MIN_CRDT_CONSISTENT_COPIES` (3)
-    /// consistent copies are required for validity when using the fallback mechanism.
-    /// The record with the highest counter is selected, and conflicts are resolved
-    /// through the standard split resolution process.
+    /// For Pointer (CRDT type with counter), the record with the highest counter is selected,
+    /// and conflicts are resolved through the standard split resolution process.
     ///
     /// # Arguments
     /// * `address` - The pointer address to fetch
@@ -129,9 +124,8 @@ impl Client {
 
     /// Fallback method to fetch Pointer from closest peers directly.
     ///
-    /// This method queries the closest peers and requires at least `MIN_CRDT_CONSISTENT_COPIES`
-    /// (3) consistent copies to consider the data valid. It resolves splits by selecting
-    /// the record with the highest counter.
+    /// This method queries the closest peers.
+    /// It resolves splits by selecting the record with the highest counter.
     async fn pointer_get_fallback(&self, key: NetworkAddress) -> Result<Pointer, PointerError> {
         let records = self
             .fetch_records_from_closest_peers(key.clone(), FALLBACK_PEERS_COUNT)
@@ -149,14 +143,12 @@ impl Client {
             pointer_from_record,
             |p: &Pointer| p.counter(),
             |a: &Pointer, b: &Pointer| a == b,
-            MIN_CRDT_CONSISTENT_COPIES,
             |multiples: HashSet<Pointer>| PointerError::Fork(multiples.into_iter().collect()),
             || {
                 PointerError::Corrupt(format!(
                     "Found multiple conflicting invalid pointers at {key:?}"
                 ))
             },
-            PointerError::InsufficientCopies,
         )?;
 
         info!("Fallback: got pointer at {key:?}: {pointer:?}");

--- a/autonomi/src/client/data_types/scratchpad.rs
+++ b/autonomi/src/client/data_types/scratchpad.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    resolve_records_from_peers, resolve_split_records, FALLBACK_PEERS_COUNT,
-    MIN_CRDT_CONSISTENT_COPIES,
-};
+use super::{resolve_records_from_peers, resolve_split_records, FALLBACK_PEERS_COUNT};
 
 use crate::{
     Amount, AttoTokens, Client,
@@ -135,10 +132,8 @@ impl Client {
     /// or returns a SplitRecord error, it resolves the split. If the initial fetch
     /// completely fails, it falls back to querying the closest peers directly.
     ///
-    /// For Scratchpad (CRDT type with counter), at least `MIN_CRDT_CONSISTENT_COPIES` (3)
-    /// consistent copies are required for validity when using the fallback mechanism.
-    /// The record with the highest counter is selected, and conflicts are resolved
-    /// through the standard split resolution process.
+    /// For Scratchpad (CRDT type with counter), the record with the highest counter is selected,
+    /// and conflicts are resolved through the standard split resolution process.
     ///
     /// # Arguments
     /// * `address` - The scratchpad address to fetch
@@ -205,9 +200,8 @@ impl Client {
 
     /// Fallback method to fetch Scratchpad from closest peers directly.
     ///
-    /// This method queries the closest peers and requires at least `MIN_CRDT_CONSISTENT_COPIES`
-    /// (3) consistent copies to consider the data valid. It resolves splits by selecting
-    /// the record with the highest counter.
+    /// This method queries the closest peers.
+    /// It resolves splits by selecting the record with the highest counter.
     async fn scratchpad_get_fallback(
         &self,
         address: &ScratchpadAddress,
@@ -235,10 +229,8 @@ impl Client {
                 a.data_encoding() == b.data_encoding()
                     && a.encrypted_data() == b.encrypted_data()
             },
-            MIN_CRDT_CONSISTENT_COPIES,
             |latest: HashSet<Scratchpad>| ScratchpadError::Fork(latest.into_iter().collect()),
             || ScratchpadError::Corrupt(*address),
-            ScratchpadError::InsufficientCopies,
         )?;
 
         info!("Fallback: got scratchpad at {network_address:?}");

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -73,7 +73,14 @@ impl Client {
         data_size: usize,
     ) -> Result<PeerQuoteWithStorageProof, NetworkError> {
         self.network
-            .get_storage_proofs_from_peer(network_address.into(), peer, nonce, difficulty, data_type, data_size)
+            .get_storage_proofs_from_peer(
+                network_address.into(),
+                peer,
+                nonce,
+                difficulty,
+                data_type,
+                data_size,
+            )
             .await
     }
 

--- a/autonomi/src/networking/driver/swarm_events.rs
+++ b/autonomi/src/networking/driver/swarm_events.rs
@@ -180,8 +180,11 @@ impl NetworkDriver {
                     .update_get_quote(request_id, quote.clone(), peer_address)
                     .is_err()
                 {
-                    self.pending_tasks
-                        .update_get_storage_proofs_from_peer(request_id, quote.ok(), storage_proofs)?;
+                    self.pending_tasks.update_get_storage_proofs_from_peer(
+                        request_id,
+                        quote.ok(),
+                        storage_proofs,
+                    )?;
                 }
             }
             Response::Query(QueryResponse::GetMerkleCandidateQuote(result)) => {

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -51,10 +51,8 @@ pub(crate) struct TaskHandler {
     get_record_accumulator: HashMap<QueryId, HashMap<PeerId, Record>>,
     get_version: HashMap<OutboundRequestId, OneShotTaskResult<String>>,
     get_record_from_peer: HashMap<OutboundRequestId, OneShotTaskResult<Option<Record>>>,
-    get_storage_proofs_from_peer: HashMap<
-        OutboundRequestId,
-        OneShotTaskResult<PeerQuoteWithStorageProof>,
-    >,
+    get_storage_proofs_from_peer:
+        HashMap<OutboundRequestId, OneShotTaskResult<PeerQuoteWithStorageProof>>,
     get_closest_peers_from_peer: HashMap<
         OutboundRequestId,
         OneShotTaskResult<Vec<(NetworkAddress, Vec<libp2p::Multiaddr>)>>,
@@ -497,7 +495,10 @@ impl TaskHandler {
         &mut self,
         id: OutboundRequestId,
         quote: Option<PaymentQuote>,
-        storage_proofs: Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>,
+        storage_proofs: Vec<(
+            NetworkAddress,
+            Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+        )>,
     ) -> Result<(), TaskHandlerError> {
         let responder =
             self.get_storage_proofs_from_peer

--- a/autonomi/src/networking/interface/mod.rs
+++ b/autonomi/src/networking/interface/mod.rs
@@ -7,12 +7,12 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::networking::{OneShotTaskResult, PeerQuoteWithStorageProof};
-use ant_evm::{merkle_payments::MerklePaymentCandidateNode, PaymentQuote};
-use ant_protocol::storage::DataTypes;
+use ant_evm::{PaymentQuote, merkle_payments::MerklePaymentCandidateNode};
 use ant_protocol::NetworkAddress;
+use ant_protocol::storage::DataTypes;
 use libp2p::{
-    kad::{PeerInfo, Quorum, Record},
     PeerId,
+    kad::{PeerInfo, Quorum, Record},
 };
 use std::num::NonZeroUsize;
 

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -56,7 +56,13 @@ pub const CLOSE_GROUP_SIZE_MAJORITY: usize = CLOSE_GROUP_SIZE / 2 + 1;
 pub(crate) const QUOTING_CANDIDATES: usize = 10;
 
 /// Peer quoting result with storage proofs attached.
-pub type PeerQuoteWithStorageProof = (Option<PaymentQuote>, Vec<(NetworkAddress, Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>)>);
+pub type PeerQuoteWithStorageProof = (
+    Option<PaymentQuote>,
+    Vec<(
+        NetworkAddress,
+        Result<ant_protocol::messages::ChunkProof, ant_protocol::error::Error>,
+    )>,
+);
 
 /// The number of closest peers to request from the network
 const N_CLOSEST_PEERS: NonZeroUsize =

--- a/autonomi/src/networking/retries.rs
+++ b/autonomi/src/networking/retries.rs
@@ -8,10 +8,14 @@
 
 use ant_evm::PaymentQuote;
 use ant_protocol::{NetworkAddress, PrettyPrintRecordKey};
+use futures::stream::{self, StreamExt};
 
 use super::{Network, RetryStrategy};
 use super::{NetworkError, PeerInfo, Record, Strategy};
 use tokio::time::sleep;
+
+/// Default number of closest peers to query in fallback fetch operations.
+pub const FALLBACK_PEERS_COUNT: usize = 20;
 
 impl Network {
     /// Put a record to the network with retries
@@ -51,19 +55,32 @@ impl Network {
         Err(NetworkError::InvalidRetryStrategy)
     }
 
-    /// Get a record from the network with retries
+    /// Get a record from the network with retries and fallback to direct peer queries.
+    ///
+    /// This function first attempts standard DHT queries with the configured retry strategy.
+    /// If all retries are exhausted without success, it falls back to querying the closest
+    /// peers directly for the record.
+    ///
+    /// # Returns
+    /// * `Ok(Some(Vec<Record>))` - Successfully retrieved records. For non-CRDT types (Chunk),
+    ///   this will typically contain a single record. For CRDT types (Pointer, Scratchpad,
+    ///   GraphEntry), this may contain multiple record versions that need resolution.
+    /// * `Ok(None)` - No records found after all attempts including fallback.
+    /// * `Err(NetworkError::SplitRecord(_))` - Multiple conflicting records detected during
+    ///   DHT query (caller should handle split resolution).
+    /// * `Err(_)` - Fatal network error that cannot be retried.
     pub async fn get_record_with_retries(
         &self,
         addr: NetworkAddress,
         strategy: &Strategy,
-    ) -> Result<Option<Record>, NetworkError> {
+    ) -> Result<Option<Vec<Record>>, NetworkError> {
         let mut errors = vec![];
         let quorum = strategy.get_quorum;
         for duration in strategy.get_retry.backoff() {
             match self.get_record(addr.clone(), quorum).await {
-                // return success
-                Ok(Some(record)) => return Ok(Some(record)),
-                // don't retry on split
+                // return success as single-element vec
+                Ok(Some(record)) => return Ok(Some(vec![record])),
+                // don't retry on split - return for caller to resolve
                 Err(err) if matches!(err, NetworkError::SplitRecord(_)) => {
                     return Err(err);
                 }
@@ -76,7 +93,7 @@ impl Network {
                     warn!("Record not found at {addr}, retrying in {duration:?}");
                     match duration {
                         Some(retry_delay) => sleep(retry_delay).await,
-                        None => return Ok(None),
+                        None => break,
                     }
                 }
                 // retry on other errors
@@ -85,12 +102,87 @@ impl Network {
                     errors.push(err.clone());
                     match duration {
                         Some(retry_delay) => sleep(retry_delay).await,
-                        None => return Err(err),
+                        None => break,
                     }
                 }
             }
         }
-        Err(NetworkError::InvalidRetryStrategy)
+        // All retries exhausted, try fallback
+        debug!("All retries exhausted for {addr} after error, trying fallback to closest peers");
+        self.fetch_records_from_closest_peers_fallback(addr).await
+    }
+
+    /// Fallback method to fetch records from the closest peers directly in parallel.
+    ///
+    /// This function queries the closest N peers for a given key and returns all
+    /// successfully retrieved records. This is useful as a fallback mechanism when
+    /// standard DHT queries fail or for CRDT types that may have different versions
+    /// on different nodes.
+    ///
+    /// # Arguments
+    /// * `addr` - The network address to query
+    ///
+    /// # Returns
+    /// * `Ok(Some(Vec<Record>))` - All successfully retrieved records from the queried peers.
+    /// * `Ok(None)` - If no peers could be found or all peer queries failed.
+    async fn fetch_records_from_closest_peers_fallback(
+        &self,
+        addr: NetworkAddress,
+    ) -> Result<Option<Vec<Record>>, NetworkError> {
+        debug!("Querying closest {FALLBACK_PEERS_COUNT} nodes directly for {addr:?}");
+
+        let closest_peers = match self
+            .get_closest_peers(addr.clone(), Some(FALLBACK_PEERS_COUNT))
+            .await
+        {
+            Ok(peers) => peers,
+            Err(e) => {
+                error!("Failed to get closest peers for {addr:?}: {e}");
+                return Ok(None);
+            }
+        };
+
+        debug!(
+            "Querying {} closest peers in parallel for {addr:?}",
+            closest_peers.len()
+        );
+
+        // Create query tasks for all closest peers
+        let network = self.clone();
+        let query_futures: Vec<_> = closest_peers
+            .into_iter()
+            .map(|peer| {
+                let network = network.clone();
+                let addr = addr.clone();
+                async move { network.get_record_from_peer(addr, peer).await }
+            })
+            .collect();
+
+        // Process all tasks concurrently
+        let results: Vec<_> = stream::iter(query_futures)
+            .buffer_unordered(FALLBACK_PEERS_COUNT)
+            .collect()
+            .await;
+
+        // Collect all successful records
+        let records: Vec<Record> = results
+            .into_iter()
+            .filter_map(|result| match result {
+                Ok(Some(record)) => Some(record),
+                _ => None,
+            })
+            .collect();
+
+        if records.is_empty() {
+            error!("❌ All closest peers failed to return records for {addr:?}");
+            Ok(None)
+        } else {
+            debug!(
+                "✅ Retrieved {} records from closest peers for {addr:?}",
+                records.len()
+            );
+            Ok(Some(records))
+        }
     }
 
     /// Get quotes from the network with retries


### PR DESCRIPTION
### Description

Implemented a common fallback mechanism for fetching records from the closest peers directly, applicable to all data types (Chunk, GraphEntry, Pointer, Scratchpad). 

For CRDT types with counter (Pointer, Scratchpad) return the multiple valid copies to carry out further CRDT merge to be carried out.

This also resolves some occasionally test failures involving mutable datatypes mutation. 

### Type of Change

Please mark the types of changes made in this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
