### PR TITLE
feat(ant): add `developer node-version` command

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -505,6 +505,20 @@ pub enum DeveloperCmd {
         #[arg(long)]
         compare: bool,
     },
+    /// Get the version of a node.
+    ///
+    /// Queries a specific node to retrieve its software version.
+    NodeVersion {
+        /// Node to query: either a PeerId or full multiaddr.
+        ///
+        /// Examples:
+        ///   - PeerId: 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
+        ///   - Multiaddr: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW...
+        ///
+        /// When only a PeerId is provided, the peer's address is discovered via the network.
+        #[arg(name = "node")]
+        node_addr: String,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -759,6 +773,9 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             } => {
                 developer::closest_peers(&node_addr, &target, num_peers, compare, network_context)
                     .await
+            }
+            DeveloperCmd::NodeVersion { node_addr } => {
+                developer::node_version(&node_addr, network_context).await
             }
         },
         None => {

--- a/ant-cli/src/commands/developer.rs
+++ b/ant-cli/src/commands/developer.rs
@@ -21,6 +21,34 @@ use autonomi::PublicKey;
 use autonomi::networking::{Multiaddr, PeerId, PeerInfo};
 use color_eyre::{Result, eyre::eyre};
 
+/// Get the version of a node.
+///
+/// This command queries a specific node to retrieve its software version.
+pub async fn node_version(node_addr: &str, network_context: NetworkContext) -> Result<()> {
+    println!("Connecting to network...");
+    let client = connect_to_network(network_context)
+        .await
+        .map_err(|(err, _exit_code)| err)?;
+
+    // Resolve the node - either from multiaddr or by discovering PeerId
+    let node_info = resolve_node(&client, node_addr).await?;
+    let peer_id = node_info.peer_id;
+
+    println!("Querying node {peer_id} for version...");
+    println!();
+
+    // Query the node for its version
+    let version = client
+        .get_node_version(node_info)
+        .await
+        .map_err(|e| eyre!("Failed to query node version: {e}"))?;
+
+    println!("Node {peer_id}");
+    println!("  Version: {version}");
+
+    Ok(())
+}
+
 /// Query a specific node to get its network view of closest peers to a target address.
 ///
 /// This command asks the specified node to perform an actual Kademlia network lookup


### PR DESCRIPTION
Requires PR #3376 to be merged.

Add `developer node-version` command to query the version of a specific node. Requires the `developer` feat flag for `ant`. 

### Usage:
` cargo run --bin ant --features developer -- developer node-version <peer-id-or-multiaddr>`

### Examples:
```
 cargo run --bin ant --features developer -- developer node-version 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE

 cargo run --bin ant --features developer -- developer node-version /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
 ```