### PR TITLE
feat(node): remove peer when failed to fetch version

### DIFF
--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::metrics::NodeMetricsRecorder;
 #[cfg(feature = "open-metrics")]
 use crate::networking::MetricsRegistries;
-use crate::networking::{Addresses, Network, NetworkConfig, NetworkError, NetworkEvent, NodeIssue};
+use crate::networking::{Addresses, Network, NetworkConfig, NetworkEvent, NodeIssue};
 use crate::{PutValidationError, RunningNode};
 use ant_bootstrap::bootstrap::Bootstrap;
 use ant_evm::EvmNetwork;
@@ -32,7 +32,6 @@ use libp2p::{
     Multiaddr, PeerId,
     identity::Keypair,
     kad::{KBucketDistance as Distance, Record, U256},
-    request_response::OutboundFailure,
 };
 use num_traits::cast::ToPrimitive;
 use rand::{
@@ -1539,13 +1538,10 @@ impl Node {
             Err(err) => {
                 info!("Failed to fetch peer version {peer:?} with error {err:?}");
                 // Failed version fetch (which contains dial then re-attempt by itself)
-                // with error of `DialFailure` indicates the peer could be dead with high chance.
+                // indicates the peer could be dead with high chance.
                 // In that case, the peer shall be removed from the routing table.
-                if let NetworkError::OutboundError(OutboundFailure::DialFailure) = err {
-                    network.remove_peer(peer);
-                    return;
-                }
-                "old".to_string()
+                network.remove_peer(peer);
+                return;
             }
         };
         network.notify_node_version(peer, version);


### PR DESCRIPTION
### Description

When peer version query originally got introduced, to be backward compatible, the keyword `old` is reserved for those nodes remained in old version that doesn't support the version query.
However, this makes some `failed to contact` peers due to communication issue to be also counted as `old` version nodes.

With the nodes' versions got evolved certain times and majority (over 96%) supports the version query, such old nodes (even still exists) shall be removed from the network as having no contribution.

Hence this PR changed to remove peer from RT when failed to fetch version.

<!--
### Footer (Hidden from GitHub view)
This template uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure your commit messages follow these guidelines for clarity and consistency.

Commit messages should be verified using [commitlint](https://commitlint.js.org/#/).

Commit Message Format:
<type>[optional scope]: <description>
[optional body]
[optional footer(s)]

Common Types:
- `feat`
- `fix`
- `docs`
- `style`
- `refactor`
- `perf`
- `test`
- `build`
- `ci`
- `chore`
- `revert`
-->
