### PR TITLE
fix: avoid empty peers on timeout

### DIFF
--- a/ant-node/src/networking/driver/event/kad.rs
+++ b/ant-node/src/networking/driver/event/kad.rs
@@ -106,9 +106,11 @@ impl SwarmDriver {
                         .network_discovery
                         .handle_get_closest_query(current_closest),
                     PendingGetClosestType::FunctionCall(sender) => {
+                        // Send the peers collected before timeout, not empty vec
+                        let peers: Vec<_> = current_closest.into_iter().collect();
                         #[allow(clippy::let_underscore_future)]
                         let _ = tokio::spawn(async move {
-                            let _ = sender.send(vec![]);
+                            let _ = sender.send(peers);
                         });
                     }
                 }

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::Client;
-use crate::networking::{NetworkError, PeerQuoteWithStorageProof};
 use crate::networking::version::PackageVersion;
+use crate::networking::{NetworkError, PeerQuoteWithStorageProof};
 use crate::utils::process_tasks_with_max_concurrency;
 use ant_protocol::NetworkAddress;
 use ant_protocol::storage::DataTypes;

--- a/evmlib/src/retry.rs
+++ b/evmlib/src/retry.rs
@@ -181,7 +181,9 @@ where
     let estimated_gas = provider
         .estimate_gas(transaction_request.clone())
         .await
-        .map_err(|e| TransactionError::TransactionFailedToSend(format!("gas estimation failed: {e}")))?;
+        .map_err(|e| {
+            TransactionError::TransactionFailedToSend(format!("gas estimation failed: {e}"))
+        })?;
     let gas_with_buffer = estimated_gas.saturating_mul(120) / 100;
     debug!("Estimated gas: {estimated_gas}, with 20% buffer: {gas_with_buffer}");
     transaction_request.set_gas_limit(gas_with_buffer);


### PR DESCRIPTION
node side fix to avoid returning an empty peers list on timeout