### PR TITLE
feat(ant): add `developer get-quote` command

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -519,6 +519,30 @@ pub enum DeveloperCmd {
         #[arg(name = "node")]
         node_addr: String,
     },
+    /// Get a storage quote from a specific peer.
+    ///
+    /// This queries a specific node to get a quote for storing data at a given address.
+    /// The quote contains pricing metrics and node information.
+    GetQuote {
+        /// Peer to query: either a PeerId or full multiaddr.
+        ///
+        /// Examples:
+        ///   - PeerId: 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
+        ///   - Multiaddr: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooW...
+        ///
+        /// When only a PeerId is provided, the peer's address is discovered via the network.
+        #[arg(name = "peer")]
+        peer_addr: String,
+        /// Target address for the quote (hex string, ChunkAddress, or XorName).
+        #[arg(name = "address")]
+        address: String,
+        /// Data type index (default: 0 for Chunk).
+        #[arg(short = 't', long, default_value = "0")]
+        data_type: u32,
+        /// Data size in bytes (default: 1048576 = 1MB).
+        #[arg(short = 's', long, default_value = "1048576")]
+        data_size: usize,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -776,6 +800,15 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
             }
             DeveloperCmd::NodeVersion { node_addr } => {
                 developer::node_version(&node_addr, network_context).await
+            }
+            DeveloperCmd::GetQuote {
+                peer_addr,
+                address,
+                data_type,
+                data_size,
+            } => {
+                developer::get_quote(&peer_addr, &address, data_type, data_size, network_context)
+                    .await
             }
         },
         None => {

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -534,8 +534,9 @@ pub enum DeveloperCmd {
         #[arg(name = "peer")]
         peer_addr: String,
         /// Target address for the quote (hex string, ChunkAddress, or XorName).
+        /// If not provided, a random address will be generated.
         #[arg(name = "address")]
-        address: String,
+        address: Option<String>,
         /// Data type index (default: 0 for Chunk).
         #[arg(short = 't', long, default_value = "0")]
         data_type: u32,
@@ -807,8 +808,14 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 data_type,
                 data_size,
             } => {
-                developer::get_quote(&peer_addr, &address, data_type, data_size, network_context)
-                    .await
+                developer::get_quote(
+                    &peer_addr,
+                    address.as_deref(),
+                    data_type,
+                    data_size,
+                    network_context,
+                )
+                .await
             }
         },
         None => {

--- a/ant-cli/src/commands/analyze/mod.rs
+++ b/ant-cli/src/commands/analyze/mod.rs
@@ -12,14 +12,13 @@ mod json;
 pub use error::{AnalysisErrorDisplay, NetworkErrorDisplay};
 
 use crate::actions::NetworkContext;
+use crate::utils::parse_network_address;
 use crate::wallet::load_wallet;
 use ant_protocol::storage::DataTypes;
-use autonomi::PublicKey;
 use autonomi::chunk::ChunkAddress;
 use autonomi::client::analyze::{Analysis, AnalysisError};
 use autonomi::client::config::CHUNK_DOWNLOAD_BATCH_SIZE;
 use autonomi::client::payment::PaymentOption;
-use autonomi::graph::GraphEntryAddress;
 use autonomi::{
     Multiaddr, RewardsAddress, SecretKey, Wallet,
     networking::{NetworkAddress, NetworkError, PeerId, PeerQuoteWithStorageProof, Record},
@@ -138,38 +137,6 @@ macro_rules! println_if {
 // ============================================================================
 // Helper Functions for Network Health Scanning
 // ============================================================================
-
-/// Parse a string address into a NetworkAddress
-fn parse_network_address(addr: &str) -> Result<NetworkAddress> {
-    let hex_addr = addr.trim_start_matches("0x");
-
-    // Try parsing as ChunkAddress first
-    if let Ok(chunk_addr) = ChunkAddress::from_hex(addr) {
-        return Ok(NetworkAddress::from(chunk_addr));
-    }
-
-    // Try parsing as PublicKey (could be GraphEntry, Pointer, or Scratchpad)
-    if let Ok(public_key) = PublicKey::from_hex(hex_addr) {
-        return Ok(NetworkAddress::from(GraphEntryAddress::new(public_key)));
-    }
-
-    // Try parsing from NetworkAddress debug format:
-    // NetworkAddress::RecordKey("e9d7b3208bcb7ef566102027ca9a7f3ced7c0f8abf87c9bb0ef9130b625572f2") - (...)
-    if let Some(start) = addr.find('"')
-        && let Some(end) = addr[start + 1..].find('"')
-    {
-        let hex_str = &addr[start + 1..start + 1 + end];
-
-        // Try parsing the extracted hex string as ChunkAddress
-        if let Ok(chunk_addr) = ChunkAddress::from_hex(hex_str) {
-            return Ok(NetworkAddress::from(chunk_addr));
-        }
-    }
-
-    Err(color_eyre::eyre::eyre!(
-        "Could not parse address. Expected a hex-encoded ChunkAddress, PublicKey, or NetworkAddress debug format"
-    ))
-}
 
 /// Perform health check for a single address by querying closest 7 peers
 async fn perform_health_check_for_address(

--- a/ant-cli/src/commands/developer.rs
+++ b/ant-cli/src/commands/developer.rs
@@ -104,16 +104,20 @@ pub async fn closest_peers(
 /// This command queries a specific node to get a quote for storing data.
 pub async fn get_quote(
     peer_addr: &str,
-    address: &str,
+    address: Option<&str>,
     data_type: u32,
     data_size: usize,
     network_context: NetworkContext,
 ) -> Result<()> {
-    // Parse the target address to XorName
-    let target_addr = parse_network_address(address)?;
-    let xorname = target_addr
-        .xorname()
-        .ok_or_else(|| eyre!("Could not extract XorName from address: {address}"))?;
+    // Parse the target address to XorName, or generate a random one
+    let xorname = if let Some(addr) = address {
+        let target_addr = parse_network_address(addr)?;
+        target_addr
+            .xorname()
+            .ok_or_else(|| eyre!("Could not extract XorName from address: {addr}"))?
+    } else {
+        xor_name::XorName::random(&mut rand::thread_rng())
+    };
 
     // Convert data_type index to DataTypes enum
     let data_type_enum = DataTypes::from_index(data_type).ok_or_else(|| {

--- a/ant-cli/src/utils.rs
+++ b/ant-cli/src/utils.rs
@@ -6,7 +6,64 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use ant_protocol::NetworkAddress;
+use autonomi::PublicKey;
+use autonomi::client::data_types::chunk::ChunkAddress;
+use autonomi::client::data_types::graph::GraphEntryAddress;
 use autonomi::client::{Amount, ClientEvent, UploadSummary};
+use autonomi::networking::PeerId;
+use color_eyre::Result;
+
+/// Parse a string into a NetworkAddress.
+///
+/// Accepts:
+/// - ChunkAddress (hex)
+/// - PublicKey (hex) - for GraphEntry, Pointer, or Scratchpad addresses
+/// - Raw 32-byte hex (XorName)
+/// - PeerId
+/// - NetworkAddress debug format (e.g., `NetworkAddress::RecordKey("...")`)
+pub fn parse_network_address(addr: &str) -> Result<NetworkAddress> {
+    let hex_str = addr.strip_prefix("0x").unwrap_or(addr);
+
+    // Try parsing as ChunkAddress first
+    if let Ok(chunk_addr) = ChunkAddress::from_hex(addr) {
+        return Ok(NetworkAddress::from(chunk_addr));
+    }
+
+    // Try parsing as PublicKey (could be GraphEntry, Pointer, or Scratchpad)
+    if let Ok(public_key) = PublicKey::from_hex(hex_str) {
+        return Ok(NetworkAddress::from(GraphEntryAddress::new(public_key)));
+    }
+
+    // Try parsing from NetworkAddress debug format:
+    // NetworkAddress::RecordKey("e9d7b3208bcb7ef566102027ca9a7f3ced7c0f8abf87c9bb0ef9130b625572f2") - (...)
+    if let Some(start) = addr.find('"')
+        && let Some(end) = addr[start + 1..].find('"')
+    {
+        let extracted_hex = &addr[start + 1..start + 1 + end];
+        if let Ok(chunk_addr) = ChunkAddress::from_hex(extracted_hex) {
+            return Ok(NetworkAddress::from(chunk_addr));
+        }
+    }
+
+    // Try to parse as raw hex bytes (xor_name)
+    if let Ok(bytes) = hex::decode(hex_str)
+        && bytes.len() == 32
+    {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        return Ok(NetworkAddress::from(xor_name::XorName(arr)));
+    }
+
+    // Try to parse as a PeerId
+    if let Ok(peer_id) = addr.parse::<PeerId>() {
+        return Ok(NetworkAddress::from(peer_id));
+    }
+
+    Err(color_eyre::eyre::eyre!(
+        "Could not parse address. Expected ChunkAddress, PublicKey, XorName, PeerId, or NetworkAddress debug format. Got: {addr}"
+    ))
+}
 
 /// Collects upload summary from the event receiver.
 /// Send a signal to the returned sender to stop collecting and to return the result via the join handle.


### PR DESCRIPTION
Requires PR https://github.com/maidsafe/autonomi/pull/3376 to be merged.

Adds a `developer get-quote` command to request a raw quote from a specific node. Requires the developer feat flag for ant.

### Usage:

```cargo run --bin ant --features developer -- developer get-quote <peer-id-or-multiaddr> <address> [OPTIONS]```

### Examples:

```
# Get a quote using just a PeerId (address discovered via network)
cargo run --bin ant --features developer -- developer get-quote 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE 0000000000000000000000000000000000000000000000000000000000000000

# Get a quote using a full multiaddr
cargo run --bin ant --features developer -- developer get-quote /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE e9d7b3208bcb7ef566102027ca9a7f3ced7c0f8abf87c9bb0ef9130b625572f2

# Get a quote for a Scratchpad (data type 3) with custom size
cargo run --bin ant --features developer -- developer get-quote 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE 0000000000000000000000000000000000000000000000000000000000000000 -t 3 -s 512000
```

### Options:

| Option          | Description                                                     | Default       |
|-----------------|-----------------------------------------------------------------|---------------|
| -t, --data-type | Data type index: 0=Chunk, 1=GraphEntry, 2=Pointer, 3=Scratchpad | 0             |
| -s, --data-size | Data size in bytes                                              | 1048576 (1MB) |

### Example Output:

```
Connecting to network...
Discovering addresses for peer 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE...
Found peer at: /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
Requesting quote from peer 12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE for address 0000000000000000000000000000000000000000000000000000000000000000...
  Data type: Chunk (index 0)
  Data size: 1048576 bytes

Quote received:
============================================================

Peer Information:
  PeerId:          12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
  Addresses:
                   /ip4/127.0.0.1/udp/12000/quic-v1/p2p/12D3KooWRBhwfeP2Y4TCx1SM6s9rUoHhR5STiGwxBhgFRcw3UERE
  Rewards Address: 0x1234567890abcdef1234567890abcdef12345678

Quote Details:
  Content:         0000000000000000000000000000000000000000000000000000000000000000
  Timestamp:       1736280000 (unix)

Quoting Metrics:
  Data Type:             0 ("Chunk")
  Data Size:             1048576 bytes
  Close Records Stored:  150
  Max Records:           16384
  Received Payment Count:42
  Live Time:             86400 seconds
  Records Per Type:
    "Chunk": 120
    "GraphEntry": 25
    "Scratchpad": 5
  Network Size:          240 nodes (estimated)
  Network Density:       0404e0e4f7fc0e2c4315992ff412e80198c32c2b1d8713d9f08140f5f0e381a2
```