### PR TITLE
fix: handle deleted binary path in upgrade hash check

### DIFF
--- a/.claude/commands/prepare-for-auto-upgrade-test.md
+++ b/.claude/commands/prepare-for-auto-upgrade-test.md
@@ -1,0 +1,40 @@
+# Prepare for Auto Upgrade Test
+
+@ant-node/src/bin/antnode/main.rs
+@ant-node/src/bin/antnode/upgrade/mod.rs
+@release-cycle-info
+@ant-build-info/src/release_info.rs
+
+I want you to help me prepare for a test of the automatic-upgrades process.
+
+The process has 2 phases: preparing the current branch for an auto-upgrade test, and preparing a new
+branch with a fake release candidate.
+
+So first, I need you to reduce the upgrade check time from 3 days to 30 minutes, and reduce the
+randomness to 2 minutes. Now you need to make a change to the `fetch_and_cache_release_info`
+function. Replace the usage of `release_repo.get_latest_autonomi_release_info` to
+`release.get_autonomi_release_info`. This function takes a string, which is the tag of the fake
+release that will be created. You need to prompt me for the name. Finally, we have code that
+downloads the new binary from an `autonomi.com` URL and uses an S3 URL as a fallback. Another
+temporary change is required here to just use the S3 URL directly, since the `autonomi.com` URL
+always points to the latest release, which is not what we want for the test.
+
+Once you've made that change, create a chore commit that indicates these are temporary changes that
+will be removed. This commit then needs to be pushed to the origin on the current branch. However,
+before you do this, let me review the diff first. Then you can push when I give the go ahead. If you
+get an error, you most likely need to force push. This is fine.
+
+Now the second phase.
+
+First, I need you to create a new branch from the current one. Prompt me for the name of the new
+branch. Second, I need you to run `cargo release version <version> --package ant-node --execute
+--no-confirm`. For the version, you should get the current version of the `ant-node` crate, then
+increment the `PATCH` component by 1, and also add the `rc.1` suffix. Third, I need you to update
+the `release-cycle-info` and `ant-build-info/src/release_info.rs` files. The cycle counter value in
+both of them needs to be incremented by 1.
+
+With these changes, create a commit with the title `chore(release): release candidate
+<release_year>.<release_month>.<release_cycle>.<release_cycle_counter>` and in the body, indicate
+that it's a fake release candidate.
+
+Allow me to review the commit, and once I approve, push the branch to the `upstream` remote.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "libp2p",
  "libp2p-swarm-test",
  "num-traits",
+ "once_cell",
  "prometheus-client",
  "prost 0.9.0",
  "pyo3",

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -71,6 +71,7 @@ libp2p = { version = "0.56.0", features = [
     "autonat",
 ] }
 num-traits = "0.2"
+once_cell = "1.19"
 prometheus-client = { version = "0.23.1", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems
 # arm builds + musl are very problematic

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -238,6 +238,14 @@ struct Opt {
 
 fn main() -> Result<()> {
     color_eyre::install()?;
+
+    // Cache the running binary's hash early, before any other node could replace the shared binary.
+    // This ensures the hash reflects the actual binary we're running, not a newer version.
+    #[cfg(unix)]
+    if let Err(e) = upgrade::get_running_binary_hash() {
+        eprintln!("Warning: Failed to cache running binary hash: {e}");
+    }
+
     let opt = Opt::parse();
 
     let network_id = if let Some(network_id) = opt.network_id {


### PR DESCRIPTION
When multiple `antnode` processes run from symlinked binaries pointing to the same source, the first
node to upgrade replaces the shared binary. Subsequent nodes then see their current_exe() path with
" (deleted)" suffix appended by Linux, causing the hash calculation to fail with "No such file or
directory".

This fix:
- Strips the " (deleted)" suffix before calculating the hash
- Caches the running binary's hash using OnceCell since it's constant
  for the process lifetime
- Avoids recalculating the hash on each upgrade check

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>