### PR TITLE
chore(release): stable release 2025.12.3.2

### DIFF
--- a/.claude/commands/prepare-for-auto-upgrade-test.md
+++ b/.claude/commands/prepare-for-auto-upgrade-test.md
@@ -1,0 +1,40 @@
+# Prepare for Auto Upgrade Test
+
+@ant-node/src/bin/antnode/main.rs
+@ant-node/src/bin/antnode/upgrade/mod.rs
+@release-cycle-info
+@ant-build-info/src/release_info.rs
+
+I want you to help me prepare for a test of the automatic-upgrades process.
+
+The process has 2 phases: preparing the current branch for an auto-upgrade test, and preparing a new
+branch with a fake release candidate.
+
+So first, I need you to reduce the upgrade check time from 3 days to 30 minutes, and reduce the
+randomness to 2 minutes. Now you need to make a change to the `fetch_and_cache_release_info`
+function. Replace the usage of `release_repo.get_latest_autonomi_release_info` to
+`release.get_autonomi_release_info`. This function takes a string, which is the tag of the fake
+release that will be created. You need to prompt me for the name. Finally, we have code that
+downloads the new binary from an `autonomi.com` URL and uses an S3 URL as a fallback. Another
+temporary change is required here to just use the S3 URL directly, since the `autonomi.com` URL
+always points to the latest release, which is not what we want for the test.
+
+Once you've made that change, create a chore commit that indicates these are temporary changes that
+will be removed. This commit then needs to be pushed to the origin on the current branch. However,
+before you do this, let me review the diff first. Then you can push when I give the go ahead. If you
+get an error, you most likely need to force push. This is fine.
+
+Now the second phase.
+
+First, I need you to create a new branch from the current one. Prompt me for the name of the new
+branch. Second, I need you to run `cargo release version <version> --package ant-node --execute
+--no-confirm`. For the version, you should get the current version of the `ant-node` crate, then
+increment the `PATCH` component by 1, and also add the `rc.1` suffix. Third, I need you to update
+the `release-cycle-info` and `ant-build-info/src/release_info.rs` files. The cycle counter value in
+both of them needs to be incremented by 1.
+
+With these changes, create a commit with the title `chore(release): release candidate
+<release_year>.<release_month>.<release_cycle>.<release_cycle_counter>` and in the body, indicate
+that it's a fake release candidate.
+
+Allow me to review the commit, and once I approve, push the branch to the `upstream` remote.

--- a/.claude/commands/release-from-rc-branch.md
+++ b/.claude/commands/release-from-rc-branch.md
@@ -1,0 +1,144 @@
+# Perform Release from Release Candidate Branch
+
+@release-cycle-info
+@.github/workflows/release.yml
+
+I need you to assist me in doing a new release for this repository.
+
+We are currently working from a release candidate branch and we already have a changelog prepared.
+
+There are 9 phases:
+
+* Reviewing secrets
+* Removing pre-release identifiers from any Rust crate versions
+* Removing pre-release identifiers from any NodeJS packages with language bindings
+* Creating the release commit
+* Submit a PR with for the current release candidate branch
+* Merge the release candidate branch into the `stable` branch
+* Publish crates from the `stable` branch
+* Running the `release` workflow
+* Update the release description
+
+## Slack Updates
+
+Before we start the process, I just to inform you how I want you to post any messages into Slack.
+
+You should use the `slack_post_message` operation from the currently configured MCP server to post
+messages to the #releases channel. All messages should be prefixed with `<release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from the `release-cycle-info` file.
+
+## Phase 1: Reviewing Secrets
+
+Post a message to Slack indicating that the release process is beginning.
+
+Before we proceed with the process, I need you to remind me to check my personal access tokens on
+the `Maidsafe-QA` user on Github. If the `autonomi-github_release` token has expired, it needs to be
+regenerated, and I need to update my `~/.bashrc` to set the `AUTONOMI_RELEASE_TOKEN` variable with
+the new token.
+
+After this, you will need to run `source ~/.bashrc` to get the updated token. It is going to be used
+in the crate publishing phase.
+
+Do not proceed to the next phase until I have confirmed with you that I have either updated my token
+or the current token is still good.
+
+## Phase 2: Removing pre-release identifiers from Rust crates
+
+First, I need you to inspect all our crates and take note of any that currently have an `rc`
+pre-release identifier. For each of these crates, use the `cargo release` tool to remove the
+pre-release identifier:
+```
+cargo release version release --package <crate-name> --execute --no-confirm
+```
+
+Give me a summary of the crates you intend to bump and let me review them before executing the
+commands.
+
+## Phase 3: Removing pre-release identifiers from NodeJS packages
+
+We have two NodeJS packages in the repository: `autonomi-nodejs` and `ant-node-nodejs`.
+
+You need to check if either of these packages currently have an `rc` pre-release identifier. If so,
+they also need to have it removed. This can be done using the following:
+```
+npm version "<current version without the pre-release identifier>" --no-git-tag-version
+```
+
+Give me a summary of the bumps you intend to make and let me review them before executing the
+commands. If no bumps are required let me know that too. In any case, wait for input from me before
+continuing.
+
+## Phase 4: Create the release commit
+
+Stage all the current changes then commit them. For the title of the commit, use `chore(release):
+stable release <release-year>.<release-month>.<release-cycle>.<release-cycle-counter>`. You can get
+all the release information from the `release-cycle-info` file.
+
+For the body of the commit, you can run the Bash script at `resources/scripts/print-versions.sh` and
+use its output.
+
+## Phase 5: Submit a PR to main for the release candidate branch
+
+The release candidate branch now needs to be merged into the `main` branch. You should submit a
+pull request to the `maidsafe/autonomi` repository. The title and body/description of the PR should
+be the same as the title/body of the release commit.
+
+The test suite takes a long time to run, but we need to wait here for it to finish and the branch to
+be merged. I can let you know when to proceed.
+
+Post a message to Slack indicating the release candidate branch has been submitted as a PR to the
+`main` branch. A link to the PR would be handy in the message.
+
+## Phase 6: Merge the release candidate branch into the stable branch
+
+The release candidate branch now needs to be merged into the `stable` branch. Since the test suite
+ran on the `main` branch, it's OK to just merge it to `stable` without submitting a PR. You can
+checkout the `stable` branch then use `git merge --no-ff <release candidate branch name>`. Then the
+`stable` branch can be pushed to the `origin`. Wait for me to approve before pushing.
+
+Post a message to Slack indicating the release candidate branch has been merged into the `stable`
+branch and that it was pushed to the origin.
+
+## Phase 7: Publish crates
+
+Post a message to Slack indicating that we are starting the crate publishing phase.
+
+Continuing to work from our checkout of the `stable` branch, use the `release-plz` tool to publish
+the Rust crates:
+```
+release-plz release --git-token $AUTONOMI_RELEASE_TOKEN
+```
+
+This command can run for a long time, depending on how many crates need published. We need to wait
+for it to finish before proceeding to the next phase. If it fails, you need to stop here and not
+continue before I instruct you to.
+
+Post a message to Slack indicating the result, whether it passed or failed.
+
+## Phase 8: Running the release workflow
+
+Now I want you to run the `release` workflow on this repository. You can see it has inputs for which
+binaries to release and they are all `false` by default. Before you run the workflow, I need you to
+allow me to choose which of the binaries will be released. Then you can run the workflow with my
+choices.
+
+Before you run the workflow, please ask for my confirmation to review the inputs you intend to run
+it with.
+
+Post a message to Slack indicating that the workflow has been dispatched. A link to the workflow run
+would be useful in the message.
+
+We need to wait for it to complete. If it was not successful, wait for my signal before continuing.
+
+Post a message to Slack indicating that the workflow has completed either successfully or with an
+error. The message should indicate that the release is now available.
+
+Once it's been done, check the output of the `s3 release` job to make sure it only uploaded the
+binary that was chosen. The others should have retained their current copy.
+
+## Phase 9: Update the release description
+
+Once the release has been created, the body of the release should be updated with a "## Detailed
+Changes" section. Important: this should be *appended* to the body; do *not* delete what is in the
+body of the release currently.
+
+The detailed changes should be the latest entry in the `CHANGELOG.md` file.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,42 +7,42 @@ on:
         description: Release nat-detection binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-node-launchpad:
         description: Release node-launchpad binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-ant:
         description: Release ant binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-antnode:
         description: Release antnode binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-antctl:
         description: Release antctl binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-antctld:
         description: Release antctld binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-antnode-rpc-client:
         description: Release antnode_rpc_client binary
         type: boolean
         required: false
-        default: true
+        default: false
       release-evm-testnet:
         description: Release evm-testnet binary
         type: boolean
         required: false
-        default: true
+        default: false
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/autonomi/actions/runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "libp2p",
  "libp2p-swarm-test",
  "num-traits",
+ "once_cell",
  "prometheus-client",
  "prost 0.9.0",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8369,6 +8369,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -8388,12 +8389,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util 0.7.17",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -10697,6 +10700,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.11" }
+ant-node = { path = "../ant-node", version = "0.4.12" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -20,7 +20,7 @@ nightly = []
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.11", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.11" }
+ant-node = { path = "../ant-node", version = "0.4.12" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -80,6 +80,7 @@ pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"], optional
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rmp-serde = "1.1.1"
 rayon = "1.8.0"
+reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls-manual-roots", "stream"] }
 semver = "1.0"
 sha2 = "0.10"
 serde = { version = "1.0.133", features = ["derive", "rc"] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -71,6 +71,7 @@ libp2p = { version = "0.56.0", features = [
     "autonat",
 ] }
 num-traits = "0.2"
+once_cell = "1.19"
 prometheus-client = { version = "0.23.1", optional = true }
 # watch out updating this, protoc compiler needs to be installed on all build systems
 # arm builds + musl are very problematic

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -238,6 +238,14 @@ struct Opt {
 
 fn main() -> Result<()> {
     color_eyre::install()?;
+
+    // Cache the running binary's hash early, before any other node could replace the shared binary.
+    // This ensures the hash reflects the actual binary we're running, not a newer version.
+    #[cfg(unix)]
+    if let Err(e) = upgrade::get_running_binary_hash() {
+        eprintln!("Warning: Failed to cache running binary hash: {e}");
+    }
+
     let opt = Opt::parse();
 
     let network_id = if let Some(network_id) = opt.network_id {

--- a/ant-node/src/bin/antnode/upgrade/mod.rs
+++ b/ant-node/src/bin/antnode/upgrade/mod.rs
@@ -321,13 +321,36 @@ pub async fn perform_upgrade() -> Result<()> {
         }
     };
 
-    if release_info
-        .commit_hash
-        .starts_with(ant_build_info::git_sha())
-    {
+    // Check if the antnode binary has changed by comparing SHA256 hashes.
+    let platform = ant_releases::get_running_platform()?;
+    let platform_binaries = release_info
+        .platform_binaries
+        .iter()
+        .find(|pb| pb.platform == platform)
+        .ok_or_else(|| UpgradeError::PlatformBinariesNotFound(format!("{platform:?}")))?;
+
+    let antnode_binary = platform_binaries
+        .binaries
+        .iter()
+        .find(|b| b.name == "antnode")
+        .ok_or_else(|| {
+            UpgradeError::PlatformBinariesNotFound(format!(
+                "antnode binary not found in release for platform: {platform:?}"
+            ))
+        })?;
+
+    let current_exe_path = std::env::current_exe()?;
+    let current_hash = calculate_sha256(&current_exe_path)?;
+    if current_hash.eq_ignore_ascii_case(&antnode_binary.sha256) {
+        info!("Current antnode binary hash matches latest release. No upgrade needed.");
         return Err(UpgradeError::AlreadyLatest);
     }
-    info!("New version detected: {}", release_info.commit_hash);
+
+    info!(
+        "New antnode binary available (current: {}; latest: {}). Proceeding with upgrade...",
+        &current_hash[..8],
+        &antnode_binary.sha256[..8]
+    );
 
     let release_repo = <dyn AntReleaseRepoActions>::default_config();
     let (new_binary_path, expected_hash) =

--- a/ant-node/src/bin/antnode/upgrade/mod.rs
+++ b/ant-node/src/bin/antnode/upgrade/mod.rs
@@ -34,13 +34,13 @@ const DEFAULT_NETWORK_SIZE: usize = 100_000;
 /// These URLs redirect to the actual binary download location.
 fn get_autonomi_download_url(platform: &Platform) -> &'static str {
     match platform {
-        Platform::LinuxMusl => "https://autonomi.com/download/node/linux-x64",
-        Platform::LinuxMuslAarch64 => "https://autonomi.com/download/node/linux-arm64",
-        Platform::LinuxMuslArm => "https://autonomi.com/download/node/linux-arm",
-        Platform::LinuxMuslArmV7 => "https://autonomi.com/download/node/linux-armv7",
-        Platform::MacOs => "https://autonomi.com/download/node/mac-intel",
-        Platform::MacOsAarch64 => "https://autonomi.com/download/node/mac-apple-silicon",
-        Platform::Windows => "https://autonomi.com/download/node/windows",
+        Platform::LinuxMusl => "https://downloads.autonomi.com/node/linux-x64",
+        Platform::LinuxMuslAarch64 => "https://downloads.autonomi.com/node/linux-arm64",
+        Platform::LinuxMuslArm => "https://downloads.autonomi.com/node/linux-arm",
+        Platform::LinuxMuslArmV7 => "https://downloads.autonomi.com/node/linux-armv7",
+        Platform::MacOs => "https://downloads.autonomi.com/node/mac-intel",
+        Platform::MacOsAarch64 => "https://downloads.autonomi.com/node/mac-apple-silicon",
+        Platform::Windows => "https://downloads.autonomi.com/node/windows",
     }
 }
 

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -15,4 +15,4 @@
 release-year: 2025
 release-month: 12
 release-cycle: 3
-release-cycle-counter: 1
+release-cycle-counter: 2


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.4.15
ant-evm: 0.1.19
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.12
ant-node-manager: 0.14.1
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.11
ant-service-management: 0.5.1
ant-token-supplies: 0.1.67
autonomi: 0.9.0
evmlib: 0.4.7
evm-testnet: 0.1.17
nat-detection: 0.2.22
node-launchpad: 0.6.1
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.4.15
antctl: 0.14.1
antctld: 0.14.1
antnode: 0.4.12
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.1
```