### PR TITLE
chore(release): stable release 2025.12.3.3

### DIFF
--- a/.claude/commands/release-from-rc-branch.md
+++ b/.claude/commands/release-from-rc-branch.md
@@ -21,10 +21,10 @@ There are 9 phases:
 
 ## Slack Updates
 
-Before we start the process, I just to inform you how I want you to post any messages into Slack.
+Before we start the process, I want to inform you how to post any messages to Slack.
 
 You should use the `slack_post_message` operation from the currently configured MCP server to post
-messages to the #releases channel. All messages should be prefixed with `<release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from the `release-cycle-info` file.
+messages to the #releases channel. All messages should be prefixed with `[timestamp] <release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from the `release-cycle-info` file.
 
 ## Phase 1: Reviewing Secrets
 
@@ -127,10 +127,11 @@ it with.
 Post a message to Slack indicating that the workflow has been dispatched. A link to the workflow run
 would be useful in the message.
 
-We need to wait for it to complete. If it was not successful, wait for my signal before continuing.
+We need to wait for it to complete. Monitor the run yourself, then when it completes, prompt me to
+confirm on moving to the next phase.
 
 Post a message to Slack indicating that the workflow has completed either successfully or with an
-error. The message should indicate that the release is now available.
+error. If successful, the message should indicate that the release is now available.
 
 Once it's been done, check the output of the `s3 release` job to make sure it only uploaded the
 binary that was chosen. The others should have retained their current copy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2026-01-09
+
+### Network
+
+#### Changed
+
+- The binaries in the automatic upgrade process are now fetched from `autonomi.com` URLs, with the
+  S3 location being used as a fallback.
+
+#### Fixed
+
+- The automatic upgrades process was being confused by the fact that our last release was a
+  client-only release. It was detecting it as a new release and scheduling a restart of the node,
+  although the binary wasn't being replaced. The process has now been changed to only check and
+  compare the sha256 hash of the `antnode` binary rather than the commit hash of the release.
+
 ## 2025-12-23
 
 ### API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.12"
+version = "0.4.13-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.13-rc.1"
+version = "0.4.13"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2025";
 pub const RELEASE_MONTH: &str = "12";
 pub const RELEASE_CYCLE: &str = "3";
-pub const RELEASE_CYCLE_COUNTER: &str = "1";
+pub const RELEASE_CYCLE_COUNTER: &str = "3";

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.12" }
+ant-node = { path = "../ant-node", version = "0.4.13-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.13-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.13" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -20,7 +20,7 @@ nightly = []
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.11", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.13-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.13" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -20,7 +20,7 @@ nightly = []
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.11", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.12" }
+ant-node = { path = "../ant-node", version = "0.4.13-rc.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.13-rc.1"
+version = "0.4.13"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.12"
+version = "0.4.13-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -15,4 +15,4 @@
 release-year: 2025
 release-month: 12
 release-cycle: 3
-release-cycle-counter: 2
+release-cycle-counter: 3


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.4.15
ant-evm: 0.1.19
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.13
ant-node-manager: 0.14.1
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.11
ant-service-management: 0.5.1
ant-token-supplies: 0.1.67
autonomi: 0.9.0
evmlib: 0.4.7
evm-testnet: 0.1.17
nat-detection: 0.2.22
node-launchpad: 0.6.1
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.4.15
antctl: 0.14.1
antctld: 0.14.1
antnode: 0.4.13
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.1
```