### PR TITLE
node(feature): approve merkle upload when node lacks network knowledge

### DIFF
--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -1259,6 +1259,17 @@ impl Node {
             }
         };
 
+        // Approve the merkle upload when self is lacking of network knowledge.
+        // A normal node shall get K_VALUE (20) entries from the kad get_closet network query.
+        // PEERS_TO_QUERY is currently at the same value as to K_VALUE.
+        if closest_peers.len() < PEERS_TO_QUERY {
+            info!("Only got {} closest peers of {midpoint_address:?}, \
+                   validates the merkle upload request as seems lacking of network knowledge",
+                   closest_peers.len());
+            return Ok(());
+        }
+
+
         let candidate_peer_ids_set: HashSet<_> =
             closest_peers.iter().map(|(peer_id, _)| *peer_id).collect();
 


### PR DESCRIPTION
## Summary

This PR adds a check to approve merkle upload requests when the node lacks sufficient network knowledge.

## Changes

- **File modified**: `ant-node/src/put_validation.rs`
- Added validation bypass when a node has fewer than `PEERS_TO_QUERY` (K_VALUE = 20) closest peers
- When the node retrieves fewer peers than expected from the kad `get_closest` network query, it indicates the node may be lacking network knowledge
- In such cases, the merkle upload request is automatically approved to avoid incorrect rejections

## Rationale

A normal node should get K_VALUE (20) entries from the kad `get_closest` network query. If fewer peers are returned, it suggests the node doesn't have enough network knowledge to make an accurate validation decision. Rather than potentially rejecting valid requests, the node approves them in these edge cases.