### PR TITLE
ci(fix): add disk space cleanup for Ubuntu CI runners

### DIFF
--- a/.github/workflows/files.yml
+++ b/.github/workflows/files.yml
@@ -18,6 +18,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free up disk space on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Check initial disk space
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "=== Initial disk space ==="
+          df -h
+          echo "=== Home directory ==="
+          du -sh /home/runner/ || true
+          echo "=== PWD ==="
+          du -sh . || true
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -25,6 +47,12 @@ jobs:
       - name: Build binaries
         run: cargo build --release --bin antnode --bin ant --bin antctl
         timeout-minutes: 30
+
+      - name: Check disk space after build
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "=== Disk space after build ==="
+          df -h
 
       - name: Start a local network
         uses: maidsafe/ant-local-testnet-action@main
@@ -237,6 +265,12 @@ jobs:
             fi
             
             echo "---"
+            
+            # Clean up test data after each test iteration to save disk space
+            echo "🧹 Cleaning up test data to free disk space..."
+            rm -rf test_upload/* test_download/* 2>/dev/null || true
+            echo "Disk space after cleanup:"
+            df -h / 2>/dev/null || df -h . 2>/dev/null || true
           done
           
           echo ""

--- a/.github/workflows/files_merkle.yml
+++ b/.github/workflows/files_merkle.yml
@@ -18,6 +18,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free up disk space on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Check initial disk space
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "=== Initial disk space ==="
+          df -h
+          echo "=== Home directory ==="
+          du -sh /home/runner/ || true
+          echo "=== PWD ==="
+          du -sh . || true
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -25,6 +47,12 @@ jobs:
       - name: Build binaries
         run: cargo build --release --bin antnode --bin ant --bin antctl
         timeout-minutes: 30
+
+      - name: Check disk space after build
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "=== Disk space after build ==="
+          df -h
 
       - name: Start a local network
         uses: maidsafe/ant-local-testnet-action@main
@@ -237,6 +265,12 @@ jobs:
             fi
             
             echo "---"
+            
+            # Clean up test data after each test iteration to save disk space
+            echo "🧹 Cleaning up test data to free disk space..."
+            rm -rf test_upload/* test_download/* 2>/dev/null || true
+            echo "Disk space after cleanup:"
+            df -h / 2>/dev/null || df -h . 2>/dev/null || true
           done
           
           echo ""


### PR DESCRIPTION
## Problem

The `File Upload/Download Tests` have been consistently failing on Ubuntu runners since December 2025, while succeeding on Windows. The root cause is **disk space exhaustion** on GitHub-hosted Ubuntu runners.

Error: `System.IO.IOException: No space left on device`

## Root Cause Analysis

1. **Large Test Data Volume** (~1.9 GB):
   - 8 file test configurations ? (25MB small + 200MB medium) = 1,800 MB
   - 4 directory test configurations ? 25MB = 100 MB

2. **No Cleanup Between Tests**: Test data accumulated across iterations

3. **Additional Storage Consumption**:
   - Rust build artifacts (~2-3 GB)
   - Local testnet with 25 nodes storing replicated data
   - Downloaded files stored again

4. **Ubuntu vs Windows**: Windows runners have more available disk space

## Solution

### 1. Added `jlumbroso/free-disk-space` action (Ubuntu only)
Removes ~30GB of unused software:
- Android SDK, .NET runtime, Haskell, Docker images, Large packages

### 2. Added disk space monitoring
Logs disk usage at key points for future debugging

### 3. Added cleanup between test iterations
Removes test data after each test to prevent accumulation:
`rm -rf test_upload/* test_download/*`

## Files Modified

- `.github/workflows/files.yml`
- `.github/workflows/files_merkle.yml`

## Expected Result

Ubuntu CI runs should now have ~40-50GB available (instead of ~14GB), sufficient to complete all test iterations successfully.