### PR TITLE
docs(fix): use --release flag for antctl in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,10 @@ RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps --workspace
 cargo run --bin evm-testnet
 
 # Create local test network with 25 nodes
-cargo run --bin antctl -- local run --build --clean --rewards-address <YOUR_ETHEREUM_ADDRESS>
+cargo run --release --bin antctl -- local run --build --clean --rewards-address <YOUR_ETHEREUM_ADDRESS>
 
 # Check node status
-cargo run --bin antctl -- status
+cargo run --release --bin antctl -- status
 
 # Upload files (requires SECRET_KEY environment variable)
 SECRET_KEY=<YOUR_EVM_SECRET_KEY> cargo run --bin ant -- --local file upload <path>
@@ -62,7 +62,7 @@ SECRET_KEY=<YOUR_EVM_SECRET_KEY> cargo run --bin ant -- --local file upload <pat
 cargo run --bin ant -- --local file download <addr> <dest_path>
 
 # Tear down network
-cargo run --bin antctl -- local kill
+cargo run --release --bin antctl -- local kill
 ```
 
 ### Binary Builds

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This creates a CSV file with the EVM network params in your data directory.
    `--rewards-address` _is the address where you will receive your node earnings on._
 
 ```bash
-cargo run --bin antctl -- local run --build --clean --rewards-address <YOUR_ETHEREUM_ADDRESS>
+cargo run --release --bin antctl -- local run --build --clean --rewards-address <YOUR_ETHEREUM_ADDRESS>
 ```
 
 The EVM Network parameters are loaded from the CSV file in your data directory automatically when the `local` mode is enabled.
@@ -121,7 +121,7 @@ The EVM Network parameters are loaded from the CSV file in your data directory a
 ##### 4. Verify node status
 
 ```bash
-cargo run --bin antctl -- status
+cargo run --release --bin antctl -- status
 ```
 
 The Antctl `run` command starts the node processes. The `status` command should show twenty-five
@@ -153,7 +153,7 @@ workspace has a client binary that can be used to run commands against these ser
 Run the `status` command with the `--details` flag to get the RPC port for each node:
 
 ```
-$ cargo run --bin antctl -- status --details
+$ cargo run --release --bin antctl -- status --details
 ...
 ===================================
 antctl-local25 - RUNNING
@@ -233,7 +233,7 @@ NOTE: it is preferable to use the node manager to control the node rather than R
 When you're finished experimenting, tear down the network:
 
 ```bash
-cargo run --bin antctl -- local kill
+cargo run --release --bin antctl -- local kill
 ```
 
 ## Metrics Dashboard

--- a/autonomi/README.md
+++ b/autonomi/README.md
@@ -67,7 +67,7 @@ To run the tests, we can run a local network:
 
 2. Run a local network and use the local EVM node.
     ```sh
-    cargo run --bin antctl -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-local
+    cargo run --release --bin antctl -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-local
     ```
 
 3. Then run the tests and pass the EVM params again:
@@ -83,7 +83,7 @@ point it to a live network.
 1. Run a local network:
 
 ```sh
-cargo run --bin antctl -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-arbitrum-one
+cargo run --release --bin antctl -- local run --build --clean --rewards-address <ETHEREUM_ADDRESS> evm-arbitrum-one
 ```
 
 2. Then pass the private key of the wallet, and ensure it has enough gas and payment tokens on the network (in this case

--- a/test.sh
+++ b/test.sh
@@ -5,10 +5,10 @@
 # 
 # Network Management Sequence (per README):
 # 1. Start EVM testnet: cargo run --bin evm-testnet
-# 2. Start local network: cargo run --bin antctl -- local run --build --clean --rewards-address <addr>
-# 3. Verify status: cargo run --bin antctl -- local status (should show 25 nodes RUNNING)
+# 2. Start local network: cargo run --release --bin antctl -- local run --build --clean --rewards-address <addr>
+# 3. Verify status: cargo run --release --bin antctl -- local status (should show 25 nodes RUNNING)
 # 4. Run tests with environment: ANT_PEERS=local SECRET_KEY=<key>
-# 5. Cleanup: cargo run --bin antctl -- local kill
+# 5. Cleanup: cargo run --release --bin antctl -- local kill
 
 set -e
 
@@ -334,14 +334,14 @@ start_network_with_logging() {
         log_message "INFO" "Starting network with logging to $network_log"
         
         # Start network with logging
-        cargo run --bin antctl -- local run --build --clean --rewards-address "$rewards_address" > "$network_log" 2>&1 &
+        cargo run --release --bin antctl -- local run --build --clean --rewards-address "$rewards_address" > "$network_log" 2>&1 &
         NETWORK_PID=$!
         
         log_message "SUCCESS" "Network startup initiated (PID: $NETWORK_PID)"
         return 0
     else
         # Fallback to original method
-        cargo run --bin antctl -- local run --build --clean --rewards-address "$rewards_address" &
+        cargo run --release --bin antctl -- local run --build --clean --rewards-address "$rewards_address" &
         NETWORK_PID=$!
     fi
 }
@@ -353,7 +353,7 @@ get_network_status_with_logging() {
         echo "# Status check at $(date -Iseconds)" >> "$status_log"
         
         # Run status command and capture output (simple approach without timeout for macOS compatibility)
-        if cargo run --bin antctl -- local status >> "$status_log" 2>&1; then
+        if cargo run --release --bin antctl -- local status >> "$status_log" 2>&1; then
             # Extract node count from the captured output
             local node_count=$(tail -30 "$status_log" | grep -c "RUNNING" 2>/dev/null || echo "0")
             # Sanitize the node count to ensure it's a clean integer
@@ -369,9 +369,9 @@ get_network_status_with_logging() {
         fi
     else
         # Fallback to original method
-        if cargo run --bin antctl -- local status > /dev/null 2>&1; then
+        if cargo run --release --bin antctl -- local status > /dev/null 2>&1; then
             local status_output
-            if status_output=$(cargo run --bin antctl -- local status 2>&1); then
+            if status_output=$(cargo run --release --bin antctl -- local status 2>&1); then
                 local node_count=$(echo "$status_output" | grep -c "RUNNING" 2>/dev/null || echo "0")
                 node_count=$(echo "$node_count" | tr -d '\n\r ' | grep -o '[0-9]*' | head -1)
                 node_count=${node_count:-0}
@@ -497,7 +497,7 @@ EOF
     fi
     
     if grep -q -i "failed to connect\|no bootstrap" "$test_log"; then
-        echo "- Verify local network is running with 'cargo run --bin antctl -- local status'" >> "$analysis_file"
+        echo "- Verify local network is running with 'cargo run --release --bin antctl -- local status'" >> "$analysis_file"
         echo "- Check ANT_PEERS=local environment variable is set" >> "$analysis_file"
         echo "- Ensure nodes have had time to establish connections" >> "$analysis_file"
     fi
@@ -1397,7 +1397,7 @@ cleanup_processes() {
     
     # Stop network using antctl (per README)
     print_status "Stopping local network..."
-    cargo run --bin antctl -- local kill > /dev/null 2>&1 || true
+    cargo run --release --bin antctl -- local kill > /dev/null 2>&1 || true
     
     # Wait a moment for graceful shutdown
     sleep 3


### PR DESCRIPTION
## Summary
- Update all documentation to use `cargo run --release --bin antctl` instead of `cargo run --bin antctl`
- Ensures consistent release builds and avoids compiling dependencies twice (debug + release)

## Background
When running `antctl` via `cargo run --bin antctl`, the binary builds in debug mode. However, `antctl` itself builds other binaries (`antnode`, `evm-testnet`) in release mode with `--release`. This causes all shared dependencies to compile twice - once for debug and once for release - wasting time and disk space.

Fixes #1456

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Test local network setup with updated commands

🤖 Generated with [Claude Code](https://claude.ai/code)