### PR TITLE
feat(windows)!: use local app data directory instead of roaming

### DIFF
--- a/.github/actions/upload-logs/action.yml
+++ b/.github/actions/upload-logs/action.yml
@@ -36,4 +36,4 @@ runs:
         compression-level: 9
         name: ${{ inputs.log_file_prefix }}_${{ inputs.runner_os }}
         path: |
-          C:\Users\runneradmin\AppData\Roaming\autonomi\**\*.log*
+          C:\Users\runneradmin\AppData\Local\autonomi\**\*.log*

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -183,7 +183,7 @@ jobs:
           - os: ubuntu-latest
             ant_path: /home/runner/.local/share/autonomi
           - os: windows-latest
-            ant_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi
+            ant_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi
           - os: macos-latest
             ant_path: /Users/runner/Library/Application\ Support/autonomi
     steps:
@@ -609,8 +609,8 @@ jobs:
             node_data_path: /home/runner/.local/share/autonomi/node
             ant_path: /home/runner/.local/share/autonomi
           - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi\\node
-            ant_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi
+            node_data_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi\\node
+            ant_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi
           - os: macos-latest
             node_data_path: /Users/runner/Library/Application Support/autonomi/node
             ant_path: /Users/runner/Library/Application Support/autonomi
@@ -770,8 +770,8 @@ jobs:
             node_data_path: /home/runner/.local/share/autonomi/node
             ant_path: /home/runner/.local/share/autonomi
           - os: windows-latest
-            node_data_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi\\node
-            ant_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi
+            node_data_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi\\node
+            ant_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi
           - os: macos-latest
             node_data_path: /Users/runner/Library/Application Support/autonomi/node
             ant_path: /Users/runner/Library/Application Support/autonomi

--- a/.github/workflows/pointer.yml
+++ b/.github/workflows/pointer.yml
@@ -16,7 +16,7 @@ jobs:
           - os: ubuntu-latest
             ant_path: /home/runner/.local/share/autonomi
           - os: windows-latest
-            ant_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi
+            ant_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi
           - os: macos-latest
             ant_path: /Users/runner/Library/Application\ Support/autonomi
     steps:

--- a/.github/workflows/scratchpad.yml
+++ b/.github/workflows/scratchpad.yml
@@ -16,7 +16,7 @@ jobs:
           - os: ubuntu-latest
             ant_path: /home/runner/.local/share/autonomi
           - os: windows-latest
-            ant_path: C:\\Users\\runneradmin\\AppData\\Roaming\\autonomi
+            ant_path: C:\\Users\\runneradmin\\AppData\\Local\\autonomi
           - os: macos-latest
             ant_path: /Users/runner/Library/Application\ Support/autonomi
     steps:

--- a/ant-bootstrap/src/config.rs
+++ b/ant-bootstrap/src/config.rs
@@ -80,7 +80,7 @@ pub struct InitialPeersConfig {
     /// The default location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
     ///  - macOS: $HOME/Library/Application Support/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
     ///
     /// We fallback to $HOME dir and then to current working directory if the platform specific directory cannot be
     /// determined.
@@ -103,7 +103,7 @@ pub struct BootstrapConfig {
     /// The default location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
     ///  - macOS: $HOME/Library/Application Support/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
     pub cache_dir: PathBuf,
     /// The cache save scaling factor. We start with the min_cache_save_duration and scale it up to the max_cache_save_duration.
     pub cache_save_scaling_factor: u32,
@@ -305,12 +305,12 @@ impl BootstrapConfig {
 /// The default location is platform specific:
 ///  - Linux: $HOME/.local/share/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
 ///  - macOS: $HOME/Library/Application Support/autonomi/bootstrap_cache/bootstrap_cache_<network_id>.json
-///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
+///  - Windows: C:\Users\<username>\AppData\Local\autonomi\bootstrap_cache\bootstrap_cache_<network_id>.json
 ///
 /// We fallback to $HOME dir and then to current working directory if the platform specific directory cannot be
 /// determined.
 fn default_cache_dir() -> PathBuf {
-    let base_dir = if let Some(dir) = dirs_next::data_dir() {
+    let base_dir = if let Some(dir) = dirs_next::data_local_dir() {
         dir
     } else if let Some(home) = dirs_next::home_dir() {
         warn!("Failed to obtain platform data directory, falling back to home directory");

--- a/ant-cli/src/access/data_dir.rs
+++ b/ant-cli/src/access/data_dir.rs
@@ -13,7 +13,7 @@ use color_eyre::{
 use std::path::PathBuf;
 
 pub fn get_client_data_dir_path() -> Result<PathBuf> {
-    let mut home_dirs = dirs_next::data_dir()
+    let mut home_dirs = dirs_next::data_local_dir()
         .ok_or_else(|| eyre!("Failed to obtain data dir, your OS might not be supported."))?;
     home_dirs.push("autonomi");
     home_dirs.push("client");

--- a/ant-cli/src/opt.rs
+++ b/ant-cli/src/opt.rs
@@ -125,7 +125,7 @@ pub(crate) struct Opt {
     /// The data directory location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/client/logs
     ///  - macOS: $HOME/Library/Application Support/autonomi/client/logs
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\client\logs
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\client\logs
     #[allow(rustdoc::invalid_html_tags)]
     #[clap(long, value_parser = LogOutputDest::parse_from_str, verbatim_doc_comment, default_value = "data-dir"
     )]

--- a/ant-logging/src/lib.rs
+++ b/ant-logging/src/lib.rs
@@ -55,7 +55,7 @@ impl LogOutputDest {
                 let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
 
                 // Get the data directory path and append the timestamp to the log file name
-                let dir = match dirs_next::data_dir() {
+                let dir = match dirs_next::data_local_dir() {
                     Some(dir) => dir
                         .join("autonomi")
                         .join("client")
@@ -359,7 +359,7 @@ impl LogBuilder {
             });
 
         let output_dest = override_dest.unwrap_or_else(|| {
-            match dirs_next::data_dir() {
+            match dirs_next::data_local_dir() {
                 Some(dir) => {
                     // Get the current timestamp and format it to be human readable
                     let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();

--- a/ant-metrics/src/main.rs
+++ b/ant-metrics/src/main.rs
@@ -57,7 +57,7 @@ struct Labels {
 }
 
 fn main() -> Result<()> {
-    let default_log_dir = dirs_next::data_dir()
+    let default_log_dir = dirs_next::data_local_dir()
         .ok_or_else(|| eyre!("could not obtain data directory path".to_string()))?
         .join("autonomi")
         .join("node");

--- a/ant-node-manager/src/bin/daemon/main.rs
+++ b/ant-node-manager/src/bin/daemon/main.rs
@@ -192,7 +192,7 @@ fn get_log_builder() -> Result<LogBuilder> {
     ];
     let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
 
-    let output_dest = dirs_next::data_dir()
+    let output_dest = dirs_next::data_local_dir()
         .ok_or_else(|| eyre!("Could not obtain user data directory"))?
         .join("autonomi")
         .join("antctld")

--- a/ant-node-manager/src/cmd/local.rs
+++ b/ant-node-manager/src/cmd/local.rs
@@ -146,7 +146,7 @@ pub async fn run(
         debug!(
             "Clean set to true, removing client, node dir, local registry and killing the network."
         );
-        let client_data_path = dirs_next::data_dir()
+        let client_data_path = dirs_next::data_local_dir()
             .ok_or_else(|| eyre!("Could not obtain user's data directory"))?
             .join("autonomi")
             .join("client");

--- a/ant-node-manager/src/config.rs
+++ b/ant-node-manager/src/config.rs
@@ -273,7 +273,7 @@ pub fn is_running_as_root() -> bool {
 }
 
 pub fn get_user_antnode_data_dir() -> Result<PathBuf> {
-    Ok(dirs_next::data_dir()
+    Ok(dirs_next::data_local_dir()
         .ok_or_else(|| {
             error!("Failed to get data_dir");
             eyre!("Could not obtain user data directory")

--- a/ant-node-manager/src/helpers.rs
+++ b/ant-node-manager/src/helpers.rs
@@ -32,7 +32,7 @@ const MAX_DOWNLOAD_RETRIES: u8 = 3;
 // We need deterministic and fix path for the faucet wallet.
 // Otherwise the test instances will not be able to find the same faucet instance.
 pub fn get_faucet_data_dir() -> PathBuf {
-    let mut data_dirs = dirs_next::data_dir().expect("A homedir to exist.");
+    let mut data_dirs = dirs_next::data_local_dir().expect("A homedir to exist.");
     data_dirs.push("autonomi");
     data_dirs.push("test_faucet");
     std::fs::create_dir_all(data_dirs.as_path())

--- a/ant-node-manager/src/local.rs
+++ b/ant-node-manager/src/local.rs
@@ -154,7 +154,7 @@ pub async fn kill_network(
     let mut system = System::new_all();
     system.refresh_all();
 
-    let genesis_data_path = dirs_next::data_dir()
+    let genesis_data_path = dirs_next::data_local_dir()
         .ok_or_else(|| eyre!("Could not obtain user's data directory"))?
         .join("autonomi")
         .join("test_genesis");

--- a/ant-node-nodejs/index.d.ts
+++ b/ant-node-nodejs/index.d.ts
@@ -49,7 +49,7 @@ export declare class RunningNode {
    * appended. The default location is platform specific:
    *  - Linux: $HOME/.local/share/autonomi/node/<peer-id>
    *  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>
-   *  - Windows: C:\Users\<username>\AppData\Roaming\autonomi
+   *  - Windows: C:\Users\<username>\AppData\Local\autonomi
   ode\<peer-id>
    */
   rootDirPath(): string

--- a/ant-node-nodejs/src/lib.rs
+++ b/ant-node-nodejs/src/lib.rs
@@ -153,7 +153,7 @@ impl RunningNode {
     /// appended. The default location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>
     #[allow(rustdoc::invalid_html_tags)]
     #[napi]
     pub fn root_dir_path(&self) -> String {

--- a/ant-node/python/antnode/README.md
+++ b/ant-node/python/antnode/README.md
@@ -103,7 +103,7 @@ Get the default root directory path for the given peer ID.
 - Platform specific paths:
   - Linux: `$HOME/.local/share/autonomi/node/<peer-id>`
   - macOS: `$HOME/Library/Application Support/autonomi/node/<peer-id>`
-  - Windows: `C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>`
+  - Windows: `C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>`
 
 #### `get_logs_dir() -> str`
 Get the logs directory path.

--- a/ant-node/src/bin/antnode/main.rs
+++ b/ant-node/src/bin/antnode/main.rs
@@ -127,7 +127,7 @@ struct Opt {
     /// The data directory location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>/logs
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>/logs
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>\logs
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>\logs
     #[expect(rustdoc::invalid_html_tags)]
     #[clap(long, default_value_t = LogOutputDestArg::DataDir, value_parser = parse_log_output, verbatim_doc_comment)]
     log_output_dest: LogOutputDestArg,
@@ -210,7 +210,7 @@ struct Opt {
     /// If not provided, the default location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>
     #[expect(rustdoc::invalid_html_tags)]
     #[clap(long, verbatim_doc_comment)]
     root_dir: Option<PathBuf>,

--- a/ant-node/src/bin/antnode/upgrade/mod.rs
+++ b/ant-node/src/bin/antnode/upgrade/mod.rs
@@ -190,7 +190,7 @@ pub fn verify_binary_hash(path: &Path, expected_hash: &str) -> Result<bool> {
 
 /// Get the upgrade directory path in the user's data directory.
 pub fn get_upgrade_dir_path() -> Result<PathBuf> {
-    let upgrade_dir_path = dirs_next::data_dir()
+    let upgrade_dir_path = dirs_next::data_local_dir()
         .ok_or_else(|| {
             UpgradeError::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,

--- a/ant-node/src/lib.rs
+++ b/ant-node/src/lib.rs
@@ -89,7 +89,7 @@ impl RunningNode {
     /// appended. The default location is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>
     #[expect(rustdoc::invalid_html_tags)]
     pub fn root_dir_path(&self) -> PathBuf {
         self.root_dir_path.clone()

--- a/ant-node/src/python.rs
+++ b/ant-node/src/python.rs
@@ -259,7 +259,7 @@ impl PyAntNode {
     /// This is platform specific:
     ///  - Linux: $HOME/.local/share/autonomi/node/<peer-id>
     ///  - macOS: $HOME/Library/Application Support/autonomi/node/<peer-id>
-    ///  - Windows: C:\Users\<username>\AppData\Roaming\autonomi\node\<peer-id>
+    ///  - Windows: C:\Users\<username>\AppData\Local\autonomi\node\<peer-id>
     #[allow(clippy::redundant_closure)]
     #[staticmethod]
     #[pyo3(signature = (peer_id=None))]

--- a/ant-node/src/utils.rs
+++ b/ant-node/src/utils.rs
@@ -44,7 +44,7 @@ pub fn get_root_dir_and_keypair(root_dir: &Option<PathBuf>) -> eyre::Result<(Pat
 
 /// Get the default antnode root dir for the provided PeerId
 pub fn get_antnode_root_dir(peer_id: PeerId) -> eyre::Result<PathBuf> {
-    let dir = dirs_next::data_dir()
+    let dir = dirs_next::data_local_dir()
         .ok_or_else(|| eyre!("could not obtain data dir"))?
         .join("autonomi")
         .join("node")

--- a/ant-service-management/src/registry.rs
+++ b/ant-service-management/src/registry.rs
@@ -228,7 +228,7 @@ impl NodeRegistry {
 }
 
 pub fn get_local_node_registry_path() -> Result<PathBuf> {
-    let path = dirs_next::data_dir()
+    let path = dirs_next::data_local_dir()
         .ok_or_else(|| {
             error!("Failed to get data_dir");
             Error::UserDataDirectoryNotObtainable

--- a/autonomi/src/client/chunk_cache.rs
+++ b/autonomi/src/client/chunk_cache.rs
@@ -24,7 +24,7 @@ pub enum ChunkCacheError {
 
 /// Get the default chunk cache directory for the Autonomi client
 pub fn default_cache_dir() -> Result<PathBuf, ChunkCacheError> {
-    let mut cache_dir = dirs_next::data_dir().ok_or_else(|| {
+    let mut cache_dir = dirs_next::data_local_dir().ok_or_else(|| {
         ChunkCacheError::DirectoryCreation(
             "Failed to obtain data dir, your OS might not be supported.".to_string(),
         )

--- a/evmlib/src/merkle_batch_payment.rs
+++ b/evmlib/src/merkle_batch_payment.rs
@@ -122,7 +122,7 @@ impl DiskMerklePaymentContract {
     /// Create a new contract with the default storage path
     /// Uses: DATA_DIR/autonomi/merkle_payments/
     pub fn new() -> Result<Self, SmartContractError> {
-        let storage_path = if let Some(data_dir) = dirs_next::data_dir() {
+        let storage_path = if let Some(data_dir) = dirs_next::data_local_dir() {
             data_dir.join("autonomi").join("merkle_payments")
         } else {
             // Fallback to current directory if data_dir is not available

--- a/node-launchpad/src/config.rs
+++ b/node-launchpad/src/config.rs
@@ -78,14 +78,14 @@ pub fn get_launchpad_nodes_data_dir_path(
 }
 
 fn get_user_data_dir() -> Result<PathBuf> {
-    dirs_next::data_dir().ok_or_else(|| eyre!("User data directory is not obtainable",))
+    dirs_next::data_local_dir().ok_or_else(|| eyre!("User data directory is not obtainable",))
 }
 
 /// Where to store the Launchpad config & logs.
 ///
 pub fn get_launchpad_data_dir_path() -> Result<PathBuf> {
     let mut home_dirs =
-        dirs_next::data_dir().ok_or_else(|| eyre!("Data directory is not obtainable"))?;
+        dirs_next::data_local_dir().ok_or_else(|| eyre!("Data directory is not obtainable"))?;
     home_dirs.push("autonomi");
     home_dirs.push("launchpad");
     std::fs::create_dir_all(home_dirs.as_path())?;

--- a/test-utils/src/testnet.rs
+++ b/test-utils/src/testnet.rs
@@ -81,7 +81,7 @@ impl DeploymentInventory {
         if path_from_env.exists() {
             Ok(path_from_env)
         } else {
-            let path = dirs_next::data_dir()
+            let path = dirs_next::data_local_dir()
                 .ok_or_else(|| eyre!("Could not obtain data_dir"))?
                 .join("autonomi")
                 .join("testnet-deploy")


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

This PR changes the default data directory on Windows from the **roaming profile** to the **local profile**.

| | Old Path | New Path |
|---|----------|----------|
| **Environment** | `%APPDATA%` | `%LOCALAPPDATA%` |
| **Full Path** | `C:\Users\<user>\AppData\Roaming\autonomi\...` | `C:\Users\<user>\AppData\Local\autonomi\...` |

### Why this change?

On Windows domain-joined machines, the roaming profile (`%APPDATA%`) is synchronized across the network. Node data directories can grow very large, causing:
- Slow login/logout times
- Network congestion
- Storage quota issues on domain controllers

The local profile (`%LOCALAPPDATA%`) is machine-specific and never synchronized.

### Impact on other platforms

**None.** On Linux and macOS, `dirs_next::data_local_dir()` returns the same path as `dirs_next::data_dir()`:
- Linux: `$HOME/.local/share` (unchanged)
- macOS: `$HOME/Library/Application Support` (unchanged)

### Migration required for existing Windows users

Existing Windows users will need to either:
1. **Move their data** from `%APPDATA%\autonomi` to `%LOCALAPPDATA%\autonomi`
2. **Start fresh** (data in old location will be ignored)

## Summary
- Changed all `dirs_next::data_dir()` calls to `dirs_next::data_local_dir()`
- Updated all documentation referencing Windows paths
- Updated CI workflow paths for Windows runners

Fixes #1510

## Test plan
- [ ] **Windows testing required** - Verify application works with new paths
- [ ] Verify existing data migration path works
- [ ] Verify Linux/macOS paths remain unchanged
- [ ] CI should pass on all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)