### PR TITLE
client(feat): improve merkle upload reliability with extended timeout and Kad fallback

### DIFF
--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -44,7 +44,10 @@ use ant_protocol::constants::{
 };
 
 /// Libp2p defaults to 10s which is quite fast, we are more patient
-pub const REQ_TIMEOUT: Duration = Duration::from_secs(30);
+/// To allow node have enough time to verify the merkle uploads,
+/// which involves a KAD network get_closest query could last for long time,
+/// this timeout need to be further extended.
+pub const REQ_TIMEOUT: Duration = Duration::from_secs(120);
 /// Libp2p defaults to 60s for kad queries, we are more patient
 pub const KAD_QUERY_TIMEOUT: Duration = Duration::from_secs(120);
 /// Libp2p defaults to 3, we are more aggressive


### PR DESCRIPTION
## Summary

This PR improves the reliability of merkle uploads through two changes:

### 1. Extend request timeout to 120s
- Increases the client request timeout from the default to 120 seconds
- Helps with network operations that may take longer due to network conditions

### 2. Add Kad-only fallback for merkle upload retries
When merkle upload fails with verified closest peers, fall back to direct Kad query to get a different set of peers and retry. This provides more resilience for merkle uploads without affecting other upload types.

**Changes:**
- Add `get_closest_peers_kad_only()` method in networking for direct Kad query without peer verification
- Modify `upload_record_with_merkle_proof()` to use fallback on failure:
  1. First attempt uses verified closest peers
  2. If upload fails, gets fresh peers via direct Kad query and retries

This fallback mechanism is specific to merkle uploads only, as requested.