### PR TITLE
Client refactors

### DIFF
--- a/ant-cli/src/commands/developer.rs
+++ b/ant-cli/src/commands/developer.rs
@@ -15,9 +15,9 @@
 use crate::actions::{NetworkContext, connect_to_network};
 use ant_protocol::NetworkAddress;
 use autonomi::Client;
+use autonomi::PublicKey;
 use autonomi::client::data_types::chunk::ChunkAddress;
 use autonomi::client::data_types::graph::GraphEntryAddress;
-use autonomi::PublicKey;
 use autonomi::networking::{Multiaddr, PeerId, PeerInfo};
 use color_eyre::{Result, eyre::eyre};
 
@@ -174,9 +174,18 @@ fn display_comparison(
 
     let client_peer_ids: HashSet<PeerId> = client_peers.iter().map(|p| p.peer_id).collect();
 
-    let common: HashSet<PeerId> = node_peer_ids.intersection(&client_peer_ids).copied().collect();
-    let node_only: HashSet<PeerId> = node_peer_ids.difference(&client_peer_ids).copied().collect();
-    let client_only: HashSet<PeerId> = client_peer_ids.difference(&node_peer_ids).copied().collect();
+    let common: HashSet<PeerId> = node_peer_ids
+        .intersection(&client_peer_ids)
+        .copied()
+        .collect();
+    let node_only: HashSet<PeerId> = node_peer_ids
+        .difference(&client_peer_ids)
+        .copied()
+        .collect();
+    let client_only: HashSet<PeerId> = client_peer_ids
+        .difference(&node_peer_ids)
+        .copied()
+        .collect();
 
     println!("Comparison of closest peers to {target}");
     println!("{}", "=".repeat(100));
@@ -195,14 +204,8 @@ fn display_comparison(
     println!();
 
     // Node's perspective
-    println!(
-        "NODE'S PERSPECTIVE (from {}):",
-        node_response.queried_node
-    );
-    println!(
-        "  {:<4} {:<54} {:<10} Status",
-        "#", "PeerId", "Distance"
-    );
+    println!("NODE'S PERSPECTIVE (from {}):", node_response.queried_node);
+    println!("  {:<4} {:<54} {:<10} Status", "#", "PeerId", "Distance");
     println!("  {}", "-".repeat(80));
 
     for (i, (peer_addr, _)) in node_response.peers.iter().enumerate() {
@@ -238,10 +241,7 @@ fn display_comparison(
 
     // Client's perspective
     println!("CLIENT'S PERSPECTIVE:");
-    println!(
-        "  {:<4} {:<54} {:<10} Status",
-        "#", "PeerId", "Distance"
-    );
+    println!("  {:<4} {:<54} {:<10} Status", "#", "PeerId", "Distance");
     println!("  {}", "-".repeat(85));
 
     // Sort client peers by distance

--- a/ant-node/src/bin/antnode/upgrade/mod.rs
+++ b/ant-node/src/bin/antnode/upgrade/mod.rs
@@ -16,9 +16,9 @@ use ant_releases::{
     AntReleaseRepoActions, ArchiveType, AutonomiReleaseInfo, Platform, ReleaseType,
 };
 use fs2::FileExt;
+use once_cell::sync::OnceCell;
 use semver::Version;
 use sha2::{Digest, Sha256};
-use once_cell::sync::OnceCell;
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -930,9 +930,7 @@ impl Node {
             Ok(peers) => {
                 let mut converted: Vec<(NetworkAddress, Vec<Multiaddr>)> = peers
                     .into_iter()
-                    .map(|(peer_id, addrs)| {
-                        (NetworkAddress::from(peer_id), addrs.0)
-                    })
+                    .map(|(peer_id, addrs)| (NetworkAddress::from(peer_id), addrs.0))
                     .collect();
 
                 // If num_of_peers is specified, limit the results

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -1263,12 +1263,13 @@ impl Node {
         // A normal node shall get K_VALUE (20) entries from the kad get_closet network query.
         // PEERS_TO_QUERY is currently at the same value as to K_VALUE.
         if closest_peers.len() < PEERS_TO_QUERY {
-            info!("Only got {} closest peers of {midpoint_address:?}, \
+            info!(
+                "Only got {} closest peers of {midpoint_address:?}, \
                    validates the merkle upload request as seems lacking of network knowledge",
-                   closest_peers.len());
+                closest_peers.len()
+            );
             return Ok(());
         }
-
 
         let candidate_peer_ids_set: HashSet<_> =
             closest_peers.iter().map(|(peer_id, _)| *peer_id).collect();

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -12,7 +12,9 @@ pub use ant_bootstrap::{
 };
 use ant_evm::EvmNetwork;
 use evmlib::contract::payment_vault::MAX_TRANSFERS_PER_TRANSACTION;
+use std::time::Duration;
 use std::{num::NonZero, sync::LazyLock};
+use tokio::time::sleep;
 
 /// Number of chunks to upload in parallel.
 ///
@@ -114,6 +116,15 @@ pub(crate) const UPLOAD_MAX_RETRIES: usize = 3;
 
 /// Pause duration in seconds between retry attempts for failed uploads.
 pub(crate) const UPLOAD_RETRY_PAUSE_SECS: u64 = 60;
+
+/// Pause before retrying failed uploads with consistent logging.
+pub(crate) async fn upload_retry_pause() {
+    crate::loud_info!(
+        "⚠️ Encountered upload failure, take {UPLOAD_RETRY_PAUSE_SECS} second pause before continue..."
+    );
+    sleep(Duration::from_secs(UPLOAD_RETRY_PAUSE_SECS)).await;
+    crate::loud_info!("🔄 continue with upload...");
+}
 
 /// Configuration for the [`crate::Client`] which can be provided through: [`crate::Client::init_with_config`].
 #[derive(Debug, Clone, Default)]

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -120,10 +120,9 @@ pub(crate) const UPLOAD_RETRY_PAUSE_SECS: u64 = 60;
 /// Pause before retrying failed uploads with consistent logging.
 pub(crate) async fn upload_retry_pause() {
     crate::loud_info!(
-        "⚠️ Encountered upload failure, take {UPLOAD_RETRY_PAUSE_SECS} second pause before continue..."
+        "⚠️ Encountered upload failure, pausing {UPLOAD_RETRY_PAUSE_SECS} seconds before retry..."
     );
     sleep(Duration::from_secs(UPLOAD_RETRY_PAUSE_SECS)).await;
-    crate::loud_info!("🔄 continue with upload...");
 }
 
 /// Configuration for the [`crate::Client`] which can be provided through: [`crate::Client::init_with_config`].

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -109,6 +109,12 @@ pub(crate) static UPLOAD_FLOW_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
     batch_size
 });
 
+/// Maximum number of retry attempts for failed chunk uploads.
+pub(crate) const UPLOAD_MAX_RETRIES: usize = 3;
+
+/// Pause duration in seconds between retry attempts for failed uploads.
+pub(crate) const UPLOAD_RETRY_PAUSE_SECS: u64 = 60;
+
 /// Configuration for the [`crate::Client`] which can be provided through: [`crate::Client::init_with_config`].
 #[derive(Debug, Clone, Default)]
 pub struct ClientConfig {

--- a/autonomi/src/client/data_map_restoration.rs
+++ b/autonomi/src/client/data_map_restoration.rs
@@ -69,9 +69,7 @@ impl Client {
     /// Chunks are only fetched from the network when actually needed by get_root_data_map.
     fn fetch_new_data_map(&self, data_map: &DataMap) -> Result<DataMap, GetError> {
         let total_chunks = data_map.infos().len();
-        #[cfg(feature = "loud")]
-        println!("Using lazy chunk fetching for {total_chunks} of datamap {data_map:?}");
-        debug!("Using lazy chunk fetching for {total_chunks} of datamap {data_map:?}");
+        crate::loud_debug!("Using lazy chunk fetching for {total_chunks} of datamap {data_map:?}");
 
         // Create a closure that fetches chunks on-demand
         let client = self.clone();
@@ -86,9 +84,7 @@ impl Client {
 
             match fetch_result {
                 Ok(chunk) => {
-                    #[cfg(feature = "loud")]
-                    println!("Successfully fetched chunk at: {chunk_addr:?}");
-                    debug!("Successfully fetched chunk at: {chunk_addr:?}");
+                    crate::loud_debug!("Successfully fetched chunk at: {chunk_addr:?}");
 
                     // Such datamap chunks shall be cleanup from chunk_cache immediately
                     client.cleanup_cached_chunks(&[chunk_addr]);
@@ -96,9 +92,7 @@ impl Client {
                     Ok(chunk.value)
                 }
                 Err(err) => {
-                    #[cfg(feature = "loud")]
-                    println!("Error fetching chunk at {chunk_addr:?}: {err:?}");
-                    error!("Error fetching chunk at {chunk_addr:?}: {err:?}");
+                    crate::loud_error!("Error fetching chunk at {chunk_addr:?}: {err:?}");
                     Err(self_encryption::Error::Generic(format!(
                         "Failed to fetch chunk at {chunk_addr:?}: {err:?}"
                     )))
@@ -112,9 +106,7 @@ impl Client {
                 GetError::Decryption(crate::self_encryption::Error::SelfEncryption(e))
             })?;
 
-        #[cfg(feature = "loud")]
-        println!("Successfully processed datamap with lazy chunk fetching");
-        debug!("Successfully processed datamap with lazy chunk fetching");
+        crate::loud_debug!("Successfully processed datamap with lazy chunk fetching");
 
         Ok(result_data_map)
     }

--- a/autonomi/src/client/high_level/data/helpers.rs
+++ b/autonomi/src/client/high_level/data/helpers.rs
@@ -190,6 +190,7 @@ impl Client {
                 }
 
                 upload_retry_pause().await;
+                crate::loud_info!("🔄 Retrying {} chunks...", retry_chunks.len());
             }
 
             current_batch = retry_chunks;

--- a/autonomi/src/client/high_level/data/private.rs
+++ b/autonomi/src/client/high_level/data/private.rs
@@ -6,13 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::time::Instant;
-
 use crate::AttoTokens;
 use crate::Client;
 use crate::client::payment::PaymentOption;
 use crate::client::{GetError, PutError};
-use crate::self_encryption::EncryptionStream;
 
 pub use crate::Bytes;
 pub use crate::client::data_types::chunk::DataMapChunk;
@@ -122,16 +119,7 @@ impl Client {
         data: Bytes,
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, DataMapChunk), PutError> {
-        let now = Instant::now();
-
-        let (chunk_stream, data_map_chunk) = EncryptionStream::new_in_memory(data, false)?;
-        debug!("Encryption took: {:.2?}", now.elapsed());
-
-        // Note within the `pay_and_upload`, UploadSummary will be sent to client via event_channel.
-        let mut chunk_streams = vec![chunk_stream];
-        self.pay_and_upload(payment_option, &mut chunk_streams)
-            .await
-            .map(|total_cost| (total_cost, data_map_chunk))
+        self.data_put_internal(data, payment_option, false).await
     }
 }
 

--- a/autonomi/src/client/high_level/files/archive_private.rs
+++ b/autonomi/src/client/high_level/files/archive_private.rs
@@ -164,8 +164,7 @@ impl Client {
             .to_bytes()
             .map_err(|e| PutError::Serialization(format!("Failed to serialize archive: {e:?}")))?;
 
-        #[cfg(feature = "loud")]
-        println!(
+        crate::loud_info!(
             "Uploading private archive referencing {} files",
             archive.map().len()
         );

--- a/autonomi/src/client/high_level/files/archive_public.rs
+++ b/autonomi/src/client/high_level/files/archive_public.rs
@@ -196,8 +196,7 @@ impl Client {
             .to_bytes()
             .map_err(|e| PutError::Serialization(format!("Failed to serialize archive: {e:?}")))?;
 
-        #[cfg(feature = "loud")]
-        println!(
+        crate::loud_info!(
             "Uploading public archive referencing {} files",
             archive.map().len()
         );

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -8,6 +8,7 @@
 
 use super::archive_private::{PrivateArchive, PrivateArchiveDataMap};
 use super::{DownloadError, UploadError};
+use crate::client::PutError;
 use crate::client::data_types::chunk::DataMapChunk;
 use crate::client::payment::PaymentOption;
 use crate::client::quote::add_costs;
@@ -87,7 +88,7 @@ impl Client {
             .dir_content_upload(dir_path, payment_option.clone())
             .await?;
         let (cost2, archive_addr) = self.archive_put(&archive, payment_option).await?;
-        let total_cost = add_costs(cost1, cost2)?;
+        let total_cost = add_costs(cost1, cost2).map_err(PutError::from)?;
         Ok((total_cost, archive_addr))
     }
 

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -99,11 +99,7 @@ impl Client {
         path: PathBuf,
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, DataMapChunk), UploadError> {
-        let (data_map_chunk, processed_chunks, free_chunks, receipts) =
-            self.stream_upload_file(path, payment_option, false).await?;
-        let total_cost = self
-            .calculate_total_cost(processed_chunks, receipts, free_chunks)
-            .await;
-        Ok((total_cost, data_map_chunk))
+        self.file_content_upload_internal(path, payment_option, false)
+            .await
     }
 }

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -8,13 +8,11 @@
 
 use super::archive_private::{PrivateArchive, PrivateArchiveDataMap};
 use super::{DownloadError, UploadError};
-
 use crate::client::data_types::chunk::DataMapChunk;
 use crate::client::payment::PaymentOption;
+use crate::client::quote::add_costs;
 use crate::{AttoTokens, Client};
 use std::path::PathBuf;
-
-use crate::self_encryption::encrypt_directory_files;
 
 impl Client {
     /// Download private file directly to filesystem. Always uses streaming.
@@ -60,49 +58,18 @@ impl Client {
         dir_path: PathBuf,
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PrivateArchive), UploadError> {
-        info!("Uploading directory as private: {dir_path:?}");
-
-        // encrypt
-        let encryption_results = encrypt_directory_files(dir_path, false).await?;
-        let mut chunk_iterators = vec![];
-        for encryption_result in encryption_results {
-            match encryption_result {
-                Ok(file_chunk_iterator) => {
-                    let file_path = file_chunk_iterator.file_path.clone();
-                    info!("Successfully encrypted file: {file_path:?}");
-                    #[cfg(feature = "loud")]
-                    println!("Successfully encrypted file: {file_path:?}");
-
-                    chunk_iterators.push(file_chunk_iterator);
-                }
-                Err(err_msg) => {
-                    error!("Error during file encryption: {err_msg}");
-                    #[cfg(feature = "loud")]
-                    println!("Error during file encryption: {err_msg}");
-                    return Err(UploadError::Encryption(err_msg));
-                }
-            }
-        }
-
-        // pay and upload
-        let total_cost = self
-            .pay_and_upload(payment_option, &mut chunk_iterators)
+        let (total_cost, streams) = self
+            .dir_content_upload_internal(dir_path, payment_option, false)
             .await?;
 
-        // create an archive
         let mut private_archive = PrivateArchive::new();
-        for file in chunk_iterators {
-            let file_path = file.file_path.clone();
-            let relative_path = file.relative_path.clone();
-            let file_metadata = file.metadata.clone();
-            let datamap = match file.data_map_chunk() {
-                Some(datamap) => datamap,
-                None => {
-                    error!("Datamap chunk not found for file: {file_path:?}, this is a BUG");
-                    continue;
-                }
-            };
-            private_archive.add_file(relative_path, datamap, file_metadata);
+        for stream in streams {
+            let file_path = stream.file_path.clone();
+            if let Some(datamap) = stream.data_map_chunk() {
+                private_archive.add_file(stream.relative_path, datamap, stream.metadata);
+            } else {
+                error!("Datamap chunk not found for file: {file_path:?}, this is a BUG");
+            }
         }
 
         Ok((total_cost, private_archive))
@@ -120,10 +87,7 @@ impl Client {
             .dir_content_upload(dir_path, payment_option.clone())
             .await?;
         let (cost2, archive_addr) = self.archive_put(&archive, payment_option).await?;
-        let total_cost = cost1.checked_add(cost2).unwrap_or_else(|| {
-            error!("Total cost overflowed: {cost1:?} + {cost2:?}");
-            cost1
-        });
+        let total_cost = add_costs(cost1, cost2)?;
         Ok((total_cost, archive_addr))
     }
 

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -9,11 +9,11 @@
 use super::archive_public::{ArchiveAddress, PublicArchive};
 use super::{DownloadError, FileCostError, Metadata, UploadError};
 use crate::AttoTokens;
-use crate::client::Client;
 use crate::client::data_types::chunk::{ChunkAddress, DataMapChunk};
 use crate::client::high_level::data::DataAddress;
 use crate::client::payment::PaymentOption;
 use crate::client::quote::add_costs;
+use crate::client::{Client, PutError};
 use bytes::Bytes;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -102,7 +102,7 @@ impl Client {
             .dir_content_upload_public(dir_path, payment_option.clone())
             .await?;
         let (cost2, archive_addr) = self.archive_put_public(&archive, payment_option).await?;
-        let total_cost = add_costs(cost1, cost2)?;
+        let total_cost = add_costs(cost1, cost2).map_err(PutError::from)?;
         Ok((total_cost, archive_addr))
     }
 

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -13,6 +13,7 @@ use crate::client::Client;
 use crate::client::data_types::chunk::{ChunkAddress, DataMapChunk};
 use crate::client::high_level::data::DataAddress;
 use crate::client::payment::PaymentOption;
+use crate::client::quote::add_costs;
 use bytes::Bytes;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -65,49 +66,19 @@ impl Client {
         dir_path: PathBuf,
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, PublicArchive), UploadError> {
-        info!("Uploading directory: {dir_path:?}");
-
-        // encrypt
-        let encryption_results =
-            crate::self_encryption::encrypt_directory_files(dir_path, true).await?;
-        let mut chunk_iterators = vec![];
-        for encryption_result in encryption_results {
-            match encryption_result {
-                Ok(file_chunk_iterator) => {
-                    let file_path = file_chunk_iterator.file_path.clone();
-                    info!("Successfully encrypted file: {file_path:?}");
-                    #[cfg(feature = "loud")]
-                    println!("Successfully encrypted file: {file_path:?}");
-
-                    chunk_iterators.push(file_chunk_iterator);
-                }
-                Err(err_msg) => {
-                    error!("Error during file encryption: {err_msg}");
-                    #[cfg(feature = "loud")]
-                    println!("Error during file encryption: {err_msg}");
-                }
-            }
-        }
-
-        // pay and upload
-        let total_cost = self
-            .pay_and_upload(payment_option, &mut chunk_iterators)
+        let (total_cost, streams) = self
+            .dir_content_upload_internal(dir_path, payment_option, true)
             .await?;
 
-        // create an archive
         let mut public_archive = PublicArchive::new();
-        for file_chunk_iterator in chunk_iterators {
-            let file_path = file_chunk_iterator.file_path.clone();
-            let relative_path = file_chunk_iterator.relative_path.clone();
-            let file_metadata = file_chunk_iterator.metadata.clone();
-            let data_address = match file_chunk_iterator.data_map_chunk() {
-                Some(datamap) => DataAddress::new(*datamap.0.name()),
-                None => {
-                    error!("Datamap chunk not found for file: {file_path:?}, this is a BUG");
-                    continue;
-                }
-            };
-            public_archive.add_file(relative_path, data_address, file_metadata);
+        for stream in streams {
+            let file_path = stream.file_path.clone();
+            if let Some(datamap) = stream.data_map_chunk() {
+                let data_address = DataAddress::new(*datamap.0.name());
+                public_archive.add_file(stream.relative_path, data_address, stream.metadata);
+            } else {
+                error!("Datamap chunk not found for file: {file_path:?}, this is a BUG");
+            }
         }
 
         for (file_path, data_addr, _meta) in public_archive.iter() {
@@ -131,10 +102,7 @@ impl Client {
             .dir_content_upload_public(dir_path, payment_option.clone())
             .await?;
         let (cost2, archive_addr) = self.archive_put_public(&archive, payment_option).await?;
-        let total_cost = cost1.checked_add(cost2).unwrap_or_else(|| {
-            error!("Total cost overflowed: {cost1:?} + {cost2:?}");
-            cost1
-        });
+        let total_cost = add_costs(cost1, cost2)?;
         Ok((total_cost, archive_addr))
     }
 

--- a/autonomi/src/client/high_level/files/fs_public.rs
+++ b/autonomi/src/client/high_level/files/fs_public.rs
@@ -82,9 +82,7 @@ impl Client {
         }
 
         for (file_path, data_addr, _meta) in public_archive.iter() {
-            info!("Uploaded file: {file_path:?} to: {data_addr}");
-            #[cfg(feature = "loud")]
-            println!("Uploaded file: {file_path:?} to: {data_addr}");
+            crate::loud_info!("Uploaded file: {file_path:?} to: {data_addr}");
         }
 
         Ok((total_cost, public_archive))
@@ -113,14 +111,10 @@ impl Client {
         path: PathBuf,
         payment_option: PaymentOption,
     ) -> Result<(AttoTokens, DataAddress), UploadError> {
-        let (data_map_chunk, processed_chunks, free_chunks, receipts) = self
-            .stream_upload_file(path.clone(), payment_option, true)
+        let (total_cost, data_map_chunk) = self
+            .file_content_upload_internal(path.clone(), payment_option, true)
             .await?;
         let addr = DataAddress::new(*data_map_chunk.0.name());
-        let total_cost = self
-            .calculate_total_cost(processed_chunks, receipts, free_chunks)
-            .await;
-
         debug!("File {path:?} uploaded to the network at {addr:?}");
         Ok((total_cost, addr))
     }

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -107,8 +107,6 @@ pub enum UploadError {
     PutError(#[from] PutError),
     #[error("Encryption error")]
     Encryption(String),
-    #[error("Cost error: {0}")]
-    Cost(#[from] CostError),
 }
 
 /// Errors that can occur during the download operation.

--- a/autonomi/src/client/merkle_payments/file.rs
+++ b/autonomi/src/client/merkle_payments/file.rs
@@ -112,8 +112,7 @@ impl Client {
             ));
         }
 
-        #[cfg(feature = "loud")]
-        println!("Encrypting files to calculate cost...");
+        crate::loud_info!("Encrypting files to calculate cost...");
 
         // Collect all XorNames
         let (all_xor_names, _file_chunk_counts, _file_results) = self
@@ -122,10 +121,7 @@ impl Client {
             .map_err(MerkleUploadError::Encryption)?;
 
         let total_chunks = all_xor_names.len();
-        debug!("merkle payment: file_cost_merkle total chunks: {total_chunks}");
-
-        #[cfg(feature = "loud")]
-        println!("Encrypted into {total_chunks} chunks");
+        crate::loud_info!("Encrypted into {total_chunks} chunks");
 
         // Split into batches of MAX_LEAVES
         let batches: Vec<Vec<XorName>> = all_xor_names
@@ -134,8 +130,7 @@ impl Client {
             .collect();
         let num_batches = batches.len();
 
-        #[cfg(feature = "loud")]
-        println!("Estimating cost for {num_batches} batch(es)...");
+        crate::loud_info!("Estimating cost for {num_batches} batch(es)...");
 
         // Estimate cost for each batch and sum
         let mut total_cost = ant_evm::U256::ZERO;
@@ -164,10 +159,7 @@ impl Client {
         }
 
         let estimated_cost = AttoTokens::from_atto(total_cost);
-        debug!("merkle payment: file_cost_merkle estimated total cost: {estimated_cost}");
-
-        #[cfg(feature = "loud")]
-        println!("Total estimated cost: {estimated_cost}");
+        crate::loud_info!("Total estimated cost: {estimated_cost}");
 
         Ok(estimated_cost)
     }
@@ -194,8 +186,7 @@ impl Client {
         }
 
         // Encrypt files to collect ALL XorNames
-        #[cfg(feature = "loud")]
-        println!("Encrypting files a first time to create the Merkle Tree(s)...");
+        crate::loud_info!("Encrypting files a first time to create the Merkle Tree(s)...");
         let (all_xor_names, file_chunk_counts, first_pass_results) = self
             .collect_xornames_from_dir(path.clone(), is_public)
             .await
@@ -214,8 +205,9 @@ impl Client {
 
         // Early return if all chunks already exist - no need for second encryption
         if to_pay_len == 0 {
-            #[cfg(feature = "loud")]
-            println!("✓ All {total_chunks} chunks already exist on the network, nothing to upload");
+            crate::loud_info!(
+                "✓ All {total_chunks} chunks already exist on the network, nothing to upload"
+            );
 
             // Send upload completion event
             self.send_upload_complete(
@@ -240,8 +232,9 @@ impl Client {
         info!("Split into {num_batches} Merkle Tree(s) of up to {MAX_LEAVES} chunks each");
 
         // Start upload streams (second encryption pass - needed to get actual chunk data)
-        #[cfg(feature = "loud")]
-        println!("🚀 Starting upload of {to_pay_len} chunks in {num_batches} Merkle Tree(s)...");
+        crate::loud_info!(
+            "🚀 Starting upload of {to_pay_len} chunks in {num_batches} Merkle Tree(s)..."
+        );
         let mut streams: Vec<EncryptionStream> = encrypt_directory_files(path, is_public)
             .await
             .map_err(|e| MerkleUploadErrorWithReceipt::encryption(receipt.clone(), e.to_string()))?
@@ -276,8 +269,9 @@ impl Client {
                     .map_err(|kind| MerkleUploadErrorWithReceipt::new(receipt.clone(), kind))?;
             }
 
-            #[cfg(feature = "loud")]
-            println!("🌳 Merkle Tree {batch_num}/{num_batches}: Uploading {batch_size} chunks...");
+            crate::loud_info!(
+                "🌳 Merkle Tree {batch_num}/{num_batches}: Uploading {batch_size} chunks..."
+            );
 
             // Upload this batch's chunks (skip chunks that already exist)
             let upload_result = self
@@ -346,19 +340,13 @@ impl Client {
             if let Some(public_addr) = stream.data_address() {
                 let path = &stream.relative_path;
                 let f = results.len();
-                debug!("[File {f}/{total_files}] ({path:?}) is now available at: {public_addr:?}");
-                #[cfg(feature = "loud")]
-                println!(
+                crate::loud_info!(
                     "[File {f}/{total_files}] ({path:?}) is now available at: {public_addr:?}"
                 );
             }
         }
 
-        debug!(
-            "merkle payment: {total_chunks} chunks uploaded for {total_files} files successfully"
-        );
-        #[cfg(feature = "loud")]
-        println!("✓ All {total_chunks} chunks uploaded successfully!");
+        crate::loud_info!("✓ All {total_chunks} chunks uploaded successfully!");
 
         // Send upload completion event
         self.send_upload_complete(
@@ -466,9 +454,7 @@ impl Client {
         &self,
         xornames: Vec<XorName>,
     ) -> (HashSet<XorName>, Vec<XorName>) {
-        #[cfg(feature = "loud")]
-        println!("Checking for existing chunks on the network...");
-        debug!("Checking for existing chunks on the network...");
+        crate::loud_info!("Checking for existing chunks on the network...");
 
         // Dedupe while preserving order (keep first occurrence only)
         let mut seen: HashSet<XorName> = HashSet::new();
@@ -491,9 +477,9 @@ impl Client {
             .collect();
 
         let existing_count = existing_set.len();
-        info!("Found {existing_count}/{total} unique chunks already exist on the network");
-        #[cfg(feature = "loud")]
-        println!("Found {existing_count}/{total} unique chunks already exist on the network");
+        crate::loud_info!(
+            "Found {existing_count}/{total} unique chunks already exist on the network"
+        );
 
         // Filter out existing, keeping original order
         let new_chunks: Vec<XorName> = unique_ordered
@@ -524,9 +510,9 @@ impl Client {
         })?;
 
         let batch_size = batch_xornames.len();
-        debug!("Merkle Tree {batch_num}/{num_batches}: Paying for {batch_size} chunks...");
-        #[cfg(feature = "loud")]
-        println!("💸 Merkle Tree {batch_num}/{num_batches}: Paying for {batch_size} chunks...");
+        crate::loud_info!(
+            "💸 Merkle Tree {batch_num}/{num_batches}: Paying for {batch_size} chunks..."
+        );
 
         let batch_receipt = self
             .pay_for_single_merkle_batch(DataTypes::Chunk, batch_xornames, MAX_CHUNK_SIZE, w)
@@ -548,21 +534,14 @@ fn collect_xor_names_from_stream(
     let estimated_total = encryption_stream.total_chunks();
     let file_path = encryption_stream.file_path.clone();
     let start = std::time::Instant::now();
-    #[cfg(feature = "loud")]
-    println!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
-    debug!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
+    crate::loud_debug!("Begin encrypting ~{estimated_total} chunks from {file_path}...");
     while let Some(batch) = encryption_stream.next_batch(xorname_collection_batch_size) {
         let batch_len = batch.len();
         total += batch_len;
         for chunk in batch {
             xor_names.push(*chunk.name());
         }
-        #[cfg(feature = "loud")]
-        println!(
-            "Encrypted {total}/{estimated_total} chunks in {:?}",
-            start.elapsed()
-        );
-        debug!(
+        crate::loud_debug!(
             "Encrypted {total}/{estimated_total} chunks in {:?}",
             start.elapsed()
         );

--- a/autonomi/src/client/merkle_payments/payments.rs
+++ b/autonomi/src/client/merkle_payments/payments.rs
@@ -302,15 +302,11 @@ impl Client {
         let batches: Vec<Vec<XorName>> = addresses.chunks(MAX_LEAVES).map(|c| c.to_vec()).collect();
         let batches_len = batches.len();
         let addresses_len = addresses.len();
-        #[cfg(feature = "loud")]
-        println!("Paying for {addresses_len} addresses in {batches_len} batch(es)");
-        info!("Paying for {addresses_len} addresses in {batches_len} batch(es)");
+        crate::loud_info!("Paying for {addresses_len} addresses in {batches_len} batch(es)");
 
         let mut merged_receipt = MerklePaymentReceipt::default();
         for (i, batch) in batches.into_iter().enumerate() {
-            #[cfg(feature = "loud")]
-            println!("Processing batch {}/{batches_len}", i + 1);
-            info!("Processing batch {}/{batches_len}", i + 1);
+            crate::loud_info!("Processing batch {}/{batches_len}", i + 1);
             let receipt = self
                 .pay_for_single_merkle_batch(data_type, batch, data_size, wallet)
                 .await?;

--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -277,7 +277,7 @@ impl Client {
 
             sleep(Duration::from_secs(retry_pause_secs)).await;
 
-            crate::loud_info!("🔄 continue with upload...");
+            crate::loud_info!("🔄 Retrying {failed_count} chunks...");
 
             // Build upload tasks
             let chunks_to_retry: Vec<Chunk> =

--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -154,14 +154,12 @@ impl Client {
                             Ok(addr) => {
                                 dont_reupload.insert(*addr.xorname());
                                 chunks_uploaded += 1;
-                                debug!("Uploaded chunk {chunks_uploaded}/{limit}: {addr:?}");
-                                #[cfg(feature = "loud")]
-                                println!("({chunks_uploaded}/{limit}) Chunk stored at: {addr:?}");
+                                crate::loud_debug!(
+                                    "({chunks_uploaded}/{limit}) Chunk stored at: {addr:?}"
+                                );
                             }
                             Err(err) => {
-                                error!("Failed to upload chunk {:?}: {err}", chunk.address());
-                                #[cfg(feature = "loud")]
-                                println!(
+                                crate::loud_error!(
                                     "Chunk failed to be stored at: {:?} ({err})",
                                     chunk.address()
                                 );
@@ -183,9 +181,9 @@ impl Client {
                     // report progress
                     let f = total_files - streams.len();
                     if let Some(a) = exhausted_stream.data_address() {
-                        debug!("[File {f}/{total_files}] ({path:?}) is now available at: {a:?}");
-                        #[cfg(feature = "loud")]
-                        println!("[File {f}/{total_files}] ({path:?}) is now available at: {a:?}");
+                        crate::loud_info!(
+                            "[File {f}/{total_files}] ({path:?}) is now available at: {a:?}"
+                        );
                     }
                 }
             }
@@ -270,21 +268,16 @@ impl Client {
             retry_attempt += 1;
             let failed_count = failed_chunks.len();
 
-            #[cfg(feature = "loud")]
-            println!("⚠️ Upload batch failed: {failed_count} chunks failed. Retrying scheduled");
-            #[cfg(feature = "loud")]
-            println!(
-                "⚠️ Encountered upload failure, take {retry_pause_secs} second pause before continue..."
+            crate::loud_info!(
+                "⚠️ Upload batch failed: {failed_count} chunks failed. Retrying scheduled"
             );
-            info!(
+            crate::loud_info!(
                 "Retry attempt {retry_attempt}/{max_retries}: {failed_count} chunks remaining. Pausing for {retry_pause_secs} seconds..."
             );
 
             sleep(Duration::from_secs(retry_pause_secs)).await;
 
-            #[cfg(feature = "loud")]
-            println!("🔄 continue with upload...");
-            info!("🔄 continue with upload...");
+            crate::loud_info!("🔄 continue with upload...");
 
             // Build upload tasks
             let chunks_to_retry: Vec<Chunk> =
@@ -316,14 +309,10 @@ impl Client {
                 match result {
                     Ok(addr) => {
                         already_exist.insert(*addr.xorname());
-                        debug!("Retry succeeded for chunk: {addr:?}");
-                        #[cfg(feature = "loud")]
-                        println!("✓ Retry succeeded for chunk: {addr:?}");
+                        crate::loud_debug!("✓ Retry succeeded for chunk: {addr:?}");
                     }
                     Err(err) => {
-                        error!("Retry failed for chunk {:?}: {err}", chunk.address());
-                        #[cfg(feature = "loud")]
-                        println!("✗ Retry failed for chunk {:?}: {err}", chunk.address());
+                        crate::loud_error!("✗ Retry failed for chunk {:?}: {err}", chunk.address());
                         failed_chunks.push((chunk, err.to_string()));
                     }
                 }

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::Client;
-use crate::networking::{NetworkError, PeerQuoteWithStorageProof};
 use crate::networking::version::PackageVersion;
+use crate::networking::{NetworkError, PeerQuoteWithStorageProof};
 use crate::utils::process_tasks_with_max_concurrency;
 use ant_protocol::NetworkAddress;
 use ant_protocol::storage::DataTypes;

--- a/autonomi/src/client/network.rs
+++ b/autonomi/src/client/network.rs
@@ -136,8 +136,7 @@ impl Client {
             existing.extend(results.into_iter().flatten().cloned());
 
             checked += batch.len();
-            #[cfg(feature = "loud")]
-            println!("Checked {checked}/{total} chunks for existence...");
+            crate::loud_info!("Checked {checked}/{total} chunks for existence...");
         }
 
         existing

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -121,9 +121,7 @@ impl Client {
         let number_of_content_addrs = content_addrs.clone().count();
         let quotes = self.get_store_quotes(data_type, content_addrs).await?;
 
-        info!("Paying for {} addresses..", quotes.len());
-        #[cfg(feature = "loud")]
-        println!("Paying for {} addresses..", quotes.len());
+        crate::loud_info!("Paying for {} addresses..", quotes.len());
 
         if !quotes.is_empty() {
             // Make sure nobody else can use the wallet while we are paying
@@ -145,13 +143,7 @@ impl Client {
         }
 
         let skipped_chunks = number_of_content_addrs - quotes.len();
-        info!(
-            "Payments of {} address completed. {} address were free / already paid for",
-            quotes.len(),
-            skipped_chunks
-        );
-        #[cfg(feature = "loud")]
-        println!(
+        crate::loud_info!(
             "Payments of {} address completed. {} address were free / already paid for",
             quotes.len(),
             skipped_chunks

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -125,9 +125,7 @@ impl Client {
         let futures: Vec<_> = content_addrs
             .into_iter()
             .map(|(content_addr, data_size)| {
-                info!("Quoting for {content_addr:?} ..");
-                #[cfg(feature = "loud")]
-                println!("Quoting for {content_addr:?} ..");
+                crate::loud_info!("Quoting for {content_addr:?} ..");
                 fetch_store_quote(
                     &self.network,
                     content_addr,

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -13,7 +13,7 @@ use crate::networking::PeerInfo;
 use crate::networking::common::Addresses;
 use crate::utils::process_tasks_with_max_concurrency;
 use ant_evm::payment_vault::get_market_price;
-use ant_evm::{Amount, PaymentQuote, QuotePayment, QuotingMetrics};
+use ant_evm::{Amount, AttoTokens, PaymentQuote, QuotePayment, QuotingMetrics};
 pub use ant_protocol::storage::DataTypes;
 use ant_protocol::{CLOSE_GROUP_SIZE, NetworkAddress, storage::ChunkAddress};
 use libp2p::PeerId;
@@ -104,6 +104,13 @@ pub enum CostError {
     InvalidCost,
     #[error("Network error: {0:?}")]
     Network(#[from] crate::networking::NetworkError),
+    #[error("Total cost overflow when adding {0} and {1}")]
+    TotalCostOverflow(AttoTokens, AttoTokens),
+}
+
+/// Add two costs together, returning an error on overflow.
+pub fn add_costs(a: AttoTokens, b: AttoTokens) -> Result<AttoTokens, CostError> {
+    a.checked_add(b).ok_or(CostError::TotalCostOverflow(a, b))
 }
 
 impl Client {

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -60,6 +60,36 @@
 #[macro_use]
 extern crate tracing;
 
+/// Log at info level and print to stdout when the `loud` feature is enabled.
+#[macro_export]
+macro_rules! loud_info {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "loud")]
+        println!($($arg)*);
+        tracing::info!($($arg)*);
+    }};
+}
+
+/// Log at debug level and print to stdout when the `loud` feature is enabled.
+#[macro_export]
+macro_rules! loud_debug {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "loud")]
+        println!($($arg)*);
+        tracing::debug!($($arg)*);
+    }};
+}
+
+/// Log at error level and print to stdout when the `loud` feature is enabled.
+#[macro_export]
+macro_rules! loud_error {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "loud")]
+        println!($($arg)*);
+        tracing::error!($($arg)*);
+    }};
+}
+
 pub mod client;
 pub mod networking;
 pub mod self_encryption;

--- a/autonomi/src/networking/driver/task_handler.rs
+++ b/autonomi/src/networking/driver/task_handler.rs
@@ -9,9 +9,9 @@
 use crate::networking::NetworkError;
 use crate::networking::OneShotTaskResult;
 use crate::networking::PeerQuoteWithStorageProof;
-use crate::networking::interface::NetworkTask;
 #[cfg(feature = "developer")]
 use crate::networking::interface::DevGetClosestPeersFromNetworkResponse;
+use crate::networking::interface::NetworkTask;
 use crate::networking::utils::get_quorum_amount;
 use ant_evm::{PaymentQuote, merkle_payments::MerklePaymentCandidateNode};
 use ant_protocol::{NetworkAddress, PrettyPrintRecordKey};
@@ -587,12 +587,9 @@ impl TaskHandler {
         id: OutboundRequestId,
         response: DevGetClosestPeersFromNetworkResponse,
     ) -> Result<(), TaskHandlerError> {
-        let responder =
-            self.dev_get_closest_peers_from_network
-                .remove(&id)
-                .ok_or(TaskHandlerError::UnknownQuery(format!(
-                    "OutboundRequestId {id:?}"
-                )))?;
+        let responder = self.dev_get_closest_peers_from_network.remove(&id).ok_or(
+            TaskHandlerError::UnknownQuery(format!("OutboundRequestId {id:?}")),
+        )?;
 
         trace!(
             "OutboundRequestId({id}): got {} closest peers from network query",

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -24,13 +24,13 @@ pub(crate) use utils::multiaddr_is_global;
 pub use ant_evm::PaymentQuote;
 pub use ant_protocol::NetworkAddress;
 pub use config::{RetryStrategy, Strategy};
+#[cfg(feature = "developer")]
+pub use interface::DevGetClosestPeersFromNetworkResponse;
 pub use libp2p::kad::PeerInfo;
 pub use libp2p::{
     Multiaddr, PeerId,
     kad::{Quorum, Record},
 };
-#[cfg(feature = "developer")]
-pub use interface::DevGetClosestPeersFromNetworkResponse;
 
 // internal needs
 use crate::networking::version::PackageVersion;

--- a/autonomi/src/self_encryption/stream_encryption.rs
+++ b/autonomi/src/self_encryption/stream_encryption.rs
@@ -282,9 +282,7 @@ impl EncryptionStream {
             drop(chunk_sender);
         });
 
-        #[cfg(feature = "loud")]
-        println!("Streaming encryption of {file_path} ...");
-        info!("Streaming encryption of {file_path} ...");
+        crate::loud_info!("Streaming encryption of {file_path} ...");
 
         let stream = EncryptionStream {
             file_path,
@@ -329,7 +327,7 @@ pub async fn encrypt_directory_files(
             let metadata = crate::client::files::fs_public::metadata_from_entry(&entry);
             let file_path = entry.path().to_path_buf();
             let relative_path =
-                get_relative_file_path_from_abs_file_and_folder_path(&file_path, &dir_path);
+                get_relative_file_path_from_abs_file_and_folder_path(&file_path, &dir_path)?;
             let file_size = entry
                 .metadata()
                 .map_err(|err| format!("Error getting file size {file_path:?}: {err:?}"))?
@@ -351,9 +349,7 @@ pub(crate) async fn encrypt_file(
     metadata: Metadata,
     is_public: bool,
 ) -> Result<EncryptionStream, String> {
-    info!("Encrypting file: {file_path:?}..");
-    #[cfg(feature = "loud")]
-    println!("Encrypting file: {file_path:?}..");
+    crate::loud_info!("Encrypting file: {file_path:?}..");
 
     // choose encryption method
     if file_size > *IN_MEMORY_ENCRYPTION_MAX_SIZE {

--- a/evmlib/src/retry.rs
+++ b/evmlib/src/retry.rs
@@ -181,7 +181,9 @@ where
     let estimated_gas = provider
         .estimate_gas(transaction_request.clone())
         .await
-        .map_err(|e| TransactionError::TransactionFailedToSend(format!("gas estimation failed: {e}")))?;
+        .map_err(|e| {
+            TransactionError::TransactionFailedToSend(format!("gas estimation failed: {e}"))
+        })?;
     let gas_with_buffer = estimated_gas.saturating_mul(120) / 100;
     debug!("Estimated gas: {estimated_gas}, with 20% buffer: {gas_with_buffer}");
     transaction_request.set_gas_limit(gas_with_buffer);


### PR DESCRIPTION
- Added `loud_info!`, `loud_debug!`, `loud_error!` macros combining `#[cfg(feature = "loud")]` `println!` with tracing
- Added shared constants: `UPLOAD_RETRY_PAUSE_SECS` (60s), `UPLOAD_MAX_RETRIES` (3)
- Extracted `upload_retry_pause()` helper in config.rs for consistent retry behavior
- Improved retry progress messages - now shows chunk count being retried ("🔄 Retrying 9 chunks...") - to avoid confusing 10mins wait after previously confusing msg: `continue with upload...`
- Changed `get_relative_file_path_from_abs_file_and_folder_path` to return `Result<PathBuf, String>` instead of using `expect()`
- Updated `stream_encryption.rs` to propagate errors with `?`
- Reduced code duplication by factoring out common code in internal functions
- clippy and fmt code
