### PR TITLE
refactor(ant-node): increase request timeout to 120 seconds

### DIFF
--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -120,6 +120,8 @@ pub(super) fn init_driver(
         // How many nodes _should_ store data.
         .set_replication_factor(REPLICATION_FACTOR)
         .set_query_timeout(KAD_QUERY_TIMEOUT_S)
+        // Extend substreams timeout to allow nodes to accept merkle upload requests from a client, which involves certain time to complete a KAD network get_closest query.
+        .set_substreams_timeout(REQUEST_TIMEOUT_DEFAULT_S)
         // may consider to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.
         // however, this has the risk of libp2p report back partial-correct result in case of high peer query failure rate.
         // .disjoint_query_paths(true)

--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -60,7 +60,7 @@ use std::{
 use tokio::sync::mpsc;
 
 // Timeout for requests sent/received through the request_response behaviour.
-const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(30);
+const REQUEST_TIMEOUT_DEFAULT_S: Duration = Duration::from_secs(120);
 // Sets the keep-alive timeout of idle connections.
 const CONNECTION_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/autonomi/src/networking/driver/mod.rs
+++ b/autonomi/src/networking/driver/mod.rs
@@ -58,8 +58,9 @@ const RESEND_IDENTIFY_INVERVAL: Duration = Duration::from_secs(3600); // todo: t
 /// Size of the LRU cache for peers and their addresses.
 /// Libp2p defaults to 100, we use 2k.
 const PEER_CACHE_SIZE: usize = 2_000;
-/// Client with poor connection requires a longer time to transmit large sized recrod to production network, via put_record_to
-const CLIENT_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(30);
+/// Client with poor connection requires a longer time to transmit large sized record to production network, via put_record_to.
+/// This should match other request timeouts (REQ_TIMEOUT, KAD_QUERY_TIMEOUT) to avoid premature substream termination.
+const CLIENT_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(120);
 /// Periodically trigger the bootstrap process to try connect to more peers in the network.
 const BOOTSTRAP_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 


### PR DESCRIPTION
- Updates the node's req/res timeout to be in line with the client req/res timeout and the KAD query timeout.
- Updates the substreams timeout for both node and client to be the same as the other request timeouts (120s).