### PR TITLE
feat(ant-node): add paid-for list tracking for data integrity

### DIFF
--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -223,6 +223,17 @@ impl SwarmDriver {
                     .store_mut()
                     .payment_received();
             }
+            LocalSwarmCmd::AddPaidForEntry {
+                xor_name,
+                data_type,
+            } => {
+                cmd_string = "AddPaidForEntry";
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .add_paid_for_entry(xor_name, data_type);
+            }
             LocalSwarmCmd::RecordNotAtTargetLocation => {
                 cmd_string = "RecordNotAtTargetLocation";
                 self.network_wide_replication.set_network_under_load();

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -224,7 +224,7 @@ impl SwarmDriver {
                     .payment_received();
             }
             LocalSwarmCmd::AddPaidForEntry {
-                xor_name,
+                key,
                 data_type,
                 proof,
             } => {
@@ -233,7 +233,7 @@ impl SwarmDriver {
                     .behaviour_mut()
                     .kademlia
                     .store_mut()
-                    .add_paid_for_entry(xor_name, data_type, proof);
+                    .add_paid_for_entry(key, data_type, proof);
             }
             LocalSwarmCmd::RecordNotAtTargetLocation => {
                 cmd_string = "RecordNotAtTargetLocation";

--- a/ant-node/src/networking/driver/cmd.rs
+++ b/ant-node/src/networking/driver/cmd.rs
@@ -226,13 +226,14 @@ impl SwarmDriver {
             LocalSwarmCmd::AddPaidForEntry {
                 xor_name,
                 data_type,
+                proof,
             } => {
                 cmd_string = "AddPaidForEntry";
                 self.swarm
                     .behaviour_mut()
                     .kademlia
                     .store_mut()
-                    .add_paid_for_entry(xor_name, data_type);
+                    .add_paid_for_entry(xor_name, data_type, proof);
             }
             LocalSwarmCmd::RecordNotAtTargetLocation => {
                 cmd_string = "RecordNotAtTargetLocation";

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -22,6 +22,7 @@ use libp2p::{
     kad::{KBucketDistance as Distance, Record, RecordKey},
 };
 use tokio::sync::oneshot;
+use xor_name::XorName;
 
 use crate::networking::Addresses;
 
@@ -96,6 +97,12 @@ pub(crate) enum LocalSwarmCmd {
     },
     /// Notify the node received a payment.
     PaymentReceived,
+    /// Add an entry to the paid-for list after payment verification.
+    /// This tracks which XorNames have been paid for.
+    AddPaidForEntry {
+        xor_name: XorName,
+        data_type: DataTypes,
+    },
     /// Put record to the local RecordStore
     PutLocalRecord {
         record: Record,
@@ -220,6 +227,15 @@ impl Debug for LocalSwarmCmd {
             }
             LocalSwarmCmd::PaymentReceived => {
                 write!(f, "LocalSwarmCmd::PaymentReceived")
+            }
+            LocalSwarmCmd::AddPaidForEntry {
+                xor_name,
+                data_type,
+            } => {
+                write!(
+                    f,
+                    "LocalSwarmCmd::AddPaidForEntry {{ xor_name: {xor_name:?}, data_type: {data_type:?} }}"
+                )
             }
             LocalSwarmCmd::GetLocalRecord { key, .. } => {
                 write!(

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -11,7 +11,7 @@ use std::{
     fmt::Debug,
 };
 
-use ant_evm::{PaymentQuote, QuotingMetrics};
+use ant_evm::{PaymentQuote, ProofOfPayment, QuotingMetrics};
 use ant_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
     storage::{DataTypes, ValidationType},
@@ -99,9 +99,11 @@ pub(crate) enum LocalSwarmCmd {
     PaymentReceived,
     /// Add an entry to the paid-for list after payment verification.
     /// This tracks which XorNames have been paid for.
+    /// Includes ProofOfPayment so other nodes can verify claims against EVM chain.
     AddPaidForEntry {
         xor_name: XorName,
         data_type: DataTypes,
+        proof: ProofOfPayment,
     },
     /// Put record to the local RecordStore
     PutLocalRecord {
@@ -231,10 +233,11 @@ impl Debug for LocalSwarmCmd {
             LocalSwarmCmd::AddPaidForEntry {
                 xor_name,
                 data_type,
+                proof: _,
             } => {
                 write!(
                     f,
-                    "LocalSwarmCmd::AddPaidForEntry {{ xor_name: {xor_name:?}, data_type: {data_type:?} }}"
+                    "LocalSwarmCmd::AddPaidForEntry {{ xor_name: {xor_name:?}, data_type: {data_type:?}, proof: <proof> }}"
                 )
             }
             LocalSwarmCmd::GetLocalRecord { key, .. } => {

--- a/ant-node/src/networking/interface/local_cmd.rs
+++ b/ant-node/src/networking/interface/local_cmd.rs
@@ -22,7 +22,6 @@ use libp2p::{
     kad::{KBucketDistance as Distance, Record, RecordKey},
 };
 use tokio::sync::oneshot;
-use xor_name::XorName;
 
 use crate::networking::Addresses;
 
@@ -98,10 +97,10 @@ pub(crate) enum LocalSwarmCmd {
     /// Notify the node received a payment.
     PaymentReceived,
     /// Add an entry to the paid-for list after payment verification.
-    /// This tracks which XorNames have been paid for.
+    /// This tracks which records have been paid for.
     /// Includes ProofOfPayment so other nodes can verify claims against EVM chain.
     AddPaidForEntry {
-        xor_name: XorName,
+        key: RecordKey,
         data_type: DataTypes,
         proof: ProofOfPayment,
     },
@@ -231,13 +230,14 @@ impl Debug for LocalSwarmCmd {
                 write!(f, "LocalSwarmCmd::PaymentReceived")
             }
             LocalSwarmCmd::AddPaidForEntry {
-                xor_name,
+                key,
                 data_type,
                 proof: _,
             } => {
                 write!(
                     f,
-                    "LocalSwarmCmd::AddPaidForEntry {{ xor_name: {xor_name:?}, data_type: {data_type:?}, proof: <proof> }}"
+                    "LocalSwarmCmd::AddPaidForEntry {{ key: {:?}, data_type: {data_type:?}, proof: <proof> }}",
+                    PrettyPrintRecordKey::from(key)
                 )
             }
             LocalSwarmCmd::GetLocalRecord { key, .. } => {

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use ant_evm::{PaymentQuote, QuotingMetrics};
 use ant_protocol::messages::{ConnectionInfo, Request, Response};
-use ant_protocol::storage::ValidationType;
+use ant_protocol::storage::{DataTypes, ValidationType};
 use ant_protocol::{NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey};
 use exponential_backoff::Backoff;
 use futures::StreamExt;
@@ -24,6 +24,7 @@ use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
+use xor_name::XorName;
 
 use super::driver::event::MsgResponder;
 use super::error::{NetworkError, Result};
@@ -183,6 +184,14 @@ impl Network {
     /// Notify the node receicced a payment.
     pub(crate) fn notify_payment_received(&self) {
         self.send_local_swarm_cmd(LocalSwarmCmd::PaymentReceived);
+    }
+
+    /// Add an entry to the paid-for list after payment verification.
+    pub(crate) fn notify_paid_for_entry_added(&self, xor_name: XorName, data_type: DataTypes) {
+        self.send_local_swarm_cmd(LocalSwarmCmd::AddPaidForEntry {
+            xor_name,
+            data_type,
+        });
     }
 
     pub(crate) fn notify_record_not_at_target_location(&self) {

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -24,7 +24,6 @@ use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
-use xor_name::XorName;
 
 use super::driver::event::MsgResponder;
 use super::error::{NetworkError, Result};
@@ -190,12 +189,12 @@ impl Network {
     /// Includes ProofOfPayment so other nodes can verify claims against EVM chain.
     pub(crate) fn notify_paid_for_entry_added(
         &self,
-        xor_name: XorName,
+        key: RecordKey,
         data_type: DataTypes,
         proof: ProofOfPayment,
     ) {
         self.send_local_swarm_cmd(LocalSwarmCmd::AddPaidForEntry {
-            xor_name,
+            key,
             data_type,
             proof,
         });

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -11,7 +11,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ant_evm::{PaymentQuote, QuotingMetrics};
+use ant_evm::{PaymentQuote, ProofOfPayment, QuotingMetrics};
 use ant_protocol::messages::{ConnectionInfo, Request, Response};
 use ant_protocol::storage::{DataTypes, ValidationType};
 use ant_protocol::{NetworkAddress, PrettyPrintKBucketKey, PrettyPrintRecordKey};
@@ -187,10 +187,17 @@ impl Network {
     }
 
     /// Add an entry to the paid-for list after payment verification.
-    pub(crate) fn notify_paid_for_entry_added(&self, xor_name: XorName, data_type: DataTypes) {
+    /// Includes ProofOfPayment so other nodes can verify claims against EVM chain.
+    pub(crate) fn notify_paid_for_entry_added(
+        &self,
+        xor_name: XorName,
+        data_type: DataTypes,
+        proof: ProofOfPayment,
+    ) {
         self.send_local_swarm_cmd(LocalSwarmCmd::AddPaidForEntry {
             xor_name,
             data_type,
+            proof,
         });
     }
 

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -847,10 +847,8 @@ impl Node {
 
         // Add to paid-for list regardless of reward amount (payment was verified)
         // Store the proof so other nodes can verify claims against EVM chain
-        if let Some(xor_name) = address.xorname() {
-            self.network()
-                .notify_paid_for_entry_added(xor_name, data_type, payment);
-        }
+        self.network()
+            .notify_paid_for_entry_added(address.to_record_key(), data_type, payment);
 
         if !reward_amount.is_zero() {
             // Notify `record_store` that the node received a payment.

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -846,9 +846,10 @@ impl Node {
         debug!("Payment of {reward_amount:?} is valid for record {pretty_key}");
 
         // Add to paid-for list regardless of reward amount (payment was verified)
+        // Store the proof so other nodes can verify claims against EVM chain
         if let Some(xor_name) = address.xorname() {
             self.network()
-                .notify_paid_for_entry_added(xor_name, data_type);
+                .notify_paid_for_entry_added(xor_name, data_type, payment);
         }
 
         if !reward_amount.is_zero() {

--- a/ant-node/src/put_validation.rs
+++ b/ant-node/src/put_validation.rs
@@ -845,6 +845,12 @@ impl Node {
 
         debug!("Payment of {reward_amount:?} is valid for record {pretty_key}");
 
+        // Add to paid-for list regardless of reward amount (payment was verified)
+        if let Some(xor_name) = address.xorname() {
+            self.network()
+                .notify_paid_for_entry_added(xor_name, data_type);
+        }
+
         if !reward_amount.is_zero() {
             // Notify `record_store` that the node received a payment.
             self.network().notify_payment_received();


### PR DESCRIPTION
Implement Phase 1 of the data integrity improvements by adding a paid-for list that tracks XorNames verified as paid. This is the foundation for closing the free data replication loophole and enabling DoYouHave gossip.

Changes:
- Add PaidForEntry struct and paid_for_list to NodeRecordStore
- Add persistence (load/save to disk) for paid-for list
- Add cleanup mechanism using 10x responsible_distance_range
- Integrate with payment verification in put_validation.rs
- Add LocalSwarmCmd::AddPaidForEntry command
- Add unit tests for paid-for list functionality

Configuration:
- PAID_FOR_TRACKING_RANGE = 16 (X closest nodes, subject to tuning)
- MAX_PAID_FOR_ENTRIES = 16K (matches MAX_RECORDS_COUNT)
- File size: ~1.3 MB maximum

Future phases will add DoYouHave gossip and replication validation.