### PR TITLE
refactor: upload flow

### DIFF
--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -116,15 +116,18 @@ pub enum FileCmd {
     Cost {
         /// The file to estimate cost for.
         file: String,
-        /// Use Merkle batch payment mode instead of standard payment.
-        /// Merkle mode pays for all chunks in a single transaction, saving gas fees.
+        /// Estimate cost for public upload. Everyone can see public data on the Network.
+        /// Default is private (data encrypted, datamaps kept local).
+        #[arg(short, long)]
+        public: bool,
+        /// Exclude archive metadata from cost estimate.
+        /// By default, archive cost is included for directory uploads.
         #[arg(long)]
-        merkle: bool,
+        no_archive: bool,
         /// Use standard payment mode instead of single-node payment (default).
         /// Standard mode pays 3 nodes individually, which costs more in gas fees.
         /// Single-node payment (default) pays only one node with 3x that amount, saving gas fees.
-        /// This flag only applies to standard payment mode (not Merkle).
-        #[arg(long, conflicts_with = "merkle")]
+        #[arg(long)]
         disable_single_node_payment: bool,
     },
 
@@ -146,16 +149,11 @@ pub enum FileCmd {
         #[arg(long)]
         #[clap(default_value = "0")]
         retry_failed: u64,
-        /// Use Merkle batch payment mode instead of standard payment.
-        /// Merkle mode pays for all chunks in a single transaction, saving gas fees.
-        #[arg(long)]
-        merkle: bool,
         /// Use standard payment mode instead of single-node payment (default).
         /// Standard mode pays 3 nodes individually, which costs more in gas fees.
         /// Single-node payment (default) pays only one node with 3x that amount, saving gas fees.
         /// Data is stored on 5 nodes regardless of payment mode.
-        /// This flag only applies to standard payment mode (not Merkle).
-        #[arg(long, conflicts_with = "merkle")]
+        #[arg(long)]
         disable_single_node_payment: bool,
         #[command(flatten)]
         transaction_opt: TransactionOpt,
@@ -573,15 +571,24 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
         Some(SubCmd::File { command }) => match command {
             FileCmd::Cost {
                 file,
-                merkle,
+                public,
+                no_archive,
                 disable_single_node_payment,
-            } => file::cost(&file, network_context, merkle, disable_single_node_payment).await,
+            } => {
+                file::cost(
+                    &file,
+                    public,
+                    !no_archive,
+                    network_context,
+                    disable_single_node_payment,
+                )
+                .await
+            }
             FileCmd::Upload {
                 file,
                 public,
                 no_archive,
                 retry_failed,
-                merkle,
                 disable_single_node_payment,
                 transaction_opt,
             } => {
@@ -592,7 +599,6 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                     network_context,
                     transaction_opt.max_fee_per_gas,
                     retry_failed,
-                    merkle,
                     disable_single_node_payment,
                 )
                 .await

--- a/ant-cli/src/commands.rs
+++ b/ant-cli/src/commands.rs
@@ -129,6 +129,14 @@ pub enum FileCmd {
         /// Single-node payment (default) pays only one node with 3x that amount, saving gas fees.
         #[arg(long)]
         disable_single_node_payment: bool,
+        /// Force merkle payment estimation (batched payments via smart contract).
+        /// Better for large uploads with many chunks. Mutually exclusive with --regular.
+        #[arg(long, conflicts_with = "regular")]
+        merkle: bool,
+        /// Force regular payment estimation (individual chunk quotes).
+        /// Better for small uploads with few chunks. Mutually exclusive with --merkle.
+        #[arg(long, conflicts_with = "merkle")]
+        regular: bool,
     },
 
     /// Upload a file and pay for it. Data on the Network is private by default.
@@ -574,6 +582,8 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                 public,
                 no_archive,
                 disable_single_node_payment,
+                merkle,
+                regular,
             } => {
                 file::cost(
                     &file,
@@ -581,6 +591,8 @@ pub async fn handle_subcommand(opt: Opt) -> Result<()> {
                     !no_archive,
                     network_context,
                     disable_single_node_payment,
+                    merkle,
+                    regular,
                 )
                 .await
             }

--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -14,6 +14,7 @@ use crate::utils::collect_upload_summary;
 use crate::wallet::load_wallet;
 use autonomi::client::PutError;
 use autonomi::client::analyze::Analysis;
+use autonomi::client::config::MERKLE_PAYMENT_THRESHOLD;
 use autonomi::client::payment::{BulkPaymentOption, PaymentOption};
 use autonomi::files::UploadError;
 use autonomi::networking::{Quorum, RetryStrategy};
@@ -23,10 +24,6 @@ use color_eyre::eyre::{Context, Result, eyre};
 use std::path::PathBuf;
 
 const MAX_ADDRESSES_TO_PRINT: usize = 3;
-
-/// Threshold for auto-selecting merkle vs regular payment estimation.
-/// Must match MERKLE_PAYMENT_THRESHOLD in autonomi crate.
-const MERKLE_PAYMENT_THRESHOLD: usize = 64;
 
 pub async fn cost(
     file: &str,

--- a/ant-cli/src/exit_code.rs
+++ b/ant-cli/src/exit_code.rs
@@ -31,6 +31,7 @@ pub(crate) fn upload_exit_code(err: &UploadError) -> i32 {
         UploadError::IoError(_) => IO_ERROR,
         UploadError::PutError(err) => put_error_exit_code(err),
         UploadError::Encryption(_) => SELF_ENCRYPTION_ERROR,
+        UploadError::MerkleUpload(_) => 44, // Same as PutError::MerkleBatch
     }
 }
 

--- a/autonomi-nodejs/src/lib.rs
+++ b/autonomi-nodejs/src/lib.rs
@@ -652,7 +652,7 @@ impl Client {
 
         let (cost, archive) = self
             .0
-            .dir_content_upload(dir_path, payment_option.0.clone())
+            .dir_content_upload(dir_path, payment_option.0.clone().into())
             .await
             .map_err(map_error)?;
 
@@ -666,13 +666,13 @@ impl Client {
     pub async fn dir_upload(
         &self,
         dir_path: /* PathBuf */ String,
-        payment_option: &PaymentOption,
+        wallet: &Wallet,
     ) -> Result</* (AttoTokens, PrivateArchiveDataMap) */ tuple_result::DirUpload> {
         let dir_path = PathBuf::from(dir_path);
 
         let (cost, data_map) = self
             .0
-            .dir_upload(dir_path, payment_option.0.clone())
+            .dir_upload(dir_path, &wallet.0)
             .await
             .map_err(map_error)?;
 
@@ -691,7 +691,7 @@ impl Client {
 
         let (cost, data_map) = self
             .0
-            .file_content_upload(path, payment_option.0.clone())
+            .file_content_upload(path, payment_option.0.clone().into())
             .await
             .map_err(map_error)?;
 
@@ -743,7 +743,7 @@ impl Client {
 
         let (cost, archive) = self
             .0
-            .dir_content_upload_public(dir_path, payment_option.0.clone())
+            .dir_content_upload_public(dir_path, payment_option.0.clone().into())
             .await
             .map_err(map_error)?;
 
@@ -757,13 +757,13 @@ impl Client {
     pub async fn dir_upload_public(
         &self,
         dir_path: /* PathBuf */ String,
-        payment_option: &PaymentOption,
+        wallet: &Wallet,
     ) -> Result</* (AttoTokens, ArchiveAddress) */ tuple_result::DirUploadPublic> {
         let dir_path = PathBuf::from(dir_path);
 
         let (cost, addr) = self
             .0
-            .dir_upload_public(dir_path, payment_option.0.clone())
+            .dir_upload_public(dir_path, &wallet.0)
             .await
             .map_err(map_error)?;
 
@@ -781,12 +781,22 @@ impl Client {
         todo!()
     }
 
-    /// Get the cost to upload a file/dir to the network. quick and dirty implementation, please refactor once files are cleanly implemented
+    /// Get the cost to upload a file/dir to the network.
+    ///
+    /// # Parameters
+    /// - `path`: Path to the file or directory to estimate cost for
+    /// - `is_public`: Whether the upload will be public (datamaps uploaded) or private (datamaps kept local)
+    /// - `include_archive`: Whether to include archive metadata cost in the estimate
     #[napi]
-    pub async fn file_cost(&self, path: /* &PathBuf */ String) -> Result</* AttoTokens */ String> {
+    pub async fn file_cost(
+        &self,
+        path: /* &PathBuf */ String,
+        is_public: bool,
+        include_archive: bool,
+    ) -> Result</* AttoTokens */ String> {
         let cost = self
             .0
-            .file_cost(&PathBuf::from(path))
+            .file_cost(&PathBuf::from(path), is_public, include_archive)
             .await
             .map_err(map_error)?;
 

--- a/autonomi/examples/put_and_dir_upload.rs
+++ b/autonomi/examples/put_and_dir_upload.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Put and fetch directory from local file system.
     let (_cost, dir_addr) = client
-        .dir_upload_public("files/to/upload".into(), wallet.into())
+        .dir_upload_public("files/to/upload".into(), &wallet)
         .await?;
     client
         .dir_download_public(&dir_addr, "files/downloaded".into())

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -117,6 +117,11 @@ pub(crate) const UPLOAD_MAX_RETRIES: usize = 3;
 /// Pause duration in seconds between retry attempts for failed uploads.
 pub(crate) const UPLOAD_RETRY_PAUSE_SECS: u64 = 60;
 
+/// Minimum number of chunks to use merkle payments instead of regular payments.
+/// Merkle payments are more efficient for larger uploads (single tree payment vs per-batch).
+/// Below this threshold, regular per-batch payments are used.
+pub(crate) const MERKLE_PAYMENT_THRESHOLD: usize = 64;
+
 /// Pause before retrying failed uploads with consistent logging.
 pub(crate) async fn upload_retry_pause() {
     crate::loud_info!(

--- a/autonomi/src/client/config.rs
+++ b/autonomi/src/client/config.rs
@@ -120,7 +120,7 @@ pub(crate) const UPLOAD_RETRY_PAUSE_SECS: u64 = 60;
 /// Minimum number of chunks to use merkle payments instead of regular payments.
 /// Merkle payments are more efficient for larger uploads (single tree payment vs per-batch).
 /// Below this threshold, regular per-batch payments are used.
-pub(crate) const MERKLE_PAYMENT_THRESHOLD: usize = 64;
+pub const MERKLE_PAYMENT_THRESHOLD: usize = 64;
 
 /// Pause before retrying failed uploads with consistent logging.
 pub(crate) async fn upload_retry_pause() {

--- a/autonomi/src/client/high_level/data/public.rs
+++ b/autonomi/src/client/high_level/data/public.rs
@@ -85,12 +85,12 @@ impl Client {
         data: Bytes,
     ) -> Result<Vec<(XorName, usize)>, CostError> {
         let now = Instant::now();
-        let (data_map_chunks, chunks) = encrypt(data)?;
+        let (data_map_chunk, chunks) = encrypt(data)?;
 
         debug!("Encryption took: {:.2?}", now.elapsed());
 
-        let map_xor_name = *data_map_chunks.address().xorname();
-        let mut content_addrs = vec![(map_xor_name, data_map_chunks.size())];
+        let map_xor_name = *data_map_chunk.address().xorname();
+        let mut content_addrs = vec![(map_xor_name, data_map_chunk.size())];
 
         for chunk in &chunks {
             content_addrs.push((*chunk.name(), chunk.size()));

--- a/autonomi/src/client/high_level/files/cost.rs
+++ b/autonomi/src/client/high_level/files/cost.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::path::PathBuf;
+
+use bytes::Bytes;
+
+use super::archive_private::PrivateArchive;
+use super::archive_public::PublicArchive;
+use super::fs_public::metadata_from_entry;
+use super::{FileCostError, estimate_directory_chunks};
+use crate::Client;
+use crate::client::config::MERKLE_PAYMENT_THRESHOLD;
+use crate::client::data_types::chunk::{Chunk, DataMapChunk};
+use crate::client::high_level::data::DataAddress;
+use crate::client::merkle_payments::MerklePaymentError;
+use crate::client::quote::add_costs;
+use crate::self_encryption::{MAX_CHUNK_SIZE, encrypt_directory_files};
+use ant_evm::AttoTokens;
+use ant_evm::merkle_payments::MAX_LEAVES;
+use ant_protocol::storage::DataTypes;
+use xor_name::XorName;
+
+impl Client {
+    /// Get the cost to upload a file/dir to the network.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the file or directory to estimate cost for
+    /// - `is_public`: Whether the upload will be public (datamaps uploaded) or private (datamaps kept local)
+    /// - `include_archive`: Whether to include archive metadata cost in the estimate
+    ///
+    /// # Cost Estimation Method
+    ///
+    /// Automatically selects the appropriate cost estimation method:
+    /// - For directories with >= 64 estimated chunks: uses merkle payment estimation
+    /// - For smaller directories: uses regular per-batch payment estimation
+    ///
+    /// # Archive Cost
+    ///
+    /// When `include_archive` is true and `path` is a directory:
+    /// - For public uploads: includes the cost of uploading the `PublicArchive` (file paths + addresses + metadata)
+    /// - For private uploads: includes the cost of uploading the `PrivateArchive` (file paths + datamaps + metadata)
+    ///
+    /// Note: Archive cost is only added for directories. Single file uploads don't create archives,
+    /// so `include_archive` is ignored when `path` points to a file.
+    pub async fn file_cost(
+        &self,
+        path: &PathBuf,
+        is_public: bool,
+        include_archive: bool,
+    ) -> Result<AttoTokens, FileCostError> {
+        // Estimate chunk count to choose cost estimation method
+        let estimated_chunks = estimate_directory_chunks(path)?;
+
+        // Get base content cost from either merkle or regular method
+        let content_cost = if estimated_chunks >= MERKLE_PAYMENT_THRESHOLD {
+            crate::loud_info!(
+                "Using merkle cost estimation for ~{estimated_chunks} chunks (threshold: {MERKLE_PAYMENT_THRESHOLD})"
+            );
+            self.file_cost_merkle(path.clone(), is_public).await?
+        } else {
+            crate::loud_info!(
+                "Using regular cost estimation for ~{estimated_chunks} chunks (threshold: {MERKLE_PAYMENT_THRESHOLD})"
+            );
+            self.file_cost_regular(path, is_public).await?
+        };
+
+        // Add archive cost if requested and path is a directory
+        // Single file uploads don't create archives, so skip archive cost for files
+        if include_archive && !path.is_file() {
+            let archive_cost = self
+                .estimate_archive_cost_from_path(path, is_public)
+                .await?;
+            let total_cost = add_costs(content_cost, archive_cost)?;
+            debug!("Total cost (content + archive): {total_cost:?}");
+            Ok(total_cost)
+        } else {
+            debug!("Total cost (content only): {content_cost:?}");
+            Ok(content_cost)
+        }
+    }
+
+    /// Get the cost to upload file/dir content using regular (non-merkle) payment estimation.
+    ///
+    /// This method only estimates the cost of the file content chunks, not the archive.
+    /// Use `file_cost` if you need to include archive cost.
+    ///
+    /// For private uploads (`is_public == false`), the datamap chunk is excluded from the estimate
+    /// since it is kept locally and not uploaded to the network.
+    pub async fn file_cost_regular(
+        &self,
+        path: &PathBuf,
+        is_public: bool,
+    ) -> Result<AttoTokens, FileCostError> {
+        let mut content_addrs = vec![];
+
+        for entry in walkdir::WalkDir::new(path) {
+            let entry = entry?;
+
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let file_path = entry.path().to_path_buf();
+            tracing::info!("Cost for file: {file_path:?}");
+
+            let data = tokio::fs::read(&file_path).await?;
+            let file_bytes = Bytes::from(data);
+
+            let addrs = self.get_content_addrs(file_bytes)?;
+
+            // For private uploads, skip the datamap chunk (first element) since it's kept locally
+            if is_public {
+                content_addrs.extend(addrs);
+            } else {
+                content_addrs.extend(addrs.into_iter().skip(1));
+            }
+        }
+
+        let total_cost = self.get_cost_estimation(content_addrs).await?;
+        debug!("Content cost for {path:?}: {total_cost:?}");
+        Ok(total_cost)
+    }
+
+    /// Estimate the cost of uploading a directory of files with Merkle batch payments.
+    ///
+    /// This calls the smart contract's view function (0 gas) which runs the exact same
+    /// pricing logic as the actual payment, ensuring accurate cost estimation.
+    /// No wallet is required since this only queries the smart contract.
+    ///
+    /// This method only estimates the cost of the file content chunks, not the archive.
+    /// Use `file_cost` if you need to include archive cost.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the directory
+    /// * `is_public` - Whether the files will be uploaded as public
+    ///
+    /// # Returns
+    /// * `AttoTokens` - Estimated total cost
+    pub async fn file_cost_merkle(
+        &self,
+        path: PathBuf,
+        is_public: bool,
+    ) -> Result<AttoTokens, FileCostError> {
+        debug!(
+            "merkle payment: file_cost_merkle starting for path: {path:?}, is_public: {is_public}"
+        );
+
+        crate::loud_info!("Encrypting files to calculate cost...");
+
+        // Collect all XorNames
+        let all_xor_names = self.collect_xornames_for_cost(path, is_public).await?;
+
+        let total_chunks = all_xor_names.len();
+        crate::loud_info!("Encrypted into {total_chunks} chunks");
+
+        // Split into batches of MAX_LEAVES
+        let batches: Vec<Vec<XorName>> = all_xor_names
+            .chunks(MAX_LEAVES)
+            .map(|c| c.to_vec())
+            .collect();
+        let num_batches = batches.len();
+
+        crate::loud_info!("Estimating cost for {num_batches} batch(es)...");
+
+        // Estimate cost for each batch and sum
+        let mut total_cost = ant_evm::U256::ZERO;
+
+        for (batch_idx, batch_xornames) in batches.into_iter().enumerate() {
+            let batch_num = batch_idx + 1;
+            debug!("Estimating batch {batch_num}/{num_batches}");
+
+            // Prepare batch (build tree, query pools)
+            let (tree, _candidate_pools, pool_commitments, merkle_payment_timestamp) = self
+                .prepare_merkle_batch(DataTypes::Chunk, batch_xornames, MAX_CHUNK_SIZE)
+                .await?;
+
+            // Estimate cost for this batch using the Network method (no wallet needed)
+            let batch_cost = self
+                .evm_network()
+                .estimate_merkle_payment_cost(
+                    tree.depth(),
+                    &pool_commitments,
+                    merkle_payment_timestamp,
+                )
+                .await
+                .map_err(MerklePaymentError::MerklePaymentVault)?;
+
+            total_cost = total_cost.saturating_add(batch_cost);
+        }
+
+        let estimated_cost = AttoTokens::from_atto(total_cost);
+        crate::loud_info!("Total estimated cost: {estimated_cost}");
+
+        Ok(estimated_cost)
+    }
+
+    /// Collect all XorNames from a directory for cost estimation.
+    /// Returns only the xornames (no file results needed for cost calculation).
+    async fn collect_xornames_for_cost(
+        &self,
+        path: PathBuf,
+        is_public: bool,
+    ) -> Result<Vec<XorName>, FileCostError> {
+        let streams = encrypt_directory_files(path, is_public).await?;
+
+        let mut all_xor_names = Vec::new();
+
+        for stream_result in streams {
+            let mut stream = stream_result.map_err(FileCostError::Encryption)?;
+            let batch_size: usize = 32;
+
+            while let Some(batch) = stream.next_batch(batch_size) {
+                for chunk in batch {
+                    all_xor_names.push(*chunk.name());
+                }
+            }
+        }
+
+        Ok(all_xor_names)
+    }
+
+    /// Estimate the cost of uploading an archive for the given directory path.
+    ///
+    /// For public archives: estimates based on file paths + addresses + metadata.
+    /// For private archives: estimates based on file paths + placeholder datamaps + metadata.
+    async fn estimate_archive_cost_from_path(
+        &self,
+        path: &PathBuf,
+        is_public: bool,
+    ) -> Result<AttoTokens, FileCostError> {
+        let mut public_archive = PublicArchive::new();
+        let mut private_archive = PrivateArchive::new();
+
+        for entry in walkdir::WalkDir::new(path) {
+            let entry = entry?;
+
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let file_path = entry.path().to_path_buf();
+            let metadata = metadata_from_entry(&entry);
+
+            if is_public {
+                // For public archives, we just need a placeholder address
+                // The actual address would come from encryption, but for cost estimation
+                // the size is the same regardless of the actual xorname
+                let placeholder_addr = DataAddress::new(xor_name::XorName::default());
+                public_archive.add_file(file_path, placeholder_addr, metadata);
+            } else {
+                // For private archives, we need to estimate datamap size
+                // Read file and encrypt to get actual datamap size
+                let data = tokio::fs::read(&file_path).await?;
+                let file_bytes = Bytes::from(data);
+                let addrs = self.get_content_addrs(file_bytes)?;
+
+                // First addr is the datamap (xorname, size)
+                // Note: unwrap_or(0) is safe - encrypt() always produces a datamap chunk,
+                // so addrs is never empty. If somehow empty, 0 size is a reasonable fallback.
+                let datamap_size = addrs.first().map(|(_, size)| *size).unwrap_or(0);
+
+                // Create placeholder DataMapChunk of the correct size for estimation
+                let placeholder_bytes = vec![0u8; datamap_size];
+                let placeholder_chunk = DataMapChunk(Chunk::new(Bytes::from(placeholder_bytes)));
+                private_archive.add_file(file_path, placeholder_chunk, metadata);
+            }
+        }
+
+        let archive_bytes = if is_public {
+            public_archive.to_bytes()?
+        } else {
+            private_archive.to_bytes()?
+        };
+
+        let archive_addrs = self.get_content_addrs(archive_bytes)?;
+
+        // For private archives, skip the datamap chunk (first element) since it's kept locally
+        let archive_addrs: Vec<_> = if is_public {
+            archive_addrs
+        } else {
+            archive_addrs.into_iter().skip(1).collect()
+        };
+
+        let archive_cost = self.get_cost_estimation(archive_addrs).await?;
+        debug!("Archive cost for {path:?}: {archive_cost:?}");
+        Ok(archive_cost)
+    }
+}

--- a/autonomi/src/client/high_level/files/fs_private.rs
+++ b/autonomi/src/client/high_level/files/fs_private.rs
@@ -7,10 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::archive_private::{PrivateArchive, PrivateArchiveDataMap};
-use super::{DownloadError, UploadError};
+use super::{DownloadError, UploadError, bulk_upload_internal, file_upload_internal};
 use crate::client::PutError;
 use crate::client::data_types::chunk::DataMapChunk;
-use crate::client::payment::PaymentOption;
+use crate::client::payment::{BulkPaymentOption, PaymentOption};
 use crate::client::quote::add_costs;
 use crate::{AttoTokens, Client};
 use std::path::PathBuf;
@@ -54,52 +54,107 @@ impl Client {
     /// The directory is recursively walked and each file is uploaded to the network.
     ///
     /// The datamaps of these (private) files are not uploaded but returned within the [`PrivateArchive`] return type.
+    ///
+    /// When using `BulkPaymentOption::Wallet`, the payment method is automatically selected:
+    /// - For directories with >= 64 estimated chunks: uses merkle payments (more efficient)
+    /// - For smaller directories: uses regular per-batch payments
     pub async fn dir_content_upload(
         &self,
         dir_path: PathBuf,
-        payment_option: PaymentOption,
+        payment_option: BulkPaymentOption,
     ) -> Result<(AttoTokens, PrivateArchive), UploadError> {
-        let (total_cost, streams) = self
-            .dir_content_upload_internal(dir_path, payment_option, false)
-            .await?;
-
-        let mut private_archive = PrivateArchive::new();
-        for stream in streams {
-            let file_path = stream.file_path.clone();
-            if let Some(datamap) = stream.data_map_chunk() {
-                private_archive.add_file(stream.relative_path, datamap, stream.metadata);
-            } else {
-                error!("Datamap chunk not found for file: {file_path:?}, this is a BUG");
+        bulk_upload_internal(self, dir_path, payment_option, false, |results| {
+            let mut archive = PrivateArchive::new();
+            for (path, datamap, metadata) in results {
+                archive.add_file(path, datamap, metadata);
             }
-        }
-
-        Ok((total_cost, private_archive))
+            archive
+        })
+        .await
     }
 
     /// Same as [`Client::dir_content_upload`] but also uploads the archive (privately) to the network.
     ///
     /// Returns the [`PrivateArchiveDataMap`] allowing the private archive to be downloaded from the network.
+    ///
+    /// # Atomic Operation
+    ///
+    /// This is an atomic operation that requires a fresh wallet payment for both content and archive.
+    ///
+    /// # Resume Support
+    ///
+    /// To resume failed uploads with payment receipts, use the two-step approach:
+    /// 1. Upload content with receipt: `dir_content_upload(path, BulkPaymentOption::ContinueMerkle(wallet, receipt))`
+    /// 2. Upload archive separately: `archive_put(&archive, PaymentOption::Wallet(wallet))`
+    ///
+    /// This allows you to preserve merkle payment receipts while still completing the full upload.
     pub async fn dir_upload(
         &self,
         dir_path: PathBuf,
-        payment_option: PaymentOption,
+        wallet: &ant_evm::EvmWallet,
     ) -> Result<(AttoTokens, PrivateArchiveDataMap), UploadError> {
         let (cost1, archive) = self
-            .dir_content_upload(dir_path, payment_option.clone())
+            .dir_content_upload(dir_path, BulkPaymentOption::Wallet(wallet.clone()))
             .await?;
-        let (cost2, archive_addr) = self.archive_put(&archive, payment_option).await?;
+        let (cost2, archive_addr) = self
+            .archive_put(&archive, PaymentOption::Wallet(wallet.clone()))
+            .await?;
         let total_cost = add_costs(cost1, cost2).map_err(PutError::from)?;
         Ok((total_cost, archive_addr))
     }
 
     /// Upload the content of a private file to the network.
     /// Reads file, splits into chunks, uploads chunks, uploads datamap, returns [`DataMapChunk`] (pointing to the datamap)
+    ///
+    /// All `BulkPaymentOption` variants are supported:
+    /// - `Wallet`: Fresh upload with auto-selection (merkle for >= 64 chunks, regular otherwise)
+    /// - `Receipt`: Resume with regular receipt
+    /// - `ContinueMerkle`: Uses merkle flow with wallet for unpaid chunks
+    /// - `MerkleReceipt`: Uses merkle flow with existing proofs (fails if unpaid chunks exist)
     pub async fn file_content_upload(
         &self,
         path: PathBuf,
-        payment_option: PaymentOption,
+        payment_option: BulkPaymentOption,
     ) -> Result<(AttoTokens, DataMapChunk), UploadError> {
-        self.file_content_upload_internal(path, payment_option, false)
-            .await
+        file_upload_internal(self, path, payment_option, false).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::self_encryption::MAX_CHUNK_SIZE;
+
+    #[test]
+    fn test_chunk_estimation_ceiling_division() {
+        // Test that we use ceiling division for accurate estimates
+        // MAX_CHUNK_SIZE is typically 1MB (1024*1024 bytes)
+
+        // Small file (500KB) should estimate correctly, not 0
+        let small_size: usize = 500 * 1024; // 500KB
+        let estimated = std::cmp::max(3, small_size.div_ceil(MAX_CHUNK_SIZE));
+        assert!(
+            estimated >= 3,
+            "Small files should estimate at least 3 chunks"
+        );
+
+        // 1.5MB file should estimate 2 chunks (ceiling of 1.5)
+        let medium_size: usize = (MAX_CHUNK_SIZE * 3) / 2; // 1.5 * MAX_CHUNK_SIZE
+        let estimated = std::cmp::max(3, medium_size.div_ceil(MAX_CHUNK_SIZE));
+        assert!(
+            estimated >= 3,
+            "1.5MB file should estimate at least 3 chunks (self-encryption minimum)"
+        );
+
+        // Exact multiple should work correctly
+        let exact_size: usize = MAX_CHUNK_SIZE * 5;
+        let estimated = exact_size.div_ceil(MAX_CHUNK_SIZE);
+        assert_eq!(estimated, 5, "Exact multiples should estimate correctly");
+
+        // Zero size should still estimate minimum
+        let zero_estimated = std::cmp::max(3, 0_usize.div_ceil(MAX_CHUNK_SIZE));
+        assert_eq!(
+            zero_estimated, 3,
+            "Empty files should estimate 3 chunks minimum"
+        );
     }
 }

--- a/autonomi/src/client/high_level/files/mod.rs
+++ b/autonomi/src/client/high_level/files/mod.rs
@@ -126,6 +126,25 @@ where
                 Ok((cost, build_archive(results)))
             }
         }
+        BulkPaymentOption::ForceMerkle(wallet) => {
+            crate::loud_info!("Using merkle payments (forced)");
+            let (cost, results) = client
+                .files_put_with_merkle_payment(
+                    dir_path,
+                    is_public,
+                    MerklePaymentOption::Wallet(&wallet),
+                )
+                .await?;
+            Ok((cost, build_archive(results)))
+        }
+        BulkPaymentOption::ForceRegular(wallet) => {
+            crate::loud_info!("Using regular payments (forced)");
+            let (cost, streams) = client
+                .dir_content_upload_internal(dir_path, PaymentOption::Wallet(wallet), is_public)
+                .await?;
+            let results = streams_to_file_results(streams)?;
+            Ok((cost, build_archive(results)))
+        }
         BulkPaymentOption::Receipt(receipt) => {
             let (cost, streams) = client
                 .dir_content_upload_internal(dir_path, PaymentOption::Receipt(receipt), is_public)

--- a/autonomi/src/client/merkle_payments/payments.rs
+++ b/autonomi/src/client/merkle_payments/payments.rs
@@ -79,6 +79,8 @@ pub enum MerklePaymentError {
     EvmWalletNetworkMismatch,
     #[error("Wallet error: {0:?}")]
     EvmWalletError(#[from] ant_evm::EvmWalletError),
+    #[error("Merkle payment vault error: {0}")]
+    MerklePaymentVault(#[from] ant_evm::merkle_payment_vault::error::Error),
     #[error("Failed to get timestamp: {0}")]
     TimestampError(#[from] std::time::SystemTimeError),
     #[error("Candidate pool verification failed: {0}")]

--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -249,7 +249,9 @@ impl Client {
         {
             Ok(peers) => peers,
             Err(e) => {
-                warn!("Failed to get verified closest peers for {network_addr:?}: {e:?}, trying Kad-only fallback");
+                warn!(
+                    "Failed to get verified closest peers for {network_addr:?}: {e:?}, trying Kad-only fallback"
+                );
                 // Fallback to Kad-only query if verification fails
                 self.network
                     .get_closest_peers_kad_only(network_addr.clone(), None)

--- a/autonomi/src/client/payment.rs
+++ b/autonomi/src/client/payment.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::Client;
+use crate::client::merkle_payments::MerklePaymentReceipt;
 use crate::client::quote::{DataTypes, StoreQuote};
 use ant_evm::{ClientProofOfPayment, EncodedPeerId, EvmWallet, EvmWalletError};
 use std::collections::HashMap;
@@ -36,20 +37,53 @@ pub enum PayError {
     Cost(#[from] CostError),
 }
 
+/// Error with partial receipt for retry support.
+///
+/// When a payment fails partway through batch processing, the successful payments
+/// are preserved in `partial_receipt`. This allows users to resume uploads without
+/// losing funds by using `PaymentOption::Receipt(partial_receipt)`.
+#[derive(Debug, thiserror::Error)]
+#[error("Payment failed after partial success: {error}")]
+pub struct PayErrorWithReceipt {
+    /// The underlying error that caused the payment to fail
+    pub error: PayError,
+    /// Receipt containing any successful payments made before the error
+    pub partial_receipt: Receipt,
+}
+
 pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
+    receipt_from_store_quotes_filtered(&quotes, None)
+}
+
+/// Create a receipt from store quotes, optionally filtering to only include paid quote hashes.
+///
+/// If `paid_quote_hashes` is Some, only includes quotes whose hash is in the set.
+/// If `paid_quote_hashes` is None, includes all quotes.
+pub fn receipt_from_store_quotes_filtered(
+    quotes: &StoreQuote,
+    paid_quote_hashes: Option<&std::collections::BTreeSet<ant_evm::QuoteHash>>,
+) -> Receipt {
     let mut receipt = Receipt::new();
 
-    for (content_addr, quote_for_address) in quotes.0 {
-        let price = AttoTokens::from_atto(quote_for_address.price());
-
+    for (content_addr, quote_for_address) in &quotes.0 {
         let mut proof_of_payment = ClientProofOfPayment {
             peer_quotes: vec![],
         };
+        let mut price_sum = ant_evm::Amount::ZERO;
 
-        for (peer_id, addrs, quote, _amount) in quote_for_address.0 {
-            proof_of_payment
-                .peer_quotes
-                .push((EncodedPeerId::from(peer_id), addrs.0, quote));
+        for (peer_id, addrs, quote, amount) in &quote_for_address.0 {
+            // If filtering, only include quotes that were paid
+            if let Some(paid_hashes) = paid_quote_hashes
+                && !paid_hashes.contains(&quote.hash())
+            {
+                continue;
+            }
+            proof_of_payment.peer_quotes.push((
+                EncodedPeerId::from(*peer_id),
+                addrs.0.clone(),
+                quote.clone(),
+            ));
+            price_sum += *amount;
         }
 
         // skip empty proofs
@@ -57,18 +91,19 @@ pub fn receipt_from_store_quotes(quotes: StoreQuote) -> Receipt {
             continue;
         }
 
-        receipt.insert(content_addr, (proof_of_payment, price));
+        let price = AttoTokens::from_atto(price_sum);
+        receipt.insert(*content_addr, (proof_of_payment, price));
     }
 
     receipt
 }
 
-/// Payment options for data payments.
+/// Payment options for single-item data payments (pointer, scratchpad, graph, chunk).
 #[derive(Clone)]
 pub enum PaymentOption {
-    /// Pay using an evm wallet
+    /// Pay using an EVM wallet
     Wallet(EvmWallet),
-    /// When data was already paid for, use the receipt
+    /// Resume upload with existing payment receipt
     Receipt(Receipt),
 }
 
@@ -90,7 +125,105 @@ impl From<Receipt> for PaymentOption {
     }
 }
 
+/// Payment options for bulk/file uploads (directories, files).
+///
+/// # Auto-Selection Behavior
+///
+/// When using `Wallet`, the payment method is **automatically selected** based on estimated chunk count:
+/// - `< 64` chunks (MERKLE_PAYMENT_THRESHOLD): uses regular per-batch payments
+/// - `>= 64` chunks: uses merkle tree payments (single tree payment, more efficient for large uploads)
+///
+/// This auto-selection applies to both file and directory uploads when using `file_content_upload`,
+/// `file_content_upload_public`, `dir_content_upload`, and `dir_content_upload_public`.
+///
+/// # Resume Support
+///
+/// All variants support resuming failed uploads:
+/// - `Receipt`: Resume regular payment upload with existing receipt
+/// - `MerkleReceipt`: Resume merkle upload with existing proofs (fails if unpaid chunks remain)
+/// - `ContinueMerkle`: Resume merkle upload, paying for any remaining chunks with wallet
+///
+/// When a merkle upload fails, check `UploadError::MerkleUpload` for a receipt containing
+/// valid payment proofs that can be reused.
+#[derive(Clone)]
+pub enum BulkPaymentOption {
+    /// Pay using an EVM wallet - auto-selects merkle vs regular based on chunk count threshold (64)
+    Wallet(EvmWallet),
+    /// Resume upload with existing regular payment receipt (from non-merkle upload)
+    Receipt(Receipt),
+    /// Resume upload with existing merkle payment receipt - assumes all chunks paid (fails if not)
+    MerkleReceipt(MerklePaymentReceipt),
+    /// Continue merkle upload - uses existing proofs from receipt, pays for any unpaid chunks with wallet
+    ContinueMerkle(EvmWallet, MerklePaymentReceipt),
+}
+
+impl From<EvmWallet> for BulkPaymentOption {
+    fn from(value: EvmWallet) -> Self {
+        BulkPaymentOption::Wallet(value)
+    }
+}
+
+impl From<&EvmWallet> for BulkPaymentOption {
+    fn from(value: &EvmWallet) -> Self {
+        BulkPaymentOption::Wallet(value.clone())
+    }
+}
+
+impl From<Receipt> for BulkPaymentOption {
+    fn from(value: Receipt) -> Self {
+        BulkPaymentOption::Receipt(value)
+    }
+}
+
+impl From<MerklePaymentReceipt> for BulkPaymentOption {
+    fn from(value: MerklePaymentReceipt) -> Self {
+        BulkPaymentOption::MerkleReceipt(value)
+    }
+}
+
+impl From<PaymentOption> for BulkPaymentOption {
+    fn from(value: PaymentOption) -> Self {
+        match value {
+            PaymentOption::Wallet(w) => BulkPaymentOption::Wallet(w),
+            PaymentOption::Receipt(r) => BulkPaymentOption::Receipt(r),
+        }
+    }
+}
+
+impl BulkPaymentOption {
+    /// Get wallet reference for single-item uploads (archives).
+    ///
+    /// This extracts the wallet from any variant. For Receipt variant,
+    /// this will panic since we can't create a wallet from a receipt.
+    /// Callers should ensure they have a wallet available for archive uploads.
+    pub fn wallet(&self) -> Option<&EvmWallet> {
+        match self {
+            BulkPaymentOption::Wallet(w) => Some(w),
+            BulkPaymentOption::Receipt(_) => None,
+            BulkPaymentOption::MerkleReceipt(_) => None,
+            BulkPaymentOption::ContinueMerkle(w, _) => Some(w),
+        }
+    }
+
+    /// Convert to PaymentOption for single-item uploads (archives).
+    ///
+    /// For Receipt/MerkleReceipt variants, returns None since archives
+    /// need a wallet for payment.
+    pub fn to_payment_option(&self) -> Option<PaymentOption> {
+        match self {
+            BulkPaymentOption::Wallet(w) => Some(PaymentOption::Wallet(w.clone())),
+            BulkPaymentOption::Receipt(_) => None,
+            BulkPaymentOption::MerkleReceipt(_) => None,
+            BulkPaymentOption::ContinueMerkle(w, _) => Some(PaymentOption::Wallet(w.clone())),
+        }
+    }
+}
+
 impl Client {
+    /// Pay for content addresses using regular (non-merkle) payment flow.
+    ///
+    /// On partial failure, logs a warning about the partial receipt but currently
+    /// does not propagate it. Use `pay()` directly if you need partial receipt preservation.
     pub(crate) async fn pay_for_content_addrs(
         &self,
         data_type: DataTypes,
@@ -99,27 +232,50 @@ impl Client {
     ) -> Result<(Receipt, AlreadyPaidAddressesCount), PayError> {
         match payment_option {
             PaymentOption::Wallet(wallet) => {
-                let (receipt, skipped) = self.pay(data_type, content_addrs, &wallet).await?;
-                Ok((receipt, skipped))
+                match self.pay(data_type, content_addrs, &wallet).await {
+                    Ok((receipt, skipped)) => Ok((receipt, skipped)),
+                    Err(err_with_receipt) => {
+                        if !err_with_receipt.partial_receipt.is_empty() {
+                            warn!(
+                                "Payment failed with {} partial payments. These can be recovered by retrying with the receipt.",
+                                err_with_receipt.partial_receipt.len()
+                            );
+                        }
+                        Err(err_with_receipt.error)
+                    }
+                }
             }
             PaymentOption::Receipt(receipt) => Ok((receipt, 0)),
         }
     }
 
     /// Pay for the content addrs and get the proof of payment.
+    ///
+    /// On partial failure (some payments succeed, then an error occurs), returns
+    /// `PayErrorWithReceipt` containing both the error and a partial receipt of
+    /// successful payments that can be used for retry.
     pub(crate) async fn pay(
         &self,
         data_type: DataTypes,
         content_addrs: impl Iterator<Item = (XorName, usize)> + Clone,
         wallet: &EvmWallet,
-    ) -> Result<(Receipt, AlreadyPaidAddressesCount), PayError> {
+    ) -> Result<(Receipt, AlreadyPaidAddressesCount), PayErrorWithReceipt> {
         // Check if the wallet uses the same network as the client
         if wallet.network() != self.evm_network() {
-            return Err(PayError::EvmWalletNetworkMismatch);
+            return Err(PayErrorWithReceipt {
+                error: PayError::EvmWalletNetworkMismatch,
+                partial_receipt: Receipt::default(),
+            });
         }
 
         let number_of_content_addrs = content_addrs.clone().count();
-        let quotes = self.get_store_quotes(data_type, content_addrs).await?;
+        let quotes = self
+            .get_store_quotes(data_type, content_addrs)
+            .await
+            .map_err(|e| PayErrorWithReceipt {
+                error: PayError::from(e),
+                partial_receipt: Receipt::default(),
+            })?;
 
         crate::loud_info!("Paying for {} addresses..", quotes.len());
 
@@ -129,13 +285,30 @@ impl Client {
             let lock_guard = wallet.lock().await;
             debug!("Locked wallet");
 
-            // TODO: the error might contain some succeeded quote payments as well. These should be returned on err, so that they can be skipped when retrying.
-            // TODO: retry when it fails?
-            // Execute payments
-            let _payments = wallet
-                .pay_for_quotes(quotes.payments())
-                .await
-                .map_err(|err| PayError::from(err.0))?;
+            // Execute payments - preserve partial receipt on failure
+            if let Err(pay_err) = wallet.pay_for_quotes(quotes.payments()).await {
+                // payment failed, unlock the wallet for other threads
+                drop(lock_guard);
+                debug!("Unlocked wallet after payment error");
+
+                // Create partial receipt from successfully paid quotes
+                let paid_hashes: std::collections::BTreeSet<_> =
+                    pay_err.1.keys().copied().collect();
+                let partial_receipt = if paid_hashes.is_empty() {
+                    Receipt::default()
+                } else {
+                    crate::loud_info!(
+                        "Payment partially failed. {} quotes were paid successfully.",
+                        paid_hashes.len()
+                    );
+                    receipt_from_store_quotes_filtered(&quotes, Some(&paid_hashes))
+                };
+
+                return Err(PayErrorWithReceipt {
+                    error: PayError::from(pay_err.0),
+                    partial_receipt,
+                });
+            }
 
             // payment is done, unlock the wallet for other threads
             drop(lock_guard);

--- a/autonomi/src/client/quote.rs
+++ b/autonomi/src/client/quote.rs
@@ -106,6 +106,8 @@ pub enum CostError {
     Network(#[from] crate::networking::NetworkError),
     #[error("Total cost overflow when adding {0} and {1}")]
     TotalCostOverflow(AttoTokens, AttoTokens),
+    #[error("No content addresses generated for file")]
+    NoAddressesForContent,
 }
 
 /// Add two costs together, returning an error on overflow.

--- a/autonomi/src/lib.rs
+++ b/autonomi/src/lib.rs
@@ -12,7 +12,6 @@
 //!
 //! ```no_run
 //! use autonomi::{Bytes, Client, Wallet};
-//! use autonomi::client::payment::PaymentOption;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -21,14 +20,13 @@
 //!     // Default wallet of testnet.
 //!     let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 //!     let wallet = Wallet::new_from_private_key(Default::default(), key)?;
-//!     let payment = PaymentOption::Wallet(wallet);
 //!
 //!     // Put and fetch data.
-//!     let (cost, data_addr) = client.data_put_public(Bytes::from("Hello, World"), payment.clone()).await?;
+//!     let (cost, data_addr) = client.data_put_public(Bytes::from("Hello, World"), (&wallet).into()).await?;
 //!     let _data_fetched = client.data_get_public(&data_addr).await?;
 //!
 //!     // Put and fetch directory from local file system.
-//!     let (cost, dir_addr) = client.dir_upload_public("files/to/upload".into(), payment).await?;
+//!     let (cost, dir_addr) = client.dir_upload_public("files/to/upload".into(), &wallet).await?;
 //!     client.dir_download_public(&dir_addr, "files/downloaded".into()).await?;
 //!
 //!     Ok(())

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -482,10 +482,7 @@ impl Network {
                         peers,
                     });
                 }
-                debug!(
-                    "Kad-only query returned {} peers for {addr:?}",
-                    peers.len()
-                );
+                debug!("Kad-only query returned {} peers for {addr:?}", peers.len());
                 Ok(peers)
             }
             Err(e) => Err(e),

--- a/autonomi/src/self_encryption/mod.rs
+++ b/autonomi/src/self_encryption/mod.rs
@@ -11,5 +11,4 @@ mod stream_encryption;
 
 pub use memory_encryption::{DataMapLevel, Error, encrypt};
 pub use self_encryption::MAX_CHUNK_SIZE;
-pub(crate) use stream_encryption::encrypt_file;
 pub use stream_encryption::{EncryptionStream, encrypt_directory_files};

--- a/autonomi/tests/address.rs
+++ b/autonomi/tests/address.rs
@@ -128,9 +128,8 @@ async fn test_data_addresses_use() -> Result<()> {
     assert_eq!(parsed_register_bls_pubkey, addr);
 
     // put private dir
-    let payment_option = PaymentOption::from(&wallet);
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_cost, archive_datamap) = client.dir_upload(path, &wallet).await?;
     let archive_datamap_addr = archive_datamap.to_hex();
     println!("Private Archive (DataMap): {archive_datamap_addr}");
 
@@ -139,9 +138,7 @@ async fn test_data_addresses_use() -> Result<()> {
 
     // put public dir
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_addr) = client
-        .dir_upload_public(path, payment_option.clone())
-        .await?;
+    let (_cost, archive_addr) = client.dir_upload_public(path, &wallet).await?;
     let archive_addr_str = archive_addr.to_hex();
     println!("Public Archive (XorName): {archive_addr_str}");
 

--- a/autonomi/tests/analyze.rs
+++ b/autonomi/tests/analyze.rs
@@ -207,10 +207,9 @@ async fn test_analyze_private_dir() -> Result<()> {
 
     let client = Client::init_local().await?;
     let wallet = get_funded_wallet();
-    let payment_option = PaymentOption::from(&wallet);
 
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_datamap) = client.dir_upload(path, payment_option.clone()).await?;
+    let (_cost, archive_datamap) = client.dir_upload(path, &wallet).await?;
     let archive_datamap_addr = archive_datamap.to_hex();
     println!("Private Archive (DataMap): {archive_datamap_addr}");
 
@@ -230,10 +229,9 @@ async fn test_analyze_public_dir() -> Result<()> {
 
     let client = Client::init_local().await?;
     let wallet = get_funded_wallet();
-    let payment_option = PaymentOption::from(&wallet);
 
     let path = "tests/file/test_dir/".into();
-    let (_cost, archive_addr) = client.dir_upload_public(path, payment_option).await?;
+    let (_cost, archive_addr) = client.dir_upload_public(path, &wallet).await?;
     let archive_addr_str = archive_addr.to_hex();
     println!("Public Archive (XorName): {archive_addr_str}");
 

--- a/autonomi/tests/files.rs
+++ b/autonomi/tests/files.rs
@@ -32,7 +32,7 @@ async fn dir_upload_download() -> Result<()> {
     let wallet = get_funded_wallet();
 
     let (_cost, addr) = client
-        .dir_upload_public("tests/file/test_dir".into(), wallet.into())
+        .dir_upload_public("tests/file/test_dir".into(), &wallet)
         .await?;
 
     sleep(Duration::from_secs(10)).await;
@@ -88,7 +88,7 @@ async fn file_into_vault() -> Result<()> {
     let client_sk = bls::SecretKey::random();
 
     let (_cost, addr) = client
-        .dir_upload_public("tests/file/test_dir".into(), wallet.clone().into())
+        .dir_upload_public("tests/file/test_dir".into(), &wallet)
         .await?;
     sleep(Duration::from_secs(2)).await;
 
@@ -125,7 +125,10 @@ async fn file_advanced_use() -> Result<()> {
 
     // upload a directory
     let (cost, mut archive) = client
-        .dir_content_upload("tests/file/test_dir/dir_a".into(), payment_option.clone())
+        .dir_content_upload(
+            "tests/file/test_dir/dir_a".into(),
+            payment_option.clone().into(),
+        )
         .await?;
     println!("cost to upload private directory: {cost:?}");
     println!("archive: {archive:#?}");
@@ -134,7 +137,7 @@ async fn file_advanced_use() -> Result<()> {
     let (cost, file_datamap) = client
         .file_content_upload(
             "tests/file/test_dir/example_file_b".into(),
-            payment_option.clone(),
+            payment_option.clone().into(),
         )
         .await?;
     println!("cost to upload additional file: {cost:?}");
@@ -152,7 +155,7 @@ async fn file_advanced_use() -> Result<()> {
     let (cost, file_datamap) = client
         .file_content_upload(
             "tests/file/test_dir/example_file_a".into(),
-            payment_option.clone(),
+            payment_option.clone().into(),
         )
         .await?;
     println!("cost to upload additional file: {cost:?}");

--- a/evmlib/src/lib.rs
+++ b/evmlib/src/lib.rs
@@ -11,8 +11,11 @@
 // Allow enum variant names that end with Error as they come from external derives
 #![allow(clippy::enum_variant_names)]
 
-use crate::common::Address;
-use crate::utils::get_evm_network;
+use crate::common::{Address, Amount};
+use crate::contract::merkle_payment_vault::error::Error as MerklePaymentError;
+use crate::contract::merkle_payment_vault::handler::MerklePaymentVaultHandler;
+use crate::merkle_batch_payment::PoolCommitment;
+use crate::utils::{get_evm_network, http_provider};
 use alloy::primitives::address;
 use alloy::transports::http::reqwest;
 use serde::{Deserialize, Serialize};
@@ -187,5 +190,45 @@ impl Network {
             Network::ArbitrumSepoliaTest => Some(&ARBITRUM_SEPOLIA_TEST_MERKLE_PAYMENTS_ADDRESS),
             Network::Custom(custom) => custom.merkle_payments_address.as_ref(),
         }
+    }
+
+    /// Estimate the cost of a Merkle tree batch using smart contract view function (0 gas).
+    ///
+    /// This calls the smart contract's view function which runs the exact same
+    /// pricing logic as the actual payment, ensuring accurate cost estimation.
+    /// No wallet is needed since view functions don't require signing.
+    ///
+    /// # Arguments
+    /// * `depth` - The Merkle tree depth
+    /// * `pool_commitments` - Vector of pool commitments with metrics (one per reward pool)
+    /// * `merkle_payment_timestamp` - Unix timestamp for the payment
+    ///
+    /// # Returns
+    /// * Estimated total cost in AttoTokens
+    pub async fn estimate_merkle_payment_cost(
+        &self,
+        depth: u8,
+        pool_commitments: &[PoolCommitment],
+        merkle_payment_timestamp: u64,
+    ) -> Result<Amount, MerklePaymentError> {
+        if pool_commitments.is_empty() {
+            return Ok(Amount::ZERO);
+        }
+
+        // Create provider (no wallet needed for view calls)
+        let provider = http_provider(self.rpc_url().clone());
+
+        // Get Merkle payment vault address
+        let merkle_vault_address = *self
+            .merkle_payments_address()
+            .ok_or(MerklePaymentError::MerklePaymentsAddressNotConfigured)?;
+
+        // Create handler and call the contract's view function
+        let handler = MerklePaymentVaultHandler::new(merkle_vault_address, provider);
+        let total_amount = handler
+            .estimate_merkle_tree_cost(depth, pool_commitments.to_vec(), merkle_payment_timestamp)
+            .await?;
+
+        Ok(total_amount)
     }
 }


### PR DESCRIPTION
Cost Estimation                                                                                     
                                                                                                      
  - Add dedicated cost.rs module for file/directory cost estimation                                   
  - Add --merkle and --regular flags to ant file cost command to force estimation method              
  - Show which method was auto-selected and why (e.g., "merkle (auto-selected: ~150 chunks >= 64      
  threshold)")                                                                                        
  - Fix single-file cost estimation to exclude archive costs (single files don't create archives)     
  - Add public estimate_archive_cost method for estimating archive metadata cost separately           
  - Export MERKLE_PAYMENT_THRESHOLD constant from autonomi crate                                      
                                                                                                      
  Error Handling                                                                                      
                                                                                                      
  - Add FileCostError enum for cost-specific errors with proper typed variants                        
  - Replace string errors in collect_xornames_for_cost with typed FileCostError                       
  - Add FileCostError::Encryption(String) for file encryption errors                                  
  - Add FileCostError::MerklePayment for merkle payment estimation errors                             
                                                                                                      
  Upload Flow Refactor                                                                                
                                                                                                      
  - Centralize file/directory upload logic in mod.rs with bulk_upload_internal and                    
  file_upload_internal                                                                                
  - Simplify CLI upload code by delegating to library functions                                       
  - Add BulkPaymentOption enum for flexible payment options (wallet, receipt, merkle receipt, continue
   merkle)                                                                                            
  - Improve separation between content upload and archive upload                                      
                                                                                                      
  API Changes                                                                                         
                                                                                                      
  - Add dir_content_upload and dir_content_upload_public for uploading directory contents without     
  archive                                                                                             
  - Add file_cost_regular and file_cost_merkle public methods for explicit cost estimation            
  - Simplify pay() to return PayError directly   