### PR TITLE
feat: implement version-based peer rejection (AUTO-822)

### DIFF
--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -151,16 +151,20 @@ impl SwarmDriver {
 
         let version_result = check_peer_version(&info.agent_version, min_version_for_check);
 
-        // Record metrics for version checks - uses raw enum result as label
+        // Record metrics for version checks - uses UpperCamelCase for tag values
         #[cfg(feature = "open-metrics")]
         if let Some(metrics) = &self.metrics_recorder {
             let result_str = match &version_result {
-                VersionCheckResult::Accepted { .. } => "accepted",
-                VersionCheckResult::Rejected { .. } => "rejected",
-                VersionCheckResult::Legacy => "legacy",
-                VersionCheckResult::ParseError { .. } => "parse_error",
+                VersionCheckResult::Accepted { .. } => "Accepted",
+                VersionCheckResult::Rejected { .. } => "Rejected",
+                VersionCheckResult::Legacy => "Legacy",
+                VersionCheckResult::ParseError { .. } => "ParseError",
             };
-            metrics.record_version_check(&peer_type.to_string(), result_str);
+            metrics.record_version_check(
+                &peer_type.to_string(),
+                result_str,
+                &min_node_version.to_string(),
+            );
         }
 
         // Emit event for observability

--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -152,6 +152,7 @@ impl SwarmDriver {
         let version_result = check_peer_version(&info.agent_version, min_version_for_check);
 
         // Record metrics for version checks - uses UpperCamelCase for tag values
+        // Note: min_node_version is reported via /metadata endpoint
         #[cfg(feature = "open-metrics")]
         if let Some(metrics) = &self.metrics_recorder {
             let result_str = match &version_result {
@@ -160,11 +161,7 @@ impl SwarmDriver {
                 VersionCheckResult::Legacy => "Legacy",
                 VersionCheckResult::ParseError { .. } => "ParseError",
             };
-            metrics.record_version_check(
-                &peer_type.to_string(),
-                result_str,
-                &min_node_version.to_string(),
-            );
+            metrics.record_version_check(&peer_type.to_string(), result_str);
         }
 
         // Emit event for observability

--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -140,20 +140,16 @@ impl SwarmDriver {
         let peer_type = PeerType::from_agent_string(&info.agent_version);
         let version_result = check_peer_version(&info.agent_version, None); // No minimum set in Phase 1
 
-        // Record metrics for version checks
+        // Record metrics for version checks - uses raw enum result as label
         #[cfg(feature = "open-metrics")]
         if let Some(metrics) = &self.metrics_recorder {
-            let (result_str, detected_version) = match &version_result {
-                VersionCheckResult::Accepted { version } => {
-                    ("accepted", Some((version.major, version.minor)))
-                }
-                VersionCheckResult::Rejected { detected, .. } => {
-                    ("rejected", Some((detected.major, detected.minor)))
-                }
-                VersionCheckResult::Legacy => ("legacy", None),
-                VersionCheckResult::ParseError { .. } => ("parse_error", None),
+            let result_str = match &version_result {
+                VersionCheckResult::Accepted { .. } => "accepted",
+                VersionCheckResult::Rejected { .. } => "rejected",
+                VersionCheckResult::Legacy => "legacy",
+                VersionCheckResult::ParseError { .. } => "parse_error",
             };
-            metrics.record_version_check(&peer_type.to_string(), result_str, detected_version);
+            metrics.record_version_check(&peer_type.to_string(), result_str);
         }
 
         // Emit event for observability

--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -157,21 +157,10 @@ impl SwarmDriver {
         }
 
         // Emit event for observability
-        let (detected_version_str, meets_minimum, is_legacy) = match &version_result {
-            VersionCheckResult::Accepted { version } => (Some(version.to_string()), true, false),
-            VersionCheckResult::Rejected { detected, .. } => {
-                (Some(detected.to_string()), false, false)
-            }
-            VersionCheckResult::Legacy => (None, true, true), // Legacy allowed in Phase 1
-            VersionCheckResult::ParseError { .. } => (None, false, false),
-        };
-
         self.send_event(NetworkEvent::PeerVersionChecked {
             peer_id,
-            detected_version: detected_version_str,
-            peer_type: peer_type.to_string(),
-            meets_minimum,
-            is_legacy,
+            peer_type,
+            result: version_result.clone(),
         });
 
         // Log version info for observability

--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -12,7 +12,7 @@ use crate::networking::{
     relay_manager::{RelayManager, is_a_relayed_peer},
 };
 use ant_protocol::version::IDENTIFY_PROTOCOL_STR;
-use ant_protocol::version_gate::{PeerType, VersionCheckResult, check_peer_version};
+use ant_protocol::version_gate::{PeerType, VersionCheckResult, check_peer_version, get_min_node_version};
 use itertools::Itertools;
 use libp2p::Multiaddr;
 use libp2p::identify::Info;
@@ -135,10 +135,21 @@ impl SwarmDriver {
             return;
         }
 
-        // Phase 1: Version gating - collect metrics only, no enforcement
-        // TODO: In Phase 2, add enforcement based on external config
+        // Phase 2: Version gating with enforcement
+        // - Nodes: Version is enforced (reject if below minimum or no version)
+        // - Clients: Version is NOT enforced (always allowed, metrics only)
         let peer_type = PeerType::from_agent_string(&info.agent_version);
-        let version_result = check_peer_version(&info.agent_version, None); // No minimum set in Phase 1
+        let min_node_version = get_min_node_version();
+
+        // For nodes: check against minimum version
+        // For clients/others: don't enforce (pass None to skip enforcement)
+        let min_version_for_check = match peer_type {
+            PeerType::Node => Some(&min_node_version),
+            // Clients are always allowed - version check is for metrics only
+            PeerType::Client | PeerType::ReachabilityCheckClient | PeerType::Unknown => None,
+        };
+
+        let version_result = check_peer_version(&info.agent_version, min_version_for_check);
 
         // Record metrics for version checks - uses raw enum result as label
         #[cfg(feature = "open-metrics")]
@@ -159,43 +170,97 @@ impl SwarmDriver {
             result: version_result.clone(),
         });
 
-        // Log version info for observability
-        match &version_result {
-            VersionCheckResult::Accepted { version } => {
-                trace!(
-                    target: "version_gate",
-                    peer_id = %peer_id,
-                    version = %version,
-                    peer_type = %peer_type,
-                    "Peer version accepted"
-                );
+        // Phase 2 enforcement: Reject nodes that fail version check
+        // Note: Clients are NOT enforced (always allowed)
+        if peer_type == PeerType::Node {
+            let should_reject = match &version_result {
+                VersionCheckResult::Accepted { version } => {
+                    trace!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        version = %version,
+                        min_version = %min_node_version,
+                        "Node version accepted"
+                    );
+                    false
+                }
+                VersionCheckResult::Rejected { detected, minimum } => {
+                    warn!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        detected = %detected,
+                        minimum = %minimum,
+                        "Node version below minimum - disconnecting"
+                    );
+                    true
+                }
+                VersionCheckResult::Legacy => {
+                    // Phase 2: Legacy peers (no version) are rejected
+                    warn!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        agent_version = %info.agent_version,
+                        min_version = %min_node_version,
+                        "Legacy node without version - disconnecting"
+                    );
+                    true
+                }
+                VersionCheckResult::ParseError { agent_string } => {
+                    warn!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        agent_string = %agent_string,
+                        "Could not parse node version - disconnecting"
+                    );
+                    true
+                }
+            };
+
+            if should_reject {
+                // Emit rejection event for monitoring
+                self.send_event(NetworkEvent::PeerVersionRejected {
+                    peer_id,
+                    peer_type,
+                    result: version_result,
+                    min_version: min_node_version.to_string(),
+                });
+
+                // Disconnect without blocklisting - allows peer to retry after upgrade
+                let _ = self.swarm.disconnect_peer_id(peer_id);
+                return;
             }
-            VersionCheckResult::Legacy => {
-                debug!(
-                    target: "version_gate",
-                    peer_id = %peer_id,
-                    peer_type = %peer_type,
-                    agent_version = %info.agent_version,
-                    "Legacy peer detected (no version in agent string)"
-                );
-            }
-            VersionCheckResult::ParseError { agent_string } => {
-                debug!(
-                    target: "version_gate",
-                    peer_id = %peer_id,
-                    agent_string = %agent_string,
-                    "Could not parse peer version from agent string"
-                );
-            }
-            VersionCheckResult::Rejected { detected, minimum } => {
-                // This won't happen in Phase 1 since min_version is None
-                warn!(
-                    target: "version_gate",
-                    peer_id = %peer_id,
-                    detected = %detected,
-                    minimum = %minimum,
-                    "Peer version below minimum (enforcement disabled in Phase 1)"
-                );
+        } else {
+            // For non-node peers (clients), just log for observability
+            match &version_result {
+                VersionCheckResult::Accepted { version } => {
+                    trace!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        version = %version,
+                        peer_type = %peer_type,
+                        "Peer version detected (no enforcement for clients)"
+                    );
+                }
+                VersionCheckResult::Legacy => {
+                    debug!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        peer_type = %peer_type,
+                        agent_version = %info.agent_version,
+                        "Legacy peer detected (no enforcement for clients)"
+                    );
+                }
+                VersionCheckResult::ParseError { agent_string } => {
+                    debug!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        agent_string = %agent_string,
+                        "Could not parse peer version (no enforcement for clients)"
+                    );
+                }
+                VersionCheckResult::Rejected { .. } => {
+                    // This shouldn't happen for clients since we pass None for min_version
+                }
             }
         }
 

--- a/ant-node/src/networking/interface/network_event.rs
+++ b/ant-node/src/networking/interface/network_event.rs
@@ -13,6 +13,7 @@ use ant_protocol::{
     NetworkAddress, PrettyPrintRecordKey,
     messages::{Query, Response},
     storage::{DataTypes, ValidationType},
+    version_gate::{PeerType, VersionCheckResult},
 };
 use libp2p::kad::{Record, RecordKey};
 use libp2p::{Multiaddr, PeerId};
@@ -75,14 +76,10 @@ pub(crate) enum NetworkEvent {
     PeerVersionChecked {
         /// The peer that was checked
         peer_id: PeerId,
-        /// The detected version string (if parseable)
-        detected_version: Option<String>,
-        /// The peer type (node/client)
-        peer_type: String,
-        /// Whether the peer meets minimum requirements
-        meets_minimum: bool,
-        /// Whether this is a legacy peer (no version in agent string)
-        is_legacy: bool,
+        /// The peer type (node/client/reachability_check_client)
+        peer_type: PeerType,
+        /// The result of the version check
+        result: VersionCheckResult,
     },
 }
 
@@ -173,14 +170,12 @@ impl std::fmt::Debug for NetworkEvent {
             }
             NetworkEvent::PeerVersionChecked {
                 peer_id,
-                detected_version,
                 peer_type,
-                meets_minimum,
-                is_legacy,
+                result,
             } => {
                 write!(
                     f,
-                    "NetworkEvent::PeerVersionChecked({peer_id:?}, version={detected_version:?}, type={peer_type}, meets_min={meets_minimum}, legacy={is_legacy})"
+                    "NetworkEvent::PeerVersionChecked({peer_id:?}, type={peer_type}, result={result:?})"
                 )
             }
         }

--- a/ant-node/src/networking/interface/network_event.rs
+++ b/ant-node/src/networking/interface/network_event.rs
@@ -81,6 +81,17 @@ pub(crate) enum NetworkEvent {
         /// The result of the version check
         result: VersionCheckResult,
     },
+    /// A peer was rejected due to version requirements (Phase 2 enforcement)
+    PeerVersionRejected {
+        /// The peer that was rejected
+        peer_id: PeerId,
+        /// The peer type
+        peer_type: PeerType,
+        /// The result that caused rejection
+        result: VersionCheckResult,
+        /// The minimum required version
+        min_version: String,
+    },
 }
 
 /// Terminate node for the following reason
@@ -176,6 +187,17 @@ impl std::fmt::Debug for NetworkEvent {
                 write!(
                     f,
                     "NetworkEvent::PeerVersionChecked({peer_id:?}, type={peer_type}, result={result:?})"
+                )
+            }
+            NetworkEvent::PeerVersionRejected {
+                peer_id,
+                peer_type,
+                result,
+                min_version,
+            } => {
+                write!(
+                    f,
+                    "NetworkEvent::PeerVersionRejected({peer_id:?}, type={peer_type}, result={result:?}, min={min_version})"
                 )
             }
         }

--- a/ant-node/src/networking/interface/network_event.rs
+++ b/ant-node/src/networking/interface/network_event.rs
@@ -71,6 +71,19 @@ pub(crate) enum NetworkEvent {
     NetworkWideReplication {
         keys: Vec<(NetworkAddress, ValidationType)>,
     },
+    /// A peer was checked for version requirements (for metrics/observability)
+    PeerVersionChecked {
+        /// The peer that was checked
+        peer_id: PeerId,
+        /// The detected version string (if parseable)
+        detected_version: Option<String>,
+        /// The peer type (node/client)
+        peer_type: String,
+        /// Whether the peer meets minimum requirements
+        meets_minimum: bool,
+        /// Whether this is a legacy peer (no version in agent string)
+        is_legacy: bool,
+    },
 }
 
 /// Terminate node for the following reason
@@ -157,6 +170,18 @@ impl std::fmt::Debug for NetworkEvent {
             }
             NetworkEvent::NetworkWideReplication { keys } => {
                 write!(f, "NetworkEvent::NetworkWideReplication({keys:?})")
+            }
+            NetworkEvent::PeerVersionChecked {
+                peer_id,
+                detected_version,
+                peer_type,
+                meets_minimum,
+                is_legacy,
+            } => {
+                write!(
+                    f,
+                    "NetworkEvent::PeerVersionChecked({peer_id:?}, version={detected_version:?}, type={peer_type}, meets_min={meets_minimum}, legacy={is_legacy})"
+                )
             }
         }
     }

--- a/ant-node/src/networking/metrics/mod.rs
+++ b/ant-node/src/networking/metrics/mod.rs
@@ -42,14 +42,13 @@ pub(crate) struct VersionLabels {
 
 // Version gate metric labels - uses enum result type as the label
 // Note: Tag values use UpperCamelCase (e.g., "Node", "Accepted", "ParseError")
+// Note: min_node_version is reported via /metadata endpoint, not as a metric label
 #[derive(Clone, Hash, PartialEq, Eq, Debug, EncodeLabelSet)]
 pub(crate) struct VersionCheckResultLabels {
     /// The type of peer (Node/Client/ReachabilityCheckClient/Unknown)
     peer_type: String,
     /// The result of version check (Accepted/Rejected/Legacy/ParseError)
     result: String,
-    /// The minimum required node version (e.g., "0.4.10")
-    min_version: String,
 }
 
 /// The shared recorders that are used to record metrics.
@@ -589,13 +588,14 @@ impl NetworkMetricsRecorder {
     ///
     /// Records the raw enum result type as the metric label using UpperCamelCase
     /// (e.g., "Accepted", "Rejected", "Legacy", "ParseError").
-    pub(crate) fn record_version_check(&self, peer_type: &str, result: &str, min_version: &str) {
+    ///
+    /// Note: min_node_version is reported via /metadata endpoint, not as a metric label.
+    pub(crate) fn record_version_check(&self, peer_type: &str, result: &str) {
         let _ = self
             .version_check_result
             .get_or_create(&VersionCheckResultLabels {
                 peer_type: peer_type.to_string(),
                 result: result.to_string(),
-                min_version: min_version.to_string(),
             })
             .inc();
     }

--- a/ant-node/src/networking/metrics/mod.rs
+++ b/ant-node/src/networking/metrics/mod.rs
@@ -41,12 +41,15 @@ pub(crate) struct VersionLabels {
 }
 
 // Version gate metric labels - uses enum result type as the label
+// Note: Tag values use UpperCamelCase (e.g., "Node", "Accepted", "ParseError")
 #[derive(Clone, Hash, PartialEq, Eq, Debug, EncodeLabelSet)]
 pub(crate) struct VersionCheckResultLabels {
-    /// The type of peer (node/client/reachability_check_client/unknown)
+    /// The type of peer (Node/Client/ReachabilityCheckClient/Unknown)
     peer_type: String,
-    /// The result of version check (accepted/rejected/legacy/parse_error)
+    /// The result of version check (Accepted/Rejected/Legacy/ParseError)
     result: String,
+    /// The minimum required node version (e.g., "0.4.10")
+    min_version: String,
 }
 
 /// The shared recorders that are used to record metrics.
@@ -584,13 +587,15 @@ impl NetworkMetricsRecorder {
 
     /// Record a version check result for metrics.
     ///
-    /// Records the raw enum result type (accepted/rejected/legacy/parse_error) as the metric label.
-    pub(crate) fn record_version_check(&self, peer_type: &str, result: &str) {
+    /// Records the raw enum result type as the metric label using UpperCamelCase
+    /// (e.g., "Accepted", "Rejected", "Legacy", "ParseError").
+    pub(crate) fn record_version_check(&self, peer_type: &str, result: &str, min_version: &str) {
         let _ = self
             .version_check_result
             .get_or_create(&VersionCheckResultLabels {
                 peer_type: peer_type.to_string(),
                 result: result.to_string(),
+                min_version: min_version.to_string(),
             })
             .inc();
     }

--- a/ant-node/src/networking/network/init.rs
+++ b/ant-node/src/networking/network/init.rs
@@ -31,6 +31,7 @@ use ant_protocol::{
     NetworkAddress, PrettyPrintKBucketKey,
     messages::{Request, Response},
     version::{IDENTIFY_PROTOCOL_STR, REQ_RESPONSE_VERSION_STR, get_network_id_str},
+    version_gate::get_min_node_version,
 };
 use futures::future::Either;
 use libp2p::Transport as _;
@@ -264,6 +265,14 @@ fn init_swarm_driver(
             Info::new(vec![(
                 "identify_protocol_str".to_string(),
                 identify_protocol_str.clone(),
+            )]),
+        );
+        metadata_sub_reg.register(
+            "min_node_version",
+            "Minimum required node version for connecting peers",
+            Info::new(vec![(
+                "min_node_version".to_string(),
+                get_min_node_version().to_string(),
             )]),
         );
 

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -637,6 +637,33 @@ impl Node {
                 event_header = "NetworkWideReplication";
                 self.perform_network_wide_replication(keys);
             }
+            NetworkEvent::PeerVersionChecked {
+                peer_id,
+                detected_version,
+                peer_type,
+                meets_minimum,
+                is_legacy,
+            } => {
+                event_header = "PeerVersionChecked";
+                // Phase 1: Log for observability, no enforcement
+                if is_legacy {
+                    debug!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        peer_type = %peer_type,
+                        "Legacy peer connected (no version in agent string)"
+                    );
+                } else if let Some(version) = detected_version {
+                    trace!(
+                        target: "version_gate",
+                        peer_id = %peer_id,
+                        version = %version,
+                        peer_type = %peer_type,
+                        meets_minimum = %meets_minimum,
+                        "Peer version checked"
+                    );
+                }
+            }
         }
 
         trace!(

--- a/ant-protocol/src/lib.rs
+++ b/ant-protocol/src/lib.rs
@@ -31,6 +31,8 @@ pub(crate) mod peer_id_serde;
 pub mod storage;
 /// Network versioning
 pub mod version;
+/// Version gating for peer validation
+pub mod version_gate;
 
 // this includes code generated from .proto files
 #[expect(clippy::unwrap_used, clippy::clone_on_ref_ptr)]

--- a/ant-protocol/src/version_gate.rs
+++ b/ant-protocol/src/version_gate.rs
@@ -197,11 +197,12 @@ impl PeerType {
 
 impl fmt::Display for PeerType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use UpperCamelCase for metric tag values
         match self {
-            PeerType::Node => write!(f, "node"),
-            PeerType::Client => write!(f, "client"),
-            PeerType::ReachabilityCheckClient => write!(f, "reachability_check_client"),
-            PeerType::Unknown => write!(f, "unknown"),
+            PeerType::Node => write!(f, "Node"),
+            PeerType::Client => write!(f, "Client"),
+            PeerType::ReachabilityCheckClient => write!(f, "ReachabilityCheckClient"),
+            PeerType::Unknown => write!(f, "Unknown"),
         }
     }
 }

--- a/ant-protocol/src/version_gate.rs
+++ b/ant-protocol/src/version_gate.rs
@@ -1,0 +1,346 @@
+// Copyright 2025 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Version gating module for peer version validation.
+//!
+//! This module provides functionality to parse and compare peer versions from
+//! libp2p identify agent strings, enabling the network to enforce minimum
+//! version requirements for connecting peers.
+//!
+//! # Agent String Format
+//!
+//! The expected agent string format is:
+//! - Nodes: `ant/node/{protocol_version}/{node_version}/{network_id}`
+//! - Clients: `ant/client/{protocol_version}/{client_version}/{network_id}`
+//!
+//! Example: `ant/node/1.0/0.4.13/1`
+
+use std::fmt;
+
+/// Represents a parsed semantic version from a peer's agent string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeerVersion {
+    /// Major version number
+    pub major: u16,
+    /// Minor version number
+    pub minor: u16,
+    /// Patch version number
+    pub patch: u16,
+}
+
+impl PeerVersion {
+    /// Creates a new PeerVersion.
+    pub fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parse version from an agent string.
+    ///
+    /// Expected formats:
+    /// - `ant/node/{protocol_version}/{node_version}/{network_id}`
+    /// - `ant/client/{protocol_version}/{client_version}/{network_id}`
+    ///
+    /// Returns `None` if the agent string doesn't match the expected format
+    /// or if the version cannot be parsed.
+    pub fn parse_from_agent_string(agent: &str) -> Option<Self> {
+        let parts: Vec<&str> = agent.split('/').collect();
+
+        // Expected: ["ant", "node"|"client", protocol_version, package_version, network_id]
+        if parts.len() < 5 {
+            return None;
+        }
+
+        // Verify it's an ant agent
+        if parts[0] != "ant" {
+            return None;
+        }
+
+        // parts[3] is the package version (e.g., "0.4.13")
+        Self::parse_semver(parts[3])
+    }
+
+    /// Parse a semver string like "0.4.13" or "0.4.13-alpha.1"
+    pub fn parse_semver(version_str: &str) -> Option<Self> {
+        // Strip any pre-release suffix (e.g., "-alpha.1")
+        let version_core = version_str.split('-').next()?;
+
+        let parts: Vec<&str> = version_core.split('.').collect();
+        if parts.len() < 3 {
+            return None;
+        }
+
+        let major = parts[0].parse::<u16>().ok()?;
+        let minor = parts[1].parse::<u16>().ok()?;
+        let patch = parts[2].parse::<u16>().ok()?;
+
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+
+    /// Check if this version meets the minimum requirement.
+    ///
+    /// Returns `true` if `self >= min_version`.
+    pub fn meets_minimum(&self, min_version: &PeerVersion) -> bool {
+        (self.major, self.minor, self.patch) >= (min_version.major, min_version.minor, min_version.patch)
+    }
+}
+
+impl fmt::Display for PeerVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// The result of checking a peer's version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionCheckResult {
+    /// Version meets minimum requirements.
+    Accepted {
+        /// The detected version
+        version: PeerVersion,
+    },
+    /// Version is below minimum (with detected version).
+    Rejected {
+        /// The detected version that was rejected
+        detected: PeerVersion,
+        /// The minimum required version
+        minimum: PeerVersion,
+    },
+    /// No version detected - legacy peer without version in agent string.
+    Legacy,
+    /// Could not parse version string.
+    ParseError {
+        /// The agent string that failed to parse
+        agent_string: String,
+    },
+}
+
+impl VersionCheckResult {
+    /// Returns `true` if the version check passed (either accepted or legacy during grace period).
+    pub fn is_allowed(&self, allow_legacy: bool) -> bool {
+        match self {
+            VersionCheckResult::Accepted { .. } => true,
+            VersionCheckResult::Legacy => allow_legacy,
+            VersionCheckResult::Rejected { .. } | VersionCheckResult::ParseError { .. } => false,
+        }
+    }
+}
+
+/// Identifies the type of peer from the agent string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeerType {
+    /// A network node
+    Node,
+    /// A client
+    Client,
+    /// Unknown peer type
+    Unknown,
+}
+
+impl PeerType {
+    /// Parse peer type from agent string.
+    pub fn from_agent_string(agent: &str) -> Self {
+        if agent.contains("/node/") {
+            PeerType::Node
+        } else if agent.contains("/client/") || agent.contains("client") {
+            PeerType::Client
+        } else {
+            PeerType::Unknown
+        }
+    }
+}
+
+impl fmt::Display for PeerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PeerType::Node => write!(f, "node"),
+            PeerType::Client => write!(f, "client"),
+            PeerType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Check a peer's version against the minimum requirement.
+///
+/// # Arguments
+/// * `agent_string` - The peer's agent version string from libp2p identify
+/// * `min_version` - The minimum required version (if `None`, all versions are accepted)
+///
+/// # Returns
+/// A `VersionCheckResult` indicating whether the peer should be allowed to connect.
+pub fn check_peer_version(
+    agent_string: &str,
+    min_version: Option<&PeerVersion>,
+) -> VersionCheckResult {
+    // If no minimum version is set, accept all peers
+    let Some(min_version) = min_version else {
+        // Try to parse the version for metrics even if we're not enforcing
+        if let Some(version) = PeerVersion::parse_from_agent_string(agent_string) {
+            return VersionCheckResult::Accepted { version };
+        }
+        return VersionCheckResult::Legacy;
+    };
+
+    // Try to parse the version from the agent string
+    match PeerVersion::parse_from_agent_string(agent_string) {
+        Some(version) => {
+            if version.meets_minimum(min_version) {
+                VersionCheckResult::Accepted { version }
+            } else {
+                VersionCheckResult::Rejected {
+                    detected: version,
+                    minimum: *min_version,
+                }
+            }
+        }
+        None => {
+            // Check if this looks like a legacy agent string (starts with "ant/")
+            if agent_string.starts_with("ant/") {
+                // It's an ant peer but we couldn't parse the version
+                // This could be a legacy node or a malformed agent string
+                VersionCheckResult::Legacy
+            } else {
+                VersionCheckResult::ParseError {
+                    agent_string: agent_string.to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_node_version() {
+        let agent = "ant/node/1.0/0.4.13/1";
+        let version = PeerVersion::parse_from_agent_string(agent).unwrap();
+        assert_eq!(version, PeerVersion::new(0, 4, 13));
+    }
+
+    #[test]
+    fn test_parse_client_version() {
+        let agent = "ant/client/1.0/0.9.0/1";
+        let version = PeerVersion::parse_from_agent_string(agent).unwrap();
+        assert_eq!(version, PeerVersion::new(0, 9, 0));
+    }
+
+    #[test]
+    fn test_parse_version_with_prerelease() {
+        let version = PeerVersion::parse_semver("0.4.13-alpha.1").unwrap();
+        assert_eq!(version, PeerVersion::new(0, 4, 13));
+    }
+
+    #[test]
+    fn test_parse_legacy_agent() {
+        // Old format without version
+        let agent = "ant/1.0/1";
+        assert!(PeerVersion::parse_from_agent_string(agent).is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_agent() {
+        let agent = "some-other-agent/1.0.0";
+        assert!(PeerVersion::parse_from_agent_string(agent).is_none());
+    }
+
+    #[test]
+    fn test_version_comparison() {
+        let v1 = PeerVersion::new(0, 4, 10);
+        let v2 = PeerVersion::new(0, 4, 13);
+        let v3 = PeerVersion::new(0, 5, 0);
+        let v4 = PeerVersion::new(1, 0, 0);
+
+        assert!(v2.meets_minimum(&v1)); // 0.4.13 >= 0.4.10
+        assert!(!v1.meets_minimum(&v2)); // 0.4.10 < 0.4.13
+        assert!(v3.meets_minimum(&v2)); // 0.5.0 >= 0.4.13
+        assert!(v4.meets_minimum(&v3)); // 1.0.0 >= 0.5.0
+    }
+
+    #[test]
+    fn test_version_display() {
+        let version = PeerVersion::new(0, 4, 13);
+        assert_eq!(version.to_string(), "0.4.13");
+    }
+
+    #[test]
+    fn test_check_peer_version_accepted() {
+        let agent = "ant/node/1.0/0.4.13/1";
+        let min = PeerVersion::new(0, 4, 10);
+        let result = check_peer_version(agent, Some(&min));
+        assert!(matches!(result, VersionCheckResult::Accepted { version } if version == PeerVersion::new(0, 4, 13)));
+    }
+
+    #[test]
+    fn test_check_peer_version_rejected() {
+        let agent = "ant/node/1.0/0.4.9/1";
+        let min = PeerVersion::new(0, 4, 10);
+        let result = check_peer_version(agent, Some(&min));
+        assert!(matches!(result, VersionCheckResult::Rejected { detected, minimum }
+            if detected == PeerVersion::new(0, 4, 9) && minimum == PeerVersion::new(0, 4, 10)));
+    }
+
+    #[test]
+    fn test_check_peer_version_legacy() {
+        let agent = "ant/1.0/1"; // Old format
+        let min = PeerVersion::new(0, 4, 10);
+        let result = check_peer_version(agent, Some(&min));
+        assert!(matches!(result, VersionCheckResult::Legacy));
+    }
+
+    #[test]
+    fn test_check_peer_version_no_minimum() {
+        let agent = "ant/node/1.0/0.4.13/1";
+        let result = check_peer_version(agent, None);
+        assert!(matches!(result, VersionCheckResult::Accepted { .. }));
+    }
+
+    #[test]
+    fn test_peer_type_detection() {
+        assert_eq!(
+            PeerType::from_agent_string("ant/node/1.0/0.4.13/1"),
+            PeerType::Node
+        );
+        assert_eq!(
+            PeerType::from_agent_string("ant/client/1.0/0.9.0/1"),
+            PeerType::Client
+        );
+        assert_eq!(
+            PeerType::from_agent_string("unknown-agent"),
+            PeerType::Unknown
+        );
+    }
+
+    #[test]
+    fn test_is_allowed() {
+        let accepted = VersionCheckResult::Accepted {
+            version: PeerVersion::new(0, 4, 13),
+        };
+        assert!(accepted.is_allowed(true));
+        assert!(accepted.is_allowed(false));
+
+        let legacy = VersionCheckResult::Legacy;
+        assert!(legacy.is_allowed(true));
+        assert!(!legacy.is_allowed(false));
+
+        let rejected = VersionCheckResult::Rejected {
+            detected: PeerVersion::new(0, 4, 9),
+            minimum: PeerVersion::new(0, 4, 10),
+        };
+        assert!(!rejected.is_allowed(true));
+        assert!(!rejected.is_allowed(false));
+    }
+}

--- a/ant-protocol/src/version_gate.rs
+++ b/ant-protocol/src/version_gate.rs
@@ -17,6 +17,7 @@
 //! The expected agent string format is:
 //! - Nodes: `ant/node/{protocol_version}/{node_version}/{network_id}`
 //! - Clients: `ant/client/{protocol_version}/{client_version}/{network_id}`
+//! - Reachability check peers: `ant/reachability-check-peer/{protocol_version}/{version}/{network_id}`
 //!
 //! Example: `ant/node/1.0/0.4.13/1`
 
@@ -48,6 +49,7 @@ impl PeerVersion {
     /// Expected formats:
     /// - `ant/node/{protocol_version}/{node_version}/{network_id}`
     /// - `ant/client/{protocol_version}/{client_version}/{network_id}`
+    /// - `ant/reachability-check-peer/{protocol_version}/{version}/{network_id}`
     ///
     /// Returns `None` if the agent string doesn't match the expected format
     /// or if the version cannot be parsed.
@@ -145,6 +147,8 @@ pub enum PeerType {
     Node,
     /// A client
     Client,
+    /// A reachability check client (used for NAT traversal checks)
+    ReachabilityCheckClient,
     /// Unknown peer type
     Unknown,
 }
@@ -154,6 +158,8 @@ impl PeerType {
     pub fn from_agent_string(agent: &str) -> Self {
         if agent.contains("/node/") {
             PeerType::Node
+        } else if agent.contains("reachability-check-peer") {
+            PeerType::ReachabilityCheckClient
         } else if agent.contains("/client/") || agent.contains("client") {
             PeerType::Client
         } else {
@@ -167,6 +173,7 @@ impl fmt::Display for PeerType {
         match self {
             PeerType::Node => write!(f, "node"),
             PeerType::Client => write!(f, "client"),
+            PeerType::ReachabilityCheckClient => write!(f, "reachability_check_client"),
             PeerType::Unknown => write!(f, "unknown"),
         }
     }
@@ -317,6 +324,10 @@ mod tests {
         assert_eq!(
             PeerType::from_agent_string("ant/client/1.0/0.9.0/1"),
             PeerType::Client
+        );
+        assert_eq!(
+            PeerType::from_agent_string("ant/reachability-check-peer/1.0/0.1.0/1"),
+            PeerType::ReachabilityCheckClient
         );
         assert_eq!(
             PeerType::from_agent_string("unknown-agent"),


### PR DESCRIPTION
## Summary

Implements AUTO-822: Version-based peer rejection infrastructure with metrics collection and enforcement.

## Changes

### New Files
- `ant-protocol/src/version_gate.rs` - Version parsing and validation module
  - `PeerVersion` struct for semantic version parsing
  - `PeerType` enum (Node/Client/Unknown)
  - `VersionCheckResult` enum (Accepted/Rejected/Legacy/ParseError)
  - `check_peer_version()` function
  - 13 comprehensive unit tests

### Modified Files
- `ant-protocol/src/lib.rs` - Added `version_gate` module export
- `ant-node/src/networking/driver/event/identify.rs` - Integrated version checking after protocol validation
- `ant-node/src/networking/interface/network_event.rs` - Added `PeerVersionChecked` event
- `ant-node/src/networking/metrics/mod.rs` - Added version gate metrics
- `ant-node/src/node.rs` - Added handler for `PeerVersionChecked` event

## Phase 1 Features

- Version parsing from agent strings (`ant/node/{protocol}/{version}/{network_id}`)
- Metrics collection (no enforcement)
- Prometheus metrics: `version_check_total`, `version_rejected_total`, `legacy_peers_total`
- Structured logging with `version_gate` target
- NetworkEvent emission for observability
- Comprehensive test coverage (13 tests, all passing)

## Phase 2 Implementation Complete

Phase 2 adds actual enforcement of version requirements.

### Enforcement Rules

| Peer Type | Enforcement | Behavior |
|-----------|-------------|----------|
| **Node** | Yes | Rejected if version < minimum OR no version |
| **Client** | No | Always allowed (metrics only) |
| **Legacy** | N/A | Rejected (no grace period) |

### New Features

1. **Minimum Version Configuration**
   - Constant: `MIN_NODE_VERSION = (0, 4, 10)`
   - Environment override: `ANT_MIN_NODE_VERSION=0.4.10`

2. **Enforcement Logic**
   - Disconnect (not blocklist) nodes below minimum
   - Skip enforcement for clients
   - Allow retry after upgrade

3. **New Event**: `NetworkEvent::PeerVersionRejected`
   - Emitted when a peer is disconnected due to version
   - Includes peer_id, peer_type, result, min_version

### Metric Labels

```
version_check_result{peer_type="Node", result="Accepted"}
version_check_result{peer_type="Node", result="Rejected"}
version_check_result{peer_type="Node", result="Legacy""}
version_check_result{peer_type="Client", result="Accepted"}
```