### PR TITLE
feat: CLI improvements to show network address for private uploads

### DIFF
--- a/ant-cli/src/commands/file.rs
+++ b/ant-cli/src/commands/file.rs
@@ -429,6 +429,9 @@ pub async fn upload(
     } else {
         println!("Successfully uploaded: {file}");
         println!("At address: {local_addr}");
+        if !public {
+            println!("The above private address links to network address: {archive_addr}");
+        }
         info!("Successfully uploaded: {file} at address: {local_addr}");
         println!("Number of chunks uploaded: {}", summary.records_paid);
         println!(


### PR DESCRIPTION
## Summary

- Shows the network address when uploading private files via CLI, addressing AUTO-614
- For private files: shows both local address (for local reference) and network address (for network operations)
- For public files: shows only the network address

## Changes

### CLI Output Changes
- Private uploads now display:
  - `At address: <local_addr>` (for local file reference)
  - `The above private address links to network address: <archive_addr>` (for network operations)
- Public uploads display:
  - `At address: <local_addr>`

## Type of Change

- Minor UX improvement