### PR TITLE
chore(release): stable release 2026.1.1.1

### DIFF
--- a/.claude/commands/produce-release-candidate.md
+++ b/.claude/commands/produce-release-candidate.md
@@ -1,0 +1,195 @@
+# Produce Release Candidate
+
+@release-cycle-info
+@ant-build-info/src/release_info.rs
+@CHANGELOG.md
+@.github/workflows/release.yml
+
+I need you to assist me in producing a new release candidate for this repository.
+
+There are 9 phases:
+
+* Preparing the new release candidate
+* Determining merged PRs
+* Analyzing changes and determining crate bumps
+* Bumping Rust crates
+* Bumping NodeJS packages
+* Generating the changelog
+* Creating the release candidate commit
+* Pushing the release candidate branch
+* Running the release workflow
+
+## Slack Updates
+
+Before we start the process, I want to inform you how to post any messages to Slack.
+
+You should use the `slack_post_message` operation from the currently configured MCP server to post
+messages to the #releases channel. All messages should be prefixed with `[timestamp] <release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from the `release-cycle-info` file.
+
+## Phase 1: Preparing the new release candidate
+
+First, prompt me to obtain the new package version for the release, which should be in the following
+form:
+```
+<release-year>.<release-month>.<release-cycle>.<release-cycle-counter>
+```
+
+We need a new branch in the form `rc-<release-year>.<release-month>.<release-cycle>` based on the
+*new* package version, not the current one. It could be the case the branch was already created and
+we are on that branch. If we are not, create it and switch to it.
+
+Now update the `release-cycle-info` and `release_info.rs` files with the values from the new package
+version.
+
+Post a message to Slack indicating that the release candidate process is beginning.
+
+## Phase 2: Determining Merged PRs
+
+Use `git log stable..main --oneline --merges` to determine the PR numbers that have been merged
+since the last stable release. We use merge commits, so the PR numbers should be readily
+identifiable.
+
+Present me with a summary of the merged PRs in the following form:
+```
+@<author>
+  <date> <pr-number> <pr-title>
+```
+
+For example:
+```
+@grumbach
+  2025-12-17 #3364 -- Merkle CLI 
+  2025-12-18 #3371 -- Merkle client optimized pool creation 
+  2025-12-18 #3369 -- Fix merkle tests 
+  2025-12-18 #3368 -- Merkle remove abusive xorname use 
+  2025-12-23 #3386 -- Merkle high level retries 
+  2025-12-23 #3387 -- feat: merkle chunk existance check progress reporting 
+  2025-12-23 #3381 -- Merkle payment Client (CLI)
+
+@maqi
+  2025-12-18 #3375 -- fix(test): refactor verify_max_parallel_fetches test setup 
+  2025-12-22 #3377 -- fix(node): avoid pruning irrelevant_records too aggressively 
+  2025-12-22 #3383 -- fix(test): make verify_max_parallel_fetches test deterministic
+
+@mickvandijke
+  2025-12-19 #3378 -- fix: failing merkle payment txs
+
+@dirvine
+  2025-12-23 #3380 -- fix(ci): resolve ring crate ARM cross-compilation failure
+```
+
+So these are grouped by the author. You should be able to obtain this information using the `gh`
+tool.
+
+Give me the opportunity to remove any PR from the list. Sometimes we have PRs that were raised from
+automated processes like `dependabot` and we are not interested in those PRs being part of the
+release list.
+
+Once I indicate we can proceed, post a message to Slack with the PR list summary.
+
+## Phase 3: Analyzing Changes and Determining Crate Bumps
+
+Analyze the changes from the merged PRs to determine which crates need to be bumped and by how much.
+
+For each crate that has changes, determine:
+- Whether it needs a `MAJOR`, `MINOR`, or `PATCH` bump based on Semantic Versioning rules
+- Whether any changes are breaking changes
+
+For our purposes right now, we only really have `MINOR` and `PATCH` bumps. When there is a breaking
+change, we should use a `MINOR` bump.
+
+**CRITICAL**: Check that `ant-protocol` does NOT have a MAJOR bump. If it does, stop immediately and
+alert me. A major protocol bump requires special handling and should not proceed through the normal
+release process.
+
+Present me with a detailed summary of:
+1. Each crate that needs a bump
+2. The recommended bump level (MAJOR/MINOR/PATCH)
+3. The reasoning for each bump (which PRs contributed to this)
+4. Any breaking changes identified
+
+Wait for my review and approval before proceeding. I may adjust the bump levels based on my
+knowledge of the changes.
+
+## Phase 4: Bumping Rust Crates
+
+Based on my approved crate bump list, use the `cargo release` tool to bump each crate:
+
+```
+cargo release version <new-version>-rc.1 --package <crate-name> --execute --no-confirm
+```
+
+For crates that need bumping, the new version should include the `-rc.1` pre-release identifier.
+
+Present me with the commands you intend to run and wait for my confirmation before executing them.
+
+After executing, show me a summary of the version changes that were made and post the same summary
+to Slack.
+
+## Phase 5: Bumping NodeJS Language Binding Packages
+
+We have two NodeJS packages in the repository: `autonomi-nodejs` and `ant-node-nodejs`. There are
+also Rust crates in the same directories.
+
+If the corresponding Rust crates were bumped in Phase 4, the NodeJS packages also need to be bumped
+to match.
+
+For each package that needs bumping, use:
+```
+npm version "<new-version>-rc.1" --no-git-tag-version
+```
+This should run from the corresponding crate directory.
+
+Present me with the commands you intend to run and wait for my confirmation before executing. If no
+bumps are required, let me know that too. In any case, wait for input from me before continuing.
+
+## Phase 6: Generating the Changelog
+
+Use the `/new-changelog-entry` skill to generate an initial changelog entry for this release
+candidate. The entry should cover all changes since the last stable release. The last stable release
+is denoted with a tag. This tag can be obtained from the latest release on the repository using the
+`gh` command.
+
+The date for the changelog entry should be today's date.
+
+Present me with the generated changelog entry for review. I will likely want to make adjustments
+and improvements to the wording. Wait for my approval before proceeding. Once approved, post the
+changelog to Slack.
+
+## Phase 7: Creating the Release Candidate Commit
+
+Stage all the current changes then commit them. For the title of the commit, use:
+`chore(release): release candidate <release-year>.<release-month>.<release-cycle>.<release-cycle-counter>`
+
+For the body of the commit, you can run the Bash script at `resources/scripts/print-versions.sh`
+and use its output.
+
+Show me the commit message you intend to use and wait for my confirmation before creating the
+commit.
+
+## Phase 8: Pushing the Release Candidate Branch
+
+Push the release candidate branch to the `origin` repository.
+
+Wait for my approval before pushing. If there is an error on the push, do NOT force push. Stop and
+let me inspect what is going on.
+
+Post a message to Slack indicating the release candidate branch has been pushed.
+
+## Phase 9: Running the Release Workflow
+
+Now I want you to run the `release` workflow on this repository. The workflow has inputs for which
+binaries to release (they are all `false` by default).
+
+Before you run the workflow, present me with the available binary options and let me choose which
+ones should be released. Then show me the complete workflow inputs for my confirmation before
+dispatching the workflow.
+
+Post a message to Slack indicating that the workflow has been dispatched. Include a link to the
+workflow run.
+
+We need to wait for it to complete. Monitor the run yourself, then when it completes, let me know
+the result.
+
+Post a message to Slack indicating the workflow result (success or failure). If successful, note
+that the release candidate binaries are now available for testing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2026-01-28
+
+### API
+
+#### Added
+
+- `BulkPaymentOption::ForceMerkle` variant to force merkle tree payments regardless of chunk count.
+- `BulkPaymentOption::ForceRegular` variant to force regular per-batch payments regardless of chunk
+  count.
+- `BulkPaymentOption::is_force_merkle()` method to check if the option forces merkle payment.
+- `BulkPaymentOption::is_force_regular()` method to check if the option forces regular payment.
+- Request/response direct message fallback for mutable data fetch operations (pointers, scratchpads,
+  graph entries), improving reliability when KAD queries fail.
+- `MERKLE_PAYMENT_THRESHOLD` constant is now publicly exported for use by consuming crates.
+
+#### Changed
+
+- The `file_content_upload`, `file_content_upload_public`, `dir_content_upload`, and
+  `dir_content_upload_public` methods now require explicit selection of payment mode via the
+  `--merkle` or `--regular` flags in the CLI, or `ForceMerkle`/`ForceRegular` variants in the API.
+  [BREAKING]
+- Client request timeout extended to 120 seconds to improve reliability on slower connections.
+- Substream timeout increased to 120 seconds to match the request timeout.
+- Cost estimation code improved for more accurate payment calculations.
+- Upload flow refactored to centralise reporting and retry logic.
+
+#### Fixed
+
+- Double slashes in normalised archive paths are now prevented.
+- `GetVersion` query errors are now properly caught and handled instead of propagating unexpected
+  failures.
+
+### Network
+
+#### Added
+
+- `DevGetClosestPeersFromNetwork` query for developer analytics, allowing nodes to perform full
+  network lookups rather than just returning local routing table entries. This query is only
+  available when the `developer` feature is enabled.
+
+#### Changed
+
+- Request timeout increased to 120 seconds to improve reliability for slower network operations.
+- Nodes now approve merkle uploads even when they lack full network knowledge (fewer than K_VALUE
+  peers in routing table), improving upload success rates during network churn.
+
+#### Fixed
+
+- Peers are now removed from the routing table when version fetch operations fail, improving routing
+  table accuracy.
+
+### Payments
+
+#### Changed
+
+- Gas estimation now uses EIP-1559 fee estimation for more accurate and predictable transaction
+  costs.
+- Gas cost information is now printed during payment operations, providing better visibility into
+  transaction costs.
+- Local merkle pricing now uses the correct formula for cost calculations.
+
+#### Fixed
+
+- Invalid gas cost aggregation corrected to provide accurate total cost reporting.
+
+### Ant Client
+
+#### Added
+
+- The `developer closest-peers` command now queries the network for closest peers to a target
+  address, with support for multiple input formats including `PeerId`.
+- The `developer closest-peers` command now supports a comparison mode to compare results from
+  different nodes.
+- The `developer node-version` command queries the version of a specific node on the network.
+- The `developer get-quote` command fetches quotes from specific peers, with the `address` parameter
+  now optional.
+
+#### Changed
+
+- The `file cost` and `file upload` commands now require explicit selection of payment mode using
+  `--merkle` or `--regular` flags. The previous automatic selection based on chunk count threshold
+  has been removed. [BREAKING]
+- Improved consistency between cost estimation and upload commands.
+- Payment selection logging improved to reduce confusion.
+
+### General
+
+#### Added
+
+- macOS signed and notarized pkg installer for the CLI suite (`ant`, `antnode`, `antctl`), providing
+  a standard macOS installation experience with binaries installed to `/usr/local/bin`.
+- Windows signed MSI installer for the CLI suite (`ant`, `antnode`, `antctl`), installing to
+  `C:\Program Files\Autonomi\` and adding binaries to PATH.
+- Linux signed Debian package (`.deb`) for the CLI suite (`ant`, `antnode`, `antctl`) on
+  Debian/Ubuntu systems, with support for x86_64, aarch64, armv7, and arm architectures. Includes
+  detached GPG signature for verification.
+- Linux signed RPM package (`.rpm`) for the CLI suite (`ant`, `antnode`, `antctl`) on
+  Fedora/RHEL/CentOS systems, with the same architecture support and GPG signing as the Debian
+  package.
+
+### Launchpad
+
+#### Added
+
+- macOS signed and notarized app bundle (`.dmg`) for Node Launchpad, allowing users to drag the
+  application to their Applications folder for standard macOS app installation.
+- Windows signed MSIX installer for Node Launchpad, with automatic update support via
+  `.appinstaller` files and Start Menu integration.
+
 ## 2026-01-09
 
 ### Network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,18 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- The `developer closest-peers` command now queries the network for closest peers to a target
-  address, with support for multiple input formats including `PeerId`.
-- The `developer closest-peers` command now supports a comparison mode to compare results from
-  different nodes.
-- The `developer node-version` command queries the version of a specific node on the network.
-- The `developer get-quote` command fetches quotes from specific peers, with the `address` parameter
-  now optional.
+- A `developer` subcommand adds various tools for querying the network.
 
 #### Changed
 
 - The `file cost` and `file upload` commands now require explicit selection of payment mode using
-  `--merkle` or `--regular` flags. The previous automatic selection based on chunk count threshold
+  `--merkle` or `--regular` flags. The previous automatic selection based on chunk-count threshold
   has been removed. [BREAKING]
 - Improved consistency between cost estimation and upload commands.
 - Payment selection logging improved to reduce confusion.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.4.15"
+version = "0.5.0-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.19"
+version = "0.1.20-rc.1"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.13"
+version = "0.4.14-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.11"
+version = "1.0.12-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.9.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3522,7 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.17"
+version = "0.1.18-rc.1"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.7"
+version = "0.4.8-rc.1"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.1"
+version = "0.6.2-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.20-rc.1"
+version = "0.1.20"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.14-rc.1"
+version = "0.4.14"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.12-rc.1"
+version = "1.0.12"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.10.0-rc.1"
+version = "0.10.0"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3522,7 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "evm-testnet"
-version = "0.1.18-rc.1"
+version = "0.1.18"
 dependencies = [
  "ant-evm",
  "clap",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.8-rc.1"
+version = "0.4.8"
 dependencies = [
  "alloy",
  "dirs-next",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.2-rc.1"
+version = "0.6.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
-pub const RELEASE_YEAR: &str = "2025";
-pub const RELEASE_MONTH: &str = "12";
-pub const RELEASE_CYCLE: &str = "3";
-pub const RELEASE_CYCLE_COUNTER: &str = "3";
+pub const RELEASE_YEAR: &str = "2026";
+pub const RELEASE_MONTH: &str = "1";
+pub const RELEASE_CYCLE: &str = "1";
+pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.4.15"
+version = "0.5.0-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
-autonomi = { path = "../autonomi", version = "0.9.0", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.0-rc.1", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.9.0" }
+autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
-autonomi = { path = "../autonomi", version = "0.10.0-rc.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+autonomi = { path = "../autonomi", version = "0.10.0", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.0" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.19"
+version = "0.1.20-rc.1"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.7", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.20-rc.1"
+version = "0.1.20"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.8", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -32,12 +32,12 @@ websockets = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -32,12 +32,12 @@ websockets = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.14-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.14" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.13" }
+ant-node = { path = "../ant-node", version = "0.4.14-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.14" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.14-rc.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.14-rc.1"
+version = "0.4.14"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,9 +26,9 @@ otlp = ["ant-logging/otlp"]
 aes-gcm-siv = "0.11.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
-autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
+autonomi = { path = "../autonomi", version = "0.10.0" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.13"
+version = "0.4.14-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,9 +26,9 @@ otlp = ["ant-logging/otlp"]
 aes-gcm-siv = "0.11.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.11", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.7" }
-autonomi = { path = "../autonomi", version = "0.9.0" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.12-rc.1"
+version = "1.0.12"
 
 [features]
 default = []
@@ -16,7 +16,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.11"
+version = "1.0.12-rc.1"
 
 [features]
 default = []
@@ -16,7 +16,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.5.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.5.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.9.0" }
+autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.10.0-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.10.0-rc.1"
+version = "0.10.0"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -28,8 +28,8 @@ loud = []
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -38,7 +38,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -79,7 +79,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.9.0"
+version = "0.10.0-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -28,8 +28,8 @@ loud = []
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -38,7 +38,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -79,7 +79,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.17"
+version = "0.1.18-rc.1"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -6,13 +6,13 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evm-testnet"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.18-rc.1"
+version = "0.1.18"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.8-rc.1"
+version = "0.4.8"
 
 [features]
 external-signer = []

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.7"
+version = "0.4.8-rc.1"
 
 [features]
 external-signer = []

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.1"
+version = "0.6.2-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -20,10 +20,10 @@ nightly = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.19" }
+ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.11" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.2-rc.1"
+version = "0.6.2"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -20,10 +20,10 @@ nightly = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.20" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -12,7 +12,7 @@
 #
 # Both of these numbers are used in the packaged version number, which is a collective version
 # number for all the released binaries.
-release-year: 2025
-release-month: 12
-release-cycle: 3
-release-cycle-counter: 3
+release-year: 2026
+release-month: 1
+release-cycle: 1
+release-cycle-counter: 1

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.8" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.7" }
+evmlib = { path = "../evmlib", version = "0.4.8-rc.1" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.5.0
ant-evm: 0.1.20
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.14
ant-node-manager: 0.14.1
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.12
ant-service-management: 0.5.1
ant-token-supplies: 0.1.67
autonomi: 0.10.0
evmlib: 0.4.8
evm-testnet: 0.1.18
nat-detection: 0.2.22
node-launchpad: 0.6.2
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.5.0
antctl: 0.14.1
antctld: 0.14.1
antnode: 0.4.14
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.2
```