### PR TITLE
feat(networking): verify popular close-range peers via get_version

### DIFF
--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -476,6 +476,7 @@ impl Network {
         let mut tasks: FuturesUnordered<_> = query_tasks.into_iter().collect();
 
         let mut peer_counts: HashMap<PeerId, usize> = HashMap::new();
+        let mut peer_addrs: HashMap<PeerId, Vec<Multiaddr>> = HashMap::new();
 
         while let Some((responder_peer_id, result)) = tasks.next().await {
             if let Ok(peers_list) = result {
@@ -484,13 +485,17 @@ impl Network {
 
                 *peer_counts.entry(responder_peer_id).or_insert(0) += 1;
 
-                // Count appearances in the response
-                for (peer_addr, _addrs) in peers_list {
+                // Count appearances in the response and collect addresses for reported peers
+                for (peer_addr, addrs) in peers_list {
                     if let Some(peer_id) = peer_addr.as_peer_id() {
                         let distance = key.distance(&peer_addr);
                         trace!("  Reported peer: {peer_id:?}, distance: {distance:?}");
 
                         *peer_counts.entry(peer_id).or_insert(0) += 1;
+                        peer_addrs
+                            .entry(peer_id)
+                            .or_default()
+                            .extend(addrs);
                     }
                 }
             } else {
@@ -511,11 +516,16 @@ impl Network {
         //    - Select peers that appear in BOTH the original Kad `candidates` AND `popular_peer_ids`
         //    - These are the most reliable: both Kad and peer consensus agree
         //
-        // 3. TIER 2 - CANDIDATES BEYOND POPULAR RANGE:
-        //    - If Tier 1 doesn't fill N slots, add peers from `candidates` that are farther than the farthest popular peer
+        // 3. TIER 2 - POPULAR NOT IN CANDIDATES (get_version verification):
+        //    - If Tier 1 doesn't fill N slots, consider peers in `popular_peer_ids` that are NOT in the original Kad `candidates`
+        //    - For each such peer (with known addresses from responses), run get_version in parallel
+        //    - Those that respond successfully are added as verified candidates (closest first)
+        //
+        // 4. TIER 3 - CANDIDATES BEYOND POPULAR RANGE:
+        //    - If still not enough, add peers from `candidates` that are farther than the farthest popular peer
         //    - These extend coverage beyond the popular consensus zone
         //
-        // 4. TIER 3 - REMAINING CANDIDATES:
+        // 5. TIER 4 - REMAINING CANDIDATES:
         //    - If still not enough, fill remaining slots with unselected `candidates`
         //    - Pick closest first (sorted by distance to target)
         //
@@ -578,46 +588,92 @@ impl Network {
             n
         );
 
-        // Step 3: Tier 2 - Pick candidates farther than the farthest popular peer
+        // Step 3: Tier 2 - Popular peers NOT in original candidates: verify via get_version, add successes
+        if verified_candidates.len() < n {
+            use ant_protocol::messages::{Query, QueryResponse};
+
+            let candidate_peer_ids: std::collections::HashSet<PeerId> =
+                candidates.iter().map(|(pid, _)| *pid).collect();
+            let popular_not_in_candidates: Vec<(PeerId, Addresses)> = popular_peer_ids
+                .iter()
+                .filter(|id| !candidate_peer_ids.contains(id))
+                .filter_map(|peer_id| {
+                    peer_addrs.get(peer_id).and_then(|addrs| {
+                        if addrs.is_empty() {
+                            None
+                        } else {
+                            Some((*peer_id, Addresses(addrs.clone())))
+                        }
+                    })
+                })
+                .collect();
+
+            if !popular_not_in_candidates.is_empty() {
+                let mut version_tasks: FuturesUnordered<_> = popular_not_in_candidates
+                    .into_iter()
+                    .map(|(peer_id, addrs)| {
+                        let network = self.clone();
+                        async move {
+                            let req = Request::Query(Query::GetVersion(NetworkAddress::from(
+                                peer_id,
+                            )));
+                            let result = network.send_request(req, peer_id, addrs.clone()).await;
+                            match result {
+                                Ok((
+                                    Response::Query(QueryResponse::GetVersion {
+                                        peer: _,
+                                        version: _,
+                                    }),
+                                    _,
+                                )) => Ok((peer_id, addrs)),
+                                _ => Err(NetworkError::EventChannelFailure(
+                                    "GetVersion failed or unexpected response".to_string(),
+                                )),
+                            }
+                        }
+                    })
+                    .collect();
+
+                let mut tier2_verified: Vec<(PeerId, Addresses)> = Vec::new();
+                while let Some(result) = version_tasks.next().await {
+                    if let Ok((peer_id, addrs)) = result {
+                        tier2_verified.push((peer_id, addrs));
+                    }
+                }
+                tier2_verified.sort_by_key(|(peer_id, _)| get_distance(peer_id));
+
+                for (peer_id, addrs) in tier2_verified {
+                    if verified_candidates.len() >= n {
+                        break;
+                    }
+                    trace!(
+                        "Tier2 (popular not in candidates, get_version ok): {:?}, distance: {:?}",
+                        peer_id,
+                        get_distance(&peer_id)
+                    );
+                    verified_candidates.push((peer_id, addrs));
+                    let _ = selected_peer_ids.insert(peer_id);
+                }
+
+                debug!(
+                    "Tier2 (popular not in candidates): selected {}/{} peers total for {pretty_key:?}",
+                    verified_candidates.len(),
+                    n
+                );
+            }
+        }
+
+        // Step 4: Tier 3 - Pick candidates farther than the farthest popular peer
         if verified_candidates.len() < n
             && let Some(farthest_popular) = farthest_popular_distance
         {
-            let mut tier2_peers: Vec<_> = candidates
+            let mut tier3_peers: Vec<_> = candidates
                 .iter()
                 .filter(|(peer_id, _)| {
                     !selected_peer_ids.contains(peer_id) && get_distance(peer_id) > farthest_popular
                 })
                 .collect();
             // Sort by distance (closest first among those beyond popular range)
-            tier2_peers.sort_by_key(|(peer_id, _)| get_distance(peer_id));
-
-            for (peer_id, addrs) in tier2_peers {
-                if verified_candidates.len() >= n {
-                    break;
-                }
-                trace!(
-                    "Tier2 selected: {:?}, distance: {:?}",
-                    peer_id,
-                    get_distance(peer_id)
-                );
-                verified_candidates.push((*peer_id, addrs.clone()));
-                let _ = selected_peer_ids.insert(*peer_id);
-            }
-
-            debug!(
-                "Tier2 (candidates beyond popular): selected {}/{} peers total for {pretty_key:?}",
-                verified_candidates.len(),
-                n
-            );
-        }
-
-        // Step 4: Tier 3 - Fill remaining slots with unselected candidates (closest first)
-        if verified_candidates.len() < n {
-            let mut tier3_peers: Vec<_> = candidates
-                .iter()
-                .filter(|(peer_id, _)| !selected_peer_ids.contains(peer_id))
-                .collect();
-            // Sort by distance (closest first)
             tier3_peers.sort_by_key(|(peer_id, _)| get_distance(peer_id));
 
             for (peer_id, addrs) in tier3_peers {
@@ -634,7 +690,36 @@ impl Network {
             }
 
             debug!(
-                "Tier3 (remaining candidates): selected {}/{} peers total for {pretty_key:?}",
+                "Tier3 (candidates beyond popular): selected {}/{} peers total for {pretty_key:?}",
+                verified_candidates.len(),
+                n
+            );
+        }
+
+        // Step 5: Tier 4 - Fill remaining slots with unselected candidates (closest first)
+        if verified_candidates.len() < n {
+            let mut tier4_peers: Vec<_> = candidates
+                .iter()
+                .filter(|(peer_id, _)| !selected_peer_ids.contains(peer_id))
+                .collect();
+            // Sort by distance (closest first)
+            tier4_peers.sort_by_key(|(peer_id, _)| get_distance(peer_id));
+
+            for (peer_id, addrs) in tier4_peers {
+                if verified_candidates.len() >= n {
+                    break;
+                }
+                trace!(
+                    "Tier4 selected: {:?}, distance: {:?}",
+                    peer_id,
+                    get_distance(peer_id)
+                );
+                verified_candidates.push((*peer_id, addrs.clone()));
+                let _ = selected_peer_ids.insert(*peer_id);
+            }
+
+            debug!(
+                "Tier4 (remaining candidates): selected {}/{} peers total for {pretty_key:?}",
                 verified_candidates.len(),
                 n
             );


### PR DESCRIPTION
## Summary

- Add a new verification tier (Tier 2) to the close group peer selection algorithm that considers popular peers not present in the original Kad candidate set
- These peers are verified via `get_version` before being accepted, ensuring reachability and protocol compatibility
- Collects peer addresses from query responses to enable direct communication with these peers

## Problem

The current peer selection algorithm queries multiple nodes to find close peers but only considers peers that appear in the local Kad candidate set. Peers that are reported as close by multiple queried nodes (popular peers) but are missing from the Kad candidate set are ignored entirely. This can lead to inaccurate close group composition, particularly when client's KAD network query has gaps.

## Solution

Insert a new **Tier 2** between the existing tiers:

1. **Tier 1** (unchanged): Peers in BOTH Kad candidates AND popular set (highest confidence)
2. **Tier 2** (NEW): Popular peers NOT in Kad candidates, verified via `get_version` - network consensus says they're close, and we confirm they're reachable
3. **Tier 3** (was Tier 2): Kad candidates beyond the farthest popular peer distance
4. **Tier 4** (was Tier 3): Remaining Kad candidates, closest first

Also collects addresses reported in query responses into a `peer_addrs` map, so Tier 2 peers can be contacted directly for verification.

## Changes

| File | Change |
|------|--------|
| `ant-node/src/networking/network/mod.rs` | Add `peer_addrs` collection, new Tier 2 with `get_version` verification via `send_request`, renumber Tier 2/3 to Tier 3/4 |
| `autonomi/src/networking/mod.rs` | Same logic using `get_node_version` and `process_tasks_with_max_concurrency` for parallel verification, renumber tiers |

Generated with [Claude Code](https://claude.com/claude-code)
