### PR TITLE
chore(release): stable release 2026.2.1.1

### DIFF
--- a/.claude/commands/backwards-compat-test.md
+++ b/.claude/commands/backwards-compat-test.md
@@ -1,0 +1,170 @@
+I need to carry out a backwards compatibility test that involves working with testnets.
+
+There are several phases:
+
+* Create a `STG-05` testnet with the previously released version
+* Node-side smoke test for the `STG-05` testnet
+* Bootstrap a `STG-06` testnet from `STG-05` using an older version
+* Node-side smoke test for the `STG-06` testnet
+* Start uploads and downloads using the `ant` client from the previous release
+* Client-side smoke test for the `STG-06` testnet
+* Let uploads and downloads run using the `ant` client from the previous release
+* Upgrade the `ant` client to the RC version
+* Start clients again
+* Upgrade hosts on the `STG-06` bootstrap network
+* Upgrade hosts on the `STG-05` main network
+* Verify there have been no upload or download failures
+
+## Slack Updates
+
+Before we start the process, I want to inform you how to post any messages to Slack.
+
+You should use the `slack_post_message` operation from the currently configured MCP server to post
+messages to the #releases channel. All messages should be prefixed with `[timestamp]
+<release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from
+the `release-cycle-info` file. The timestamp should have both the date and time and be in the
+ISO-style format (though the timezone doesn't need to be included).
+
+## Phase 1: Create a `STG-05` testnet with the previously released version
+
+Post a message to Slack to indicate the backwards compatibility test is now beginning.
+
+Prompt me to supply the package version for the previous release.
+
+After you have that, use the `gh` tool to get the releases for this repository and find the release
+with title matching the package version I provided. From the description for that release you can
+obtain the version numbers for `ant`, `antnode` and `antctl`.
+
+Now deploy a `STG-05` testnet with the following details:
+
+* 5 generic node VMs with 20 nodes per VM
+* The `ant` version should be the version you obtained from me
+* The `antnode` version should be the version you obtained from me
+* The `antctl` version should be the version you obtained from me
+* A custom evm network with the following:
+  - rpc-url: https://sepolia-rollup.arbitrum.io/rpc
+  - payment-token-address: 0x4bc1aCE0E66170375462cB4E6Af42Ad4D5EC689C
+  - data-payments-address: 0xfE875D65021A7497a5DC7762c59719c8531f7146
+  - merkle-payments-address: 0x393F6825C248a29295A7f9Bfa03e475decb44dc0
+
+Post a message to Slack to indicate the first staging environment is now being deployed.
+
+Wait for the deployment to complete by polling every 2 minutes.
+
+Once complete, wait for my approval to advance to the next phase.
+
+Post a message to Slack indicating the environment was successfully deployed.
+
+## Phase 2: Node-side smoke test for the `STG-05` testnet
+
+Run the node smoke tests for `STG-05`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 3: Bootstrap a `STG-06` testnet from `STG-05` using an older version
+
+Bootstrap a `STG-06` network from the `STG-05` network using the following configuration:
+* 5 generic VMs with 10 nodes per VM
+* `antnode` version 0.4.9
+* `antctl` version 0.13.3
+* peer: <from STG-01>
+* network-id: 23
+* I need to use a custom evm network with the following:
+  - rpc-url: https://sepolia-rollup.arbitrum.io/rpc
+  - payment-token-address: 0x4bc1aCE0E66170375462cB4E6Af42Ad4D5EC689C
+  - data-payments-address: 0xfE875D65021A7497a5DC7762c59719c8531f7146
+  - merkle-payments-address: 0x393F6825C248a29295A7f9Bfa03e475decb44dc0
+
+You need to prompt me for the peer address from the `STG-05` network.
+
+Post a message to Slack to indicate the second staging environment is now being deployed.
+
+After you have dispatched the workflow, wait for it to complete by polling every 2 minutes.
+
+Then wait for me to give you the OK to proceed to the next phase.
+
+Post a message to Slack indicating the environment was successfully deployed.
+
+## Phase 4: Node-side smoke test for the `STG-06` testnet
+
+Run the node smoke tests for `STG-06`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 5: Run uploads and downloads using the `ant` client from the previous release
+
+Start the uploaders and downloaders for the `STG-05` environment.
+
+Post a message to Slack to say the workflows for starting clients have been dispatched.
+
+Now wait for my input before proceeding to the next phase.
+
+## Phase 6: Client-side smoke test for the `STG-05` testnet
+
+Run the client smoke tests for `STG-01`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 7: Let uploads and downloads run using the `ant` client from the previous release
+
+Wait for 10 minutes to allow some uploads and downloads to accumulate using the previous client
+version.
+
+Now stop both the uploaders and downloaders for `STG-05`.
+
+Post a message to Slack to say the workflows for stopping clients have been dispatched.
+
+Wait for my signal before proceeding to the next phase. I need to verify that both networks have
+received payments. For now this is done manually.
+
+## Phase 8: Upgrade the `ant` client to the RC version
+
+For now this is a step that will be done manually.
+
+So just wait here for my signal to advance to the next phase.
+
+Post a message to Slack to `ant` has been upgraded to the RC version.
+
+## Phase 9: Start clients again
+
+Start the uploaders and downloaders for the `STG-05` environment.
+
+Wait for my signal to proceed to the next phase.
+
+## Phase 10: Upgrade hosts on the `STG-06` bootstrap network
+
+I want to upgrade testnet `STG-06` with the following configuration:
+* The `antnode` version is the same RC version you obtained from me in phase 1
+* Use the `force` argument
+
+Post a message to Slack to say the upgrade to the RC version is beginning for `STG-06` hosts.
+
+Wait for 30 minutes then prompt for my approval to proceed to the next phase.
+
+Post a message to Slack to say the upgrade has completed for `STG-06` hosts.
+
+## Phase 11: Upgrade hosts on the `STG-05` bootstrap network
+
+I want to upgrade testnet `STG-05` with the following configuration:
+* The `antnode` version is the same RC version you obtained from me in phase 1
+* Use the `force` argument
+
+Post a message to Slack to say the upgrade to the RC version is beginning for `STG-05` hosts.
+
+Wait for 30 minutes then prompt for my approval to proceed to the next phase.
+
+Post a message to Slack to say the upgrade has completed for `STG-05` hosts.
+
+## Phase 12: Verify there have been no upload or download failures
+
+For now this is manual step.
+
+Wait for my input to inform you of the result.
+
+Post a message to slack to say the backwards compatibility test has completed successfully.

--- a/.claude/commands/setup-rc-testing-context.md
+++ b/.claude/commands/setup-rc-testing-context.md
@@ -1,0 +1,173 @@
+I need you to setup two testnets and two client deployments that will be used for testing a release
+candidate.
+
+There are several phases:
+
+* Deploy a `STG-01` testnet with the release candidate
+* Deploy a `STG-02` testnet with the stable release
+* Node-side smoke test for the `STG-01` testnet
+* Node-side smoke test for the `STG-02` testnet
+* Start the clients for both testnets
+* Client-side smoke test for the `STG-01` testnet
+* Client-side smoke test for the `STG-02` testnet
+* Create a release candidate project in Linear
+* Create a comparison in the Testnet Registry database
+* Create a Linear issue for the comparison in the release candidate project
+* Create a Slack post for the comparison
+* Deploy a `STG-03` client for testing production downloads
+* Deploy a `STG-04` client for testing production uploads
+
+## Slack Updates
+
+Before we start the process, I want to inform you how to post any messages to Slack.
+
+You should use the `slack_post_message` operation from the currently configured MCP server to post
+messages to the #releases channel. All messages should be prefixed with `[timestamp]
+<release-year>.<release-month>.<release-cycle>.<release-cycle-counter>: `, which you can obtain from
+the `release-cycle-info` file. The timestamp should have both the date and time and be in the
+ISO-style format (though the timezone doesn't need to be included).
+
+## Phase 1: Deploy a `STG-01` testnet with the release candidate
+
+Use the `gh` command to obtain the recent releases for this repository and find the most recent
+release candidate pre-release.
+
+Obtain the versions of the `ant`, `antnode` and `antctl` binaries from the description for that
+release. You should ensure they all have an `-rc.X` suffix, where `X` would be an integer. The
+release description has a `Binary Versions` section at the top.
+
+Prompt me to confirm the versions you obtained are correct.
+
+Now launch a `STG-01` testnet with the `rc` preset using the version numbers you obtained.
+
+Post a message to Slack to indicate the test staging environment is now being deployed.
+
+Wait for the deployment to complete by polling every 2 minutes for its status. If you find an error
+in the status query, inform me and wait till I direct you further before proceeding.
+
+Post a message to Slack indicating the environment was successfully deployed.
+
+## Phase 2: Deploy a `STG-02` testnet with the latest version
+
+The stable release can be obtained by getting the latest release from the `maidsafe/autonomi` Github
+repository. The release description has a `Binary Versions` section at the top.
+
+Prompt me to confirm the versions you obtained are correct.
+
+Now launch a `STG-02` testnet with the `rc` preset using the version numbers you obtained.
+
+Post a message to Slack to indicate the reference staging environment is now being deployed.
+
+Wait for the deployment to complete by polling every 2 minutes for its status. If you find an error
+in the status query, inform me and wait till I direct you further before proceeding.
+
+Post a message to Slack indicating the environment was successfully deployed.
+
+## Phase 3: Node-side smoke test for the `STG-01` testnet
+
+Run the node smoke tests for `STG-01`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 4: Node-side smoke test for the `STG-02` testnet
+
+Run the node smoke tests for `STG-02`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 5: Start the clients for both testnets
+
+Now we need to start the clients for both testnets.
+
+Start the uploaders and downloaders for both `STG-01` and `STG-02`.
+
+Post a message to Slack to say the workflows for starting clients have been dispatched.
+
+Now wait for my input before proceeding to the next phase.
+
+## Phase 6: Client-side smoke test for the `STG-01` testnet
+
+Run the client smoke tests for `STG-01`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 7: Client-side smoke test for the `STG-02` testnet
+
+Run the client smoke tests for `STG-02`.
+
+Whether they pass or fail, inform me of the results and wait for my input before proceeding.
+
+Post the results to Slack.
+
+## Phase 8: Create a release candidate project in Linear
+
+For now this is a step I need to perform manually.
+
+Wait for my input here before proceeding to the next phase.
+
+## Phase 9: Create a comparison in the Testnet Registry database
+
+Create a comparison between `STG-01` and `STG-02`, where the former is the test environment and the
+latter is the reference.
+
+The label to be used should be: `<RC package version> vs <stable release package version>`. The
+package version is the title of the respective Github releases for the RC and the latest stable
+release. It is in the form `YYYY.M.X.Y`, where each of those are integers.
+
+Prompt me to confirm the label you are going to use before you create the comparison.
+
+Take note of the ID of the comparison because it will be used in the next phase.
+
+## Phase 10: Create a Linear issue for the comparison in the release candidate project
+
+Post comparison `<id>` to Linear with the following details:
+  * `Releases` team
+  * The `Release Candidate <package version>` project
+  * The `Environment Comparison` test type
+  * Label: `<RC package version> RC [STG-01] vs <stable release package version> [STG-02]`
+
+The `<id>` is the ID of the comparison you created in the last phase.
+
+Prompt me to confirm exactly which value you are going to use.
+
+## Phase 11: Create a Slack post for the comparison
+
+Post the `<id>` comparison to Slack.
+
+Again, the ID comes from the comparison created in phase downloads.
+
+## Phase 12: Deploy a `STG-03` client for testing production downloads
+
+Launch a `STG-03` client deployment with the following details:
+* Use the `production-downloads` preset
+* The `ant` version should be the RC version obtained from phase 1
+
+Prompt me to confirm you are using the correct version.
+
+Post a message to Slack to indicate the `STG-03` environment is now being deployed.
+
+Wait for the deployment to complete by polling every 2 minutes for its status. If you find an error
+in the status query, inform me and wait till I direct you further before proceeding.
+
+Post a message to Slack indicating the environment was successfully deployed.
+
+## Phase 13: Deploy a `STG-04` client for testing production uploads
+
+Launch a `STG-04` client deployment with the following details:
+* Use the `production-uploads` preset
+* The `ant` version should be the RC version obtained from phase 1
+
+Prompt me to confirm you are using the correct version.
+
+Post a message to Slack to indicate the `STG-04` environment is now being deployed.
+
+Wait for the deployment to complete by polling every 2 minutes for its status. If you find an error
+in the status query, inform me and wait till I direct you further before proceeding.
+
+Post a message to Slack indicating the environment was successfully deployed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2026-02-04
+
+### Network
+
+#### Added
+
+- Version-based peer rejection system that enforces minimum node version requirements during the
+  identify protocol exchange. Nodes running versions below the minimum are disconnected.
+- New metrics for version gating: `version_check_result` (tracking accepted, rejected, legacy, and
+  parse error outcomes) and `peer_type` (tracking node, client, and unknown peer types).
+
+#### Changed
+
+- Trust-based replication scoring has been re-enabled, allowing nodes to factor peer trust scores
+  into replication decisions.
+- The minimum required node version has been set to `0.4.14`.
+
+### Payments
+
+#### Changed
+
+- Merkle payment calldata has been compacted by packing data type and total cost unit into a single
+  `U256` value. This reduces on-chain transaction size and gas costs for merkle batch payments.
+
+### API
+
+#### Added
+
+- `MerkleBatchPaymentComplete` client event, emitted after each merkle tree batch payment completes.
+  This enables progressive saving of receipts to disk for upload resume support.
+- `RegularBatchPaymentComplete` client event, emitted after each regular batch payment completes,
+  providing the same progressive saving capability for non-merkle uploads.
+- `MerklePaymentReceipt::add_already_existed` method to record chunks that were found to already
+  exist on the network, avoiding redundant network queries on upload resume.
+- `already_existed` field on `MerklePaymentReceipt` to persist the set of chunks known to exist on
+  the network across upload resume attempts.
+
+#### Changed
+
+- Merkle upload resume now skips network existence checks for chunks that are already known to exist
+  or have been previously paid for, reducing unnecessary network queries.
+- Stream batch size and upload concurrency are now configured independently in merkle uploads. Stream
+  batch size uses `UPLOAD_FLOW_BATCH_SIZE` while upload concurrency uses `CHUNK_UPLOAD_BATCH_SIZE`.
+
+#### Fixed
+
+- Chunks that already existed on the network are no longer re-quoted during upload resume,
+  preventing unnecessary payment attempts.
+
+### Ant Client
+
+#### Added
+
+- The `file upload` command now displays the network address for private uploads alongside the
+  private address.
+
+#### Changed
+
+- Payment receipts are now progressively saved to disk during uploads for both merkle and regular
+  payment modes. This improves upload resume reliability by preserving payment state as batches
+  complete rather than only on failure.
+- Cached payment receipt files are now cleaned up before saving a new receipt, preventing stale
+  files with different timestamp prefixes from accumulating.
+
 ## 2026-01-28
 
 ### API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.5.1-rc.1"
+version = "0.5.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.21-rc.1"
+version = "0.1.21"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.15-rc.1"
+version = "0.4.15"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.13-rc.1"
+version = "1.0.13"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.10.1-rc.1"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.9-rc.1"
+version = "0.4.9"
 dependencies = [
  "alloy",
  "dirs-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.5.0"
+version = "0.5.1-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ant-evm"
-version = "0.1.20"
+version = "0.1.21-rc.1"
 dependencies = [
  "ant-merkle",
  "custom_debug",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.14"
+version = "0.4.15-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.12"
+version = "1.0.13-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.10.0"
+version = "0.10.1-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.4.8"
+version = "0.4.9-rc.1"
 dependencies = [
  "alloy",
  "dirs-next",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2026";
-pub const RELEASE_MONTH: &str = "1";
+pub const RELEASE_MONTH: &str = "2";
 pub const RELEASE_CYCLE: &str = "1";
 pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.5.1-rc.1"
+version = "0.5.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
-autonomi = { path = "../autonomi", version = "0.10.1-rc.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+autonomi = { path = "../autonomi", version = "0.10.1", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.5.0"
+version = "0.5.1-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
-autonomi = { path = "../autonomi", version = "0.10.0", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.1-rc.1", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.10.0" }
+autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.21-rc.1"
+version = "0.1.21"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.9", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-evm/Cargo.toml
+++ b/ant-evm/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-evm"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.1.20"
+version = "0.1.21-rc.1"
 
 [features]
 external-signer = ["evmlib/external-signer"]
@@ -16,7 +16,7 @@ test-utils = []
 [dependencies]
 ant-merkle = "1.5.1"
 custom_debug = "~0.6.1"
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 hex = "~0.4.3"
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = { version = "~0.8.5", features = ["small_rng"] }
@@ -31,7 +31,7 @@ tracing = { version = "~0.1.26" }
 xor_name = "5.0.0"
 
 [dev-dependencies]
-evmlib = { path = "../evmlib", version = "0.4.8", features = ["test-utils"] }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1", features = ["test-utils"] }
 tokio = { version = "1.43.1", features = ["macros", "rt"] }
 
 [lints]

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -32,12 +32,12 @@ websockets = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -32,12 +32,12 @@ websockets = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 colored = "2.0.4"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.15-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.15" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.14" }
+ant-node = { path = "../ant-node", version = "0.4.15-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.15-rc.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.15" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.14"
+version = "0.4.15-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,9 +26,9 @@ otlp = ["ant-logging/otlp"]
 aes-gcm-siv = "0.11.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.12", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8" }
-autonomi = { path = "../autonomi", version = "0.10.0" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.15-rc.1"
+version = "0.4.15"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -26,9 +26,9 @@ otlp = ["ant-logging/otlp"]
 aes-gcm-siv = "0.11.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13", features = ["rpc"] }
 assert_fs = "1.0.0"
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
-autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
+autonomi = { path = "../autonomi", version = "0.10.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.12"
+version = "1.0.13-rc.1"
 
 [features]
 default = []
@@ -16,7 +16,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.13-rc.1"
+version = "1.0.13"
 
 [features]
 default = []
@@ -16,7 +16,7 @@ rpc = ["tonic", "prost"]
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-merkle = "1.5.1"
 blake2 = "0.10"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.5.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.5.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.10.0" }
+autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
 bytes = { version = "1.11.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.10.1-rc.1"
+version = "0.10.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -28,8 +28,8 @@ loud = []
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -38,7 +38,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -79,7 +79,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.10.0"
+version = "0.10.1-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -28,8 +28,8 @@ loud = []
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"
@@ -38,7 +38,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 const-hex = "1.12.0"
 custom_debug = "~0.6.1"
 dirs-next = "2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 exponential-backoff = "2.0.0"
 eyre = "0.6.5"
 futures = "0.3.30"
@@ -79,7 +79,7 @@ xor_name = "5.0.0"
 [dev-dependencies]
 alloy = { version = "1.0.32", default-features = false, features = ["contract", "json-rpc", "network", "node-bindings", "provider-http", "reqwest-rustls-tls", "rpc-client", "rpc-types", "signer-local", "std"] }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 eyre = "0.6.5"
 serial_test = "3.2.0"
 tempfile = "3.12.0"

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/maidsafe/autonomi"
 version = "0.1.18"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evm-testnet/Cargo.toml
+++ b/evm-testnet/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/maidsafe/autonomi"
 version = "0.1.18"
 
 [dependencies]
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 clap = { version = "4.5", features = ["derive"] }
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 tokio = { version = "1.43", features = ["rt-multi-thread", "signal"] }
 
 [lints]

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.8"
+version = "0.4.9-rc.1"
 
 [features]
 external-signer = []

--- a/evmlib/Cargo.toml
+++ b/evmlib/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "evmlib"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.4.9-rc.1"
+version = "0.4.9"
 
 [features]
 external-signer = []

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -20,10 +20,10 @@ nightly = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.20" }
+ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.12" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -20,10 +20,10 @@ nightly = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-evm = { path = "../ant-evm", version = "0.1.21-rc.1" }
+ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -13,6 +13,6 @@
 # Both of these numbers are used in the packaged version number, which is a collective version
 # number for all the released binaries.
 release-year: 2026
-release-month: 1
+release-month: 2
 release-cycle: 1
 release-cycle-counter: 1

--- a/resources/scripts/remove-s3-antnode-rc-binaries.sh
+++ b/resources/scripts/remove-s3-antnode-rc-binaries.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# This script removes RC versions of the `antnode` binary from S3.
+# It is used to clean up after a release candidate test.
+#
+# Usage: ./remove-s3-antnode-rc-binaries.sh <version>
+# Example: ./remove-s3-antnode-rc-binaries.sh 0.3.1-rc.1
+#
+# Safety: The script will only remove RC versions (containing '-rc').
+
+set -e
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.3.1-rc.1"
+  exit 1
+fi
+
+version="$1"
+
+# Safety check: only allow RC versions
+if [[ ! "$version" =~ -rc\. ]]; then
+  echo "Error: This script only removes RC versions for safety."
+  echo "The version must contain '-rc.' (e.g., 0.3.1-rc.1)"
+  exit 1
+fi
+
+architectures=(
+  "aarch64-apple-darwin"
+  "aarch64-unknown-linux-musl"
+  "arm-unknown-linux-musleabi"
+  "armv7-unknown-linux-musleabihf"
+  "x86_64-apple-darwin"
+  "x86_64-pc-windows-msvc"
+  "x86_64-unknown-linux-musl"
+)
+
+bucket_name="antnode"
+
+echo "Removing antnode binary version $version from S3..."
+
+for arch in "${architectures[@]}"; do
+  zip_filename="antnode-${version}-${arch}.zip"
+  tar_filename="antnode-${version}-${arch}.tar.gz"
+
+  dest="s3://${bucket_name}/${zip_filename}"
+  if aws s3 ls "$dest" > /dev/null 2>&1; then
+    aws s3 rm "$dest"
+    echo "Removed $dest"
+  else
+    echo "$dest did not exist"
+  fi
+
+  dest="s3://${bucket_name}/${tar_filename}"
+  if aws s3 ls "$dest" > /dev/null 2>&1; then
+    aws s3 rm "$dest"
+    echo "Removed $dest"
+  else
+    echo "$dest did not exist"
+  fi
+done
+
+echo "Done."

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.11.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
+evmlib = { path = "../evmlib", version = "0.4.9" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.21"
 bytes = { version = "1.11.1", features = ["serde"] }
 color-eyre = "0.6.3"
 dirs-next = "~2.0.0"
-evmlib = { path = "../evmlib", version = "0.4.8" }
+evmlib = { path = "../evmlib", version = "0.4.9-rc.1" }
 libp2p = { version = "0.56.0", features = ["identify", "kad"] }
 rand = "0.8.5"
 serde = { version = "1.0.133", features = ["derive"] }


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.5.1
ant-evm: 0.1.21
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.15
ant-node-manager: 0.14.1
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.13
ant-service-management: 0.5.1
ant-token-supplies: 0.1.67
autonomi: 0.10.1
evmlib: 0.4.9
evm-testnet: 0.1.18
nat-detection: 0.2.22
node-launchpad: 0.6.2
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.5.1
antctl: 0.14.1
antctld: 0.14.1
antnode: 0.4.15
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.2
```