### PR TITLE
client(feature): merkle upload progress every 10th chunk (loud_info)

### DIFF
--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -157,6 +157,12 @@ impl Client {
                             Ok(addr) => {
                                 dont_reupload.insert(*addr.xorname());
                                 chunks_uploaded += 1;
+                                // Extra progressing trace at every 10th chunk
+                                if chunks_uploaded == 1 || chunks_uploaded % 10 == 0 {
+                                    crate::loud_info!(
+                                        "Uploaded {chunks_uploaded}/{limit} chunks..."
+                                    );
+                                }
                                 crate::loud_debug!(
                                     "({chunks_uploaded}/{limit}) Chunk stored at: {addr:?}"
                                 );


### PR DESCRIPTION
Adds progress visibility during merkle uploads:
 **loud_info** at the 1st and every 10th chunk (e.g. 1, 10, 20, ??, with **loud_debug** for the rest. 

Merkle upload Batch size can be up to ~85, so per-10th progress avoids long waits before any message.

Co-authored-by: Cursor Auto <noreply@cursor.com>