### PR TITLE
chore: apply rustfmt formatting fixes

### DIFF
--- a/ant-cli/src/utils.rs
+++ b/ant-cli/src/utils.rs
@@ -139,7 +139,10 @@ pub fn collect_upload_summary(
                     // Accumulate and progressively save receipt to disk for upload resume
                     if let Some(ref file) = file_name {
                         accumulated_regular_receipt.extend(batch_receipt);
-                        if let Err(e) = cached_payments::save_regular_payment(file, &accumulated_regular_receipt) {
+                        if let Err(e) = cached_payments::save_regular_payment(
+                            file,
+                            &accumulated_regular_receipt,
+                        ) {
                             eprintln!("Warning: Failed to save regular payment receipt: {e}");
                         }
                     }

--- a/ant-node/src/networking/driver/event/identify.rs
+++ b/ant-node/src/networking/driver/event/identify.rs
@@ -12,7 +12,9 @@ use crate::networking::{
     relay_manager::{RelayManager, is_a_relayed_peer},
 };
 use ant_protocol::version::IDENTIFY_PROTOCOL_STR;
-use ant_protocol::version_gate::{PeerType, VersionCheckResult, check_peer_version, get_min_node_version};
+use ant_protocol::version_gate::{
+    PeerType, VersionCheckResult, check_peer_version, get_min_node_version,
+};
 use itertools::Itertools;
 use libp2p::Multiaddr;
 use libp2p::identify::Info;

--- a/ant-node/src/networking/network/mod.rs
+++ b/ant-node/src/networking/network/mod.rs
@@ -492,10 +492,7 @@ impl Network {
                         trace!("  Reported peer: {peer_id:?}, distance: {distance:?}");
 
                         *peer_counts.entry(peer_id).or_insert(0) += 1;
-                        peer_addrs
-                            .entry(peer_id)
-                            .or_default()
-                            .extend(addrs);
+                        peer_addrs.entry(peer_id).or_default().extend(addrs);
                     }
                 }
             } else {
@@ -614,9 +611,8 @@ impl Network {
                     .map(|(peer_id, addrs)| {
                         let network = self.clone();
                         async move {
-                            let req = Request::Query(Query::GetVersion(NetworkAddress::from(
-                                peer_id,
-                            )));
+                            let req =
+                                Request::Query(Query::GetVersion(NetworkAddress::from(peer_id)));
                             let result = network.send_request(req, peer_id, addrs.clone()).await;
                             match result {
                                 Ok((

--- a/ant-node/src/networking/replication_fetcher.rs
+++ b/ant-node/src/networking/replication_fetcher.rs
@@ -449,18 +449,15 @@ impl ReplicationFetcher {
                     .collect();
 
                 // Also accumulate for majority - this maintains parallel operation of both approaches
-                let majority_results =
-                    self.initial_majority_replicates(holder, new_incoming_keys);
+                let majority_results = self.initial_majority_replicates(holder, new_incoming_keys);
 
                 // Dedup on (addr, val_type) only, ignoring PeerId.
                 // This prevents queuing the same key for fetch from multiple peers,
                 // which would waste the limited fetch slots.
                 for (peer, addr, val_type) in majority_results {
-                    let already_present = result
-                        .iter()
-                        .any(|(_, existing_addr, existing_type)| {
-                            existing_addr == &addr && existing_type == &val_type
-                        });
+                    let already_present = result.iter().any(|(_, existing_addr, existing_type)| {
+                        existing_addr == &addr && existing_type == &val_type
+                    });
                     if !already_present {
                         result.push((peer, addr, val_type));
                     }
@@ -474,9 +471,7 @@ impl ReplicationFetcher {
                 vec![]
             }
             None => {
-                debug!(
-                    "No scoring history for {holder:?}, using majority scheme for validation."
-                );
+                debug!("No scoring history for {holder:?}, using majority scheme for validation.");
                 // Unknown peer: use majority approach only
                 // Keys will be accepted once enough different peers report the same keys
                 self.initial_majority_replicates(holder, new_incoming_keys)

--- a/ant-node/src/node.rs
+++ b/ant-node/src/node.rs
@@ -2195,7 +2195,7 @@ fn duration_score_scheme(duration: Duration) -> usize {
         value
     } else {
         info!("Cannot get milli seconds from {duration:?}, using a default value of 1000ms.");
-        HIGHEST_SCORE * TIME_STEP 
+        HIGHEST_SCORE * TIME_STEP
     };
 
     let step = std::cmp::min(HIGHEST_SCORE, in_ms / TIME_STEP);

--- a/autonomi/src/client/high_level/data/helpers.rs
+++ b/autonomi/src/client/high_level/data/helpers.rs
@@ -9,10 +9,10 @@
 use crate::Client;
 use crate::chunk::DataMapChunk;
 use crate::client::config::{UPLOAD_FLOW_BATCH_SIZE, upload_retry_pause};
+use crate::client::merkle_payments::MerklePaymentReceipt;
 use crate::client::payment::PayError::EvmWalletError;
 use crate::client::payment::PaymentOption;
 use crate::client::payment::Receipt;
-use crate::client::merkle_payments::MerklePaymentReceipt;
 use crate::client::{ClientEvent, PutError, UploadSummary};
 use crate::self_encryption::EncryptionStream;
 use crate::utils::format_upload_error;

--- a/autonomi/src/client/merkle_payments/file.rs
+++ b/autonomi/src/client/merkle_payments/file.rs
@@ -439,9 +439,7 @@ impl Client {
 
         // Only check network for unknown chunks
         if need_check.is_empty() {
-            crate::loud_info!(
-                "All {total} chunks accounted for (no network check needed)"
-            );
+            crate::loud_info!("All {total} chunks accounted for (no network check needed)");
             // Return known_existing and chunks that need upload (already_paid)
             // Note: already_paid chunks still need to be uploaded, so they go in the "new" list
             let new_chunks: Vec<XorName> = unique_ordered

--- a/autonomi/src/client/merkle_payments/upload.rs
+++ b/autonomi/src/client/merkle_payments/upload.rs
@@ -146,7 +146,8 @@ impl Client {
                     }
 
                     let task_count = tasks.len();
-                    let results = process_tasks_with_max_concurrency(tasks, upload_concurrency).await;
+                    let results =
+                        process_tasks_with_max_concurrency(tasks, upload_concurrency).await;
 
                     // Count all attempted chunks (success or failure)
                     chunks_attempted += task_count;

--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -725,8 +725,7 @@ impl Network {
                     })
                     .collect();
                 let version_results =
-                    crate::utils::process_tasks_with_max_concurrency(version_tasks, n.get())
-                        .await;
+                    crate::utils::process_tasks_with_max_concurrency(version_tasks, n.get()).await;
 
                 let mut tier2_verified: Vec<PeerInfo> = version_results
                     .into_iter()

--- a/node-launchpad/build.rs
+++ b/node-launchpad/build.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // build dependency when the host is Windows.
     #[cfg(windows)]
     {
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-            .expect("CARGO_MANIFEST_DIR should be set by cargo");
+        let manifest_dir =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set by cargo");
         let icon_path = std::path::Path::new(&manifest_dir)
             .join("../resources/icons/windows/node-launchpad/node-launchpad.ico");
 

--- a/node-launchpad/src/components/status.rs
+++ b/node-launchpad/src/components/status.rs
@@ -394,14 +394,11 @@ impl Status<'_> {
             .items
             .as_ref()
             .map(|items| {
-                items
-                    .items
-                    .iter()
-                    .any(|i| {
-                        i.status == NodeStatus::Starting
-                            || i.status == NodeStatus::Stopping
-                            || i.status == NodeStatus::Updating
-                    })
+                items.items.iter().any(|i| {
+                    i.status == NodeStatus::Starting
+                        || i.status == NodeStatus::Stopping
+                        || i.status == NodeStatus::Updating
+                })
             })
             .unwrap_or(false);
         let interval = if has_transitioning_nodes {
@@ -409,8 +406,7 @@ impl Status<'_> {
         } else {
             NODE_REGISTRY_UPDATE_INTERVAL
         };
-        if self.node_registry_last_update.elapsed() > interval || force_update
-        {
+        if self.node_registry_last_update.elapsed() > interval || force_update {
             self.node_registry_last_update = Instant::now();
             let action_sender = self.get_actions_sender()?;
 
@@ -870,9 +866,7 @@ impl Component for Status<'_> {
                     let all_moved_past_starting = services.iter().all(|service_name| {
                         self.items
                             .as_ref()
-                            .and_then(|items| {
-                                items.items.iter().find(|i| i.name == *service_name)
-                            })
+                            .and_then(|items| items.items.iter().find(|i| i.name == *service_name))
                             .map(|item| item.status != NodeStatus::Starting)
                             .unwrap_or(false)
                     });


### PR DESCRIPTION
## Summary
- Apply `rustfmt` formatting fixes across 11 files in `ant-cli`, `ant-node`, `autonomi`, and `node-launchpad` crates
- No functional changes; formatting only (line wrapping, import ordering, closure formatting)

## Test plan
- [ ] CI passes `cargo fmt --all -- --check`
- [ ] CI passes `cargo clippy --all-targets --all-features -- -Dwarnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)