### PR TITLE
fix: propagate fatal errors from put_record to retry loop

### DIFF
--- a/autonomi/src/networking/mod.rs
+++ b/autonomi/src/networking/mod.rs
@@ -404,6 +404,7 @@ impl Network {
                         return Ok(());
                     }
                 }
+                Err(e) if e.cannot_retry() => return Err(e),
                 Err(e) => err_res.push((peer.peer_id, e.to_string())),
             }
         }


### PR DESCRIPTION
(To be verified! WIP)

`put_record` converts per-peer errors to strings via `PutRecordTooManyPeerFailed`, which is retryable. This means `OutdatedRecordRejected` — a fatal error that `cannot_retry()` is designed to catch — goes through the full backoff cycle instead of short-circuiting.

One-line fix: early-return `cannot_retry()` errors from `put_record` so `put_record_with_retries` sees them directly and stops immediately.

For immutable scratchpad overwrites this brings rejection time from ~30s (`Balanced` backoff) down to under 2s.