### PR TITLE
chore: bump MIN_NODE_VERSION to 0.4.15

### DIFF
--- a/ant-protocol/src/version_gate.rs
+++ b/ant-protocol/src/version_gate.rs
@@ -35,7 +35,7 @@ use std::fmt;
 /// This can be overridden via the `ANT_MIN_NODE_VERSION` environment variable.
 ///
 /// Format: (major, minor, patch)
-pub const MIN_NODE_VERSION: (u16, u16, u16) = (0, 4, 14);
+pub const MIN_NODE_VERSION: (u16, u16, u16) = (0, 4, 15);
 
 /// Get the minimum node version, checking environment variable override first.
 ///
@@ -403,7 +403,7 @@ mod tests {
         let (major, minor, patch) = MIN_NODE_VERSION;
         assert_eq!(major, 0);
         assert_eq!(minor, 4);
-        assert_eq!(patch, 14);
+        assert_eq!(patch, 15);
     }
 
     // ============ Release Candidate (RC) Version Tests ============


### PR DESCRIPTION
## Summary

Older nodes (0.4.14 and below) are contributing to upload errors when using Merkle payments. Bumping
the minimum version rejects these problematic nodes from connecting to the network.

- Update `MIN_NODE_VERSION` from `(0, 4, 14)` to `(0, 4, 15)` in `ant-protocol/src/version_gate.rs`
- Update corresponding test assertion

## Test plan

- [x] `cargo test --release --package ant-protocol` — all 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)