### PR TITLE
fix(node): reset connection prune deadline on incoming requests

### DIFF
--- a/ant-node/src/networking/driver/event/mod.rs
+++ b/ant-node/src/networking/driver/event/mod.rs
@@ -15,6 +15,12 @@ use crate::networking::NetworkEvent;
 use crate::networking::{
     Addresses, driver::SwarmDriver, error::Result, relay_manager::is_a_relayed_peer,
 };
+
+/// Time after which a connection to a peer not in our routing table (e.g. a client) may be pruned.
+/// Must be at least as long as the request-response timeout (120s) so that put_record and other
+/// long-running requests are not cut off by the node closing the connection (ApplicationClosed).
+/// This deadline is reset each time a new request is received on the connection.
+const CONNECTION_PRUNE_AFTER_SECS: u64 = 120;
 use ant_protocol::messages::ConnectionInfo;
 use custom_debug::Debug as CustomDebug;
 use libp2p::kad::K_VALUE;

--- a/ant-node/src/networking/driver/event/swarm.rs
+++ b/ant-node/src/networking/driver/event/swarm.rs
@@ -8,26 +8,26 @@
 
 use super::SwarmDriver;
 use crate::networking::{
-    NetworkEvent, NodeIssue, Result,
     error::{dial_error_to_str, listen_error_to_str},
     interface::TerminateNodeReason,
+    NetworkEvent, NodeIssue, Result,
 };
 use itertools::Itertools;
 #[cfg(feature = "open-metrics")]
 use libp2p::metrics::Recorder;
 use libp2p::{
-    Multiaddr, TransportError,
     core::ConnectedPoint,
     multiaddr::Protocol,
     swarm::{
-        ConnectionId, DialError, SwarmEvent,
         dial_opts::{DialOpts, PeerCondition},
+        ConnectionId, DialError, SwarmEvent,
     },
+    Multiaddr, TransportError,
 };
 use std::time::Instant;
 use tokio::time::Duration;
 
-use super::NodeEvent;
+use super::{CONNECTION_PRUNE_AFTER_SECS, NodeEvent};
 
 impl SwarmDriver {
     /// Handle `SwarmEvents`
@@ -273,7 +273,7 @@ impl SwarmDriver {
                     (
                         peer_id,
                         endpoint.get_remote_address().clone(),
-                        Instant::now() + Duration::from_secs(60),
+                        Instant::now() + Duration::from_secs(CONNECTION_PRUNE_AFTER_SECS),
                     ),
                 );
 


### PR DESCRIPTION
## Summary
- Fix ConnectionLost(ApplicationClosed) errors during PutRecordReq by resetting the node connection prune deadline each time a new request is received
- The node remove_outdated_connections() was setting the prune deadline once at connection establishment and never resetting it when new requests arrived on the same connection, causing active connections to be killed mid-request
- Moved CONNECTION_PRUNE_AFTER_SECS constant to a shared module so both swarm.rs and request_response.rs can reference it

## Context
When a client reuses an existing connection for a new PutRecordReq, the original prune timer (set at connection establishment) may fire while the node is still processing the request. This causes the node to call swarm.close_connection() which sends a QUIC APPLICATION_CLOSE frame, killing all in-flight requests on that connection.

Linear: AUTO-876

## Test plan
- [x] Deploy testnet with simulated slow node response (80s sleep in validate_and_store_chunk)
- [x] Verify that PutRecordReq sent over reused connections no longer fail with ConnectionLost(ApplicationClosed)
- [x] Verify that idle connections (no requests for 120s) are still pruned correctly