### PR TITLE
chore(release): stable release 2026.2.2.1

### DIFF
--- a/.claude/commands/backwards-compat-test.md
+++ b/.claude/commands/backwards-compat-test.md
@@ -67,9 +67,9 @@ Post the results to Slack.
 
 Bootstrap a `STG-06` network from the `STG-05` network using the following configuration:
 * 5 generic VMs with 10 nodes per VM
-* `antnode` version 0.4.9
-* `antctl` version 0.13.3
-* peer: <from STG-01>
+* `antnode` <prompt for version>
+* `antctl` <prompt for version>
+* peer: <from STG-05>
 * network-id: 23
 * I need to use a custom evm network with the following:
   - rpc-url: https://sepolia-rollup.arbitrum.io/rpc
@@ -77,7 +77,7 @@ Bootstrap a `STG-06` network from the `STG-05` network using the following confi
   - data-payments-address: 0xfE875D65021A7497a5DC7762c59719c8531f7146
   - merkle-payments-address: 0x393F6825C248a29295A7f9Bfa03e475decb44dc0
 
-You need to prompt me for the peer address from the `STG-05` network.
+You need to prompt me for the peer address from the `STG-05` network and the previous versions of `antnode` and `antctl`.
 
 Post a message to Slack to indicate the second staging environment is now being deployed.
 
@@ -145,7 +145,7 @@ I want to upgrade testnet `STG-06` with the following configuration:
 
 Post a message to Slack to say the upgrade to the RC version is beginning for `STG-06` hosts.
 
-Wait for 30 minutes then prompt for my approval to proceed to the next phase.
+Wait for 15 minutes then prompt for my approval to proceed to the next phase.
 
 Post a message to Slack to say the upgrade has completed for `STG-06` hosts.
 
@@ -157,7 +157,7 @@ I want to upgrade testnet `STG-05` with the following configuration:
 
 Post a message to Slack to say the upgrade to the RC version is beginning for `STG-05` hosts.
 
-Wait for 30 minutes then prompt for my approval to proceed to the next phase.
+Wait for 15 minutes then prompt for my approval to proceed to the next phase.
 
 Post a message to Slack to say the upgrade has completed for `STG-05` hosts.
 

--- a/.claude/commands/produce-release-candidate.md
+++ b/.claude/commands/produce-release-candidate.md
@@ -14,6 +14,7 @@ There are 9 phases:
 * Analyzing changes and determining crate bumps
 * Bumping Rust crates
 * Bumping NodeJS packages
+* Creating the release candidate project on Linear
 * Generating the changelog
 * Creating the release candidate commit
 * Pushing the release candidate branch
@@ -143,7 +144,26 @@ This should run from the corresponding crate directory.
 Present me with the commands you intend to run and wait for my confirmation before executing. If no
 bumps are required, let me know that too. In any case, wait for input from me before continuing.
 
-## Phase 6: Generating the Changelog
+## Phase 6: Creating the release candidate project
+
+Create a release candidate using the package version number you obtained from me in phase 1.
+
+It needs to have a list of PR numbers, which is the list you obtained in phase 2.
+
+It also needs to have the versions of these binaries:
+* antnode
+* antctl
+* antctld
+* ant
+* evm-testnet
+* nat-detection
+* node-launchpad
+
+You should read the values from the crates, since it needs to be the versions they were bumped to.
+
+Wait for me to verify the release candidate project has been successfully created until proceeding to the next phase
+
+## Phase 7: Generating the Changelog
 
 Use the `/new-changelog-entry` skill to generate an initial changelog entry for this release
 candidate. The entry should cover all changes since the last stable release. The last stable release
@@ -156,7 +176,7 @@ Present me with the generated changelog entry for review. I will likely want to 
 and improvements to the wording. Wait for my approval before proceeding. Once approved, post the
 changelog to Slack.
 
-## Phase 7: Creating the Release Candidate Commit
+## Phase 8: Creating the Release Candidate Commit
 
 Stage all the current changes then commit them. For the title of the commit, use:
 `chore(release): release candidate <release-year>.<release-month>.<release-cycle>.<release-cycle-counter>`
@@ -167,7 +187,7 @@ and use its output.
 Show me the commit message you intend to use and wait for my confirmation before creating the
 commit.
 
-## Phase 8: Pushing the Release Candidate Branch
+## Phase 9: Pushing the Release Candidate Branch
 
 Push the release candidate branch to the `origin` repository.
 
@@ -176,7 +196,7 @@ let me inspect what is going on.
 
 Post a message to Slack indicating the release candidate branch has been pushed.
 
-## Phase 9: Running the Release Workflow
+## Phase 10: Running the Release Workflow
 
 Now I want you to run the `release` workflow on this repository. The workflow has inputs for which
 binaries to release (they are all `false` by default).

--- a/.claude/commands/setup-rc-testing-context.md
+++ b/.claude/commands/setup-rc-testing-context.md
@@ -10,7 +10,6 @@ There are several phases:
 * Start the clients for both testnets
 * Client-side smoke test for the `STG-01` testnet
 * Client-side smoke test for the `STG-02` testnet
-* Create a release candidate project in Linear
 * Create a comparison in the Testnet Registry database
 * Create a Linear issue for the comparison in the release candidate project
 * Create a Slack post for the comparison
@@ -105,13 +104,7 @@ Whether they pass or fail, inform me of the results and wait for my input before
 
 Post the results to Slack.
 
-## Phase 8: Create a release candidate project in Linear
-
-For now this is a step I need to perform manually.
-
-Wait for my input here before proceeding to the next phase.
-
-## Phase 9: Create a comparison in the Testnet Registry database
+## Phase 8: Create a comparison in the Testnet Registry database
 
 Create a comparison between `STG-01` and `STG-02`, where the former is the test environment and the
 latter is the reference.
@@ -124,7 +117,7 @@ Prompt me to confirm the label you are going to use before you create the compar
 
 Take note of the ID of the comparison because it will be used in the next phase.
 
-## Phase 10: Create a Linear issue for the comparison in the release candidate project
+## Phase 9: Create a Linear issue for the comparison in the release candidate project
 
 Post comparison `<id>` to Linear with the following details:
   * `Releases` team
@@ -136,13 +129,13 @@ The `<id>` is the ID of the comparison you created in the last phase.
 
 Prompt me to confirm exactly which value you are going to use.
 
-## Phase 11: Create a Slack post for the comparison
+## Phase 10: Create a Slack post for the comparison
 
 Post the `<id>` comparison to Slack.
 
 Again, the ID comes from the comparison created in phase downloads.
 
-## Phase 12: Deploy a `STG-03` client for testing production downloads
+## Phase 11: Deploy a `STG-03` client for testing production downloads
 
 Launch a `STG-03` client deployment with the following details:
 * Use the `production-downloads` preset
@@ -157,7 +150,7 @@ in the status query, inform me and wait till I direct you further before proceed
 
 Post a message to Slack indicating the environment was successfully deployed.
 
-## Phase 13: Deploy a `STG-04` client for testing production uploads
+## Phase 12: Deploy a `STG-04` client for testing production uploads
 
 Launch a `STG-04` client deployment with the following details:
 * Use the `production-uploads` preset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2026-02-11
+
+### Network
+
+#### Changed
+
+- The minimum required node version has been updated to `0.4.15`.
+- Peer candidate selection now includes an additional verification tier that checks popular
+  close-range peers via `get_version` queries before selecting them. This improves peer selection
+  quality by confirming peer responsiveness.
+
+### API
+
+#### Added
+
+- `MerklePaymentReceipt::add_uploaded` method to record chunks that were successfully uploaded,
+  enabling more efficient upload resume by skipping re-upload of known chunks.
+- `uploaded` field on `MerklePaymentReceipt` to persist the set of successfully uploaded chunks
+  across upload resume attempts.
+
+#### Changed
+
+- Merkle payment candidate selection now falls back to KAD-only peer discovery when initial
+  Kademlia queries do not return enough candidates, improving upload reliability during network
+  churn.
+- Merkle upload resume now skips network existence checks for chunks that were successfully uploaded
+  in previous batches, in addition to chunks that already existed on the network.
+- Merkle uploads now display progress at info level every 10 chunks, providing better visibility
+  into upload status.
+
+#### Fixed
+
+- The `--retry-failed` flag is now honoured for merkle uploads. Previously, the flag only affected
+  regular uploads and merkle uploads would always use the default retry count.
+
+### Launchpad
+
+#### Fixed
+
+- Node status transitions are now reflected in the UI in real-time. The status panel polls more
+  frequently during transitional states (starting, stopping) and updates the display as soon as the
+  node registry confirms the new state.
+- Stale error messages from node start operations are no longer shown when the underlying services
+  have already transitioned successfully.
+
 ## 2026-02-04
 
 ### Network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `uploaded` field on `MerklePaymentReceipt` to persist the set of successfully uploaded chunks
   across upload resume attempts.
 
+### Ant Client
+
 #### Changed
 
 - Merkle payment candidate selection now falls back to KAD-only peer discovery when initial

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.5.1"
+version = "0.5.2-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.15"
+version = "0.4.16-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.13"
+version = "1.0.14-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.10.1"
+version = "0.10.2-rc.1"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.2"
+version = "0.6.3-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ant-cli"
-version = "0.5.2-rc.1"
+version = "0.5.2"
 dependencies = [
  "ant-build-info",
  "ant-logging",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.16-rc.1"
+version = "0.4.16"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.14-rc.1"
+version = "1.0.14"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1684,7 +1684,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autonomi"
-version = "0.10.2-rc.1"
+version = "0.10.2"
 dependencies = [
  "alloy",
  "ant-bootstrap",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.3-rc.1"
+version = "0.6.3"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2026";
 pub const RELEASE_MONTH: &str = "2";
-pub const RELEASE_CYCLE: &str = "1";
+pub const RELEASE_CYCLE: &str = "2";
 pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.5.1"
+version = "0.5.2-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
-autonomi = { path = "../autonomi", version = "0.10.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.2-rc.1", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.10.1" }
+autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "ant-cli"
 description = "CLI client for the Autonomi network"
 license = "GPL-3.0"
-version = "0.5.2-rc.1"
+version = "0.5.2"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -26,8 +26,8 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
-autonomi = { path = "../autonomi", version = "0.10.2-rc.1", features = ["loud"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+autonomi = { path = "../autonomi", version = "0.10.2", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -59,7 +59,7 @@ walkdir = "2.5.0"
 xor_name = "5.0.0"
 
 [dev-dependencies]
-autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.2" }
 criterion = "0.5.1"
 eyre = "0.6.8"
 rand = { version = "~0.8.5", features = ["small_rng"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -34,7 +34,7 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 evmlib = { path = "../evmlib", version = "0.4.9" }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -34,7 +34,7 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 evmlib = { path = "../evmlib", version = "0.4.9" }

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.15" }
+ant-node = { path = "../ant-node", version = "0.4.16-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.16-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.16" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.15" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.16-rc.1" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.16-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.16" }
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.15"
+version = "0.4.16-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -28,7 +28,7 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.13", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.9" }
-autonomi = { path = "../autonomi", version = "0.10.1" }
+autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.16-rc.1"
+version = "0.4.16"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -28,7 +28,7 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 ant-releases = "0.4.3"
 ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
 async-trait = "0.1"
@@ -110,10 +110,10 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.9" }
-autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.2" }
 reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls-manual-roots",
 ] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.13"
+version = "1.0.14-rc.1"
 
 [features]
 default = []

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.14-rc.1"
+version = "1.0.14"
 
 [features]
 default = []

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.5.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.5.1"
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.10.1-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
 bytes = { version = "1.11.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi-nodejs/Cargo.toml
+++ b/autonomi-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-autonomi = { path = "../autonomi", version = "0.10.2-rc.1" }
+autonomi = { path = "../autonomi", version = "0.10.2" }
 bytes = { version = "1.11.1", features = ["serde"] }
 eyre = "0.6.12"
 futures = "0.3"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.10.1"
+version = "0.10.2-rc.1"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -29,7 +29,7 @@ loud = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Autonomi client API"
 name = "autonomi"
 license = "GPL-3.0"
-version = "0.10.2-rc.1"
+version = "0.10.2"
 edition = "2024"
 homepage = "https://maidsafe.net"
 readme = "README.md"
@@ -29,7 +29,7 @@ loud = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.2"
+version = "0.6.3-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -23,7 +23,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.13" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.3-rc.1"
+version = "0.6.3"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -23,7 +23,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
 ant-releases = "0.4.3"
 ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
 arboard = "3.4.1"

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -14,5 +14,5 @@
 # number for all the released binaries.
 release-year: 2026
 release-month: 2
-release-cycle: 1
+release-cycle: 2
 release-cycle-counter: 1


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.5.2
ant-evm: 0.1.21
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.16
ant-node-manager: 0.14.1
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.14
ant-service-management: 0.5.1
ant-token-supplies: 0.1.67
autonomi: 0.10.2
evmlib: 0.4.9
evm-testnet: 0.1.18
nat-detection: 0.2.22
node-launchpad: 0.6.3
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.5.2
antctl: 0.14.1
antctld: 0.14.1
antnode: 0.4.16
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.3
```