### PR TITLE
fix: use non-virtualized path for winsw.exe in launchpad

### DIFF
--- a/node-launchpad/src/config.rs
+++ b/node-launchpad/src/config.rs
@@ -99,11 +99,19 @@ pub fn get_config_dir() -> Result<PathBuf> {
     Ok(config_dir)
 }
 
+/// Download and configure WinSW for Windows service management.
+///
+/// WinSW is placed at `C:\ProgramData\antctl\winsw.exe` (via `get_node_manager_path`) rather than
+/// the launchpad's own data directory. This is necessary because when the launchpad is installed via
+/// MSIX, Windows virtualizes `%APPDATA%` paths, redirecting file writes to an MSIX-specific
+/// location. The service management code then cannot find `winsw.exe` at the expected standard
+/// path. Using `C:\ProgramData\antctl` avoids this problem since it is not subject to MSIX
+/// filesystem virtualization.
 #[cfg(windows)]
 pub async fn configure_winsw() -> Result<()> {
-    let data_dir_path = get_launchpad_data_dir_path()?;
+    let winsw_path = ant_node_manager::config::get_node_manager_path()?.join("winsw.exe");
     ant_node_manager::helpers::configure_winsw(
-        &data_dir_path.join("winsw.exe"),
+        &winsw_path,
         ant_node_manager::VerbosityLevel::Minimal,
     )
     .await?;


### PR DESCRIPTION
## Summary

When node-launchpad is installed via MSIX on Windows, the `%APPDATA%` path is virtualized by the
MSIX filesystem, redirecting file writes to a package-specific location. The service management
code then cannot find `winsw.exe` at the expected standard path, causing node addition to fail
with "Failed to resolve full path of the current executable".

This changes `configure_winsw()` to place `winsw.exe` at `C:\ProgramData\antctl\winsw.exe` (via
`get_node_manager_path()`) instead of the launchpad data directory (via `dirs_next::data_dir()`).
The `C:\ProgramData` path is not subject to MSIX virtualization, so it works for both MSIX and
standalone installations.

- Change is Windows-only (`#[cfg(windows)]`), no impact on other platforms
- Single file changed: `node-launchpad/src/config.rs`

## Test plan

- [x] All 23 node-launchpad unit tests pass
- [x] Clippy clean with no warnings
- [ ] Manual test: Install launchpad via MSIX on Windows, verify node addition works
- [ ] Manual test: Run standalone launchpad binary, verify node addition still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)