### PR TITLE
chore(release): stable release 2026.2.3.2

### DIFF
--- a/.claude/commands/backwards-compat-test.md
+++ b/.claude/commands/backwards-compat-test.md
@@ -35,6 +35,8 @@ After you have that, use the `gh` tool to get the releases for this repository a
 with title matching the package version I provided. From the description for that release you can
 obtain the version numbers for `ant`, `antnode` and `antctl`.
 
+Before you proceed, let me review the versions you have obtained.
+
 Now deploy a `STG-05` testnet with the following details:
 
 * 5 generic node VMs with 20 nodes per VM
@@ -49,19 +51,18 @@ Now deploy a `STG-05` testnet with the following details:
 
 Post a message to Slack to indicate the first staging environment is now being deployed.
 
-Wait for the deployment to complete by polling every 2 minutes.
+Wait for the deployment to complete by polling every 2 minutes. If there is a failure, inform me and
+wait for my input.
 
-Once complete, wait for my approval to advance to the next phase.
-
-Post a message to Slack indicating the environment was successfully deployed.
+When we have a successful deployment, post a message to Slack indicating the environment was
+deployed and move to the next phase.
 
 ## Phase 2: Node-side smoke test for the `STG-05` testnet
 
-Run the node smoke tests for `STG-05`.
+Run the node-side smoke tests for `STG-05`.
 
-Whether they pass or fail, inform me of the results and wait for my input before proceeding.
-
-Post the results to Slack.
+If there is a failure, inform me and wait for my input before proceeding. Otherwise, post the
+results to Slack and proceed to the next phase.
 
 ## Phase 3: Bootstrap a `STG-06` testnet from `STG-05` using an older version
 
@@ -77,51 +78,55 @@ Bootstrap a `STG-06` network from the `STG-05` network using the following confi
   - data-payments-address: 0xfE875D65021A7497a5DC7762c59719c8531f7146
   - merkle-payments-address: 0x393F6825C248a29295A7f9Bfa03e475decb44dc0
 
-You need to prompt me for the peer address from the `STG-05` network and the previous versions of `antnode` and `antctl`.
+You need to prompt me for the peer address for the `STG-05` network and the previous versions of
+`antnode` and `antctl`.
+
+Before you proceed, let me review the versions and peer address you are going to use.
 
 Post a message to Slack to indicate the second staging environment is now being deployed.
 
-After you have dispatched the workflow, wait for it to complete by polling every 2 minutes.
+Wait for the deployment to complete by polling every 2 minutes. If there is a failure, inform me and
+wait for my input.
 
-Then wait for me to give you the OK to proceed to the next phase.
-
-Post a message to Slack indicating the environment was successfully deployed.
+When we have a successful deployment, post a message to Slack indicating the environment was
+deployed and move to the next phase.
 
 ## Phase 4: Node-side smoke test for the `STG-06` testnet
 
-Run the node smoke tests for `STG-06`.
+Run the node-side smoke tests for `STG-06`.
 
-Whether they pass or fail, inform me of the results and wait for my input before proceeding.
-
-Post the results to Slack.
+If there is a failure, inform me and wait for my input before proceeding. Otherwise, post the
+results to Slack and proceed to the next phase.
 
 ## Phase 5: Run uploads and downloads using the `ant` client from the previous release
 
 Start the uploaders and downloaders for the `STG-05` environment.
 
-Post a message to Slack to say the workflows for starting clients have been dispatched.
+Post a message to Slack to say the workflows for starting clients have been dispatched and we will
+wait for 10 minutes for some uploads to accumulate.
 
-Now wait for my input before proceeding to the next phase.
+Now wait for those 10 minutes. After that, proceed to the next phase.
 
 ## Phase 6: Client-side smoke test for the `STG-05` testnet
 
-Run the client smoke tests for `STG-01`.
+Run the client-side smoke tests for `STG-05`.
 
-Whether they pass or fail, inform me of the results and wait for my input before proceeding.
-
-Post the results to Slack.
+If there is a failure, inform me and wait for my input before proceeding. Otherwise, post the
+results to Slack and proceed to the next phase.
 
 ## Phase 7: Let uploads and downloads run using the `ant` client from the previous release
 
-Wait for 10 minutes to allow some uploads and downloads to accumulate using the previous client
-version.
+Post a message to Slack to say we are going to allow uploads and downloads to accumulate for 10
+minutes using the previous client version.
 
-Now stop both the uploaders and downloaders for `STG-05`.
+Now wait for those 10 minutes.
+
+After that, stop both the uploaders and downloaders for `STG-05`.
 
 Post a message to Slack to say the workflows for stopping clients have been dispatched.
 
-Wait for my signal before proceeding to the next phase. I need to verify that both networks have
-received payments. For now this is done manually.
+Stop here and remind me to verify we have had no upload or download failures. Then proceed to the
+next phase when I signal.
 
 ## Phase 8: Upgrade the `ant` client to the RC version
 
@@ -135,7 +140,8 @@ Post a message to Slack to `ant` has been upgraded to the RC version.
 
 Start the uploaders and downloaders for the `STG-05` environment.
 
-Wait for my signal to proceed to the next phase.
+Wait for 10 minutes for some uploads and downloads to accumulate again, then proceed to the next
+phase.
 
 ## Phase 10: Upgrade hosts on the `STG-06` bootstrap network
 
@@ -145,9 +151,10 @@ I want to upgrade testnet `STG-06` with the following configuration:
 
 Post a message to Slack to say the upgrade to the RC version is beginning for `STG-06` hosts.
 
-Wait for 15 minutes then prompt for my approval to proceed to the next phase.
+Wait for 20 minutes, then remind me to check the upgrade workflow to make sure there were no errors
+during the upgrade. I will then signal when you can proceed to the next phase.
 
-Post a message to Slack to say the upgrade has completed for `STG-06` hosts.
+Before we move on, post a message to Slack to say the upgrade has completed for `STG-06` hosts.
 
 ## Phase 11: Upgrade hosts on the `STG-05` bootstrap network
 
@@ -157,9 +164,10 @@ I want to upgrade testnet `STG-05` with the following configuration:
 
 Post a message to Slack to say the upgrade to the RC version is beginning for `STG-05` hosts.
 
-Wait for 15 minutes then prompt for my approval to proceed to the next phase.
+Wait for 15 minutes, then remind me to check the upgrade workflow to make sure there were no errors
+during the upgrade. I will then signal when you can proceed to the next phase.
 
-Post a message to Slack to say the upgrade has completed for `STG-05` hosts.
+Before we move on, post a message to Slack to say the upgrade has completed for `STG-05` hosts.
 
 ## Phase 12: Verify there have been no upload or download failures
 
@@ -167,4 +175,4 @@ For now this is manual step.
 
 Wait for my input to inform you of the result.
 
-Post a message to slack to say the backwards compatibility test has completed successfully.
+Post a message to Slack to say the backwards compatibility test has completed successfully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy for Windows services, handling the `self-replace` crate's `.__relocated__` filename pattern
   for process identification, and updating the `service-manager` dependency to `0.11.0`.
 
+#### Fixed
+
+- The `merkle_payments_address` setting is now retained when upgrading a node service via `antctl`.
+  Previously, `build_upgrade_install_context()` was not passing this argument when reinstalling,
+  causing the setting to be lost.
+
 ### Launchpad
 
 #### Added
@@ -48,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On Windows, WinSW is now placed at `C:\ProgramData\antctl\winsw.exe` instead of the launchpad's
   own data directory. This avoids MSIX filesystem virtualisation redirecting the path and preventing
   the service management code from finding the executable.
+- On Windows, the launchpad now uses `C:\ProgramData\antctl\data` for the node data directory
+  instead of `dirs_next::data_dir()`. The MSIX filesystem virtualises the `%APPDATA%` path, causing
+  the antnode binary to be written to a virtualised location that the service manager cannot find.
 
 ## 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *When editing this file, please respect a line length of 100.*
 
+## 2026-02-18
+
+### Network
+
+#### Added
+
+- The `antnode` binary now supports automatic upgrades on Windows. The same periodic upgrade check
+  that was previously available on macOS and Linux will now also run on Windows. The `self-replace`
+  crate is used to handle binary replacement while the process is running. Retries with backoff are
+  used to handle transient antivirus file locks.
+
+#### Changed
+
+- The connection prune deadline for non-routing-table peers (e.g. clients) has been increased from
+  60 seconds to 120 seconds and is now reset each time a new request is received on the connection.
+  This prevents premature connection closure during long-running operations such as `put_record`.
+
+### Antctl
+
+#### Changed
+
+- Updated to accommodate automatic upgrades on Windows. This includes using an `OnFailure` restart
+  policy for Windows services, handling the `self-replace` crate's `.__relocated__` filename pattern
+  for process identification, and updating the `service-manager` dependency to `0.11.0`.
+
+### Launchpad
+
+#### Added
+
+- A scrollbar on the node grid that appears when the content overflows the visible area.
+
+#### Fixed
+
+- The connection mode display now correctly maps `no_upnp` and default flags to their respective
+  modes. Previously, UPnP and Manual modes were swapped.
+- The TUI no longer blocks on a full node registry refresh at startup. Instead, it renders
+  immediately using disk-cached state and triggers a background refresh once the action handler is
+  registered.
+- On Windows, WinSW is now placed at `C:\ProgramData\antctl\winsw.exe` instead of the launchpad's
+  own data directory. This avoids MSIX filesystem virtualisation redirecting the path and preventing
+  the service management code from finding the executable.
+
 ## 2026-02-11
 
 ### Network

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.14.2-rc.1"
+version = "0.14.2-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.5.2-rc.1"
+version = "0.5.3-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -6789,7 +6789,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.4-rc.1"
+version = "0.6.4-rc.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.17-rc.1"
+version = "0.4.17"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.14.2-rc.2"
+version = "0.14.2"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.15-rc.1"
+version = "1.0.15"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.5.3-rc.1"
+version = "0.5.3"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -6789,7 +6789,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.4-rc.2"
+version = "0.6.4"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.4.16"
+version = "0.4.17-rc.1"
 dependencies = [
  "aes-gcm-siv",
  "ant-bootstrap",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "ant-node-manager"
-version = "0.14.1"
+version = "0.14.2-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "1.0.14"
+version = "1.0.15-rc.1"
 dependencies = [
  "ant-build-info",
  "ant-evm",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "ant-service-management"
-version = "0.5.1"
+version = "0.5.2-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-evm",
@@ -6789,7 +6789,7 @@ dependencies = [
 
 [[package]]
 name = "node-launchpad"
-version = "0.6.3"
+version = "0.6.4-rc.1"
 dependencies = [
  "ant-bootstrap",
  "ant-build-info",

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-bootstrap/Cargo.toml
+++ b/ant-bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.13"
 
 [dependencies]
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 atomic-write-file = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "env"] }

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2026";
 pub const RELEASE_MONTH: &str = "2";
 pub const RELEASE_CYCLE: &str = "3";
-pub const RELEASE_CYCLE_COUNTER: &str = "1";
+pub const RELEASE_CYCLE_COUNTER: &str = "2";

--- a/ant-build-info/src/release_info.rs
+++ b/ant-build-info/src/release_info.rs
@@ -1,4 +1,4 @@
 pub const RELEASE_YEAR: &str = "2026";
 pub const RELEASE_MONTH: &str = "2";
-pub const RELEASE_CYCLE: &str = "2";
+pub const RELEASE_CYCLE: &str = "3";
 pub const RELEASE_CYCLE_COUNTER: &str = "1";

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -26,7 +26,7 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 autonomi = { path = "../autonomi", version = "0.10.2", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-cli/Cargo.toml
+++ b/ant-cli/Cargo.toml
@@ -26,7 +26,7 @@ harness = false
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 autonomi = { path = "../autonomi", version = "0.10.2", features = ["loud"] }
 chrono = "0.4"
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.14.1"
+version = "0.14.2-rc.1"
 
 [[bin]]
 name = "antctl"
@@ -34,9 +34,9 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
 evmlib = { path = "../evmlib", version = "0.4.9" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.14.2-rc.2"
+version = "0.14.2"
 
 [[bin]]
 name = "antctl"
@@ -34,9 +34,9 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3" }
 evmlib = { path = "../evmlib", version = "0.4.9" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }

--- a/ant-node-manager/Cargo.toml
+++ b/ant-node-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-node-manager"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.14.2-rc.1"
+version = "0.14.2-rc.2"
 
 [[bin]]
 name = "antctl"
@@ -36,7 +36,7 @@ ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
 evmlib = { path = "../evmlib", version = "0.4.9" }
 chrono = "~0.4.19"
 clap = { version = "4.4.6", features = ["derive", "env"] }

--- a/ant-node-manager/src/lib.rs
+++ b/ant-node-manager/src/lib.rs
@@ -5897,6 +5897,8 @@ mod tests {
                         OsString::from("0x5FbDB2315678afecb367f032d93F642f64180aa3"),
                         OsString::from("--data-payments-address"),
                         OsString::from("0x8464135c8F25Da09e49BC8782676a84730C318bC"),
+                        OsString::from("--merkle-payments-address"),
+                        OsString::from("0x1234567890AbcdEF1234567890aBcdef12345678"),
                     ],
                     autostart: true,
                     contents: None,
@@ -5968,7 +5970,9 @@ mod tests {
                 data_payments_address: RewardsAddress::from_str(
                     "0x8464135c8F25Da09e49BC8782676a84730C318bC",
                 )?,
-                merkle_payments_address: None,
+                merkle_payments_address: Some(RewardsAddress::from_str(
+                    "0x1234567890abcdef1234567890abcdef12345678",
+                )?),
             }),
             relay: false,
             initial_peers_config: Default::default(),

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.17-rc.1" }
+ant-node = { path = "../ant-node", version = "0.4.17" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-nodejs/Cargo.toml
+++ b/ant-node-nodejs/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-ant-node = { path = "../ant-node", version = "0.4.16" }
+ant-node = { path = "../ant-node", version = "0.4.17-rc.1" }
 hex = "0.4.3"
 napi = { version = "2.12.2", default-features = false, features = ["napi4", "napi6", "tokio_rt", "serde-json"] }
 napi-derive = "2.12.2"

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,9 +19,9 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.17-rc.1" }
-ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.17" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -19,9 +19,9 @@ nightly = []
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14", features=["rpc"] }
-ant-node = { path = "../ant-node", version = "0.4.16" }
-ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features=["rpc"] }
+ant-node = { path = "../ant-node", version = "0.4.17-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node-rpc-client/Cargo.toml
+++ b/ant-node-rpc-client/Cargo.toml
@@ -21,7 +21,7 @@ ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features=["rpc"] }
 ant-node = { path = "../ant-node", version = "0.4.17-rc.1" }
-ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 clap = { version = "4.2.1", features = ["derive"] }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.17-rc.1"
+version = "0.4.17"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -28,9 +28,9 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.11.1", features = ["serde"] }
@@ -111,7 +111,7 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.9" }
 autonomi = { path = "../autonomi", version = "0.10.2" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "The Autonomi node binary"
 name = "ant-node"
-version = "0.4.16"
+version = "0.4.17-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -28,9 +28,9 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.11.1", features = ["serde"] }
@@ -111,7 +111,7 @@ xor_name = "5.0.0"
 void = "1.0.2"
 
 [dev-dependencies]
-ant-protocol = { path = "../ant-protocol", version = "1.0.14", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features = ["rpc"] }
 assert_fs = "1.0.0"
 evmlib = { path = "../evmlib", version = "0.4.9" }
 autonomi = { path = "../autonomi", version = "0.10.2" }

--- a/ant-node/Cargo.toml
+++ b/ant-node/Cargo.toml
@@ -30,7 +30,7 @@ ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0", features = ["process-metrics"] }
 ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { path = "../ant-service-management", version = "0.5.2-rc.1" }
+ant-service-management = { path = "../ant-service-management", version = "0.5.3-rc.1" }
 async-trait = "0.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.11.1", features = ["serde"] }

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.14"
+version = "1.0.15-rc.1"
 
 [features]
 default = []

--- a/ant-protocol/Cargo.toml
+++ b/ant-protocol/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-protocol"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "1.0.15-rc.1"
+version = "1.0.15"
 
 [features]
 default = []

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.5.3-rc.1"
+version = "0.5.3"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.5.2-rc.1"
+version = "0.5.3-rc.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }

--- a/ant-service-management/Cargo.toml
+++ b/ant-service-management/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0"
 name = "ant-service-management"
 readme = "README.md"
 repository = "https://github.com/maidsafe/autonomi"
-version = "0.5.1"
+version = "0.5.2-rc.1"
 
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14", features = ["rpc"] }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1", features = ["rpc"] }
 async-trait = "0.1"
 dirs-next = "2.0.0"
 libp2p = { version = "0.56.0", features = ["kad"] }

--- a/ant-service-management/src/node/mod.rs
+++ b/ant-service-management/src/node/mod.rs
@@ -137,6 +137,10 @@ impl ServiceStateActions for NodeService {
             args.push(OsString::from(
                 custom_network.data_payments_address.to_string(),
             ));
+            if let Some(merkle_payments_address) = custom_network.merkle_payments_address {
+                args.push(OsString::from("--merkle-payments-address"));
+                args.push(OsString::from(merkle_payments_address.to_string()));
+            }
         }
 
         Ok(ServiceInstallCtx {

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -29,7 +29,7 @@ loud = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/autonomi/Cargo.toml
+++ b/autonomi/Cargo.toml
@@ -29,7 +29,7 @@ loud = []
 [dependencies]
 ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 bip39 = "2.0.0"
 blst = "0.3.13"
 blstrs = "0.7.1"

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/nat-detection/Cargo.toml
+++ b/nat-detection/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 
 [dependencies]
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 color-eyre = { version = "0.6", default-features = false }

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.3"
+version = "0.6.4-rc.1"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -22,10 +22,10 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-node-manager = { version = "0.14.1", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.14" }
+ant-node-manager = { version = "0.14.2-rc.1", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { version = "0.5.1", path = "../ant-service-management" }
+ant-service-management = { version = "0.5.2-rc.1", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.4-rc.1"
+version = "0.6.4-rc.2"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -22,10 +22,10 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-node-manager = { version = "0.14.2-rc.1", path = "../ant-node-manager" }
+ant-node-manager = { version = "0.14.2-rc.2", path = "../ant-node-manager" }
 ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
 ant-releases = "0.4.3"
-ant-service-management = { version = "0.5.2-rc.1", path = "../ant-service-management" }
+ant-service-management = { version = "0.5.3-rc.1", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/node-launchpad/Cargo.toml
+++ b/node-launchpad/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "TUI for running nodes on the Autonomi network"
 name = "node-launchpad"
-version = "0.6.4-rc.2"
+version = "0.6.4"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://maidsafe.net"
@@ -22,10 +22,10 @@ ant-bootstrap = { path = "../ant-bootstrap", version = "0.2.13" }
 ant-build-info = { path = "../ant-build-info", version = "0.1.29" }
 ant-evm = { path = "../ant-evm", version = "0.1.21" }
 ant-logging = { path = "../ant-logging", version = "0.3.0" }
-ant-node-manager = { version = "0.14.2-rc.2", path = "../ant-node-manager" }
-ant-protocol = { path = "../ant-protocol", version = "1.0.15-rc.1" }
+ant-node-manager = { version = "0.14.2", path = "../ant-node-manager" }
+ant-protocol = { path = "../ant-protocol", version = "1.0.15" }
 ant-releases = "0.4.3"
-ant-service-management = { version = "0.5.3-rc.1", path = "../ant-service-management" }
+ant-service-management = { version = "0.5.3", path = "../ant-service-management" }
 arboard = "3.4.1"
 atty = "0.2.14"
 better-panic = "0.3.0"

--- a/node-launchpad/src/config.rs
+++ b/node-launchpad/src/config.rs
@@ -9,6 +9,7 @@
 use crate::connection_mode::ConnectionMode;
 use crate::system::get_primary_mount_point;
 use crate::{action::Action, mode::Scene};
+#[cfg(not(windows))]
 use ant_node_manager::config::is_running_as_root;
 use color_eyre::eyre::{Result, eyre};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -32,23 +33,30 @@ pub fn get_launchpad_nodes_data_dir_path(
     should_create: bool,
 ) -> Result<PathBuf> {
     let mut mount_point = PathBuf::new();
-    let is_root = is_running_as_root();
 
     let data_directory: PathBuf = if *base_dir == get_primary_mount_point() {
-        if is_root {
+        // On Windows, always use C:\ProgramData\antctl\data regardless of root status.
+        // This path is not subject to MSIX filesystem virtualization, which redirects
+        // %APPDATA% paths to a package-specific location. Using dirs_next::data_dir()
+        // would cause the antnode binary to be written to the virtualized path, but the
+        // node registry would store the non-virtualized path, preventing the service
+        // manager from finding the binary.
+        #[cfg(windows)]
+        {
+            let path = PathBuf::from("C:\\ProgramData\\antctl\\data");
+            debug!("Using non-virtualized path for nodes data directory: {path:?}");
+            path
+        }
+        #[cfg(not(windows))]
+        if is_running_as_root() {
             // The root's data directory isn't accessible to the user `ant`, so we are using an
             // alternative default path that `ant` can access.
-            #[cfg(unix)]
-            {
-                let default_data_dir_path = PathBuf::from("/var/antctl/services");
-                debug!(
-                    "Running as root; using default path {:?} for nodes data directory instead of primary mount point",
-                    default_data_dir_path
-                );
+            let default_data_dir_path = PathBuf::from("/var/antctl/services");
+            debug!(
+                "Running as root; using default path {:?} for nodes data directory instead of primary mount point",
                 default_data_dir_path
-            }
-            #[cfg(windows)]
-            get_user_data_dir()?
+            );
+            default_data_dir_path
         } else {
             get_user_data_dir()?
         }
@@ -77,6 +85,7 @@ pub fn get_launchpad_nodes_data_dir_path(
     Ok(mount_point)
 }
 
+#[cfg(not(windows))]
 fn get_user_data_dir() -> Result<PathBuf> {
     dirs_next::data_dir().ok_or_else(|| eyre!("User data directory is not obtainable",))
 }

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -15,4 +15,4 @@
 release-year: 2026
 release-month: 2
 release-cycle: 3
-release-cycle-counter: 1
+release-cycle-counter: 2

--- a/release-cycle-info
+++ b/release-cycle-info
@@ -14,5 +14,5 @@
 # number for all the released binaries.
 release-year: 2026
 release-month: 2
-release-cycle: 2
+release-cycle: 3
 release-cycle-counter: 1


### PR DESCRIPTION
```
==================
  Crate Versions  
==================
ant-bootstrap: 0.2.13
ant-build-info: 0.1.29
ant-cli: 0.5.2
ant-evm: 0.1.21
ant-logging: 0.3.0
ant-metrics: 0.1.30
ant-node: 0.4.17
ant-node-manager: 0.14.2
ant-node-rpc-client: 0.6.49
ant-protocol: 1.0.15
ant-service-management: 0.5.3
ant-token-supplies: 0.1.67
autonomi: 0.10.2
evmlib: 0.4.9
evm-testnet: 0.1.18
nat-detection: 0.2.22
node-launchpad: 0.6.4
autonomi-nodejs: 0.5.0
ant-node-nodejs: 0.1.5
test-utils: 0.4.21
===================
  Binary Versions  
===================
ant: 0.5.2
antctl: 0.14.2
antctld: 0.14.2
antnode: 0.4.17
antnode_rpc_client: 0.6.49
nat-detection: 0.2.22
node-launchpad: 0.6.4
```