### PR TITLE
chore(ci): fix python-bindings venv already exists on cache restore

### DIFF
--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -70,7 +70,8 @@ jobs:
         shell: bash
         working-directory: autonomi
         run: |
-          uv venv
+          # --clear replaces existing .venv (e.g. from cache restore) to avoid "virtual environment already exists" errors
+          uv venv --clear
           # create lockfile if absent
           test -f uv.lock || uv lock
           uv sync --locked


### PR DESCRIPTION
Use uv venv --clear so a restored .venv from the Actions cache is replaced instead of failing.

**Problem:** The python-bindings workflow failed with:
A virtual environment already exists at .../autonomi/.venv. Use `--clear` to replace it
when the uv cache step restored an existing .venv and the next step ran uv venv without --clear.

**Fix:** Run uv venv --clear in the Build and test step so the venv is recreated when present (e.g. from cache). uv sync --locked then installs the correct deps as before.

Fixes the CI failure seen in e.g. [PR #3466 python-bindings run](https://github.com/maidsafe/autonomi/actions/runs/21965056579).